### PR TITLE
Fix JetBrains JCEF loading on 2026.2

### DIFF
--- a/editors/jetbrains/build.gradle.kts
+++ b/editors/jetbrains/build.gradle.kts
@@ -27,6 +27,10 @@ kotlin {
 dependencies {
     testImplementation(kotlin("test"))
     intellijPlatform {
+        // Compile at the 2024.1 support floor. JCEF is part of the platform at
+        // this version, so the 2025.3.1+ `intellij.platform.ui.jcef` bundled
+        // plugin cannot be added to this compile classpath. plugin.xml carries
+        // the optional compatibility dependency used by newer IDEs instead.
         intellijIdeaUltimate("2024.1")
         bundledPlugin("org.jetbrains.plugins.textmate")
 
@@ -94,7 +98,13 @@ intellijPlatform {
             create(org.jetbrains.intellij.platform.gradle.IntelliJPlatformType.IntellijIdeaUltimate, "2024.1")
             create(org.jetbrains.intellij.platform.gradle.IntelliJPlatformType.IntellijIdeaUltimate, "2025.1.7.1")
             create(org.jetbrains.intellij.platform.gradle.IntelliJPlatformType.IntellijIdeaUltimate, "2025.2.6.2")
+            // First release whose core plugin advertises the JCEF dependency
+            // alias used to bridge the pre- and post-extraction layouts.
+            create(org.jetbrains.intellij.platform.gradle.IntelliJPlatformType.IntellijIdeaUltimate, "2025.3.1")
             create(org.jetbrains.intellij.platform.gradle.IntelliJPlatformType.IntellijIdeaUltimate, "2026.2.1")
+            // #1780 was reported against this exact product/version, where
+            // JCEF is isolated behind the bundled Web Browser plugin.
+            create(org.jetbrains.intellij.platform.gradle.IntelliJPlatformType.CLion, "2026.2.2")
         }
     }
 

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/CompilerExplorerToolWindowFactory.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/CompilerExplorerToolWindowFactory.kt
@@ -52,6 +52,7 @@ private const val SERVER_WAIT_TIMEOUT_MS = 10_000L
 class CompilerExplorerToolWindowFactory : ToolWindowFactory, DumbAware {
 
     override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
+        if (!isJcefSupported()) return
         val panel = CompilerExplorerPanel(project)
         val content = ContentFactory.getInstance().createContent(panel.browser.component, "", false)
         // Disposing the content tears down the panel: it unregisters from the
@@ -61,7 +62,7 @@ class CompilerExplorerToolWindowFactory : ToolWindowFactory, DumbAware {
         toolWindow.contentManager.addContent(content)
     }
 
-    override fun shouldBeAvailable(project: Project): Boolean = true
+    override fun shouldBeAvailable(project: Project): Boolean = isJcefSupported()
 }
 
 internal class CompilerExplorerPanel(private val project: Project) : Disposable {

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/JcefSupport.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/JcefSupport.kt
@@ -1,0 +1,30 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package com.tcllsp.jetbrains
+
+private const val JBCEF_APP_CLASS = "com.intellij.ui.jcef.JBCefApp"
+
+/**
+ * Whether this IDE can construct a JCEF browser.
+ *
+ * JCEF was platform-owned through 2025.3.0, then exposed through the
+ * `com.intellij.modules.jcef` dependency alias before moving behind that
+ * plugin's classloader in 2026.2.  A source-level JBCefApp reference would
+ * itself throw NoClassDefFoundError when that optional plugin is unavailable,
+ * so probe reflectively before either tool window touches a JCEF type.
+ */
+internal fun isJcefSupported(
+    classLoader: ClassLoader = JcefSupportMarker::class.java.classLoader,
+): Boolean = try {
+    val appClass = Class.forName(JBCEF_APP_CLASS, false, classLoader)
+    appClass.getMethod("isSupported").invoke(null) == true
+} catch (_: ReflectiveOperationException) {
+    false
+} catch (_: LinkageError) {
+    false
+} catch (_: SecurityException) {
+    false
+}
+
+private object JcefSupportMarker

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/SpecStudioToolWindowFactory.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/SpecStudioToolWindowFactory.kt
@@ -37,13 +37,15 @@ private val SPEC_LOG = Logger.getInstance("com.tcllsp.jetbrains.SpecStudio")
 
 class SpecStudioToolWindowFactory : ToolWindowFactory, DumbAware {
     override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
+        if (!isJcefSupported()) return
         val panel = SpecStudioPanel(project)
         val content = ContentFactory.getInstance().createContent(panel.browser.component, "", false)
         content.setDisposer(panel)
         toolWindow.contentManager.addContent(content)
     }
 
-    override fun shouldBeAvailable(project: Project): Boolean = project.basePath != null
+    override fun shouldBeAvailable(project: Project): Boolean =
+        project.basePath != null && isJcefSupported()
 }
 
 internal class SpecStudioPanel(private val project: Project) : Disposable {

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/actions/OpenInCompilerExplorerAction.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/actions/OpenInCompilerExplorerAction.kt
@@ -28,6 +28,7 @@ import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.wm.ToolWindowManager
 import com.tcllsp.jetbrains.CompilerExplorerService
 import com.tcllsp.jetbrains.TclFileType
+import com.tcllsp.jetbrains.isJcefSupported
 
 /**
  * Editor / project-view context-menu action that opens the current Tcl file in
@@ -40,13 +41,14 @@ class OpenInCompilerExplorerAction : AnAction(), DumbAware {
     override fun update(e: AnActionEvent) {
         val file = e.getData(CommonDataKeys.VIRTUAL_FILE)
         e.presentation.isEnabledAndVisible =
-            e.project != null && file != null && !file.isDirectory && TclFileType.isSupported(file)
+            e.project != null && file != null && !file.isDirectory &&
+                TclFileType.isSupported(file) && isJcefSupported()
     }
 
     override fun actionPerformed(e: AnActionEvent) {
         val project = e.project ?: return
         val file = e.getData(CommonDataKeys.VIRTUAL_FILE) ?: return
-        if (!TclFileType.isSupported(file)) return
+        if (!TclFileType.isSupported(file) || !isJcefSupported()) return
 
         // Make sure the file is open in an editor so highlight round-trips have
         // a document to target, then reveal the explorer and push the source.

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/actions/OpenSpecStudioAction.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/actions/OpenSpecStudioAction.kt
@@ -7,14 +7,17 @@ import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.wm.ToolWindowManager
+import com.tcllsp.jetbrains.isJcefSupported
 
 class OpenSpecStudioAction : AnAction(), DumbAware {
     override fun actionPerformed(event: AnActionEvent) {
         val project = event.project ?: return
+        if (!isJcefSupported()) return
         ToolWindowManager.getInstance(project).getToolWindow("Tcl Spec Studio")?.show()
     }
 
     override fun update(event: AnActionEvent) {
-        event.presentation.isEnabledAndVisible = event.project?.basePath != null
+        event.presentation.isEnabledAndVisible =
+            event.project?.basePath != null && isJcefSupported()
     }
 }

--- a/editors/jetbrains/src/main/resources/META-INF/com.tcllsp.jetbrains-jcef.xml
+++ b/editors/jetbrains/src/main/resources/META-INF/com.tcllsp.jetbrains-jcef.xml
@@ -1,0 +1,1 @@
+<idea-plugin/>

--- a/editors/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/editors/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -19,6 +19,13 @@
 
     <depends>com.intellij.modules.platform</depends>
     <depends>com.intellij.modules.ultimate</depends>
+    <!-- JCEF moved behind its own plugin classloader in 2026.2.  The alias
+         only exists from 2025.3.1 onward, so this must remain optional while
+         the plugin supports the 2024.1 floor (where JCEF is platform-owned).
+         The supplemental descriptor is intentionally empty: the dependency
+         edge itself is what makes JCEF classes visible on newer IDEs. -->
+    <depends optional="true"
+             config-file="com.tcllsp.jetbrains-jcef.xml">com.intellij.modules.jcef</depends>
     <depends>org.jetbrains.plugins.textmate</depends>
 
     <extensions defaultExtensionNs="com.intellij">

--- a/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/JcefSupportTest.kt
+++ b/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/JcefSupportTest.kt
@@ -1,0 +1,44 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package com.tcllsp.jetbrains
+
+import java.io.ByteArrayInputStream
+import javax.xml.parsers.DocumentBuilderFactory
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+
+class JcefSupportTest {
+    @Test
+    fun descriptorBridgesThePostExtractionJcefClassloader() {
+        val descriptor = parseResource("META-INF/plugin.xml")
+        val dependencies = descriptor.getElementsByTagName("depends")
+        val jcefDependency = (0 until dependencies.length)
+            .map { dependencies.item(it) }
+            .firstOrNull { it.textContent.trim() == "com.intellij.modules.jcef" }
+
+        assertNotNull(jcefDependency)
+        assertEquals("true", jcefDependency.attributes.getNamedItem("optional")?.nodeValue)
+        val configFile = assertNotNull(
+            jcefDependency.attributes.getNamedItem("config-file")?.nodeValue,
+        )
+        assertEquals("com.tcllsp.jetbrains-jcef.xml", configFile)
+        assertEquals("idea-plugin", parseResource("META-INF/$configFile").documentElement.tagName)
+    }
+
+    @Test
+    fun unavailableJcefDoesNotEscapeAsNoClassDefFoundError() {
+        val emptyLoader = object : ClassLoader(null) {}
+
+        assertFalse(isJcefSupported(emptyLoader))
+    }
+
+    private fun parseResource(path: String) =
+        DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(
+            ByteArrayInputStream(
+                assertNotNull(javaClass.classLoader.getResourceAsStream(path)).readAllBytes(),
+            ),
+        )
+}


### PR DESCRIPTION
## Summary

- declare the extracted Web Browser/JCEF plugin as an optional compatibility dependency
- preserve the 2024.1 support floor, where JCEF remains platform-owned
- hide browser-backed tools cleanly when JCEF is unavailable
- add regression coverage and verifier targets for the dependency-alias boundary and the reported CLion release

Fixes #1780

## Validation

- `make rust-check`
- `make prep-pr`
- focused JetBrains unit/build checks
- IntelliJ Plugin Verifier reports Compatible for all six configured targets, including CLion 2026.2.2