### PR TITLE
feat(spectcl): close #1643 on the 2.0 environment block; evaluate block bodies as scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -953,6 +953,12 @@ to add another.
 Third-party and in-house commands that are not in the registry can be declared
 with [stub annotations](docs/kcs/kcs-howto-annotate-commands-with-stubs.md).
 
+A SpecTcl pack can go further and declare a shell of its own, with an
+`environment NAME { … ambient PACKAGE VERSION }` block: a library that
+comes with one shell and not another is then floored — and excused from
+`package require` — in exactly the shell that has it. See
+[how to scope an ambient package](docs/kcs/kcs-howto-scope-an-ambient-package-to-one-dialect.md).
+
 ### Dialect profiles
 
 Switch between Tcl 8.4/8.5/8.6/9.0/9.1, F5 iRules, F5 iApps, F5 tmsh, and EDA

--- a/docs/design/dialect-and-package-registry-redesign.md
+++ b/docs/design/dialect-and-package-registry-redesign.md
@@ -1376,6 +1376,26 @@ maximally.
   table, so a pack-declared core cannot yet be *lexed* with. That waits on
   the `DialectProfile` re-type (ledger C1).
 
+**Status (#1643, the environment block's first outside user).** The issue
+predates 2.0 and asked for `ambient_package NAME VERSION -dialects {…}`.
+The environment block already covers all of it — an `ambient` row states
+the placement inside the environment that has the package, which is the
+scoping the flag was reaching for — and a version shared by several
+environments is written once as a Tcl variable, because a pack is an
+evaluated program. One thing stood in the way and is now fixed: the
+capture layer preferred the file's own bytes to the evaluated invocation
+whenever the source statement at that line had the same shape, so a row
+that *substituted* was replayed with the dollar sign still in it. It now
+prefers the source text only for a statement that substitutes nothing
+(`LOADER_EVAL_VERSION` bumped with it). The flag itself is not added: it
+cannot be desugared for the workspace and studio tiers, which §6.4 forbids
+from extending a compiled environment, and carrying it as a scoped row
+beside the placements would fork the floor model in two. `ambient_package`
+therefore stays exactly the unscoped 1.2 word it was, and a row bearing
+`-dialects` is dropped whole — an availability-narrowing word a reader
+cannot honour must not leave the wider claim standing (§6.1) — with a
+notice naming the environment spelling instead.
+
 **Status (P2-H remainder).** `provides` (with the fallback-provider
 default), `co_provides` (parsed and carried as data; the alias mechanics
 that consume it are P3+), `dynamic_surface` / `unknown_members` (mapping
@@ -1410,7 +1430,7 @@ lowering). The invocation-refinement descriptor (Q12) has since landed as
 |---|---|
 | `available {PROVIDER WINDOW…}` on commands/subcommands/options/values | the §4 algebra: `available {tcl 8.6-} {jim 0.78-}` / `available {package Tk 8.5-8.6}`; replaces `dialects` + implicit `required_package` gating |
 | `provides NAME VERSION ?VERSION…?` (pack level) | declares the package trains this pack describes, including parallel majors; commands default their provider to the pack's `provides` |
-| `environment NAME { … }` (pack level) | declares an environment definition: `core tcl 8.5 ?-build PROFILE?`, `ambient PACKAGE VERSION\|tracks-base\|keyed KEY`, `hosted PACKAGE …`, `alias NAME…`, `editor_identity ID` (selecting from the **fixed contributed set** — review B7, never minting a new editor language id), `file_extension`/`filename`/`signature` server-side detection rows, `display_name`, `policy` knobs — subsumes and closes #1643 (`ambient_package -dialects`) by scoping placements to the declaring environment instead of flag-scoping a global claim |
+| `environment NAME { … }` (pack level) | declares an environment definition: `core tcl 8.5 ?-build PROFILE?`, `ambient PACKAGE VERSION\|tracks-base\|keyed KEY`, `hosted PACKAGE …`, `alias NAME…`, `editor_identity ID` (selecting from the **fixed contributed set** — review B7, never minting a new editor language id), `file_extension`/`filename`/`signature` server-side detection rows, `display_name`, `policy` knobs — subsumes and closes #1643 (`ambient_package -dialects`) by scoping placements to the declaring environment instead of flag-scoping a global claim. **Shipped, and #1643 closed on it**: a shared version is an ordinary Tcl variable substituted into each `ambient` row (which needed one capture-layer fix — see the §6.2 status note below), the two-environment floor is pinned by `tests/ambient_environment_floor.rs`, and the proposed flag is refused fail-closed rather than added as a second spelling |
 | `placement` spellings: `ambient` / `hosted`, versions `Pinned` / `tracks-base` / `keyed KEY` / requirement sets | closes blockers 6–8: a pack can say "hosted, floored by requirement" (Tk under tclsh — on Tk's **own** axis, per review B11) and "ambient at the BIG-IP-implied version, in this environment only" (iapps); `tracks-base` survives only for hosts that genuinely guarantee matched versions; the closed-world vendor gate re-derives from *all* declared environments, compiled and pack-declared alike |
 | `co_provides` / loader aliases (predicated) | corrected per review B11 — Tk 9 registers lowercase `tk` as the loading package and provides uppercase `Tk` via an `ifneeded` chain requiring the exact lowercase version, only when built without `TK_NO_DEPRECATED`. The spelling is a predicated relation ("requiring `Tk` requires exact `tk`; successful load co-provides `Tk`, under this build predicate"), not a flat alias; tcllib's D1 wrapper names ride the same mechanism |
 | `dynamic_surface` / `unknown_members` | the honesty escape hatch (review B6): a provider whose member set is runtime-extensible (`struct::tree` methods via `info commands`, `oo::dialect` DSLs, pave's computed methods) declares so instead of pretending closure |

--- a/docs/design/dialect-and-package-registry-redesign.md
+++ b/docs/design/dialect-and-package-registry-redesign.md
@@ -1382,12 +1382,20 @@ The environment block already covers all of it — an `ambient` row states
 the placement inside the environment that has the package, which is the
 scoping the flag was reaching for — and a version shared by several
 environments is written once as a Tcl variable, because a pack is an
-evaluated program. One thing stood in the way and is now fixed: the
+evaluated program. Two things stood in the way and are now fixed. The
 capture layer preferred the file's own bytes to the evaluated invocation
 whenever the source statement at that line had the same shape, so a row
-that *substituted* was replayed with the dollar sign still in it. It now
-prefers the source text only for a statement that substitutes nothing
-(`LOADER_EVAL_VERSION` bumped with it). The flag itself is not added: it
+that *substituted* was replayed with the dollar sign still in it; it now
+prefers the source text only for a statement that substitutes nothing.
+And the `environment` and `dialect` blocks were read as literal data
+while `command` blocks were evaluated — an asymmetry no author could have
+predicted, since a pack is one Tcl program. Both are now **evaluated
+scopes**: the body runs as a script, its rows are captured exactly as a
+`command` body's are, and `environment_block` / `dialect_block` stay the
+single owner of what each row means through a shared `parse_rows` seam
+that the literal reader and the evaluator both enter. So a variable, a
+`foreach`, or an `if` works inside a block, and an unknown row still
+rejects it. (`LOADER_EVAL_VERSION` bumped once for both.) The flag itself is not added: it
 cannot be desugared for the workspace and studio tiers, which §6.4 forbids
 from extending a compiled environment, and carrying it as a scoped row
 beside the placements would fork the floor model in two. `ambient_package`
@@ -1430,7 +1438,7 @@ lowering). The invocation-refinement descriptor (Q12) has since landed as
 |---|---|
 | `available {PROVIDER WINDOW…}` on commands/subcommands/options/values | the §4 algebra: `available {tcl 8.6-} {jim 0.78-}` / `available {package Tk 8.5-8.6}`; replaces `dialects` + implicit `required_package` gating |
 | `provides NAME VERSION ?VERSION…?` (pack level) | declares the package trains this pack describes, including parallel majors; commands default their provider to the pack's `provides` |
-| `environment NAME { … }` (pack level) | declares an environment definition: `core tcl 8.5 ?-build PROFILE?`, `ambient PACKAGE VERSION\|tracks-base\|keyed KEY`, `hosted PACKAGE …`, `alias NAME…`, `editor_identity ID` (selecting from the **fixed contributed set** — review B7, never minting a new editor language id), `file_extension`/`filename`/`signature` server-side detection rows, `display_name`, `policy` knobs — subsumes and closes #1643 (`ambient_package -dialects`) by scoping placements to the declaring environment instead of flag-scoping a global claim. **Shipped, and #1643 closed on it**: a shared version is an ordinary Tcl variable substituted into each `ambient` row (which needed one capture-layer fix — see the §6.2 status note below), the two-environment floor is pinned by `tests/ambient_environment_floor.rs`, and the proposed flag is refused fail-closed rather than added as a second spelling |
+| `environment NAME { … }` (pack level) | declares an environment definition: `core tcl 8.5 ?-build PROFILE?`, `ambient PACKAGE VERSION\|tracks-base\|keyed KEY`, `hosted PACKAGE …`, `alias NAME…`, `editor_identity ID` (selecting from the **fixed contributed set** — review B7, never minting a new editor language id), `file_extension`/`filename`/`signature` server-side detection rows, `display_name`, `policy` knobs — subsumes and closes #1643 (`ambient_package -dialects`) by scoping placements to the declaring environment instead of flag-scoping a global claim. **Shipped, and #1643 closed on it**: a shared version is an ordinary Tcl variable substituted into each `ambient` row (which needed one capture-layer fix — see the §6.2 status note below), the two-environment floor is pinned by `tests/ambient_environment_floor.rs`, the block body is an evaluated scope like a `command` body (so `foreach`/`if`/variables work in it), and the proposed flag is refused fail-closed rather than added as a second spelling |
 | `placement` spellings: `ambient` / `hosted`, versions `Pinned` / `tracks-base` / `keyed KEY` / requirement sets | closes blockers 6–8: a pack can say "hosted, floored by requirement" (Tk under tclsh — on Tk's **own** axis, per review B11) and "ambient at the BIG-IP-implied version, in this environment only" (iapps); `tracks-base` survives only for hosts that genuinely guarantee matched versions; the closed-world vendor gate re-derives from *all* declared environments, compiled and pack-declared alike |
 | `co_provides` / loader aliases (predicated) | corrected per review B11 — Tk 9 registers lowercase `tk` as the loading package and provides uppercase `Tk` via an `ifneeded` chain requiring the exact lowercase version, only when built without `TK_NO_DEPRECATED`. The spelling is a predicated relation ("requiring `Tk` requires exact `tk`; successful load co-provides `Tk`, under this build predicate"), not a flat alias; tcllib's D1 wrapper names ride the same mechanism |
 | `dynamic_surface` / `unknown_members` | the honesty escape hatch (review B6): a provider whose member set is runtime-extensible (`struct::tree` methods via `info commands`, `oo::dialect` DSLs, pave's computed methods) declares so instead of pretending closure |

--- a/docs/design/spec-dsl-examples/README.md
+++ b/docs/design/spec-dsl-examples/README.md
@@ -55,10 +55,16 @@ speclib <pack-name> <dsl-version> {
 }
 ```
 
-A pack is **one Tcl script, read from the CST and never executed.** Every
-declaration is `word word…` with braced words for blocks and prose — the
-loader walks the parse tree. The only Tcl that is ever *evaluated* is a
-hook body, and only at query time, in the sandbox described below.
+A pack is **one Tcl program, evaluated in a sandbox** (design E): the
+declarations below are the registration commands it calls, and a
+straight-line pack — which is what nearly every pack is — registers
+exactly the statements it is written as. Every declaration is
+`word word…` with braced words for blocks and prose, and the blocks that
+have a body (`command`, `subcommand`, `environment`, `dialect`) run that
+body as a script, so a variable, a `foreach`, or an `if` works inside
+them. What each row *means* is still decided by that row's own reader,
+never by the program. Hook bodies are the one Tcl evaluated later, at
+query time, in the sandbox described below.
 
 `speclib`'s version is the **DSL vocabulary version**, not the library's:
 it gates hard breaks (a word whose *meaning* changed), never additions.

--- a/docs/design/spec-dsl-examples/README.md
+++ b/docs/design/spec-dsl-examples/README.md
@@ -405,6 +405,16 @@ then the profile compiled into the server. Repeat the row across a
 pack's files and the highest version wins, so merge order cannot lower a
 floor.
 
+The row is **unscoped**: it floors its package for every document the
+pack is active in. To say a package is ambient under one of a pack's
+environments and not another, write the placement inside that
+environment — `environment NAME { ambient PACKAGE VERSION }` (2.0) —
+and share a version between environments with an ordinary Tcl variable.
+`ambient_package NAME VERSION -dialects {…}` is not vocabulary; the row
+is dropped whole rather than applied everywhere, because dropping only
+the flag would leave the wider claim standing. See
+[`spec-packs.md`](../spec-packs.md), "Scoping an ambient package".
+
 ### Block statements
 
 Ten properties take a braced block instead of a value, and each may

--- a/docs/design/spec-packs.md
+++ b/docs/design/spec-packs.md
@@ -645,6 +645,14 @@ whatever it declares. It closes the versioned-signature gap and adds the
   control: the require in this file, then the pack in this workspace,
   then the profile compiled into the server.
 
+  The row is **unscoped by construction**: it floors its package for
+  every document the pack is active in. Issue #1643 — filed before 2.0
+  existed — asked for a `-dialects {…}` flag to narrow it to some of the
+  pack's dialects. That flag is *not* vocabulary, and the loader refuses
+  it rather than reading it or ignoring it: see
+  ["Scoping an ambient package"](#scoping-an-ambient-package-issue-1643)
+  below for what to write instead and why the row fails closed.
+
 - **`option … -taints-var-write`.** Marks a variable-valued option whose
   linked variable can be written from external input. The bit belongs to the
   individual option argument, so an editable widget's `-variable` can be a
@@ -728,6 +736,71 @@ fails the selected shape but fits *another* declared window draws
 rather than a bare "too many arguments": the call is not malformed, it is
 written for a different release, and the two have different fixes. A
 count fitting no window at all stays an ordinary E002/E003.
+
+### Scoping an ambient package (issue #1643)
+
+`ambient_package` says "this package is here, at this version" about the
+whole pack. Issue #1643 asked for the narrower claim — *here, under this
+dialect and not that one* — and proposed spelling it as a flag,
+`ambient_package NAME VERSION -dialects {…}`. The issue predates SpecTcl
+2.0, and 2.0 answers the same question from the other end.
+
+**What to write.** State the placement inside the environment that has
+the package, with `environment NAME { ambient PACKAGE VERSION }` (the
+redesign document's §6.2). A pack is an evaluated Tcl program, so a
+version several environments share is written once as an ordinary
+variable and substituted into each row — there is no scoping vocabulary
+to learn, and nothing says the package is ambient anywhere it is not:
+
+```tcl
+speclib mypack 2.0 {
+    set tkver 8.6
+
+    environment mypack-shell "
+        core    tcl 8.6
+        ambient Tk $tkver
+    "
+
+    environment mypack-plain {
+        core tcl 8.6
+    }
+}
+```
+
+A document that resolves to `mypack-shell` gets the Tk 8.6 floor and is
+never asked for a `package require Tk`; one that resolves to
+`mypack-plain` gets neither. Both answers come from the same placement,
+so they cannot drift apart.
+
+Note the quotes. A `{ … }` word is Tcl's literal, and the loader reads it
+as one: a variable inside a braced environment body stays a dollar sign,
+exactly as it would anywhere else in Tcl. Quote the body — or build it —
+when a row needs substitution.
+
+**Why the flag is refused rather than read.** Two reasons, both from the
+model rather than from taste:
+
+- **It cannot be desugared.** A `-dialects` list naming a compiled
+  environment (`tcl8.6`, `f5-irules`) means "add an ambient placement to
+  that environment", which is `environment NAME -extend { ambient … }` —
+  and §6.4's trust lattice forbids exactly that for the workspace and
+  Spec Studio tiers most packs come from. The sugar would work for
+  bundled packs and fail the whole registration for everyone else.
+- **It would fork the floor model.** A scoped row kept in the pack's own
+  ambient table reports as a pack-declared floor; the same claim written
+  as a placement reports as the environment's own. One question with two
+  answers, differing only in how it was spelled, is the parallel table
+  the #1631 redesign set out to remove.
+
+**Why the whole row is dropped.** Ignoring an unknown flag and keeping
+the row would leave the *unscoped* claim standing — the pack would floor
+the package in every dialect, including the ones it had just said the
+package is absent from. That is the compatibility contract's fail-closed
+rule read backwards: an availability-**narrowing** word that a reader
+cannot honour must not leave the wider claim behind. So the row fails
+closed, with a notice naming the environment spelling to use instead, and
+the same rule is registered generically — a scoping word is
+semantic-class vocabulary, never decoration.
 
 ## Loading and tooling
 

--- a/docs/design/spec-packs.md
+++ b/docs/design/spec-packs.md
@@ -747,19 +747,20 @@ dialect and not that one* — and proposed spelling it as a flag,
 
 **What to write.** State the placement inside the environment that has
 the package, with `environment NAME { ambient PACKAGE VERSION }` (the
-redesign document's §6.2). A pack is an evaluated Tcl program, so a
-version several environments share is written once as an ordinary
-variable and substituted into each row — there is no scoping vocabulary
-to learn, and nothing says the package is ambient anywhere it is not:
+redesign document's §6.2). An `environment` body is an evaluated script,
+exactly as a `command` body is, so a version several environments share
+is written once as an ordinary variable and a repetitive ladder is an
+ordinary `foreach` — there is no scoping vocabulary to learn, and nothing
+says the package is ambient anywhere it is not:
 
 ```tcl
 speclib mypack 2.0 {
     set tkver 8.6
 
-    environment mypack-shell "
+    environment mypack-shell {
         core    tcl 8.6
         ambient Tk $tkver
-    "
+    }
 
     environment mypack-plain {
         core tcl 8.6
@@ -772,10 +773,10 @@ never asked for a `package require Tk`; one that resolves to
 `mypack-plain` gets neither. Both answers come from the same placement,
 so they cannot drift apart.
 
-Note the quotes. A `{ … }` word is Tcl's literal, and the loader reads it
-as one: a variable inside a braced environment body stays a dollar sign,
-exactly as it would anywhere else in Tcl. Quote the body — or build it —
-when a row needs substitution.
+The block reader is still the single owner of what a row *means*: the
+body decides which rows are registered, and `environment_block` decides
+whether each one is valid. An unknown row is semantic-class vocabulary
+and rejects the whole block however it was produced.
 
 **Why the flag is refused rather than read.** Two reasons, both from the
 model rather than from taste:

--- a/docs/kcs/README.md
+++ b/docs/kcs/README.md
@@ -217,6 +217,10 @@ symptom with several possible causes worth telling apart. See rule 13 in
   — the SpecTcl pack quickstart: the minimal `.tclspec` shape, the
   three discovery tiers, validation, and how the running server picks
   a saved pack up.
+- [kcs-howto-scope-an-ambient-package-to-one-dialect.md](kcs-howto-scope-an-ambient-package-to-one-dialect.md)
+  — say a library is ambient under one of a pack's environments and not
+  another, with an `environment { ambient … }` row and a shared version
+  variable.
 - [kcs-howto-derive-version-ranges-from-releases.md](kcs-howto-derive-version-ranges-from-releases.md)
   — derive `introduced_version` / `retired_version` facts from several
   package releases with `tcl spec import`, read the evidence header it

--- a/docs/kcs/kcs-howto-scope-an-ambient-package-to-one-dialect.md
+++ b/docs/kcs/kcs-howto-scope-an-ambient-package-to-one-dialect.md
@@ -25,17 +25,18 @@ file is written for?
 
 Declare each shell as an `environment`, and put an `ambient` row in the one
 that has the library. A shared version is an ordinary Tcl variable — a pack
-is a Tcl program, so you set it once and substitute it where it is needed.
+is a Tcl program and an `environment` body is a script, so you set it once
+and substitute it where it is needed.
 
 ```tcl
 speclib mypack 2.0 {
     set tkver 8.6
 
-    environment mypack-shell "
+    environment mypack-shell {
         display_name {Mypack Shell}
         core         tcl 8.6
         ambient      Tk $tkver
-    "
+    }
 
     environment mypack-plain {
         display_name {Mypack Plain}
@@ -46,10 +47,11 @@ speclib mypack 2.0 {
 
 Two details are worth knowing:
 
-1. **Quote the body when a row uses a variable.** `{ … }` is Tcl's literal,
-   here as everywhere else, so `$tkver` inside a braced environment body
-   stays a dollar sign. The braced form is right for the second environment,
-   which substitutes nothing.
+1. **The body is a script, so ordinary Tcl works in it.** Variables
+   substitute, and a repetitive ladder can be a `foreach` — the same as
+   inside a `command` block. What each row *means* is still decided by the
+   environment reader, so a misspelt row is rejected however it was
+   produced.
 2. **`ambient_package` is the wrong tool for this.** That row floors its
    package for *every* document the pack is active in, and it has no
    scoping flag. Writing `ambient_package Tk 8.6 -dialects {mypack-shell}`

--- a/docs/kcs/kcs-howto-scope-an-ambient-package-to-one-dialect.md
+++ b/docs/kcs/kcs-howto-scope-an-ambient-package-to-one-dialect.md
@@ -1,0 +1,80 @@
+# KCS: How do I say a package is ambient under one of my pack's dialects and not another?
+
+> **Audience:** User
+> **Type:** How-To
+
+## Applies to
+
+all-editors, MCP
+
+## Question
+
+My pack describes two shells. One of them ships a library the author never
+has to `package require`; the other does not. How do I say that, so the
+version floor and the missing-require warning both follow the shell the
+file is written for?
+
+## Before you start
+
+- You have a `.tclspec` pack. If not, start with
+  [writing a SpecTcl pack](kcs-howto-write-a-tclspec-pack.md).
+- Your pack declares `speclib <name> 2.0` (or later). The environment
+  block is 2.0 vocabulary.
+
+## Answer
+
+Declare each shell as an `environment`, and put an `ambient` row in the one
+that has the library. A shared version is an ordinary Tcl variable — a pack
+is a Tcl program, so you set it once and substitute it where it is needed.
+
+```tcl
+speclib mypack 2.0 {
+    set tkver 8.6
+
+    environment mypack-shell "
+        display_name {Mypack Shell}
+        core         tcl 8.6
+        ambient      Tk $tkver
+    "
+
+    environment mypack-plain {
+        display_name {Mypack Plain}
+        core         tcl 8.6
+    }
+}
+```
+
+Two details are worth knowing:
+
+1. **Quote the body when a row uses a variable.** `{ … }` is Tcl's literal,
+   here as everywhere else, so `$tkver` inside a braced environment body
+   stays a dollar sign. The braced form is right for the second environment,
+   which substitutes nothing.
+2. **`ambient_package` is the wrong tool for this.** That row floors its
+   package for *every* document the pack is active in, and it has no
+   scoping flag. Writing `ambient_package Tk 8.6 -dialects {mypack-shell}`
+   does not narrow it — the loader drops the whole row and tells you to
+   write the environment block above, because keeping the row without the
+   scoping would floor Tk in the shell you just said does not have it.
+
+## How to tell it worked
+
+Open a file that resolves to `mypack-shell` and call something the library
+provides. The "needs a `package require`" warning (W120) is gone, and a
+call gated above the declared version is reported against it — for the
+example above, `entry .e -placeholder hi` reports that `-placeholder`
+requires Tk 8.7.
+
+Open the same file under `mypack-plain` and both go the other way: the
+missing require is reported again, and there is no version floor to fail.
+
+If the pack panel shows a notice mentioning `-dialects`, an
+`ambient_package` row still carries the flag; replace it with an
+`environment` block as above.
+
+## Related
+
+- [KCS index](README.md)
+- [Glossary](../GLOSSARY.md)
+- [How do I write a SpecTcl pack?](kcs-howto-write-a-tclspec-pack.md)
+- [W120 — missing package require](codes/kcs-diagnostic-w120-missing-package-require.md)

--- a/rust/tcl-compiler/src/analyser/diagnostics/version_gate.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/version_gate.rs
@@ -1002,6 +1002,30 @@ impl Analyser {
         }
     }
 
+    /// The name a guarantor phrase calls this document's environment.
+    ///
+    /// The resolved environment's own canonical id, not the interned
+    /// [`tcl_dialect::DialectProfile`]'s name. Every compiled environment
+    /// shares its name with its profile, so no shipped message moves; a
+    /// **pack-declared** environment has no compiled profile and sinks to
+    /// the permissive fallback, which used to make its placements report as
+    /// `tcl ships Tk 8.6` — naming a profile the author never chose instead
+    /// of the shell they declared.
+    fn environment_label(&self) -> String {
+        let id = self
+            .analysis_context()
+            .context()
+            .environment
+            .id
+            .as_str()
+            .to_owned();
+        if id.is_empty() {
+            self.profile.name.to_owned()
+        } else {
+            id
+        }
+    }
+
     /// The resolved version floor on `axis`, with the phrase naming what
     /// guarantees it.
     ///
@@ -1020,7 +1044,7 @@ impl Analyser {
                             format!("a spec pack declares {package} {floor} ambient here")
                         }
                         FloorSource::ProfilePin => {
-                            format!("{} ships {package} {floor}", self.profile.name)
+                            format!("{} ships {package} {floor}", self.environment_label())
                         }
                     };
                     (floor, guarantee)

--- a/rust/tcl-registry/src/commands/spectcl/blocks.rs
+++ b/rust/tcl-registry/src/commands/spectcl/blocks.rs
@@ -233,7 +233,7 @@ fn ambient_package_statement() -> CommandSpec {
         "ambient_package",
         Arity::exact(2),
         "Declare a package the dialect provides with no `package require`.",
-        "One row per package (`ambient_package mylib 2.1`). The version is the one the environment guarantees, and it floors that package for every document the pack is active in — so a call gated on `mylib 2.1` is not reported as needing a require the runtime already satisfies. Both words are required: a row naming no version would floor at nothing, which is the situation the row exists to prevent, so it is dropped with a notice. Two active packs declaring different versions for one package compose by taking the greater.",
+        "One row per package (`ambient_package mylib 2.1`). The version is the one the environment guarantees, and it floors that package for every document the pack is active in — so a call gated on `mylib 2.1` is not reported as needing a require the runtime already satisfies. Both words are required: a row naming no version would floor at nothing, which is the situation the row exists to prevent, so it is dropped with a notice. Two active packs declaring different versions for one package compose by taking the greater. The row is unscoped and has no scoping flag: to say a package is ambient under one of the pack's environments and not another, write `environment NAME { ambient PACKAGE VERSION }` instead. A row carrying `-dialects` is dropped whole rather than applied everywhere.",
     )
 }
 

--- a/rust/tcl-spectcl/src/loader.rs
+++ b/rust/tcl-spectcl/src/loader.rs
@@ -1064,7 +1064,34 @@ fn empty_pack() -> Pack {
 /// so the identity is the pair).
 fn read_environment(pack: &mut Pack, stmt: &Stmt, log: &mut Log) {
     log.v20(stmt.line, "environment");
-    let Some(environment) = environment_block::parse(stmt, log) else {
+    push_environment(pack, environment_block::parse(stmt, log), stmt.line, log);
+}
+
+/// [`read_environment`] from an already-read row list — the seam the
+/// evaluation loader enters through, having run the block body as a script.
+///
+/// A pack is a Tcl program, so `environment NAME { … ambient Tk $v … }`
+/// substitutes exactly as a `command` body does. Both entries meet the same
+/// parser, the same validation, and the same redeclare rule; only where the
+/// rows came from differs.
+fn read_environment_rows(pack: &mut Pack, stmt: &Stmt, rows: Option<&[Stmt]>, log: &mut Log) {
+    log.v20(stmt.line, "environment");
+    push_environment(
+        pack,
+        environment_block::parse_rows(stmt, rows, log),
+        stmt.line,
+        log,
+    );
+}
+
+/// Keep an accepted environment block, or report the redeclaration.
+fn push_environment(
+    pack: &mut Pack,
+    environment: Option<PackEnvironment>,
+    line: u32,
+    log: &mut Log,
+) {
+    let Some(environment) = environment else {
         return;
     };
     if pack
@@ -1073,7 +1100,7 @@ fn read_environment(pack: &mut Pack, stmt: &Stmt, log: &mut Log) {
         .any(|prior| prior.id == environment.id && prior.extends == environment.extends)
     {
         log.say(
-            stmt.line,
+            line,
             format!(
                 "`environment {}` redeclared; the first is kept",
                 environment.id
@@ -1081,6 +1108,36 @@ fn read_environment(pack: &mut Pack, stmt: &Stmt, log: &mut Log) {
         );
     } else {
         pack.environments.push(environment);
+    }
+}
+
+/// Read one `dialect NAME { … }` declaration from its already-read rows.
+///
+/// The dialect twin of [`read_environment_rows`], and reached the same two
+/// ways: the literal reader splits the braced body, the evaluation loader
+/// runs it as a script.
+fn read_dialect_rows(pack: &mut Pack, stmt: &Stmt, rows: Option<&[Stmt]>, log: &mut Log) {
+    log.v20(stmt.line, "dialect");
+    push_dialect(
+        pack,
+        dialect_block::parse_rows(stmt, rows, log),
+        stmt.line,
+        log,
+    );
+}
+
+/// Keep an accepted dialect block, or report the redeclaration.
+fn push_dialect(pack: &mut Pack, dialect: Option<PackDialect>, line: u32, log: &mut Log) {
+    let Some(dialect) = dialect else {
+        return;
+    };
+    if pack.dialects.iter().any(|prior| prior.name == dialect.name) {
+        log.say(
+            line,
+            format!("`dialect {}` redeclared; the first is kept", dialect.name),
+        );
+    } else {
+        pack.dialects.push(dialect);
     }
 }
 
@@ -1187,16 +1244,7 @@ fn apply_pack_stmt(pack: &mut Pack, tables: &mut PackTables, stmt: &Stmt, log: &
         "environment" => read_environment(pack, stmt, log),
         "dialect" => {
             log.v20(stmt.line, "dialect");
-            if let Some(dialect) = dialect_block::parse(stmt, log) {
-                if pack.dialects.iter().any(|prior| prior.name == dialect.name) {
-                    log.say(
-                        stmt.line,
-                        format!("`dialect {}` redeclared; the first is kept", dialect.name),
-                    );
-                } else {
-                    pack.dialects.push(dialect);
-                }
-            }
+            push_dialect(pack, dialect_block::parse(stmt, log), stmt.line, log);
         }
         "command" => return true,
         _ => log.unknown_property(stmt),

--- a/rust/tcl-spectcl/src/loader.rs
+++ b/rust/tcl-spectcl/src/loader.rs
@@ -1318,12 +1318,52 @@ pub const NEWEST_VOCABULARY_VERSION: &str = "2.0";
 /// safer-looking result" the contract forbids.
 const NEWEST_SUPPORTED_MAJOR: u32 = 2;
 
+/// The scoping flag issue #1643 proposed for `ambient_package`, recognised
+/// only so it can be **refused**.
+///
+/// The issue predates `SpecTcl` 2.0. It asked for
+/// `ambient_package NAME VERSION -dialects {…}` so a pack could say a
+/// library is ambient under one of its dialects and not another; 2.0
+/// answers the same question with `environment NAME { ambient PACKAGE
+/// VERSION }`, which states the placement *inside* the environment it
+/// belongs to instead of flag-scoping a global claim, and a version shared
+/// by several environments is an ordinary Tcl variable substituted into
+/// each row.
+///
+/// The flag is not carried as a second spelling of that, for two reasons
+/// the model does not let us wish away:
+///
+/// - **Desugaring it is not available.** A `-dialects` list naming a
+///   compiled environment (`tcl8.6`, `f5-irules`) desugars to
+///   `environment NAME -extend { ambient … }`, and §6.4's trust lattice
+///   forbids exactly that for the workspace and studio tiers most packs
+///   come from (`registration::untrusted_compiled_extension`). The sugar
+///   would work for bundled packs and fail the whole registration for
+///   everyone else.
+/// - **It would fork the floor model.** A scoped row kept in the pack's own
+///   ambient table reports as `PackAmbient` (a pack the workspace owns);
+///   the same claim written as a placement reports as the environment's own
+///   pin. One question with two answers, differing only in how it was
+///   spelled, is the parallel table the redesign set out to remove.
+///
+/// So the word is refused, and the row goes with it. Dropping only the flag
+/// would leave the *unscoped* claim standing — the pack would floor the
+/// package in every dialect, including the ones it just said the package is
+/// absent from, which is §6.1's fail-closed rule read backwards.
+const AMBIENT_SCOPE_FLAG: &str = "-dialects";
+
 /// `ambient_package NAME VERSION` — one package the pack's dialect provides
 /// without a `package require`.
 ///
 /// Both words are required. A row naming no version is dropped rather than
 /// defaulted: an ambient package with no version would floor at nothing, which
 /// is what the row exists to stop being the case.
+///
+/// The row is **unscoped by construction**: it floors its package for every
+/// document the pack is active in. Scoping the claim to some of a pack's
+/// environments is what `environment NAME { ambient PACKAGE VERSION }`
+/// (`SpecTcl` 2.0 §6.2) says, and [`AMBIENT_SCOPE_FLAG`] is refused here
+/// rather than read — see that constant for why.
 fn ambient_package_row(stmt: &Stmt, log: &mut Log) -> Option<AmbientPackage> {
     let name = stmt.word_text(1);
     if name.is_empty() {
@@ -1335,6 +1375,26 @@ fn ambient_package_row(stmt: &Stmt, log: &mut Log) -> Option<AmbientPackage> {
         log.say(
             stmt.line,
             format!("`ambient_package {name}` needs the version the runtime provides; dropped"),
+        );
+        return None;
+    }
+    if stmt
+        .words
+        .iter()
+        .skip(3)
+        .any(|word| word.text == AMBIENT_SCOPE_FLAG)
+    {
+        log.say_classified(
+            stmt.line,
+            VocabularyClass::Semantic,
+            format!(
+                "`ambient_package {name}` uses `{AMBIENT_SCOPE_FLAG}`, which is not \
+                 SpecTcl vocabulary; the whole row is dropped rather than applied \
+                 to every dialect, because a reader that ignored the scoping would \
+                 floor {name} where the pack says it is absent (design §6.1). Write \
+                 `environment NAME {{ ambient {name} {version} }}` for each \
+                 environment the package is ambient in"
+            ),
         );
         return None;
     }
@@ -7602,6 +7662,52 @@ mod tests {
             "{:?}",
             older.notices
         );
+    }
+
+    /// Issue #1643 asked for `ambient_package NAME VERSION -dialects {…}`.
+    /// The flag is refused, and — the point of the test — it takes the row
+    /// with it.
+    ///
+    /// Dropping the flag alone would leave the claim *unscoped*, flooring
+    /// the package in every dialect including the ones the pack just said
+    /// it is absent from. That is §6.1's fail-closed rule read backwards,
+    /// so the row fails closed instead, and the notice names the 2.0
+    /// spelling that says the same thing properly.
+    #[test]
+    fn an_ambient_package_row_scoped_with_dialects_fails_closed() {
+        for declared in ["1.2", "2.0"] {
+            let pack = evaluate_pack(&format!(
+                "speclib probe {declared} {{\n \
+                 ambient_package Tk 8.6 -dialects {{tcl8.6}}\n \
+                 ambient_package Itcl 4.0\n \
+                 command demo {{ arity 1 }}\n}}"
+            ));
+            let named: Vec<&str> = pack.ambient_packages.iter().map(|row| row.name).collect();
+            assert_eq!(
+                named,
+                vec!["Itcl"],
+                "the scoped row is dropped whole, the unscoped one is untouched ({declared})"
+            );
+            let scoping = pack
+                .notices
+                .iter()
+                .find(|n| n.message.contains("-dialects"))
+                .unwrap_or_else(|| {
+                    panic!("a notice names the flag ({declared}): {:?}", pack.notices)
+                });
+            assert_eq!(
+                scoping.class,
+                VocabularyClass::Semantic,
+                "an availability-narrowing word is semantic ({declared})"
+            );
+            assert!(
+                scoping
+                    .message
+                    .contains("environment NAME { ambient Tk 8.6 }"),
+                "the notice names the 2.0 spelling ({declared}): {}",
+                scoping.message
+            );
+        }
     }
 
     /// `display_name` and `file_extension` are pack-level metadata: names

--- a/rust/tcl-spectcl/src/loader/dialect_block.rs
+++ b/rust/tcl-spectcl/src/loader/dialect_block.rs
@@ -237,12 +237,24 @@ impl PackDialect {
 
 /// Parse one `dialect NAME { … }` block, or reject it.
 pub(super) fn parse(stmt: &Stmt, log: &mut Log) -> Option<PackDialect> {
+    let rows = stmt.arg(2).map(block);
+    parse_rows(stmt, rows.as_deref(), log)
+}
+
+/// Parse one `dialect` declaration from its header and its already-read
+/// rows, or reject it.
+///
+/// The single owner of the block's validation and notices, shared by the
+/// literal reader above and the evaluation loader, which runs the body as
+/// a script and passes the rows the script registered. `rows` is `None`
+/// when the declaration carried no `{ … }` body word at all.
+pub(super) fn parse_rows(stmt: &Stmt, rows: Option<&[Stmt]>, log: &mut Log) -> Option<PackDialect> {
     let name = stmt.word_text(1);
     if name.is_empty() || stmt.words.get(1).is_some_and(|word| word.braced) {
         log.say(stmt.line, "`dialect` needs a name and a `{ … }` block");
         return None;
     }
-    let Some(body) = stmt.arg(2) else {
+    let Some(rows) = rows else {
         log.say(
             stmt.line,
             format!("`dialect {name}` has no `{{ … }}` block; the block is rejected"),
@@ -257,8 +269,8 @@ pub(super) fn parse(stmt: &Stmt, log: &mut Log) -> Option<PackDialect> {
     };
     let mut rejected = false;
     log.scoped(format!("dialect {name}"), |log| {
-        for row in block(body) {
-            if !read_row(&mut dialect, &row, log) {
+        for row in rows {
+            if !read_row(&mut dialect, row, log) {
                 rejected = true;
             }
         }

--- a/rust/tcl-spectcl/src/loader/environment_block.rs
+++ b/rust/tcl-spectcl/src/loader/environment_block.rs
@@ -306,8 +306,31 @@ fn release_line(family: Family, release: Release) -> VersionSet {
 }
 
 /// Parse one `environment NAME { … }` block (or
-/// `environment NAME -extend { … }`), or reject it.
+/// `environment NAME -extend { … }`) written **literally**, or reject it.
+///
+/// The thin half of the reader: it splits the braced body into rows and
+/// hands them to [`parse_rows`], which owns every validation and notice.
+/// The evaluation loader runs the body as a script instead and calls
+/// [`parse_rows`] with the rows the script registered, so a block written
+/// with a variable, a `foreach`, or an `if` is validated by exactly the
+/// same code as one written out longhand.
 pub(super) fn parse(stmt: &Stmt, log: &mut Log) -> Option<PackEnvironment> {
+    let body_index = if stmt.word_text(2) == "-extend" { 3 } else { 2 };
+    let rows = stmt.arg(body_index).map(block);
+    parse_rows(stmt, rows.as_deref(), log)
+}
+
+/// Parse one `environment` declaration from its header and its already-read
+/// rows, or reject it.
+///
+/// `rows` is `None` when the declaration had no `{ … }` body word at all —
+/// the brace-on-the-next-line mistake — which is a rejection with its own
+/// notice rather than an empty block.
+pub(super) fn parse_rows(
+    stmt: &Stmt,
+    rows: Option<&[Stmt]>,
+    log: &mut Log,
+) -> Option<PackEnvironment> {
     let name = stmt.word_text(1);
     if name.is_empty() || stmt.words.get(1).is_some_and(|word| word.braced) {
         log.say(stmt.line, "`environment` needs a name and a `{ … }` block");
@@ -317,8 +340,7 @@ pub(super) fn parse(stmt: &Stmt, log: &mut Log) -> Option<PackEnvironment> {
     if extends {
         log.since(stmt.line, "environment -extend", "2.0");
     }
-    let body_index = if extends { 3 } else { 2 };
-    let Some(body) = stmt.arg(body_index) else {
+    let Some(rows) = rows else {
         log.say(
             stmt.line,
             format!("`environment {name}` has no `{{ … }}` block; the block is rejected"),
@@ -357,8 +379,8 @@ pub(super) fn parse(stmt: &Stmt, log: &mut Log) -> Option<PackEnvironment> {
     };
     let mut rejected = false;
     log.scoped(format!("environment {name}"), |log| {
-        for row in block(body) {
-            if !read_row(&mut environment, &row, log) {
+        for row in rows {
+            if !read_row(&mut environment, row, log) {
                 rejected = true;
             }
         }

--- a/rust/tcl-spectcl/src/loader/eval.rs
+++ b/rust/tcl-spectcl/src/loader/eval.rs
@@ -194,8 +194,6 @@ const ROW_WORDS: &[&str] = &[
     "ambient_package",
     "provides",
     "co_provides",
-    "environment",
-    "dialect",
     // command scope
     "dialects",
     "available",
@@ -395,11 +393,34 @@ struct StagedCommand {
     body: Option<Vec<Node>>,
 }
 
+/// One `environment` / `dialect` declaration captured at pack scope, with
+/// its body evaluated as a script.
+///
+/// A pack is a Tcl program, so these blocks are programs too: a version
+/// shared by several environments is an ordinary variable substituted into
+/// each `ambient` row, and a repetitive ladder is a `foreach` (issue
+/// #1643). Only the rows the body registered are kept — the block's own
+/// reader (`environment_block` / `dialect_block`) is still the single
+/// owner of what a row means.
+#[derive(Debug)]
+struct StagedBlock {
+    /// `environment` or `dialect`.
+    word: &'static str,
+    /// The declaration's own words — the block word, the name, and any
+    /// flag — with the body word left out.
+    head: Vec<Word>,
+    line: u32,
+    /// `None` when no `{ … }` body word was found, which the block reader
+    /// reports as the brace-on-the-next-line mistake.
+    body: Option<Vec<Node>>,
+}
+
 /// One captured top-level statement.
 #[derive(Debug)]
 enum PackNode {
     Row(Stmt),
     Command(StagedCommand),
+    Block(StagedBlock),
 }
 
 /// What scope the evaluation is currently capturing into.
@@ -407,6 +428,11 @@ enum PackNode {
 enum ScopeKind {
     Command,
     Subcommand,
+    /// An `environment` or `dialect` body. Its rows are whatever the block
+    /// reader accepts, so nothing is dispatched specially inside it — an
+    /// unknown word is captured like any other row and the block reader
+    /// decides, which is what makes those rows semantic-class by scope.
+    Block,
 }
 
 /// One body block as the file spells it, for line-exact evaluation.
@@ -550,6 +576,22 @@ impl Skeleton {
         let body_stmts = block(body);
         index.record_rows(&body_stmts);
         for stmt in &body_stmts {
+            // `environment` / `dialect` bodies are evaluated like a
+            // `command` body, so they need the same verbatim record: the
+            // physical lines their rows report, and the rows themselves for
+            // the ones that substitute nothing.
+            if let word @ ("environment" | "dialect") = stmt.word_text(0) {
+                let word = if word == "environment" {
+                    "environment"
+                } else {
+                    "dialect"
+                };
+                if let Some(block_body) = stmt.words.iter().skip(2).find(|word| word.braced) {
+                    index.record_rows(&block(block_body));
+                    index.record(word, stmt.word_text(1), stmt, block_body);
+                }
+                continue;
+            }
             if stmt.word_text(0) != "command" {
                 continue;
             }
@@ -1038,6 +1080,106 @@ fn stage_subcommand(
     Ok(())
 }
 
+/// The `environment` / `dialect` handler: at pack scope the declaration's
+/// body is **evaluated**, in a fresh block scope, exactly as a `command`
+/// body is. Anywhere else it is a plain row, which replays to the ordinary
+/// unknown-property notice.
+fn block_handler(word: &'static str, state: &Rc<RefCell<State>>, fast_path: bool) -> WordHandler {
+    let state = Rc::clone(state);
+    Rc::new(move |ctx: &mut PackEvalCtx<'_>, args: &[String]| {
+        let line = state.borrow().absolute_line(ctx.line());
+        if !state.borrow().scopes.is_empty() {
+            let mut st = state.borrow_mut();
+            let stmt = st.captured(word, args, line);
+            st.push_node(Node::Row(stmt));
+            return Ok(None);
+        }
+        let name = args.first().cloned().unwrap_or_default();
+        // Evaluation loses per-word braced-ness, so the body is the first
+        // blockish word after the name — the same reconstruction
+        // `command` makes, and the reason `-extend` never has to be
+        // special-cased here.
+        let body_at = args
+            .iter()
+            .enumerate()
+            .skip(1)
+            .find(|(_, arg)| blockish(arg))
+            .map(|(index, _)| index);
+        let head: Vec<Word> = std::iter::once(synth_word(word, line))
+            .chain(
+                args.iter()
+                    .enumerate()
+                    .filter(|(index, _)| Some(*index) != body_at)
+                    .map(|(_, arg)| synth_word(arg, line)),
+            )
+            .collect();
+        let Some(body_at) = body_at else {
+            state
+                .borrow_mut()
+                .pack_nodes
+                .push(PackNode::Block(StagedBlock {
+                    word,
+                    head,
+                    line,
+                    body: None,
+                }));
+            return Ok(None);
+        };
+        let body = {
+            let mut st = state.borrow_mut();
+            match st.verbatim.take(word, &name, line) {
+                Some(verbatim) => BodyText {
+                    text: verbatim.text,
+                    base: verbatim.body_line,
+                    verbatim: true,
+                },
+                None => BodyText {
+                    text: args[body_at].clone(),
+                    base: line,
+                    verbatim: false,
+                },
+            }
+        };
+        stage_block(interpreted(ctx, fast_path), &state, word, head, line, &body)?;
+        Ok(None)
+    })
+}
+
+/// Evaluate one `environment` / `dialect` body in a fresh block scope and
+/// stage the declaration. Shared by the host command and the static driver,
+/// so the two evaluation paths cannot drift.
+fn stage_block(
+    drive: Drive<'_, '_>,
+    state: &Rc<RefCell<State>>,
+    word: &'static str,
+    head: Vec<Word>,
+    line: u32,
+    body: &BodyText,
+) -> Result<(), String> {
+    {
+        let mut st = state.borrow_mut();
+        st.scopes.push((ScopeKind::Block, Vec::new()));
+        st.base_lines.push(body.base);
+    }
+    let outcome = run_body(drive, state, body);
+    let nodes = {
+        let mut st = state.borrow_mut();
+        st.base_lines.pop();
+        st.scopes.pop().map(|(_, nodes)| nodes).unwrap_or_default()
+    };
+    outcome?;
+    state
+        .borrow_mut()
+        .pack_nodes
+        .push(PackNode::Block(StagedBlock {
+            word,
+            head,
+            line,
+            body: Some(nodes),
+        }));
+    Ok(())
+}
+
 /// The `include` handler (2.0, Q6): valid only as a literal pack-scope
 /// row; the resolved fragment evaluates in place with provenance
 /// inherited, under the determinism contract's content-hash cycle key.
@@ -1305,6 +1447,48 @@ fn drive_static(
                 let words: Vec<&str> = stmt.words.iter().skip(1).map(|w| w.text.as_str()).collect();
                 stage_include(drive.reborrow(), state, &words, stmt.line)?;
             }
+            head @ ("environment" | "dialect") if at_pack => {
+                let word = if head == "environment" {
+                    "environment"
+                } else {
+                    "dialect"
+                };
+                // The body is the first braced word past the name, which is
+                // index 2 for a declaration and 3 for `-extend`.
+                let body_at = stmt
+                    .words
+                    .iter()
+                    .enumerate()
+                    .skip(2)
+                    .find(|(_, word)| word.braced)
+                    .map(|(index, _)| index);
+                let head_words: Vec<Word> = stmt
+                    .words
+                    .iter()
+                    .enumerate()
+                    .filter(|(index, _)| Some(*index) != body_at)
+                    .map(|(_, word)| word.clone())
+                    .collect();
+                let Some(body_at) = body_at else {
+                    state
+                        .borrow_mut()
+                        .pack_nodes
+                        .push(PackNode::Block(StagedBlock {
+                            word,
+                            head: head_words,
+                            line: stmt.line,
+                            body: None,
+                        }));
+                    continue;
+                };
+                let body = &stmt.words[body_at];
+                let block = BodyText {
+                    text: body.text.clone(),
+                    base: body.line,
+                    verbatim: true,
+                };
+                stage_block(drive.reborrow(), state, word, head_words, stmt.line, &block)?;
+            }
             _ => state.borrow_mut().push_node(Node::Row(stmt.clone())),
         }
     }
@@ -1419,6 +1603,11 @@ pub fn evaluate_pack_in(
     vocabulary.push(("subcommand", subcommand_handler(&state, fast_path)));
     vocabulary.push(("available?", available_handler(&state)));
     vocabulary.push(("include", include_handler(&state, fast_path)));
+    vocabulary.push((
+        "environment",
+        block_handler("environment", &state, fast_path),
+    ));
+    vocabulary.push(("dialect", block_handler("dialect", &state, fast_path)));
     let unknown = unknown_handler(&state);
 
     let outcome = pack_eval::run_pack_program(source, &vocabulary, &unknown, &options.config);
@@ -1702,9 +1891,13 @@ fn replay(state: State, options: &EvalOptions) -> Pack {
     // commands are staged separately and built in pass 2.
     let mut tables = PackTables::default();
     for node in &state.pack_nodes {
-        if let PackNode::Row(stmt) = node {
-            let is_command = apply_pack_stmt(&mut pack, &mut tables, stmt, &mut log);
-            debug_assert!(!is_command, "a raw `command` row cannot reach pack scope");
+        match node {
+            PackNode::Row(stmt) => {
+                let is_command = apply_pack_stmt(&mut pack, &mut tables, stmt, &mut log);
+                debug_assert!(!is_command, "a raw `command` row cannot reach pack scope");
+            }
+            PackNode::Block(staged) => apply_block(&mut pack, staged, &mut log),
+            PackNode::Command(_) => {}
         }
     }
 
@@ -1756,6 +1949,40 @@ fn replay(state: State, options: &EvalOptions) -> Pack {
     pack
 }
 
+/// Replay one evaluated `environment` / `dialect` declaration through its
+/// own block reader.
+///
+/// The reader owns every validation and notice; all this does is hand it
+/// the header and the rows the body registered, so a block written with a
+/// variable or a loop is read by exactly the code a longhand one is.
+fn apply_block(pack: &mut Pack, staged: &StagedBlock, log: &mut Log) {
+    let head = Stmt {
+        words: staged.head.clone(),
+        line: staged.line,
+    };
+    let rows = staged.body.as_deref().map(row_stmts);
+    if staged.word == "environment" {
+        super::read_environment_rows(pack, &head, rows.as_deref(), log);
+    } else {
+        super::read_dialect_rows(pack, &head, rows.as_deref(), log);
+    }
+}
+
+/// A block body's staged nodes as row statements.
+///
+/// Every node is a row: `subcommand` only opens a scope inside a `command`
+/// body, so nothing nested can reach here, and a `command` written inside
+/// a block is captured as an ordinary row for the block reader to reject.
+fn row_stmts(nodes: &[Node]) -> Vec<Stmt> {
+    nodes
+        .iter()
+        .map(|node| match node {
+            Node::Row(stmt) => stmt.clone(),
+            Node::Sub(sub) => capture_stmt("subcommand", std::slice::from_ref(&sub.name), sub.line),
+        })
+        .collect()
+}
+
 /// The staged top-level nodes as canonical registrations.
 fn record_nodes(nodes: &[PackNode]) -> Vec<Registration> {
     nodes
@@ -1777,6 +2004,15 @@ fn record_nodes(nodes: &[PackNode]) -> Vec<Registration> {
                     Some(body) => Registration::block(head, record_body(body), staged.line),
                 }
             }
+            PackNode::Block(staged) => match &staged.body {
+                // Same rule as `command`: a declaration that never opened a
+                // block exports as the row it was, so the reload reports the
+                // identical missing-block notice.
+                None => Registration::row_words(staged.head.clone(), staged.line),
+                Some(body) => {
+                    Registration::block(staged.head.clone(), record_body(body), staged.line)
+                }
+            },
         })
         .collect()
 }

--- a/rust/tcl-spectcl/src/loader/eval.rs
+++ b/rust/tcl-spectcl/src/loader/eval.rs
@@ -702,24 +702,30 @@ impl State {
         }
     }
 
-    /// A captured invocation as a [`Stmt`]: the file's verbatim statement
-    /// when the invocation corresponds to one, the evaluated values
-    /// otherwise. Inside an included fragment the verbatim index (which
-    /// describes the root file) is not consulted, so a line-number
-    /// coincidence cannot substitute the wrong statement.
+    /// The file's own statement for a captured invocation, when the file
+    /// has one of the same shape at that line. Inside an included fragment
+    /// the verbatim index (which describes the root file) is not consulted,
+    /// so a line-number coincidence cannot substitute the wrong statement.
     ///
-    /// The verbatim statement stands in only when it **substitutes
-    /// nothing**. A row built from a variable or a command substitution has
-    /// values the source text does not spell, and replaying
-    /// `ambient Tk $tkver` verbatim would hand the reader the dollar sign
-    /// instead of the version (issue #1643).
-    fn captured(&mut self, word: &str, args: &[String], line: u32) -> Stmt {
+    /// The source statement stands in only when it **substitutes nothing**.
+    /// A row built from a variable or a command substitution has values the
+    /// source text does not spell, and replaying `ambient Tk $tkver`
+    /// verbatim would hand the reader the dollar sign instead of the
+    /// version (issue #1643).
+    fn source_stmt(&mut self, word: &str, args: &[String], line: u32) -> Option<Stmt> {
         if self.in_include {
-            return capture_stmt(word, args, line);
+            return None;
         }
         self.verbatim
             .row(word, args.len(), line)
             .filter(substitution_free)
+    }
+
+    /// A captured invocation as a [`Stmt`]: the file's verbatim statement
+    /// when the invocation corresponds to one, the evaluated values
+    /// otherwise.
+    fn captured(&mut self, word: &str, args: &[String], line: u32) -> Stmt {
+        self.source_stmt(word, args, line)
             .unwrap_or_else(|| capture_stmt(word, args, line))
     }
 }
@@ -1095,24 +1101,8 @@ fn block_handler(word: &'static str, state: &Rc<RefCell<State>>, fast_path: bool
             return Ok(None);
         }
         let name = args.first().cloned().unwrap_or_default();
-        // Evaluation loses per-word braced-ness, so the body is the first
-        // blockish word after the name — the same reconstruction
-        // `command` makes, and the reason `-extend` never has to be
-        // special-cased here.
-        let body_at = args
-            .iter()
-            .enumerate()
-            .skip(1)
-            .find(|(_, arg)| blockish(arg))
-            .map(|(index, _)| index);
-        let head: Vec<Word> = std::iter::once(synth_word(word, line))
-            .chain(
-                args.iter()
-                    .enumerate()
-                    .filter(|(index, _)| Some(*index) != body_at)
-                    .map(|(_, arg)| synth_word(arg, line)),
-            )
-            .collect();
+        let source = state.borrow_mut().source_stmt(word, args, line);
+        let (head, body_at) = block_head(word, args, line, source.as_ref());
         let Some(body_at) = body_at else {
             state
                 .borrow_mut()
@@ -1143,6 +1133,51 @@ fn block_handler(word: &'static str, state: &Rc<RefCell<State>>, fast_path: bool
         stage_block(interpreted(ctx, fast_path), &state, word, head, line, &body)?;
         Ok(None)
     })
+}
+
+/// Split an `environment` / `dialect` declaration into its head words and
+/// the argument index of its body.
+///
+/// Evaluation hands over values, not words, so neither the body nor a
+/// braced name survives in them: `{emit}` and `emit` are the same string,
+/// and so are `{custom}` and `custom`. The file's own statement decides
+/// both whenever it has one at this line, which is what keeps a braced name
+/// rejected on this path as well. Failing that the layout decides —
+/// `NAME ?-extend? BODY`, the body always last — never whitespace in the
+/// value, which would lose a one-word body such as `{emit}`.
+fn block_head(
+    word: &'static str,
+    args: &[String],
+    line: u32,
+    source: Option<&Stmt>,
+) -> (Vec<Word>, Option<usize>) {
+    if let Some(stmt) = source {
+        let body_at = stmt
+            .words
+            .iter()
+            .enumerate()
+            .skip(2)
+            .find(|(_, source_word)| source_word.braced)
+            .map(|(index, _)| index);
+        let head = stmt
+            .words
+            .iter()
+            .enumerate()
+            .filter(|(index, _)| Some(*index) != body_at)
+            .map(|(_, source_word)| source_word.clone())
+            .collect();
+        return (head, body_at.map(|index| index - 1));
+    }
+    let body_at = (args.len() > 1).then(|| args.len() - 1);
+    let head = std::iter::once(synth_word(word, line))
+        .chain(
+            args.iter()
+                .enumerate()
+                .filter(|(index, _)| Some(*index) != body_at)
+                .map(|(_, arg)| synth_word(arg, line)),
+        )
+        .collect();
+    (head, body_at)
 }
 
 /// Evaluate one `environment` / `dialect` body in a fresh block scope and

--- a/rust/tcl-spectcl/src/loader/eval.rs
+++ b/rust/tcl-spectcl/src/loader/eval.rs
@@ -105,7 +105,7 @@ use tcl_dialect::model::SpecSurface;
 /// The evaluation loader's own version, part of the snapshot cache key: a
 /// change to how evaluation captures or replays invalidates every cached
 /// evaluated snapshot exactly once, independent of the vocabulary version.
-pub const LOADER_EVAL_VERSION: u32 = 1;
+pub const LOADER_EVAL_VERSION: u32 = 2;
 
 /// How to evaluate a pack: the provenance tier gating registrations (E-R2)
 /// and the sandbox budget.
@@ -665,12 +665,19 @@ impl State {
     /// otherwise. Inside an included fragment the verbatim index (which
     /// describes the root file) is not consulted, so a line-number
     /// coincidence cannot substitute the wrong statement.
+    ///
+    /// The verbatim statement stands in only when it **substitutes
+    /// nothing**. A row built from a variable or a command substitution has
+    /// values the source text does not spell, and replaying
+    /// `ambient Tk $tkver` verbatim would hand the reader the dollar sign
+    /// instead of the version (issue #1643).
     fn captured(&mut self, word: &str, args: &[String], line: u32) -> Stmt {
         if self.in_include {
             return capture_stmt(word, args, line);
         }
         self.verbatim
             .row(word, args.len(), line)
+            .filter(substitution_free)
             .unwrap_or_else(|| capture_stmt(word, args, line))
     }
 }
@@ -1215,6 +1222,21 @@ fn static_stmt(stmt: &Stmt) -> bool {
     {
         return false;
     }
+    substitution_free(stmt)
+}
+
+/// Whether every word of `stmt` means, as written, exactly what evaluating
+/// it would yield: a braced word is its own value, and an unbraced one is
+/// only when it carries no substitution.
+///
+/// Two readers share it. The static fast path uses it to decide a statement
+/// can be captured without an interpreter at all, and [`State::captured`]
+/// uses it to decide the file's own bytes may stand in for the evaluated
+/// invocation. Both are the same question — "would replaying the source
+/// text reproduce the values?" — and answering it in one place is what
+/// stops the fast path and the interpreter path from disagreeing about a
+/// row that substitutes.
+fn substitution_free(stmt: &Stmt) -> bool {
     stmt.words.iter().all(|word| {
         word.braced
             || !(word.text.contains('$') || word.text.contains('[') || word.text.contains('\\'))

--- a/rust/tcl-spectcl/src/loader/vocabulary_class.rs
+++ b/rust/tcl-spectcl/src/loader/vocabulary_class.rs
@@ -126,6 +126,12 @@ const MARKERS: &[(&str, VocabularyClass)] = &[
     ("switch", VocabularyClass::Semantic),
     ("target", VocabularyClass::Semantic),
     ("ambient", VocabularyClass::Semantic),
+    // Anything that scopes a declaration to a dialect or an environment
+    // narrows *availability*. A build that drops the scoping keeps the
+    // unscoped claim, which is broader than the pack wrote — the one
+    // direction §6.1 forbids (issue #1643).
+    ("dialect", VocabularyClass::Semantic),
+    ("environment", VocabularyClass::Semantic),
     ("closed", VocabularyClass::Semantic),
     ("policy", VocabularyClass::Semantic),
     ("world", VocabularyClass::Semantic),
@@ -187,6 +193,22 @@ mod tests {
             "-dynamic-surface",
             "-unknown-members",
             "include",
+        ] {
+            assert_eq!(classify(word), VocabularyClass::Semantic, "{word}");
+        }
+    }
+
+    /// The §6.1 downgrade fixture for a **scoping** word (issue #1643): a
+    /// word that narrows which dialects or environments a declaration
+    /// applies to must never be dropped as decoration, because what
+    /// survives the drop is the wider claim.
+    #[test]
+    fn scoping_words_classify_semantic() {
+        for word in [
+            "-dialects",
+            "dialect_scope",
+            "-environments",
+            "environment_scope",
         ] {
             assert_eq!(classify(word), VocabularyClass::Semantic, "{word}");
         }

--- a/rust/tcl-spectcl/tests/ambient_environment_floor.rs
+++ b/rust/tcl-spectcl/tests/ambient_environment_floor.rs
@@ -22,11 +22,11 @@
 //! The issue asked for `ambient_package NAME VERSION -dialects {…}` — a
 //! flag narrowing a pack-wide claim to some of the file's dialects. 2.0
 //! states the same fact where it belongs instead, as an `ambient` placement
-//! **inside** the environment that has the package, and a version several
-//! environments share is an ordinary Tcl variable substituted into each
-//! row. This file is the acceptance: one pack, two environments, one
-//! variable, and a version floor that reaches a document resolved to the
-//! first environment and not the second.
+//! **inside** the environment that has the package. The block body is an
+//! evaluated script, so a version several environments share is an ordinary
+//! Tcl variable substituted into each row. This file is the acceptance: one
+//! pack, two environments, one variable, and a version floor that reaches a
+//! document resolved to the first environment and not the second.
 //!
 //! It runs in its own test binary on purpose. Environment registration is
 //! process-global, and `publish_pack_set` in a sibling file retires what
@@ -39,30 +39,26 @@ use tcl_spectcl::{Tier, evaluate_pack};
 
 /// A pack declaring one Tk version and two environments: one that has Tk
 /// ambient at that version, one that says nothing about Tk at all.
-const PACK: &str = "speclib ambientpack 2.0 {\n\
-                    set tkver 8.6\n\
-                    environment ambientpack-shell \"\n\
-                    display_name {Ambientpack Shell}\n\
-                    core tcl 8.6\n\
-                    ambient Tk $tkver\n\
-                    \"\n\
-                    environment ambientpack-plain {\n\
-                    \x20   display_name {Ambientpack Plain}\n\
-                    \x20   core tcl 8.6\n\
-                    }\n\
-                    }\n";
+const PACK: &str = "speclib ambientpack 2.0 {\n\nset tkver 8.6\n\nenvironment ambientpack-shell {\n    display_name {Ambientpack Shell}\n    core tcl 8.6\n    ambient Tk $tkver\n}\n\nenvironment ambientpack-plain {\n    display_name {Ambientpack Plain}\n    core tcl 8.6\n}\n\n}\n";
 
 /// `-placeholder` on `entry` arrived in Tk 8.7, so a document with a Tk
 /// floor of 8.6 draws W136 and one with no floor at all draws nothing.
 const DOCUMENT: &str = "entry .e -placeholder hi\n";
 
 fn version_gate_codes(source: &str, environment: &str) -> Vec<String> {
+    version_gate_diagnostics(source, environment)
+        .into_iter()
+        .map(|(code, _)| code)
+        .collect()
+}
+
+fn version_gate_diagnostics(source: &str, environment: &str) -> Vec<(String, String)> {
     Analyser::new()
         .analyse(source, environment)
         .diagnostics
         .iter()
         .filter(|diagnostic| matches!(diagnostic.code.as_str(), "W135" | "W136" | "W139"))
-        .map(|diagnostic| diagnostic.code.to_string())
+        .map(|diagnostic| (diagnostic.code.to_string(), diagnostic.message.clone()))
         .collect()
 }
 
@@ -115,6 +111,16 @@ fn an_environment_scoped_ambient_version_floors_only_its_own_environment() {
         version_gate_codes(DOCUMENT, "ambientpack-plain").is_empty(),
         "an environment with no Tk placement has no Tk floor: {:?}",
         version_gate_codes(DOCUMENT, "ambientpack-plain")
+    );
+
+    // And the diagnostic names the environment the author declared, not
+    // the permissive profile a pack-declared environment falls back to.
+    let messages = version_gate_diagnostics(DOCUMENT, "ambientpack-shell");
+    assert!(
+        messages
+            .iter()
+            .any(|(_, message)| message.contains("ambientpack-shell ships Tk 8.6")),
+        "the guarantor is the declared shell: {messages:?}"
     );
 
     // The same placement decides the *other* ambient question — whether the

--- a/rust/tcl-spectcl/tests/ambient_environment_floor.rs
+++ b/rust/tcl-spectcl/tests/ambient_environment_floor.rs
@@ -1,0 +1,132 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! **Issue #1643, as `SpecTcl` 2.0 answers it**: an ambient package version
+//! that applies under one of a pack's environments and not another.
+//!
+//! The issue asked for `ambient_package NAME VERSION -dialects {…}` — a
+//! flag narrowing a pack-wide claim to some of the file's dialects. 2.0
+//! states the same fact where it belongs instead, as an `ambient` placement
+//! **inside** the environment that has the package, and a version several
+//! environments share is an ordinary Tcl variable substituted into each
+//! row. This file is the acceptance: one pack, two environments, one
+//! variable, and a version floor that reaches a document resolved to the
+//! first environment and not the second.
+//!
+//! It runs in its own test binary on purpose. Environment registration is
+//! process-global, and `publish_pack_set` in a sibling file retires what
+//! this one registers.
+
+use tcl_compiler::analyser::Analyser;
+use tcl_dialect::model::Placement;
+use tcl_spectcl::registration::register_pack_environments;
+use tcl_spectcl::{Tier, evaluate_pack};
+
+/// A pack declaring one Tk version and two environments: one that has Tk
+/// ambient at that version, one that says nothing about Tk at all.
+const PACK: &str = "speclib ambientpack 2.0 {\n\
+                    set tkver 8.6\n\
+                    environment ambientpack-shell \"\n\
+                    display_name {Ambientpack Shell}\n\
+                    core tcl 8.6\n\
+                    ambient Tk $tkver\n\
+                    \"\n\
+                    environment ambientpack-plain {\n\
+                    \x20   display_name {Ambientpack Plain}\n\
+                    \x20   core tcl 8.6\n\
+                    }\n\
+                    }\n";
+
+/// `-placeholder` on `entry` arrived in Tk 8.7, so a document with a Tk
+/// floor of 8.6 draws W136 and one with no floor at all draws nothing.
+const DOCUMENT: &str = "entry .e -placeholder hi\n";
+
+fn version_gate_codes(source: &str, environment: &str) -> Vec<String> {
+    Analyser::new()
+        .analyse(source, environment)
+        .diagnostics
+        .iter()
+        .filter(|diagnostic| matches!(diagnostic.code.as_str(), "W135" | "W136" | "W139"))
+        .map(|diagnostic| diagnostic.code.to_string())
+        .collect()
+}
+
+fn codes(source: &str, environment: &str) -> Vec<String> {
+    Analyser::new()
+        .analyse(source, environment)
+        .diagnostics
+        .iter()
+        .map(|diagnostic| diagnostic.code.to_string())
+        .collect()
+}
+
+#[test]
+fn an_environment_scoped_ambient_version_floors_only_its_own_environment() {
+    let pack = evaluate_pack(PACK);
+    assert!(pack.notices.is_empty(), "{:?}", pack.notices);
+    assert!(pack.load_error.is_none(), "{:?}", pack.load_error);
+
+    // The shared variable reached the placement as a version, not a
+    // spelling — the whole point of writing it once.
+    let placement = pack
+        .environments
+        .iter()
+        .find(|environment| environment.id == "ambientpack-shell")
+        .expect("the ambient environment loads")
+        .placements
+        .iter()
+        .find(|row| row.package == "Tk")
+        .expect("the Tk placement loads");
+    assert!(placement.ambient);
+    assert!(
+        matches!(&placement.version, Placement::Pinned(version) if version.to_string() == "8.6"),
+        "{:?}",
+        placement.version
+    );
+
+    let outcome = register_pack_environments(&pack, Tier::User).expect("registration succeeds");
+    assert_eq!(outcome.declared, 2);
+
+    // The floor applies where the pack placed the package…
+    assert_eq!(
+        version_gate_codes(DOCUMENT, "ambientpack-shell"),
+        vec!["W136".to_owned()],
+        "the environment's own ambient Tk 8.6 is the floor `-placeholder` fails"
+    );
+    // …and nowhere else. The second environment shares the pack, the core
+    // release, and the Tk-using document, and differs only in having no
+    // placement — which is exactly the scoping #1643 asked for.
+    assert!(
+        version_gate_codes(DOCUMENT, "ambientpack-plain").is_empty(),
+        "an environment with no Tk placement has no Tk floor: {:?}",
+        version_gate_codes(DOCUMENT, "ambientpack-plain")
+    );
+
+    // The same placement decides the *other* ambient question — whether the
+    // document needs a `package require` — so the two answers cannot drift.
+    assert!(
+        !codes("entry .e\n", "ambientpack-shell").contains(&"W120".to_owned()),
+        "Tk is ambient here, so nothing asks for a require: {:?}",
+        codes("entry .e\n", "ambientpack-shell")
+    );
+    assert!(
+        codes("entry .e\n", "ambientpack-plain").contains(&"W120".to_owned()),
+        "Tk is not placed here, so the missing require is real: {:?}",
+        codes("entry .e\n", "ambientpack-plain")
+    );
+}

--- a/rust/tcl-spectcl/tests/eval_loader.rs
+++ b/rust/tcl-spectcl/tests/eval_loader.rs
@@ -37,6 +37,7 @@
 
 use std::path::{Path, PathBuf};
 
+use tcl_dialect::model::{Placement, SpecProvider};
 use tcl_spectcl::loader::{EvalOptions, Notice, Pack, evaluate_pack, evaluate_pack_with};
 use tcl_spectcl::{LoadError, Tier};
 
@@ -332,6 +333,70 @@ fn a_command_body_may_template_its_own_rows() {
     let command = pack.command("lsortish").expect("loads");
     let options: Vec<&str> = command.spec.options.iter().map(|o| o.name).collect();
     assert_eq!(options, vec!["-ascii", "-dictionary", "-integer", "-real"]);
+}
+
+/// A variable set once and substituted into rows reaches the model as its
+/// **value**, at pack scope and inside a declaration body alike.
+///
+/// The capture layer prefers the file's own bytes to the evaluated
+/// invocation whenever the source statement at that line has the same
+/// shape, because evaluation loses per-word braced-ness and physical
+/// lines. That preference has to stop at a statement that substitutes:
+/// replaying `ambient Tk $tkver` verbatim hands the reader the dollar sign
+/// instead of the version, and the pack silently means something it did not
+/// say (issue #1643).
+#[test]
+fn a_variable_substitutes_into_rows_at_every_scope() {
+    let source = "speclib versioned 2.0 {\n\
+                  set tkver 8.6\n\
+                  environment probe-shell \"\ncore tcl 8.6\nambient Tk $tkver\n\"\n\
+                  command demo {\n\
+                  \x20   arity 1\n\
+                  \x20   available \"package Tk $tkver-\"\n\
+                  }\n\
+                  }\n";
+    let pack = evaluate_pack(source);
+    assert!(pack.load_error.is_none(), "{:#?}", pack.notices);
+
+    // The environment's `ambient` row carries the version, not the spelling.
+    let environment = pack
+        .environments
+        .iter()
+        .find(|environment| environment.id == "probe-shell")
+        .expect("the environment block loads");
+    let placement = environment
+        .placements
+        .iter()
+        .find(|row| row.package == "Tk")
+        .expect("the ambient placement loads");
+    assert!(placement.ambient);
+    assert!(
+        matches!(&placement.version, Placement::Pinned(version) if version.to_string() == "8.6"),
+        "{:?}",
+        placement.version
+    );
+
+    // And the `available` window names the same package by value.
+    let surface = pack
+        .command("demo")
+        .expect("the command loads")
+        .spec
+        .surface
+        .expect("the available row loads");
+    assert!(
+        surface
+            .iter()
+            .any(|row| matches!(&row.provider, SpecProvider::Package(name) if *name == "Tk")),
+        "{surface:?}"
+    );
+    assert!(
+        !pack
+            .notices
+            .iter()
+            .any(|notice| notice.message.contains("$tkver")),
+        "nothing reports the unsubstituted spelling: {:?}",
+        pack.notices
+    );
 }
 
 // Determinism and budgets (§1.2)

--- a/rust/tcl-spectcl/tests/eval_loader.rs
+++ b/rust/tcl-spectcl/tests/eval_loader.rs
@@ -347,14 +347,7 @@ fn a_command_body_may_template_its_own_rows() {
 /// say (issue #1643).
 #[test]
 fn a_variable_substitutes_into_rows_at_every_scope() {
-    let source = "speclib versioned 2.0 {\n\
-                  set tkver 8.6\n\
-                  environment probe-shell \"\ncore tcl 8.6\nambient Tk $tkver\n\"\n\
-                  command demo {\n\
-                  \x20   arity 1\n\
-                  \x20   available \"package Tk $tkver-\"\n\
-                  }\n\
-                  }\n";
+    let source = "speclib versioned 2.0 {\n\nset tkver 8.6\n\nenvironment probe-shell {\n    core tcl 8.6\n    ambient Tk $tkver\n}\n\ncommand demo {\n    arity 1\n    available \"package Tk $tkver-\"\n}\n\n}\n";
     let pack = evaluate_pack(source);
     assert!(pack.load_error.is_none(), "{:#?}", pack.notices);
 
@@ -396,6 +389,107 @@ fn a_variable_substitutes_into_rows_at_every_scope() {
             .any(|notice| notice.message.contains("$tkver")),
         "nothing reports the unsubstituted spelling: {:?}",
         pack.notices
+    );
+}
+
+/// An `environment` body is an evaluated **script**, exactly as a `command`
+/// body is: a `foreach` inside it registers one row per iteration, and an
+/// `if` decides whether a row is registered at all.
+///
+/// This is what makes the block the answer to #1643 rather than a second
+/// declarative dialect — the author writes ordinary Tcl, and the block
+/// reader still owns what every row it produced means.
+#[test]
+fn an_environment_body_runs_as_a_program() {
+    let source = "speclib looped 2.0 {\n\nset shipped 1\n\nenvironment looped-shell {\n    core tcl 8.6\n    foreach suffix {aaa bbb ccc} {\n        file_extension $suffix\n    }\n    if {$shipped} {\n        ambient looplib 1.5\n    }\n}\n\n}\n";
+    let pack = evaluate_pack(source);
+    assert!(pack.load_error.is_none(), "{:#?}", pack.notices);
+    assert!(pack.notices.is_empty(), "{:#?}", pack.notices);
+
+    let environment = pack
+        .environments
+        .iter()
+        .find(|environment| environment.id == "looped-shell")
+        .expect("the environment block loads");
+    let extensions: Vec<&str> = environment
+        .file_extensions
+        .iter()
+        .map(|claim| claim.extension.as_ref())
+        .collect();
+    assert_eq!(
+        extensions,
+        vec!["aaa", "bbb", "ccc"],
+        "the loop registered one row per iteration"
+    );
+    assert!(
+        environment
+            .placements
+            .iter()
+            .any(|row| row.package == "looplib" && row.ambient),
+        "the `if` registered its row: {:?}",
+        environment.placements
+    );
+}
+
+/// The block readers keep every notice they had, reached through the
+/// evaluated path.
+///
+/// An `environment` body is a script now, but it is still *that* block's
+/// body: an unknown row is semantic-class and rejects the whole block, a
+/// reserved compiled name is refused, and a `dialect` whose axes reproduce
+/// a compiled release is sent back to `environment`. None of that moved
+/// into the evaluator.
+#[test]
+fn the_block_readers_still_report_from_the_evaluated_path() {
+    let unknown = evaluate_pack(
+        "speclib probe 2.0 {\n\nenvironment probe-shell {\n    core tcl 8.6\n    invented_row yes\n}\n\n}\n",
+    );
+    assert!(
+        unknown.environments.is_empty(),
+        "an unknown row rejects the block"
+    );
+    assert!(
+        unknown
+            .notices
+            .iter()
+            .any(|notice| notice.message.contains("invented_row")),
+        "{:?}",
+        unknown.notices
+    );
+
+    let reserved =
+        evaluate_pack("speclib probe 2.0 {\n\nenvironment tcl8.6 {\n    core tcl 8.6\n}\n\n}\n");
+    assert!(reserved.environments.is_empty());
+    assert!(
+        reserved
+            .notices
+            .iter()
+            .any(|notice| notice.message.contains("compiled environment name")),
+        "{:?}",
+        reserved.notices
+    );
+
+    let missing_body = evaluate_pack("speclib probe 2.0 {\n\nenvironment probe-shell\n\n}\n");
+    assert!(missing_body.environments.is_empty());
+    assert!(
+        missing_body
+            .notices
+            .iter()
+            .any(|notice| notice.message.contains("has no `{ … }` block")),
+        "{:?}",
+        missing_body.notices
+    );
+
+    let classified =
+        evaluate_pack("speclib probe 2.0 {\n\ndialect probe-lang {\n    release tcl9.0\n}\n\n}\n");
+    assert!(classified.dialects.is_empty());
+    assert!(
+        classified
+            .notices
+            .iter()
+            .any(|notice| notice.message.contains("not a new dialect")),
+        "{:?}",
+        classified.notices
     );
 }
 

--- a/rust/tcl-spectcl/tests/eval_loader.rs
+++ b/rust/tcl-spectcl/tests/eval_loader.rs
@@ -493,6 +493,119 @@ fn the_block_readers_still_report_from_the_evaluated_path() {
     );
 }
 
+/// A block body is the declaration's body **word**, whatever its value
+/// looks like.
+///
+/// Evaluation hands the handler values, not words, so a one-word body
+/// (`{emit}`) is the same string a flag would be. Picking the body out by
+/// whitespace therefore missed it, staged the declaration with no body at
+/// all, and rejected `environment one-word {emit}` for its formatting
+/// rather than its content (issue #1643).
+#[test]
+fn a_block_body_is_located_by_position_not_by_whitespace() {
+    // `emit` is a pack-defined proc, so both bodies are a single bare
+    // word. The second declaration is templated, so it matches no source
+    // statement and its body comes from the argument layout alone.
+    let one_word = "speclib shaped 2.0 {\n\nproc emit {} {\n    core tcl 8.6\n    \
+                    file_extension one\n}\n\nenvironment spelled {emit}\n\n\
+                    foreach id {templated} {\n    environment $id {emit}\n}\n\n}\n";
+    let pack = evaluate_through_the_interpreter(one_word);
+    assert!(pack.load_error.is_none(), "{:#?}", pack.notices);
+    for id in ["spelled", "templated"] {
+        let environment = pack
+            .environments
+            .iter()
+            .find(|environment| environment.id == id)
+            .unwrap_or_else(|| panic!("the one-word block `{id}` loads: {:#?}", pack.notices));
+        assert!(environment.core.is_some(), "the body ran: {environment:#?}");
+        assert_eq!(
+            environment
+                .file_extensions
+                .iter()
+                .map(|claim| claim.extension.as_ref())
+                .collect::<Vec<&str>>(),
+            vec!["one"],
+            "the proc registered its row into the block"
+        );
+    }
+
+    // The empty body and the ordinary multi-row body stage and replay the
+    // same way whichever path reads them.
+    let shapes = "speclib shaped 2.0 {\n\nenvironment empty-shell {}\n\n\
+                  environment normal-shell {\n    core tcl 8.6\n    \
+                  file_extension many\n}\n\ndialect empty-lang {}\n\n}\n";
+    let fast = evaluate_pack(shapes);
+    let slow = evaluate_through_the_interpreter(shapes);
+    assert!(fast.load_error.is_none(), "{:#?}", fast.notices);
+    let keys = |pack: &Pack| {
+        let mut rows: Vec<_> = pack.notices.iter().map(notice_key).collect();
+        rows.sort();
+        rows
+    };
+    assert_eq!(keys(&fast), keys(&slow));
+    assert_eq!(
+        fast.environments
+            .iter()
+            .map(|environment| environment.id.as_str())
+            .collect::<Vec<&str>>(),
+        slow.environments
+            .iter()
+            .map(|environment| environment.id.as_str())
+            .collect::<Vec<&str>>(),
+    );
+    let normal = fast
+        .environments
+        .iter()
+        .find(|environment| environment.id == "normal-shell")
+        .expect("the multi-row block loads");
+    assert_eq!(
+        normal
+            .file_extensions
+            .iter()
+            .map(|claim| claim.extension.as_ref())
+            .collect::<Vec<&str>>(),
+        vec!["many"],
+    );
+}
+
+/// A braced name is refused on the evaluated path too.
+///
+/// `environment {custom} { … }` is the issue-#1638 mistake the block
+/// readers reject, but evaluation loses per-word braced-ness: rebuilding
+/// the header from values alone made the name look bare, and the
+/// declaration was accepted whenever the pack happened to need the
+/// interpreter.
+#[test]
+fn a_braced_block_name_is_rejected_on_both_paths() {
+    for word in ["environment", "dialect"] {
+        // The declarative pack takes the static path; the `set` makes the
+        // same declaration reach the interpreter instead.
+        let declarative =
+            format!("speclib braced 2.0 {{\n\n{word} {{custom}} {{\n    core tcl 8.6\n}}\n\n}}\n");
+        let programmed = format!(
+            "speclib braced 2.0 {{\n\nset forced 1\n\n{word} {{custom}} {{\n    \
+             core tcl 8.6\n}}\n\n}}\n"
+        );
+        for pack in [
+            evaluate_pack(&declarative),
+            evaluate_pack(&programmed),
+            evaluate_through_the_interpreter(&declarative),
+        ] {
+            assert!(
+                pack.environments.is_empty() && pack.dialects.is_empty(),
+                "`{word} {{custom}}` declares nothing: {:#?}",
+                pack.notices
+            );
+            assert!(
+                pack.notices.iter().any(|notice| notice.message
+                    == format!("`{word}` needs a name and a `{{ … }}` block")),
+                "{:?}",
+                pack.notices
+            );
+        }
+    }
+}
+
 // Determinism and budgets (§1.2)
 
 #[test]

--- a/rust/tcl-spectcl/tests/export.rs
+++ b/rust/tcl-spectcl/tests/export.rs
@@ -254,15 +254,20 @@ fn count(registrations: &[tcl_spectcl::Registration]) -> usize {
 /// The fixture packs written as *programs* — the shape gate B exists for.
 fn templated() -> Vec<(&'static str, String)> {
     let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/templated");
-    ["fleet.tclspec", "rows.tclspec", "table.tclspec"]
-        .into_iter()
-        .map(|name| {
-            (
-                name,
-                std::fs::read_to_string(dir.join(name)).expect("a templated fixture"),
-            )
-        })
-        .collect()
+    [
+        "fleet.tclspec",
+        "rows.tclspec",
+        "table.tclspec",
+        "environments.tclspec",
+    ]
+    .into_iter()
+    .map(|name| {
+        (
+            name,
+            std::fs::read_to_string(dir.join(name)).expect("a templated fixture"),
+        )
+    })
+    .collect()
 }
 
 /// Gate B: `export(evaluate_pack(src))` is canonical source whose reload is
@@ -324,7 +329,7 @@ fn round_trip_gate_b_a_templated_pack_exports_as_its_expansion() {
         commands += evaluated.commands.len();
     }
     println!("export gate B: {packs} templated packs, {commands} expanded commands");
-    assert!(packs >= 3, "only {packs} templated packs exported");
+    assert!(packs >= 4, "only {packs} templated packs exported");
     assert!(commands >= 9, "only {commands} expanded commands");
 }
 
@@ -346,6 +351,43 @@ fn the_expansion_names_every_registration_the_loop_made() {
     // The `speclib` header is the pack's own, not the newest vocabulary:
     // raising a declared vocabulary is `spec upgrade`'s job, not export's.
     assert!(exported.starts_with("speclib fleet 2.0 {\n"), "{exported}");
+}
+
+/// The expansion of a pack that shares one version between its
+/// environments carries the **version**, not the variable (issue #1643).
+///
+/// Gate B already proves the export reloads to the evaluated snapshot, but
+/// two empty environment lists would satisfy that as happily as two
+/// correct ones — an unsubstituted `$libver` rejects the block, and the
+/// rejection round-trips. So the assertion here is on the text.
+#[test]
+fn a_shared_environment_version_expands_to_the_version() {
+    let source = std::fs::read_to_string(
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/templated/environments.tclspec"),
+    )
+    .expect("the environments fixture");
+    let pack = evaluate_pack(&source);
+    assert!(pack.load_error.is_none(), "{:#?}", pack.notices);
+    assert_eq!(pack.environments.len(), 2, "{:#?}", pack.environments);
+
+    let exported = export_pack_reporting(&pack).0;
+    let rows: Vec<String> = exported
+        .lines()
+        .map(|line| line.split_whitespace().collect::<Vec<_>>().join(" "))
+        .collect();
+    assert!(
+        rows.iter().any(|row| row == "ambient envlib 3.2"),
+        "the ambient row carries the version: {exported}"
+    );
+    assert!(
+        rows.iter().any(|row| row == "hosted envlib 3.2-"),
+        "and so does the hosted one: {exported}"
+    );
+    assert!(
+        !exported.contains("libver"),
+        "the variable itself does not survive the expansion: {exported}"
+    );
 }
 
 /// The 2.0 word batch (P2-H): `provides`, `co_provides`,

--- a/rust/tcl-spectcl/tests/export.rs
+++ b/rust/tcl-spectcl/tests/export.rs
@@ -388,6 +388,36 @@ fn a_shared_environment_version_expands_to_the_version() {
         !exported.contains("libver"),
         "the variable itself does not survive the expansion: {exported}"
     );
+    // The `foreach` inside the block expanded into one row per iteration,
+    // and the loop itself is gone — a block body is a program, and its
+    // expansion is what it registered.
+    for suffix in ["envp", "envs"] {
+        assert!(
+            rows.iter()
+                .any(|row| row == &format!("file_extension {suffix}")),
+            "the loop registered `file_extension {suffix}`: {exported}"
+        );
+    }
+    assert!(
+        !exported.contains("foreach"),
+        "the expansion carries rows, not the loop: {exported}"
+    );
+}
+
+/// A canonical `environment` block — one already written the way the
+/// renderer writes it — exports back to itself, byte for byte.
+///
+/// The evaluated block body must not cost the round trip its fixed point:
+/// export is how an author reads what a pack registered, and a canonical
+/// pack that came back reshaped would make every diff noise.
+#[test]
+fn a_canonical_environment_block_round_trips_byte_identically() {
+    let source = "speclib canon 2.0 {\n\nenvironment canon-shell {\n    display_name {Canon Shell}\n    core tcl 8.6\n    ambient canonlib 2.4\n    alias canon\n}\n\n}\n";
+    let pack = evaluate_pack(source);
+    assert!(pack.load_error.is_none(), "{:#?}", pack.notices);
+    assert_eq!(pack.environments.len(), 1, "{:#?}", pack.notices);
+    let exported = export_pack_reporting(&pack).0;
+    assert_eq!(exported, source, "canonical source is its own expansion");
 }
 
 /// The 2.0 word batch (P2-H): `provides`, `co_provides`,

--- a/rust/tcl-spectcl/tests/fixtures/templated/environments.tclspec
+++ b/rust/tcl-spectcl/tests/fixtures/templated/environments.tclspec
@@ -1,0 +1,37 @@
+# A pack whose *environments* share one version. Two shells, one library,
+# and the version written once — the SpecTcl 2.0 answer to issue #1643's
+# "ambient here and not there". The shell that has the library says so with
+# an `ambient` row inside its own block; the plain shell only *hosts* it,
+# so there the library arrives with a `package require` and floors nothing
+# on its own.
+#
+# The quoted bodies are deliberate: `{ … }` is Tcl's literal, so a variable
+# only substitutes into a body that is quoted or built.
+
+speclib environments 2.0 {
+
+    set libver 3.2
+
+    environment envpack-shell "
+        display_name {Envpack Shell}
+        core         tcl 8.6
+        ambient      envlib $libver
+        alias        envpack
+        policy       ambient-plus-require
+    "
+
+    environment envpack-plain "
+        display_name {Envpack Plain}
+        core         tcl 8.6
+        hosted       envlib $libver-
+    "
+
+    command envlib::open {
+        arity 1
+        available "package envlib $libver-"
+        hover {
+            summary {Open an envlib handle.}
+            returns {The handle.}
+        }
+    }
+}

--- a/rust/tcl-spectcl/tests/fixtures/templated/environments.tclspec
+++ b/rust/tcl-spectcl/tests/fixtures/templated/environments.tclspec
@@ -1,30 +1,34 @@
-# A pack whose *environments* share one version. Two shells, one library,
-# and the version written once — the SpecTcl 2.0 answer to issue #1643's
-# "ambient here and not there". The shell that has the library says so with
-# an `ambient` row inside its own block; the plain shell only *hosts* it,
-# so there the library arrives with a `package require` and floors nothing
-# on its own.
+# A pack whose *environments* are programs. Two shells, one library, and the
+# version written once — the SpecTcl 2.0 answer to issue #1643's "ambient
+# here and not there". The shell that has the library says so with an
+# `ambient` row inside its own block; the plain shell only *hosts* it, so
+# there the library arrives with a `package require` and floors nothing on
+# its own.
 #
-# The quoted bodies are deliberate: `{ … }` is Tcl's literal, so a variable
-# only substitutes into a body that is quoted or built.
+# An `environment` body is an evaluated script, exactly like a `command`
+# body: a variable substitutes inside the braces, and a repetitive ladder is
+# an ordinary `foreach`.
 
 speclib environments 2.0 {
 
     set libver 3.2
 
-    environment envpack-shell "
+    environment envpack-shell {
         display_name {Envpack Shell}
         core         tcl 8.6
         ambient      envlib $libver
         alias        envpack
         policy       ambient-plus-require
-    "
+        foreach suffix {envp envs} {
+            file_extension $suffix
+        }
+    }
 
-    environment envpack-plain "
+    environment envpack-plain {
         display_name {Envpack Plain}
         core         tcl 8.6
         hosted       envlib $libver-
-    "
+    }
 
     command envlib::open {
         arity 1


### PR DESCRIPTION
Closes #1643.

#1643 predates SpecTcl 2.0. It asked for an `ambient_package NAME VERSION -dialects LIST` flag; under 2.0 a pack is a Tcl program, and the scoping it wanted is already expressible without new vocabulary: an environment-scoped placement row, with a shared version as an ordinary variable.

```tcl
set tkver 8.6
environment wish { core tcl 8.6; ambient Tk $tkver }
```

## What this PR does

- **No new vocabulary; no vocabulary version moves.** `NEWEST_VOCABULARY_VERSION` stays `2.0` and 1.0 / 1.1 / 1.2 / 2.0 packs load exactly as before (`make test-spectcl-compat` green, 24 shipped-pack goldens byte-identical). The legacy `-dialects` flag is recognised only to be refused, and it takes the whole row with it (a fail-closed §6.1 downgrade: dropping just the flag would leave an *unscoped* claim standing). `dialect` and `environment` join the semantic-class markers so any future scoping word fails closed generically. Desugaring the flag was rejected because a workspace or studio pack cannot extend a compiled environment (§6.4 trust lattice), so the sugar would fail the registration for exactly the packs that use it.
- **The loader bug that blocked the 2.0 answer.** The evaluation loader preferred a statement's verbatim source text whenever head word and arity matched, including statements that substitute, so `ambient Tk $tkver` was replayed with the dollar sign. That preference now goes through the shared `substitution_free` predicate the static fast path already used. `LOADER_EVAL_VERSION` 1 → 2.
- **`environment` and `dialect` block bodies are evaluated scopes**, the same as `command` bodies: the body runs through `run_body`, rows are captured into a `ScopeKind::Block`, and replay hands them to the block's own reader (`parse_rows` seam on both readers; validation, reserved-name and classification gates, and every notice stay the single owner and are covered from the evaluated path). Variables, `foreach`, and `if` work inside a braced block. Export renders a block from its captured rows, so a programmed block exports as its expansion and a canonical block round-trips byte-identically.
- **W136 guarantor label** names the resolved environment's canonical id, so a pack-declared environment reports `NAME ships Tk 8.6` rather than the permissive `tcl` profile.

## Acceptance test

`rust/tcl-spectcl/tests/ambient_environment_floor.rs`: one pack, `set libver`, two environments; the ambient version floors documents resolved to the declaring environment (W136 fires, W120 silenced) and not the other. Plus variable substitution into `ambient` and `available {package …}` rows, a `foreach` inside a block emitting rows, the evaluated-path notice tests, an export round-trip, the flag refusal at declared 1.2 and 2.0, and the downgrade-class fixture.

## Docs

`docs/design/spec-packs.md` (new "Scoping an ambient package (issue #1643)" section, pointer from the 1.2 `ambient_package` text), `docs/design/dialect-and-package-registry-redesign.md` (§6.2 row and status note), `docs/design/spec-dsl-examples/README.md` (corrected a stale "never executed" claim), new KCS how-to `docs/kcs/kcs-howto-scope-an-ambient-package-to-one-dialect.md`, `README.md`.

## Gates

`make rust-check`, `cargo test -p tcl-spectcl -p tcl-registry -p tcl-compiler` (99 suites), `make test-spectcl-compat` (28 tests), `make check-source-data`: pass.

Related: #1599's remaining gap (`# tcl-dialect: tk` directive) is handled in the #1631 remainders PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LRTFmQ5XHByfBZFXuqJbjX

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRTFmQ5XHByfBZFXuqJbjX)_