### PR TITLE
feat(docker): generate Dockerfiles that install the native tcl CLI

### DIFF
--- a/.claude/skills/dockerfile-generate/SKILL.md
+++ b/.claude/skills/dockerfile-generate/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Generate a Dockerfile for a Tcl project targeting a specific base image
   and Tcl version. Analyses the project to detect tclpkg.tcl manifests,
   entry points, and dependencies, then produces a production-ready
-  Dockerfile with Python 3, the tcl CLI zipapp, and tcl pkg/venv integration.
+  Dockerfile with the native tcl CLI binary and tcl pkg/venv integration.
   Use when creating Docker containers for Tcl applications, setting up CI
   images, or containerising Tcl projects.
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep
@@ -20,36 +20,62 @@ user's chosen base image and Tcl version.
 The `tcl docker create` CLI verb generates Dockerfiles that:
 
 1. Install the requested **Tcl version** (8.4, 8.5, 8.6, 9.0)
-2. Install **Python 3** (required to run the tcl CLI tool)
-3. Download the **tcl CLI zipapp** (`tcl-VERSION.pyz`) from GitHub releases
-4. Run `tcl pkg sync --frozen` to install packages from `tclpkg.lock`
-5. Optionally run `tcl venv create` to set up a virtual environment
+2. Download the **native `tcl` CLI binary** for the build's target
+   architecture from a GitHub release, verified against the release's
+   `SHA256SUMS`
+3. Run `tcl pkg install --frozen` to install packages from `tclpkg.lock`
+4. Optionally run `tcl venv create` to set up a virtual environment
 
-This skill wraps that capability with AI-driven project analysis to produce
-better results than the CLI alone.
+Nothing in the image needs a Python interpreter — the whole toolchain is the
+single static-ish `tcl` binary. This skill wraps that capability with
+AI-driven project analysis to produce better results than the CLI alone.
 
 ### How it works inside the container
 
-The generated Dockerfile downloads the self-contained `tcl-VERSION.pyz` zipapp
-from `https://github.com/bitwisecook/tcl-lsp/releases/`. This zipapp only
-needs a Python 3.10+ interpreter — no pip installs required. It provides the
-full `tcl pkg` and `tcl venv` toolchain:
+The generated Dockerfile fetches `tcl-<triple>` from
+`https://github.com/bitwisecook/tcl-lsp/releases/` and refuses to install it
+unless its SHA-256 matches the release's `SHA256SUMS` entry — the same trust
+model `scripts/tcl-mcp` uses for the MCP binary. The architecture comes from
+BuildKit's `TARGETARCH` (falling back to `uname -m` under the classic
+builder), so one Dockerfile works for `linux/amd64`, `linux/arm64`, and
+`linux/riscv64`:
 
 ```dockerfile
-# Install Python 3 (required by the tcl CLI tool)
-RUN apt-get update && apt-get install -y --no-install-recommends python3 curl ca-certificates && ...
+# Fetch and verify the native tcl CLI release asset
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates curl && \
+    rm -rf /var/lib/apt/lists/*
 
-# Download the tcl CLI zipapp from GitHub releases
-RUN curl -fSL "https://github.com/bitwisecook/tcl-lsp/releases/download/v1.6.0/tcl-1.6.0.pyz" \
-        -o /usr/local/bin/tcl.pyz && \
-    chmod +x /usr/local/bin/tcl.pyz
+# Install the native tcl CLI from a verified release asset
+ARG TCL_LSP_VERSION=2.2.1
+ARG TARGETARCH
+RUN set -eu; \
+    arch="${TARGETARCH:-$(uname -m)}"; \
+    case "$arch" in \
+        amd64 | x86_64) triple="x86_64-unknown-linux-gnu" ;; \
+        arm64 | aarch64) triple="aarch64-unknown-linux-gnu" ;; \
+        riscv64) triple="riscv64gc-unknown-linux-gnu" ;; \
+        *) echo "no tcl release asset for $arch" >&2; exit 1 ;; \
+    esac; \
+    ... curl the asset + SHA256SUMS, sha256sum -c, chmod +x, tcl --version
 
 # Install Tcl packages from lockfile
-RUN if [ -f tclpkg.lock ]; then python3 /usr/local/bin/tcl.pyz pkg sync --frozen; fi
+RUN if [ -f tclpkg.lock ]; then tcl pkg install --frozen; fi
 
 # Create Tcl virtual environment
-RUN python3 /usr/local/bin/tcl.pyz venv create .venv --tcl 8.6
+RUN tcl venv create .venv --tcl 8.6
 ```
+
+`ARG TCL_LSP_VERSION` defaults to the release the generating `tcl` binary was
+built from, and stays overridable at build time:
+
+```bash
+docker build --build-arg TCL_LSP_VERSION=2.2.1 -t myapp .   # pin
+docker build --build-arg TCL_LSP_VERSION= -t myapp .        # newest release
+```
+
+The final `tcl --version` in that layer is deliberate: a binary that cannot
+start fails the build instead of shipping.
 
 ### Available Tcl versions
 - **8.4** — legacy, built from source on all platforms
@@ -58,9 +84,17 @@ RUN python3 /usr/local/bin/tcl.pyz venv create .venv --tcl 8.6
 - **9.0** — latest, built from source on most platforms
 
 ### Supported base-image families
-- **debian** (also ubuntu, buildpack-deps, slim variants)
-- **alpine**
-- **redhat** (also fedora, centos, rockylinux, almalinux, amazonlinux)
+- **debian** (also ubuntu, buildpack-deps, slim variants) — Tcl **and** CLI
+- **redhat** (also fedora, centos, rockylinux, almalinux, amazonlinux) —
+  Tcl **and** CLI
+- **alpine** — Tcl only
+
+Alpine is musl, and every published Linux `tcl` asset is glibc-linked (the
+release matrix has no musl leg). `gcompat` does not close the gap — it
+re-exports neither `fcntl64` nor `__res_init`, so the binary dies in the
+dynamic loader. `tcl docker create alpine:… ` therefore **errors** as soon as
+a CLI verb is wanted. For an Alpine image, either drop the CLI
+(`--no-packages`, no `--venv`) for a plain Tcl runtime, or pick a glibc base.
 
 ## Steps
 
@@ -74,26 +108,22 @@ RUN python3 /usr/local/bin/tcl.pyz venv create .venv --tcl 8.6
 2. **Determine the Tcl install strategy** based on the base image:
    - For Tcl 8.6 on Debian/Ubuntu/Alpine/RHEL: use OS package manager
    - For Tcl 8.4, 8.5, 9.0 or exotic images: build from source
-   - Run the recipe lookup to verify:
+   - Inspect the recipes with the CLI itself:
      ```bash
-     uv run --no-dev python -c "
-     from tclpkg.docker import tcl_install_recipe, detect_image_family, python_install_recipe
-     family = detect_image_family('IMAGE_NAME')
-     print(f'Family: {family}')
-     print(tcl_install_recipe('IMAGE_NAME', 'TCL_VERSION'))
-     print(python_install_recipe('IMAGE_NAME'))
-     "
+     tcl docker info                                  # families, versions, CLI targets
+     tcl docker recipe IMAGE --tcl-version VERSION    # the Tcl install layer
+     tcl docker recipe IMAGE --cli                    # the tcl CLI install layer
      ```
 
-3. **Generate the Dockerfile** using the CLI tool as a starting point:
+3. **Generate the Dockerfile**:
    ```bash
-   uv run --no-dev python -m explorer.tcl_cli docker create BASE_IMAGE \
+   tcl docker create BASE_IMAGE \
        --tcl-version VERSION \
        --output Dockerfile \
        --force \
        [--entrypoint main.tcl] \
        [--venv] \
-       [--cli-version 1.6.0] \
+       [--cli-version 2.2.1] \
        [--extra-package PACKAGE]
    ```
 
@@ -115,8 +145,7 @@ RUN python3 /usr/local/bin/tcl.pyz venv create .venv --tcl 8.6
    .git
    .venv
    .vscode
-   __pycache__
-   *.pyc
+   target/
    tmp/
    .claude/
    ```
@@ -138,8 +167,11 @@ After generation, provide:
 - If the user doesn't specify a Tcl version, default to `8.6`
 - For unknown/custom base images, fall back to Debian-style recipes and warn
 - Always prefer OS package manager installs over building from source when possible
-- The `tclpkg.docker` module in `tclpkg/docker.py` has the recipe database
-- Use `--no-packages` to skip the tcl CLI download + pkg sync (pure Tcl image)
-- Use `--cli-version` to pin a specific tcl-lsp release version
+- The recipe database is `rust/tcl-pkg/src/docker.rs`
+- Use `--no-packages` to skip the tcl CLI download entirely (pure Tcl image)
+- Use `--cli-version` to pin a specific tcl-lsp release; pass an empty value
+  to resolve the newest release at build time
+- Building the image needs network access to `github.com` (release assets)
+  and, when unpinned, `api.github.com` (tag resolution)
 
 $ARGUMENTS

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1823,10 +1823,9 @@ jobs:
           artefact-name: vsix-darwin-arm64
 
   # ---------------------------------------------------------------------
-  # build-claude-skills builds the AI zipapp first (since `make
-  # claude-skills` bundles the AI zipapp into the skills release zip),
-  # smokes both, then attests and uploads the skills zip + the AI zipapp.
-  # Stays standalone because it produces TWO artefacts in one go.
+  # build-claude-skills packages the Claude Code skills bundle, then attests
+  # and uploads it. The skills drive the native MCP server, so nothing here
+  # builds or ships the retired AI zipapp any more.
   # ---------------------------------------------------------------------
   build-claude-skills:
     if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,10 +1,11 @@
 name: CodeQL
 
 # Static-analysis for the languages whose source ships in this repo and
-# runs on user machines: Python (LSP server / zipapps) and TypeScript
-# (VS Code extension).  CodeQL's `actions` query pack also lints the
-# workflows themselves, catching expression-injection and similar
-# mistakes before they reach rust.
+# runs on user machines: Python (the BIG-IP report generator and its
+# `.pyz`, plus the Sublime Text plugin — the LSP server itself is Rust
+# now) and TypeScript (VS Code extension).  CodeQL's `actions` query pack
+# also lints the workflows themselves, catching expression-injection and
+# similar mistakes before they reach rust.
 #
 # Rust (editors/zed) is intentionally excluded.  CodeQL Rust support is
 # still maturing, and the extension cross-compiles to `wasm32-wasip2`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4519,6 +4519,7 @@ dependencies = [
  "tcl-sandbox",
  "tcl-syntax",
  "tcl-userdirs",
+ "tcl-version",
  "toml",
  "ureq",
  "zip",

--- a/README.md
+++ b/README.md
@@ -866,6 +866,7 @@ Every feature has a KCS note: what it does, how to use it, and its settings.
 | Package Scaffolding | [`package-scaffolding`](docs/kcs/features/kcs-feature-package-scaffolding.md) |
 | tcl pkg | [`tcl-pkg`](docs/kcs/features/kcs-feature-tcl-pkg.md) |
 | tcl venv | [`tcl-venv`](docs/kcs/features/kcs-feature-tcl-venv.md) |
+| tcl docker | [`tcl-docker`](docs/kcs/features/kcs-feature-tcl-docker.md) |
 
 **Compiler, VM, and tooling**
 

--- a/docs/kcs/README.md
+++ b/docs/kcs/README.md
@@ -191,6 +191,9 @@ symptom with several possible causes worth telling apart. See rule 13 in
   — write sample files and cursor marker comments for screenshots.
 - [kcs-howto-manage-tcl-packages.md](kcs-howto-manage-tcl-packages.md)
   — add, install, and lock Tcl package dependencies with tclpkg.
+- [kcs-howto-containerise-a-tcl-project.md](kcs-howto-containerise-a-tcl-project.md)
+  — generate a Dockerfile that installs Tcl plus the native `tcl` CLI from a
+  checksum-verified release asset, and why musl base images cannot carry it.
 - [kcs-howto-run-tcltest-bundles.md](kcs-howto-run-tcltest-bundles.md)
   — run the Tcl 9 tcltest files through the bytecode VM, compare against
   reference `tclsh`, and read the parity scoreboard.

--- a/docs/kcs/features/README.md
+++ b/docs/kcs/features/README.md
@@ -148,4 +148,5 @@ combine them when more than one form helps:
 - [kcs-feature-claude-code-skills.md](kcs-feature-claude-code-skills.md)
 - [kcs-feature-tcl-pkg.md](kcs-feature-tcl-pkg.md)
 - [kcs-feature-tcl-venv.md](kcs-feature-tcl-venv.md)
+- [kcs-feature-tcl-docker.md](kcs-feature-tcl-docker.md)
 - [kcs-feature-bpf-tcl.md](kcs-feature-bpf-tcl.md)

--- a/docs/kcs/features/kcs-feature-tcl-docker.md
+++ b/docs/kcs/features/kcs-feature-tcl-docker.md
@@ -1,0 +1,100 @@
+# KCS: feature — tcl docker
+
+> **Audience:** User
+> **Type:** Functionality
+
+## Summary
+
+Generate a Dockerfile that installs a chosen Tcl version and the native `tcl`
+CLI, verified against the release checksums, and installs your locked packages.
+
+## Applies to
+
+tcl-lsp CLI
+
+## Question
+
+What does `tcl docker` do, and how do I use it?
+
+## How to use
+
+### tcl-lsp CLI
+
+```sh
+tcl docker info                          # families, Tcl versions, CLI targets
+tcl docker recipe debian:bookworm-slim --tcl-version 9.0   # the Tcl install layer
+tcl docker recipe debian:bookworm-slim --cli               # the tcl CLI install layer
+tcl docker create debian:bookworm-slim --tcl-version 8.6   # write a Dockerfile
+tcl docker create alpine:3.21 --tcl-version 8.6 --no-packages   # Tcl only
+tcl docker create ubuntu:24.04 --venv --entrypoint main.tcl --force
+```
+
+`create` writes a Dockerfile that installs Tcl (the OS package manager for 8.6
+on Debian, Alpine, and RHEL families, a source build otherwise), downloads the
+`tcl` binary built for the image's architecture, checks it against the
+release's `SHA256SUMS`, and runs `tcl pkg install --frozen` when a
+`tclpkg.lock` is present. No Python interpreter is installed or needed.
+
+### Choosing the release
+
+The Dockerfile pins the release as a build argument, defaulting to the one the
+`tcl` that wrote the file came from. Repin without regenerating:
+
+```sh
+docker build --build-arg TCL_LSP_VERSION=2.2.1 -t myapp .   # pin
+docker build --build-arg TCL_LSP_VERSION= -t myapp .        # newest release
+```
+
+An unpinned build resolves the newest release the first time only: the
+instruction text never changes, so a later rebuild reuses the cached layer
+until something above it changes or you build with `--no-cache`.
+
+### Alpine and other musl images
+
+`tcl docker create alpine:…` fails as soon as it would install the CLI. Every
+published Linux `tcl` asset is glibc-linked, and Alpine's `gcompat` shim
+re-exports neither `fcntl64` nor `__res_init`, so the binary cannot start.
+Either use a glibc base image, or pass `--no-packages` (and no `--venv`) for a
+Tcl-only image. `tcl docker info` lists which families can carry the CLI.
+
+## Options
+
+- `--tcl-version 8.4|8.5|8.6|9.0` — the Tcl to install (default 8.6).
+- `-o PATH` / `--force` — output path; overwrite an existing file.
+- `--workdir DIR` — container `WORKDIR` (default `/app`).
+- `--entrypoint SCRIPT` — the script `CMD` runs under `tclsh`.
+- `--venv` — create a Tcl virtual environment inside the image.
+- `--no-copy` — omit `COPY . .`, for multi-stage builds.
+- `--no-packages` — skip the CLI download and `pkg install` entirely.
+- `--extra-package PKG` — extra OS package (repeatable).
+- `--label k=v`, `--env k=v` — Docker `LABEL` / `ENV` (repeatable).
+- `--cli-version X.Y.Z` — pin the tcl-lsp release; empty resolves the newest.
+- `--cli` — on `recipe`, print the CLI install layer instead of the Tcl one.
+- `--json` — emit JSON output.
+
+## Example
+
+```sh
+$ tcl docker create debian:bookworm-slim --tcl-version 8.6
+  ✓ wrote Dockerfile
+  base: debian:bookworm-slim  tcl: 8.6
+  docker build -t myapp .
+
+$ docker build -t myapp .
+ => [5/8] RUN set -eu; ... sha256sum -c -; chmod +x /usr/local/bin/tcl; tcl --version
+ #10 1.7 /usr/local/bin/tcl: OK
+ #10 1.7 tcl 2.2.1+g45196df1
+
+$ docker run --rm myapp tcl --version
+tcl 2.2.1+g45196df1
+```
+
+`/usr/local/bin/tcl: OK` is the downloaded asset matching the release's
+`SHA256SUMS`. The build fails rather than installing an asset that is
+unlisted, mismatched, or unable to start.
+
+## Related
+
+- [tcl pkg](kcs-feature-tcl-pkg.md) — the packages this image installs.
+- [tcl venv](kcs-feature-tcl-venv.md) — what `--venv` creates.
+- [How to containerise a Tcl project](../kcs-howto-containerise-a-tcl-project.md)

--- a/docs/kcs/kcs-howto-add-compiler-pass.md
+++ b/docs/kcs/kcs-howto-add-compiler-pass.md
@@ -15,7 +15,7 @@ existing one?
 ## Before you start
 
 - You have a local checkout with the development environment set up
-  (`uv sync` passes).
+  (`cargo build --workspace` passes).
 - You have read the
   [compiler pipeline overview](../design/compiler/compiler-pipeline-overview.md)
   and know where in the pipeline your pass should sit.

--- a/docs/kcs/kcs-howto-containerise-a-tcl-project.md
+++ b/docs/kcs/kcs-howto-containerise-a-tcl-project.md
@@ -74,6 +74,11 @@ Its default is the release the `tcl` that generated the file was built from,
 so an image built from a generated Dockerfile ships the CLI line you develop
 with.
 
+An unpinned build resolves the newest release the first time only. The
+instruction text does not change between builds, so Docker reuses the cached
+layer — and the binary in it — until something above it changes or you build
+with `--no-cache`. Pin the release when you need a rebuild to track it.
+
 ## How to tell it worked
 
 The build prints the checksum verification and the version of the CLI it

--- a/docs/kcs/kcs-howto-containerise-a-tcl-project.md
+++ b/docs/kcs/kcs-howto-containerise-a-tcl-project.md
@@ -1,0 +1,130 @@
+# KCS: how to containerise a Tcl project
+
+> **Audience:** User
+> **Type:** How-To
+
+## Applies to
+
+tcl-lsp CLI
+
+## Question
+
+How do I build a Docker image that runs my Tcl project, with the same Tcl
+version and the same locked packages I develop against?
+
+## Before you start
+
+- The `tcl` CLI on `$PATH` (see [INSTALL-cli.md](../../INSTALL-cli.md)).
+- Docker (or another OCI builder) able to reach `github.com` — the image
+  downloads the `tcl` release binary during the build.
+- A `tclpkg.lock` in the project, if you want packages installed for you.
+
+## Answer
+
+`tcl docker create` writes a Dockerfile that installs Tcl, installs the
+**native `tcl` CLI binary** from a GitHub release, and runs
+`tcl pkg install --frozen` against your lockfile. No Python interpreter is
+installed or needed — the 1.x-era zipapp is gone.
+
+### 1. Pick a base image and Tcl version
+
+```sh
+tcl docker info
+```
+
+Lists the Tcl versions with install recipes (8.4, 8.5, 8.6, 9.0), the
+base-image families they cover, the release the CLI is pinned to by default,
+and the architectures a release asset exists for.
+
+### 2. Generate the Dockerfile
+
+```sh
+tcl docker create debian:bookworm-slim --tcl-version 8.6 --entrypoint main.tcl
+```
+
+Useful flags:
+
+| Flag | Effect |
+|---|---|
+| `--venv` | create a `tcl venv` inside the image and install into it |
+| `--no-packages` | skip the CLI download and `pkg install` entirely |
+| `--no-copy` | omit `COPY . .` (for multi-stage builds) |
+| `--cli-version 2.2.1` | pin the tcl-lsp release the CLI comes from |
+| `--extra-package tk` | add an OS package |
+| `-o path` / `--force` | write elsewhere / overwrite |
+
+### 3. Build and run
+
+```sh
+docker build -t myapp .
+docker run --rm myapp
+```
+
+### 4. (Optional) Repin or float the CLI version
+
+The generated Dockerfile carries the release as a build argument, so you can
+change it without regenerating:
+
+```sh
+docker build --build-arg TCL_LSP_VERSION=2.2.1 -t myapp .   # pin a release
+docker build --build-arg TCL_LSP_VERSION= -t myapp .        # newest release
+```
+
+Its default is the release the `tcl` that generated the file was built from,
+so an image built from a generated Dockerfile ships the CLI line you develop
+with.
+
+## How to tell it worked
+
+The build prints the checksum verification and the version of the CLI it
+installed, then the image runs Tcl:
+
+```text
+ => [5/8] RUN set -eu; ... sha256sum -c -; chmod +x /usr/local/bin/tcl; tcl --version
+ #10 1.7 /usr/local/bin/tcl: OK
+ #10 1.7 tcl 2.2.1+g45196df1
+```
+
+```sh
+$ docker run --rm myapp tcl --version
+tcl 2.2.1+g45196df1
+$ docker run --rm myapp sh -c 'echo "puts [info patchlevel]" | tclsh'
+8.6.13
+```
+
+`/usr/local/bin/tcl: OK` is the SHA-256 of the downloaded asset matching the
+release's `SHA256SUMS`. The build fails rather than installing an asset that
+is unlisted, mismatched, or unable to start.
+
+## Alpine and other musl images
+
+`tcl docker create alpine:…` **fails** as soon as it would install the CLI:
+
+```text
+error: the native tcl CLI has no musl release asset, so it cannot run on
+alpine (its glibc shim is missing fcntl64 and __res_init). Use a glibc base
+image (debian, ubuntu, fedora, rockylinux, …), or build a Tcl-only alpine
+image with --no-packages and no --venv.
+```
+
+Every published Linux `tcl` asset is glibc-linked, and `gcompat` re-exports
+neither `fcntl64` nor `__res_init`, so the binary dies in the dynamic loader.
+Either move to a glibc base image, or keep Alpine and drop the CLI:
+
+```sh
+tcl docker create alpine:3.21 --tcl-version 8.6 --no-packages
+```
+
+That still gives a working `tclsh` image — it just cannot resolve packages or
+create a venv inside the container. Vendor them instead (`tcl pkg vendor`)
+and `COPY` the result in.
+
+## Related
+
+- [KCS index](README.md)
+- [Glossary](../GLOSSARY.md)
+- [kcs-howto-manage-tcl-packages.md](kcs-howto-manage-tcl-packages.md) —
+  declare, resolve, and lock the dependencies this image installs.
+- [tcl pkg feature page](features/kcs-feature-tcl-pkg.md)
+- [tcl venv feature page](features/kcs-feature-tcl-venv.md)
+- [Design: tclpkg architecture](../design/tclpkg-architecture.md)

--- a/rust/tcl-cli/src/cli.rs
+++ b/rust/tcl-cli/src/cli.rs
@@ -1049,7 +1049,8 @@ pub enum DockerCommand {
         /// Docker ENV as key=value (repeatable).
         #[arg(long)]
         env: Vec<String>,
-        /// tcl CLI zipapp version to download (default: latest known).
+        /// tcl-lsp release to install the native tcl CLI from
+        /// (default: this binary's own release; empty resolves the latest).
         #[arg(long = "cli-version")]
         cli_version: Option<String>,
         /// Overwrite existing Dockerfile.
@@ -1066,6 +1067,13 @@ pub enum DockerCommand {
         /// Tcl version.
         #[arg(long = "tcl-version", default_value = "8.6", value_parser = ["8.4", "8.5", "8.6", "9.0"])]
         tcl_version: String,
+        /// Show the native tcl CLI install recipe instead of the Tcl one.
+        #[arg(long)]
+        cli: bool,
+        /// tcl-lsp release the --cli recipe pins
+        /// (default: this binary's own release; empty resolves the latest).
+        #[arg(long = "cli-version")]
+        cli_version: Option<String>,
         /// Emit JSON output.
         #[arg(long)]
         json: bool,

--- a/rust/tcl-cli/src/commands/docker.rs
+++ b/rust/tcl-cli/src/commands/docker.rs
@@ -30,8 +30,9 @@ use std::collections::BTreeMap;
 
 use serde_json::json;
 use tcl_pkg::docker::{
-    DockerfileSpec, SUPPORTED_TCL_VERSIONS, available_recipes, generate_dockerfile,
-    tcl_install_recipe, write_dockerfile,
+    DockerfileSpec, RELEASE_TRIPLES, SUPPORTED_TCL_VERSIONS, available_recipes,
+    cli_capable_families, cli_prereq_recipe, default_cli_version, generate_dockerfile,
+    tcl_cli_install_recipe, tcl_install_recipe, write_dockerfile,
 };
 use tcl_pkg::ui;
 
@@ -44,8 +45,10 @@ pub fn run(action: &DockerCommand) -> anyhow::Result<u8> {
         DockerCommand::Recipe {
             image,
             tcl_version,
+            cli,
+            cli_version,
             json,
-        } => run_recipe(image, tcl_version, *json),
+        } => run_recipe(image, tcl_version, *cli, cli_version.as_deref(), *json),
         DockerCommand::Info { json } => run_info(*json),
     }
 }
@@ -148,12 +151,30 @@ fn run_create(action: &DockerCommand) -> anyhow::Result<u8> {
     Ok(0)
 }
 
-fn run_recipe(image: &str, tcl_version: &str, json: bool) -> anyhow::Result<u8> {
-    let recipe = match tcl_install_recipe(image, tcl_version) {
-        Ok(r) => r,
-        Err(e) => {
-            eprintln!("error: {e}");
-            return Ok(1);
+fn run_recipe(
+    image: &str,
+    tcl_version: &str,
+    cli: bool,
+    cli_version: Option<&str>,
+    json: bool,
+) -> anyhow::Result<u8> {
+    // `--cli` prints what installs the tcl CLI itself (prerequisites plus the
+    // verified release-asset fetch); the default prints what installs Tcl.
+    let recipe = if cli {
+        match cli_prereq_recipe(image) {
+            Ok(prereq) => format!("{prereq}\n\n{}", tcl_cli_install_recipe(cli_version)),
+            Err(e) => {
+                eprintln!("error: {e}");
+                return Ok(1);
+            }
+        }
+    } else {
+        match tcl_install_recipe(image, tcl_version) {
+            Ok(r) => r,
+            Err(e) => {
+                eprintln!("error: {e}");
+                return Ok(1);
+            }
         }
     };
     if json {
@@ -162,6 +183,7 @@ fn run_recipe(image: &str, tcl_version: &str, json: bool) -> anyhow::Result<u8> 
             ui::json_output(&json!({
                 "image": image,
                 "tcl_version": tcl_version,
+                "kind": if cli { "cli" } else { "tcl" },
                 "recipe": recipe,
             }))
         );
@@ -173,6 +195,9 @@ fn run_recipe(image: &str, tcl_version: &str, json: bool) -> anyhow::Result<u8> 
 
 fn run_info(json: bool) -> anyhow::Result<u8> {
     let recipes = available_recipes();
+    let cli_version = default_cli_version();
+    let triples: Vec<&str> = RELEASE_TRIPLES.iter().map(|(_, _, t)| *t).collect();
+    let cli_families = cli_capable_families();
     if json {
         let families: BTreeMap<String, Vec<String>> = recipes.clone();
         println!(
@@ -180,6 +205,9 @@ fn run_info(json: bool) -> anyhow::Result<u8> {
             ui::json_output(&json!({
                 "supported_tcl_versions": SUPPORTED_TCL_VERSIONS.to_vec(),
                 "families": families,
+                "default_cli_version": cli_version,
+                "cli_target_triples": triples,
+                "cli_families": cli_families,
             }))
         );
     } else {
@@ -193,6 +221,16 @@ fn run_info(json: bool) -> anyhow::Result<u8> {
         for (family, versions) in &recipes {
             println!("  {family:12}  {}", versions.join(", "));
         }
+        println!();
+        println!("{}", ui::bold("Native tcl CLI:", colour));
+        println!(
+            "  default release  {}",
+            cli_version
+                .as_deref()
+                .unwrap_or("latest (resolved at build time)")
+        );
+        println!("  target triples   {}", triples.join(", "));
+        println!("  base families    {}", cli_families.join(", "));
     }
     Ok(0)
 }

--- a/rust/tcl-cli/tests/pkg_verbs.rs
+++ b/rust/tcl-cli/tests/pkg_verbs.rs
@@ -80,6 +80,32 @@ fn docker_info_lists_families() {
     assert!(stdout.contains("alpine        8.4, 8.5, 8.6, 9.0"));
     assert!(stdout.contains("debian        8.4, 8.5, 8.6, 9.0"));
     assert!(stdout.contains("redhat        8.4, 8.5, 8.6, 9.0"));
+    // The native CLI half: which releases and architectures it can install.
+    assert!(stdout.contains("Native tcl CLI:"));
+    assert!(stdout.contains("x86_64-unknown-linux-gnu"));
+    assert!(stdout.contains("base families    debian, redhat"));
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn docker_recipe_cli_fetches_a_verified_release_asset() {
+    let dir = temp_dir("docker-recipe-cli");
+    let (stdout, _stderr, code) = run_in(
+        &dir,
+        &[
+            "docker",
+            "recipe",
+            "debian:bookworm-slim",
+            "--cli",
+            "--cli-version",
+            "2.2.1",
+        ],
+    );
+    assert_eq!(code, 0);
+    assert!(stdout.contains("ARG TCL_LSP_VERSION=2.2.1"));
+    assert!(stdout.contains("SHA256SUMS"));
+    assert!(stdout.contains("sha256sum -c -"));
+    assert!(!stdout.contains("python"), "{stdout}");
     let _ = std::fs::remove_dir_all(&dir);
 }
 
@@ -103,6 +129,53 @@ fn docker_create_writes_dockerfile() {
     assert!(content.contains("# Install Tcl 8.6"));
     assert!(content.contains("WORKDIR /app"));
     assert!(content.trim_end().ends_with("CMD [\"tclsh\"]"));
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn docker_create_installs_the_native_cli() {
+    let dir = temp_dir("docker-create-cli");
+    let (_stdout, _stderr, code) = run_in(
+        &dir,
+        &[
+            "docker",
+            "create",
+            "debian:bookworm-slim",
+            "--tcl-version",
+            "8.6",
+            "--cli-version",
+            "2.2.1",
+        ],
+    );
+    assert_eq!(code, 0);
+    let content = std::fs::read_to_string(dir.join("Dockerfile")).unwrap();
+    // The CLI arrives as a verified native release asset, never a zipapp.
+    assert!(content.contains("ARG TCL_LSP_VERSION=2.2.1"));
+    assert!(content.contains("releases/download/$tag"));
+    assert!(content.contains("sha256sum -c -"));
+    assert!(content.contains("RUN if [ -f tclpkg.lock ]; then tcl pkg install --frozen; fi"));
+    assert!(
+        !content.to_lowercase().contains("python"),
+        "generated Dockerfile still mentions Python:\n{content}"
+    );
+    assert!(!content.contains(".pyz"));
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn docker_create_rejects_the_cli_on_musl() {
+    let dir = temp_dir("docker-create-alpine");
+    let (_stdout, stderr, code) = run_in(&dir, &["docker", "create", "alpine:3.19"]);
+    assert_eq!(code, 1);
+    assert!(stderr.contains("musl"), "{stderr}");
+    assert!(!dir.join("Dockerfile").exists());
+
+    // Without the CLI verbs an alpine image is still generated.
+    let (_stdout, _stderr, code) =
+        run_in(&dir, &["docker", "create", "alpine:3.19", "--no-packages"]);
+    assert_eq!(code, 0);
+    let content = std::fs::read_to_string(dir.join("Dockerfile")).unwrap();
+    assert!(content.contains("RUN apk add --no-cache tcl"));
     let _ = std::fs::remove_dir_all(&dir);
 }
 

--- a/rust/tcl-pkg/Cargo.toml
+++ b/rust/tcl-pkg/Cargo.toml
@@ -32,6 +32,7 @@ tcl-lexer = { path = "../tcl-lexer" }
 tcl-syntax = { path = "../tcl-syntax" }
 tcl-sandbox = { path = "../tcl-sandbox" }
 tcl-userdirs = { path = "../tcl-userdirs" }
+tcl-version = { path = "../tcl-version" }
 regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/rust/tcl-pkg/src/docker.rs
+++ b/rust/tcl-pkg/src/docker.rs
@@ -18,10 +18,12 @@
 
 //! Dockerfile generation for Tcl projects.
 //!
-//! Generates production-ready
-//! Dockerfiles that install a specific Tcl version, download the `tcl` CLI
-//! zipapp, and wire `tcl pkg sync` / `tcl venv create`. Also exposes recipe
-//! lookup helpers for AI skills composing custom Dockerfiles.
+//! Generates production-ready Dockerfiles that install a specific Tcl version,
+//! download the **native** `tcl` CLI binary for the target architecture from a
+//! GitHub release, verify it against the release's `SHA256SUMS`, and wire
+//! `tcl pkg install --frozen` / `tcl venv create`. Nothing in the generated
+//! image needs a Python interpreter. Also exposes recipe lookup helpers for AI
+//! skills composing custom Dockerfiles.
 
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
@@ -32,8 +34,22 @@ pub const SUPPORTED_TCL_VERSIONS: [&str; 4] = ["8.4", "8.5", "8.6", "9.0"];
 pub const DEFAULT_TCL_VERSION: &str = "8.6";
 pub const DEFAULT_BASE_IMAGE: &str = "debian:bookworm-slim";
 
-const TCL_CLI_URL_PREFIX: &str = "https://github.com/bitwisecook/tcl-lsp/releases/download/v";
-const DEFAULT_CLI_VERSION: &str = "1.6.0";
+/// The GitHub repository the release assets are published from.
+pub const RELEASE_REPO: &str = "bitwisecook/tcl-lsp";
+
+/// The version `tcl-version` stamps when the checkout has no reachable tag.
+/// It names no release, so it can never be pinned in a generated Dockerfile.
+const MANIFEST_PLACEHOLDER_VERSION: &str = "0.1.0";
+
+/// Docker's `TARGETARCH` (and the `uname -m` spelling it degrades to under the
+/// classic builder) mapped to the Rust target triple the release assets are
+/// named for. Keep in sync with the Linux legs of `build-server-matrix` in
+/// `.github/workflows/ci.yml`.
+pub const RELEASE_TRIPLES: &[(&str, &str, &str)] = &[
+    ("amd64", "x86_64", "x86_64-unknown-linux-gnu"),
+    ("arm64", "aarch64", "aarch64-unknown-linux-gnu"),
+    ("riscv64", "riscv64", "riscv64gc-unknown-linux-gnu"),
+];
 
 // Map well-known image prefixes to recipe families.
 const IMAGE_FAMILY: &[(&str, &str)] = &[
@@ -75,9 +91,12 @@ fn family_versions(family: &str) -> Option<&'static [(&'static str, &'static str
     }
 }
 
-const PYTHON_INSTALL_DEBIAN: &str = "RUN apt-get update && apt-get install -y --no-install-recommends \\\n        python3 curl ca-certificates && \\\n    rm -rf /var/lib/apt/lists/*";
-const PYTHON_INSTALL_ALPINE: &str = "RUN apk add --no-cache python3 curl";
-const PYTHON_INSTALL_REDHAT: &str = "RUN dnf install -y python3 curl && dnf clean all";
+// Fetching and verifying the release asset needs curl, a trust store, and
+// sha256sum/awk (already in coreutils everywhere below).
+const CLI_PREREQ_DEBIAN: &str = "RUN apt-get update && apt-get install -y --no-install-recommends \\\n        ca-certificates curl && \\\n    rm -rf /var/lib/apt/lists/*";
+// `dnf install curl` on an image carrying curl-minimal is a package swap, not
+// an install — guard on the binary so a present curl is left alone.
+const CLI_PREREQ_REDHAT: &str = "RUN if ! command -v curl >/dev/null 2>&1; then dnf install -y curl; fi && \\\n    dnf install -y ca-certificates && \\\n    dnf clean all";
 
 fn strip_registry(image: &str) -> String {
     let parts: Vec<&str> = image.split('/').collect();
@@ -128,23 +147,138 @@ pub fn tcl_install_recipe(image: &str, tcl_version: &str) -> Result<String, TclP
         })
 }
 
-/// Return the Dockerfile snippet that installs Python 3 on `image`.
-pub fn python_install_recipe(image: &str) -> Result<String, TclPkgError> {
+/// Return the Dockerfile snippet that installs what fetching and verifying the
+/// native `tcl` release asset needs on `image`: curl and a CA bundle.
+///
+/// Alpine is rejected. Every published Linux `tcl` asset is glibc-linked — the
+/// release matrix has no musl leg — and `gcompat` does not close the gap
+/// (`fcntl64` and `__res_init` are not among the symbols it re-exports, so the
+/// binary dies in the dynamic loader). A Tcl-only Alpine image is still fine:
+/// drop the CLI verbs (`--no-packages`, no `--venv`) and nothing is fetched.
+pub fn cli_prereq_recipe(image: &str) -> Result<String, TclPkgError> {
     match detect_image_family(image).as_str() {
-        "debian" => Ok(PYTHON_INSTALL_DEBIAN.to_string()),
-        "alpine" => Ok(PYTHON_INSTALL_ALPINE.to_string()),
-        "redhat" => Ok(PYTHON_INSTALL_REDHAT.to_string()),
+        "debian" => Ok(CLI_PREREQ_DEBIAN.to_string()),
+        "redhat" => Ok(CLI_PREREQ_REDHAT.to_string()),
+        "alpine" => Err(docker_error(
+            "the native tcl CLI has no musl release asset, so it cannot run on \
+             alpine (its glibc shim is missing fcntl64 and __res_init). Use a \
+             glibc base image (debian, ubuntu, fedora, rockylinux, …), or build \
+             a Tcl-only alpine image with --no-packages and no --venv.",
+        )),
         family => Err(docker_error(format!(
-            "no Python install recipe for image family: {family}"
+            "no tcl CLI prerequisite recipe for image family: {family}"
         ))),
     }
 }
 
-/// Return the GitHub release URL for the `tcl` CLI zipapp.
+/// The image families a generated Dockerfile can install the native `tcl` CLI
+/// on, sorted. Every family in [`available_recipes`] can still install Tcl
+/// itself; only these can also carry the CLI.
 #[must_use]
-pub fn tcl_cli_download_url(cli_version: Option<&str>) -> String {
-    let version = cli_version.unwrap_or(DEFAULT_CLI_VERSION);
-    format!("{TCL_CLI_URL_PREFIX}{version}/tcl-{version}.pyz")
+pub fn cli_capable_families() -> Vec<String> {
+    ["debian", "redhat"].map(ToString::to_string).to_vec()
+}
+
+/// The release version a generated Dockerfile pins by default.
+///
+/// Derived from the version stamped into this binary, so a generated image
+/// installs the CLI line that generated it. Build metadata (`+g<hash>`,
+/// `.dirty`) and the `git describe` distance (`-<n>`) are stripped, leaving the
+/// tag the build descends from: `2.2.1-7+gc1a17793` pins `2.2.1`.
+///
+/// `None` when the build carries no release base at all — a tagless checkout
+/// stamps the workspace manifest's placeholder, which names no release. The
+/// generated Dockerfile then resolves the newest release at build time instead
+/// of pinning a tag that was never published.
+#[must_use]
+pub fn default_cli_version() -> Option<String> {
+    release_base(tcl_version::VERSION)
+}
+
+/// Reduce a stamped version to the release tag it descends from.
+fn release_base(version: &str) -> Option<String> {
+    let base = version.split('+').next().unwrap_or(version);
+    let base = base.strip_suffix("-dirty").unwrap_or(base);
+    // `git describe` counts commits since the tag: `2.2.1-7` came from `v2.2.1`.
+    let base = match base.rsplit_once('-') {
+        Some((tag, distance))
+            if !distance.is_empty() && distance.chars().all(|c| c.is_ascii_digit()) =>
+        {
+            tag
+        }
+        _ => base,
+    };
+    (!base.is_empty() && base != MANIFEST_PLACEHOLDER_VERSION).then(|| base.to_string())
+}
+
+/// Normalise a release version for the `TCL_LSP_VERSION` build argument: no
+/// leading `v` (the fetch step adds it back when it builds the tag).
+fn normalise_cli_version(version: &str) -> String {
+    version.trim().trim_start_matches('v').to_string()
+}
+
+/// Return the Dockerfile snippet that downloads the native `tcl` CLI for the
+/// build's target architecture and verifies it against the release's
+/// `SHA256SUMS` before installing it at `/usr/local/bin/tcl`.
+///
+/// `cli_version` pins a release; `None` defers to [`default_cli_version`], and
+/// when that is also `None` the emitted `TCL_LSP_VERSION` build argument is
+/// empty and the snippet resolves the newest release itself. Either way the
+/// version stays overridable at build time with
+/// `docker build --build-arg TCL_LSP_VERSION=…`.
+///
+/// The trust model mirrors `scripts/tcl-mcp`: an asset missing from
+/// `SHA256SUMS`, or one whose hash does not match, fails the build rather than
+/// landing an unverified binary in the image.
+#[must_use]
+pub fn tcl_cli_install_recipe(cli_version: Option<&str>) -> String {
+    let pinned = cli_version
+        .map(normalise_cli_version)
+        .or_else(default_cli_version)
+        .unwrap_or_default();
+
+    let arch_cases = RELEASE_TRIPLES
+        .iter()
+        .map(|(target_arch, uname, triple)| {
+            // The two spellings coincide on some architectures (riscv64);
+            // emitting both would be a duplicate `case` pattern.
+            let pattern = if target_arch == uname {
+                (*target_arch).to_string()
+            } else {
+                format!("{target_arch} | {uname}")
+            };
+            format!("        {pattern}) triple=\"{triple}\" ;; \\")
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    format!(
+        "ARG TCL_LSP_VERSION={pinned}\n\
+         ARG TARGETARCH\n\
+         RUN set -eu; \\\n\
+         \x20   arch=\"${{TARGETARCH:-$(uname -m)}}\"; \\\n\
+         \x20   case \"$arch\" in \\\n\
+         {arch_cases}\n\
+         \x20       *) echo \"no tcl release asset for $arch\" >&2; exit 1 ;; \\\n\
+         \x20   esac; \\\n\
+         \x20   if [ -n \"${{TCL_LSP_VERSION:-}}\" ]; then \\\n\
+         \x20       tag=\"v${{TCL_LSP_VERSION#v}}\"; \\\n\
+         \x20   else \\\n\
+         \x20       tag=\"$(curl -fsSL \"https://api.github.com/repos/{RELEASE_REPO}/releases?per_page=1\" \\\n\
+         \x20           | grep -m1 '\"tag_name\"' \\\n\
+         \x20           | sed -E 's/.*\"tag_name\": *\"([^\"]+)\".*/\\1/')\"; \\\n\
+         \x20       [ -n \"$tag\" ] || {{ echo \"cannot resolve the latest {RELEASE_REPO} release\" >&2; exit 1; }}; \\\n\
+         \x20   fi; \\\n\
+         \x20   base=\"https://github.com/{RELEASE_REPO}/releases/download/$tag\"; \\\n\
+         \x20   curl -fsSL \"$base/tcl-$triple\" -o /usr/local/bin/tcl; \\\n\
+         \x20   curl -fsSL \"$base/SHA256SUMS\" -o /tmp/SHA256SUMS; \\\n\
+         \x20   want=\"$(awk -v a=\"tcl-$triple\" '$2 == a || $2 == \"*\"a {{ print $1; exit }}' /tmp/SHA256SUMS)\"; \\\n\
+         \x20   [ -n \"$want\" ] || {{ echo \"tcl-$triple is not listed in $tag SHA256SUMS\" >&2; exit 1; }}; \\\n\
+         \x20   echo \"$want  /usr/local/bin/tcl\" | sha256sum -c -; \\\n\
+         \x20   rm -f /tmp/SHA256SUMS; \\\n\
+         \x20   chmod +x /usr/local/bin/tcl; \\\n\
+         \x20   tcl --version"
+    )
 }
 
 /// Return `{family: [versions]}` for all known recipe families (sorted).
@@ -223,15 +357,12 @@ pub fn generate_dockerfile(spec: &DockerfileSpec) -> Result<String, TclPkgError>
     lines.push(String::new());
 
     if needs_cli {
-        lines.push("# Install Python 3 (required by the tcl CLI tool)".to_string());
-        lines.push(python_install_recipe(&spec.base_image)?);
+        lines.push("# Fetch and verify the native tcl CLI release asset".to_string());
+        lines.push(cli_prereq_recipe(&spec.base_image)?);
         lines.push(String::new());
 
-        let url = tcl_cli_download_url(spec.cli_version.as_deref());
-        lines.push("# Download the tcl CLI zipapp from GitHub releases".to_string());
-        lines.push(format!(
-            "RUN curl -fSL \"{url}\" \\\n        -o /usr/local/bin/tcl.pyz && \\\n    chmod +x /usr/local/bin/tcl.pyz"
-        ));
+        lines.push("# Install the native tcl CLI from a verified release asset".to_string());
+        lines.push(tcl_cli_install_recipe(spec.cli_version.as_deref()));
         lines.push(String::new());
     }
 
@@ -261,7 +392,7 @@ pub fn generate_dockerfile(spec: &DockerfileSpec) -> Result<String, TclPkgError>
         let venv_abs = format!("{}/.venv", spec.workdir);
         lines.push("# Create Tcl virtual environment".to_string());
         lines.push(format!(
-            "RUN python3 /usr/local/bin/tcl.pyz venv create .venv --tcl {}",
+            "RUN tcl venv create .venv --tcl {}",
             spec.tcl_version
         ));
         lines.push(format!("ENV TCLLIBPATH=\"{venv_abs}/lib\""));
@@ -276,10 +407,7 @@ pub fn generate_dockerfile(spec: &DockerfileSpec) -> Result<String, TclPkgError>
         } else {
             lines.push("# Install Tcl packages from lockfile".to_string());
         }
-        lines.push(
-            "RUN if [ -f tclpkg.lock ]; then python3 /usr/local/bin/tcl.pyz pkg install --frozen; fi"
-                .to_string(),
-        );
+        lines.push("RUN if [ -f tclpkg.lock ]; then tcl pkg install --frozen; fi".to_string());
         lines.push(String::new());
     }
 
@@ -389,15 +517,86 @@ mod tests {
     }
 
     #[test]
-    fn cli_url() {
+    fn default_version_strips_describe_and_build_metadata() {
+        assert_eq!(release_base("2.2.1+gc1a17793").as_deref(), Some("2.2.1"));
+        assert_eq!(release_base("2.2.1-7+gc1a17793").as_deref(), Some("2.2.1"));
         assert_eq!(
-            tcl_cli_download_url(None),
-            "https://github.com/bitwisecook/tcl-lsp/releases/download/v1.6.0/tcl-1.6.0.pyz"
+            release_base("2.2.1+gc1a17793.dirty").as_deref(),
+            Some("2.2.1")
         );
-        assert_eq!(
-            tcl_cli_download_url(Some("2.0.0")),
-            "https://github.com/bitwisecook/tcl-lsp/releases/download/v2.0.0/tcl-2.0.0.pyz"
+        assert_eq!(release_base("2.2.1-dirty").as_deref(), Some("2.2.1"));
+        // A real pre-release segment is part of the tag, not a describe count.
+        assert_eq!(release_base("2.3.0-rc1").as_deref(), Some("2.3.0-rc1"));
+        // The manifest placeholder names no release, so nothing is pinned.
+        assert_eq!(release_base("0.1.0+gc1a17793"), None);
+    }
+
+    #[test]
+    fn cli_install_recipe_pins_and_verifies() {
+        let recipe = tcl_cli_install_recipe(Some("2.2.1"));
+        assert!(recipe.starts_with("ARG TCL_LSP_VERSION=2.2.1\nARG TARGETARCH\n"));
+        // A caller-supplied `v` prefix must not double up in the tag.
+        assert!(tcl_cli_install_recipe(Some("v2.2.1")).starts_with("ARG TCL_LSP_VERSION=2.2.1\n"));
+        assert!(
+            recipe
+                .contains("base=\"https://github.com/bitwisecook/tcl-lsp/releases/download/$tag\"")
         );
+        assert!(recipe.contains("$base/tcl-$triple"));
+        assert!(recipe.contains("$base/SHA256SUMS"));
+        assert!(recipe.contains("sha256sum -c -"));
+        assert!(recipe.contains("chmod +x /usr/local/bin/tcl"));
+        assert!(recipe.ends_with("tcl --version"));
+        for (target_arch, _, triple) in RELEASE_TRIPLES {
+            assert!(recipe.contains(triple), "{triple} missing from arch case");
+            assert!(recipe.contains(target_arch));
+        }
+        // Nothing Python-shaped survives.
+        assert!(!recipe.contains("python"));
+        assert!(!recipe.contains(".pyz"));
+    }
+
+    #[test]
+    fn cli_install_recipe_without_a_pin_resolves_the_latest_release() {
+        // `tcl_cli_install_recipe(None)` follows the build's own version, which
+        // varies; drive the empty-pin shape through the shared formatter.
+        let recipe = tcl_cli_install_recipe(Some(""));
+        assert!(recipe.starts_with("ARG TCL_LSP_VERSION=\n"));
+        assert!(recipe.contains("api.github.com/repos/bitwisecook/tcl-lsp/releases?per_page=1"));
+    }
+
+    #[test]
+    fn cli_prereqs_carry_no_python() {
+        for image in ["debian:bookworm-slim", "fedora:39"] {
+            let recipe = cli_prereq_recipe(image).unwrap();
+            assert!(recipe.contains("curl"), "{image}: no curl");
+            assert!(!recipe.contains("python"), "{image}: still installs python");
+        }
+    }
+
+    #[test]
+    fn alpine_cannot_carry_the_glibc_cli() {
+        let err = cli_prereq_recipe("alpine:3.19").unwrap_err().to_string();
+        assert!(err.contains("musl"), "unhelpful alpine error: {err}");
+        assert!(
+            err.contains("--no-packages"),
+            "no escape hatch named: {err}"
+        );
+
+        // Asking for the CLI on alpine fails ...
+        let with_cli = DockerfileSpec {
+            base_image: "alpine:3.19".to_string(),
+            ..Default::default()
+        };
+        assert!(generate_dockerfile(&with_cli).is_err());
+
+        // ... but a Tcl-only alpine image still generates.
+        let tcl_only = DockerfileSpec {
+            install_packages: false,
+            ..with_cli
+        };
+        let out = generate_dockerfile(&tcl_only).unwrap();
+        assert!(out.contains("RUN apk add --no-cache tcl"));
+        assert!(!out.contains("ARG TCL_LSP_VERSION"));
     }
 
     #[test]
@@ -425,5 +624,50 @@ mod tests {
         assert!(out.contains("WORKDIR /app"));
         assert!(out.contains("COPY . ."));
         assert!(out.trim_end().ends_with("CMD [\"tclsh\"]"));
+        // No CLI verbs are used, so no CLI is fetched.
+        assert!(!out.contains("ARG TCL_LSP_VERSION"));
+    }
+
+    #[test]
+    fn generate_installs_the_native_cli() {
+        let spec = DockerfileSpec {
+            cli_version: Some("2.2.1".to_string()),
+            create_venv: true,
+            entrypoint: Some("main.tcl".to_string()),
+            ..Default::default()
+        };
+        let out = generate_dockerfile(&spec).unwrap();
+        assert!(out.contains("ARG TCL_LSP_VERSION=2.2.1"));
+        assert!(out.contains("triple=\"x86_64-unknown-linux-gnu\""));
+        assert!(out.contains("sha256sum -c -"));
+        assert!(out.contains("RUN tcl venv create .venv --tcl 8.6"));
+        assert!(out.contains("RUN if [ -f tclpkg.lock ]; then tcl pkg install --frozen; fi"));
+        assert!(out.trim_end().ends_with("CMD [\"tclsh\", \"main.tcl\"]"));
+        assert!(
+            !out.to_lowercase().contains("python"),
+            "generated Dockerfile still mentions Python:\n{out}"
+        );
+        assert!(!out.contains(".pyz"));
+    }
+
+    #[test]
+    fn generate_carries_no_python_on_any_family() {
+        for image in ["debian:bookworm-slim", "fedora:39"] {
+            for version in SUPPORTED_TCL_VERSIONS {
+                let spec = DockerfileSpec {
+                    base_image: image.to_string(),
+                    tcl_version: version.to_string(),
+                    cli_version: Some("2.2.1".to_string()),
+                    create_venv: true,
+                    ..Default::default()
+                };
+                let out = generate_dockerfile(&spec).unwrap();
+                assert!(
+                    !out.to_lowercase().contains("python"),
+                    "{image} tcl {version} still mentions Python"
+                );
+                assert!(out.contains("ARG TCL_LSP_VERSION=2.2.1"));
+            }
+        }
     }
 }

--- a/rust/tcl-pkg/src/docker.rs
+++ b/rust/tcl-pkg/src/docker.rs
@@ -98,6 +98,13 @@ const CLI_PREREQ_DEBIAN: &str = "RUN apt-get update && apt-get install -y --no-i
 // an install — guard on the binary so a present curl is left alone.
 const CLI_PREREQ_REDHAT: &str = "RUN if ! command -v curl >/dev/null 2>&1; then dnf install -y curl; fi && \\\n    dnf install -y ca-certificates && \\\n    dnf clean all";
 
+/// The image families the native `tcl` CLI can be installed on, and what each
+/// needs first. One table so [`cli_prereq_recipe`] and [`cli_capable_families`]
+/// cannot drift into advertising a family that errors, or omitting one that
+/// works. Sorted, because `cli_capable_families` is a user-facing listing.
+const CLI_PREREQS: &[(&str, &str)] =
+    &[("debian", CLI_PREREQ_DEBIAN), ("redhat", CLI_PREREQ_REDHAT)];
+
 fn strip_registry(image: &str) -> String {
     let parts: Vec<&str> = image.split('/').collect();
     if parts.len() >= 2 && (parts[0].contains('.') || parts[0].contains(':')) {
@@ -156,19 +163,21 @@ pub fn tcl_install_recipe(image: &str, tcl_version: &str) -> Result<String, TclP
 /// binary dies in the dynamic loader). A Tcl-only Alpine image is still fine:
 /// drop the CLI verbs (`--no-packages`, no `--venv`) and nothing is fetched.
 pub fn cli_prereq_recipe(image: &str) -> Result<String, TclPkgError> {
-    match detect_image_family(image).as_str() {
-        "debian" => Ok(CLI_PREREQ_DEBIAN.to_string()),
-        "redhat" => Ok(CLI_PREREQ_REDHAT.to_string()),
-        "alpine" => Err(docker_error(
+    let family = detect_image_family(image);
+    if let Some((_, prereq)) = CLI_PREREQS.iter().find(|(f, _)| *f == family) {
+        return Ok((*prereq).to_string());
+    }
+    if family == "alpine" {
+        return Err(docker_error(
             "the native tcl CLI has no musl release asset, so it cannot run on \
              alpine (its glibc shim is missing fcntl64 and __res_init). Use a \
              glibc base image (debian, ubuntu, fedora, rockylinux, …), or build \
              a Tcl-only alpine image with --no-packages and no --venv.",
-        )),
-        family => Err(docker_error(format!(
-            "no tcl CLI prerequisite recipe for image family: {family}"
-        ))),
+        ));
     }
+    Err(docker_error(format!(
+        "no tcl CLI prerequisite recipe for image family: {family}"
+    )))
 }
 
 /// The image families a generated Dockerfile can install the native `tcl` CLI
@@ -176,7 +185,7 @@ pub fn cli_prereq_recipe(image: &str) -> Result<String, TclPkgError> {
 /// itself; only these can also carry the CLI.
 #[must_use]
 pub fn cli_capable_families() -> Vec<String> {
-    ["debian", "redhat"].map(ToString::to_string).to_vec()
+    CLI_PREREQS.iter().map(|(f, _)| (*f).to_string()).collect()
 }
 
 /// The release version a generated Dockerfile pins by default.
@@ -357,7 +366,7 @@ pub fn generate_dockerfile(spec: &DockerfileSpec) -> Result<String, TclPkgError>
     lines.push(String::new());
 
     if needs_cli {
-        lines.push("# Fetch and verify the native tcl CLI release asset".to_string());
+        lines.push("# Prerequisites for fetching and verifying the tcl CLI".to_string());
         lines.push(cli_prereq_recipe(&spec.base_image)?);
         lines.push(String::new());
 
@@ -571,6 +580,23 @@ mod tests {
             assert!(recipe.contains("curl"), "{image}: no curl");
             assert!(!recipe.contains("python"), "{image}: still installs python");
         }
+    }
+
+    #[test]
+    fn every_advertised_cli_family_has_a_recipe() {
+        let families = cli_capable_families();
+        assert!(!families.is_empty());
+        for family in &families {
+            assert!(
+                cli_prereq_recipe(family).is_ok(),
+                "{family} is advertised as CLI-capable but has no prerequisite recipe"
+            );
+        }
+        assert!(!families.iter().any(|f| f == "alpine"));
+        // Sorted, because this is a user-facing listing.
+        let mut sorted = families.clone();
+        sorted.sort();
+        assert_eq!(families, sorted);
     }
 
     #[test]

--- a/samples/optimiser/README.md
+++ b/samples/optimiser/README.md
@@ -12,7 +12,7 @@ produces from a single input file.
 | `profile_standard.tcl` | Output at **standard** — readability + constant folding |
 | `profile_full.tcl` | Output at **full** — all passes, single pass |
 | `profile_aggressive.tcl` | Output at **aggressive** — all passes, multi-pass to fixpoint |
-| `deep_pipeline.tcl` | Deep multi-pass stress sample — layered so each optimisation exposes the next (5+ passes, interprocedural folding). Runs on C Tcl 9; `tests/test_optimiser_deep_sample.py` proves the optimised / formatted / minified forms all stay behaviourally identical. |
+| `deep_pipeline.tcl` | Deep multi-pass stress sample — layered so each optimisation exposes the next (5+ passes, interprocedural folding). Runs on C Tcl 9; the optimised / formatted / minified forms all print the same line (see its header comment). |
 
 ## Profiles
 
@@ -121,19 +121,13 @@ source text reaches a fixpoint (no further changes).
 ## Regenerating samples
 
 ```bash
-uv run python -c "
-from server._codes_init import *
-from shared.optimisation_profiles import profile_to_disabled, OptimisationProfile
-from compiler.optimiser import optimise_source, optimise_source_multipass
-
-source = open('samples/optimiser/input.tcl').read()
-for p in [OptimisationProfile.READABILITY, OptimisationProfile.STANDARD, OptimisationProfile.FULL]:
-    disabled = profile_to_disabled(p)
-    result, _ = optimise_source(source, disabled=disabled)
-    open(f'samples/optimiser/profile_{p.value}.tcl', 'w').write(result)
-
-disabled = profile_to_disabled(OptimisationProfile.AGGRESSIVE)
-result, _, _ = optimise_source_multipass(source, disabled=disabled)
-open('samples/optimiser/profile_aggressive.tcl', 'w').write(result)
-"
+for p in readability standard full aggressive; do
+    tcl opt --profile "$p" samples/optimiser/input.tcl \
+        > "samples/optimiser/profile_$p.tcl"
+done
 ```
+
+The committed outputs predate the Rust optimiser and have not been
+regenerated: it is deliberately more conservative on some passes (O114's
+`incr` rewrite, for one, now needs the target proven `TclType::Int`), so
+re-running the loop above will not reproduce them byte-for-byte.

--- a/samples/optimiser/deep_pipeline.tcl
+++ b/samples/optimiser/deep_pipeline.tcl
@@ -1,7 +1,6 @@
 # Deep optimiser stress sample.
 #
-# Run: uv run python ai/claude/tcl_ai.py optimize --profile aggressive \
-#          samples/optimiser/deep_pipeline.tcl
+# Run: tcl opt --profile aggressive samples/optimiser/deep_pipeline.tcl
 #
 # This program is deliberately layered so that each optimisation exposes
 # the next, driving the multi-pass (aggressive) optimiser through many
@@ -21,8 +20,11 @@
 #
 # It runs unchanged on C Tcl 9 (tclsh9.0) and prints one deterministic
 # line, so the optimised / formatted / minified forms can each be executed
-# and diffed for behavioural equivalence — the property
-# tests/test_optimiser_deep_sample.py asserts.
+# and diffed for behavioural equivalence:
+#
+#   for form in "opt --profile aggressive" format minify; do
+#       tcl $form samples/optimiser/deep_pipeline.tcl | tclsh9.0
+#   done
 #
 # Expected output:  tcl v9.0 score=62 x2=124
 

--- a/samples/optimiser/input.tcl
+++ b/samples/optimiser/input.tcl
@@ -1,6 +1,6 @@
 # Sample Tcl code exercising all optimisation passes.
 # Used to demonstrate what each profile produces.
-# Run: uv run python ai/claude/tcl_ai.py optimize samples/optimiser/input.tcl
+# Run: tcl opt samples/optimiser/input.tcl
 
 # --- Readability candidates (O111, O114, O115, O117, O120) ---
 

--- a/samples/optimiser/profile_aggressive.tcl
+++ b/samples/optimiser/profile_aggressive.tcl
@@ -1,6 +1,6 @@
 # Sample Tcl code exercising all optimisation passes.
 # Used to demonstrate what each profile produces.
-# Run: uv run python ai/claude/tcl_ai.py optimize --profile aggressive samples/optimiser/input.tcl
+# Run: tcl opt --profile aggressive samples/optimiser/input.tcl
 
 # --- Readability candidates (O111, O114, O115, O117, O120) ---
 

--- a/samples/optimiser/profile_full.tcl
+++ b/samples/optimiser/profile_full.tcl
@@ -1,6 +1,6 @@
 # Sample Tcl code exercising all optimisation passes.
 # Used to demonstrate what each profile produces.
-# Run: uv run python ai/claude/tcl_ai.py optimize samples/optimiser/input.tcl
+# Run: tcl opt --profile full samples/optimiser/input.tcl
 
 # --- Readability candidates (O111, O114, O115, O117, O120) ---
 

--- a/samples/optimiser/profile_readability.tcl
+++ b/samples/optimiser/profile_readability.tcl
@@ -1,6 +1,6 @@
 # Sample Tcl code exercising all optimisation passes.
 # Used to demonstrate what each profile produces.
-# Run: uv run python ai/claude/tcl_ai.py optimize --profile readability samples/optimiser/input.tcl
+# Run: tcl opt --profile readability samples/optimiser/input.tcl
 
 # --- Readability candidates (O111, O114, O115, O117, O120) ---
 

--- a/samples/optimiser/profile_standard.tcl
+++ b/samples/optimiser/profile_standard.tcl
@@ -1,6 +1,6 @@
 # Sample Tcl code exercising all optimisation passes.
 # Used to demonstrate what each profile produces.
-# Run: uv run python ai/claude/tcl_ai.py optimize --profile standard samples/optimiser/input.tcl
+# Run: tcl opt --profile standard samples/optimiser/input.tcl
 
 # --- Readability candidates (O111, O114, O115, O117, O120) ---
 

--- a/samples/tcl9_smoke/README.md
+++ b/samples/tcl9_smoke/README.md
@@ -5,11 +5,13 @@ primitives **without** using `tcltest`.  Each sample sits next to
 a `.expected` file containing the stdout we expect the compiled
 WASM to emit when the sample runs.  The pair serves two purposes:
 
-1. **Regression smoke** — `tests/external/run_tcl9_samples.py`
-   compiles every `.tcl` under this tree, runs it under wasmtime,
-   and asserts the captured stdout matches its sibling `.expected`
-   byte-for-byte.  A failing sample pinpoints the primitive the
-   commit broke without requiring tcltest's harness to be healthy.
+1. **Regression smoke** — compile a sample to WASM, run it under
+   wasmtime, and compare the captured stdout against its sibling
+   `.expected` byte-for-byte.  A failing sample pinpoints the
+   primitive the commit broke without requiring tcltest's harness to
+   be healthy.  The Python runner that did this for the whole tree
+   went with the rest of Python; there is currently no automated
+   harness, so run samples by hand (below) until one is rebuilt.
 2. **Architectural signal** — the corpus is organised by
    primitive (one directory per concern), so which primitives
    drift after a compiler change is immediately visible from the
@@ -31,9 +33,21 @@ their header comment.
 
 ## Running locally
 
+Evaluate a sample through the Rust runtime and diff it against its
+expectation (`--quiet` matches `tclsh script.tcl`: only `puts` reaches
+stdout):
+
+```sh
+cd runtime/rust
+sample=../../samples/tcl9_smoke/<primitive>/NN_<aspect>
+cargo run --quiet --example run_script -- --quiet "$sample.tcl" \
+    | diff - "$sample.expected"
 ```
-make test-tcl9-samples
-```
+
+No output from `diff` means the sample matches its expectation.  To check
+the compiled path instead, `tcl compwasm` emits the module — note it
+imports the runtime's host functions, so a bare `wasmtime` cannot
+instantiate it.
 
 ## Adding a sample
 
@@ -44,13 +58,13 @@ make test-tcl9-samples
    * Run `tclsh9.0 path/to/sample.tcl > path/to/sample.expected`
      if you have Tcl 9 installed locally.
    * Hand-author the `.expected` based on the Tcl 9 man pages.
-3. Rerun `make test-tcl9-samples`; a green result confirms our
-   compiler produces the same stdout.
+3. Rerun the run-and-diff above; a silent `diff` confirms our
+   implementation produces the same stdout.
 
 ## When a sample fails
 
-The harness prints a unified diff of expected vs actual.  Treat
-the failure as a regression of the compiler, NOT of the sample —
+`diff` shows expected vs actual.  Treat the failure as a
+regression of the compiler or runtime, NOT of the sample —
 the `.expected` is the source of truth (pinned to Tcl 9 reference
 behaviour).  If Tcl 9 semantics change, regenerate the `.expected`
 and note the version bump in the commit.


### PR DESCRIPTION
## Summary

- **`tcl docker create` emitted Python-era Dockerfiles.** It installed `python3`, downloaded `tcl-<ver>.pyz` from a 1.x release, and ran the zipapp under `python3`. The 2.x line publishes native `tcl-<triple>` binaries and no zipapp, so every generated Dockerfile pinned an asset that no longer exists.
- **The CLI now arrives as a verified release asset.** The generated layer maps BuildKit's `TARGETARCH` (falling back to `uname -m`) to the release triple, fetches `tcl-<triple>` plus `SHA256SUMS`, refuses an asset that is unlisted or mismatched, and ends on `tcl --version` so a binary that cannot start fails the build instead of shipping. Same trust model `scripts/tcl-mcp` already uses for the MCP binary. `python3` is gone from the base-image recipes — nothing else in them needed it.
- **`DEFAULT_CLI_VERSION`'s hardcoded `1.6.0` is replaced by `default_cli_version()`,** derived from `tcl-version`: build metadata and the `git describe` distance are stripped, so `2.2.1-7+gc1a17793` pins `2.2.1`. A tagless checkout stamps the manifest placeholder, which names no release — there the emitted `ARG TCL_LSP_VERSION` is empty and the layer resolves the newest release itself. `--cli-version` still overrides, and `--build-arg TCL_LSP_VERSION=` repins without regenerating.
- **Alpine now errors rather than generating an image that cannot run.** Every published Linux asset is glibc-linked (no musl leg in the release matrix) and `gcompat` re-exports neither `fcntl64` nor `__res_init`, so the binary dies in the dynamic loader. The error names both escapes — a glibc base image, or `--no-packages` for a Tcl-only Alpine image, which still generates. Tracked as #1791.
- **New CLI surface:** `tcl docker recipe --cli` prints the CLI install layer on its own (which the skill previously got by calling into the Python package), and `tcl docker info` gains the default release, target triples, and the families that can carry the CLI.

### Documentation

`tcl docker` had **no feature page**, so the whole verb group was invisible to `tcl help`, the MCP `help` tool, and VS Code's `/help` — `rust/tcl-cli/build.rs` compiles `docs/kcs/features/*.md` into the FTS5 database behind all three, and `tcl pkg` / `tcl venv` each have one. Both the repo's `/code-review` pass and Codex flagged this; fixed in d82463170.

- `docs/kcs/features/kcs-feature-tcl-docker.md` — new Functionality note (the template the help tool parses), indexed in the features README and added to `README.md`'s feature table beside `tcl pkg` and `tcl venv`. `tcl help docker` resolves it.
- `docs/kcs/kcs-howto-containerise-a-tcl-project.md` — new task-shaped How-To covering the generated Dockerfile end to end, the Alpine limit, and the fact that an unpinned `TCL_LSP_VERSION` only resolves the newest release on the first build (the instruction text never changes, so the layer caches).
- `.claude/skills/dockerfile-generate/SKILL.md` — no longer claims the file fetches a `.pyz` and needs `python3`, and drives the real CLI instead of `uv run --no-dev python -m explorer.tcl_cli`. Rebased onto #1783's tightened prompt style rather than reverting it.

### Python-era audit (rest of the tree)

Four more genuine leftovers, all fixed here:

| Where | Was | Now |
|---|---|---|
| `samples/optimiser/*.tcl`, `README.md` | `uv run python ai/claude/tcl_ai.py optimize` (deleted file); README regenerated samples by importing retired `server.` / `compiler.` / `shared.` modules | `tcl opt --profile …` |
| `samples/tcl9_smoke/README.md` | `tests/external/run_tcl9_samples.py` and `make test-tcl9-samples`, neither of which exists | the runtime's `run_script` example |
| `docs/kcs/kcs-howto-add-compiler-pass.md` | prerequisite `uv sync` passes | `cargo build --workspace` passes |
| `.github/workflows/{ci,codeql}.yml` | comments describing an AI zipapp build/upload, and naming Python as the LSP server's language | corrected |

Confirmed **not** stale and left alone: the installer's legacy-zipapp cleanup, the BIG-IP report generator and its `.pyz`, Sublime's `plugin.py`, `scripts/check_c_api_ownership.py`, and the `python` CI job.

The committed optimiser sample *outputs* are deliberately left as they are — the Rust optimiser is more conservative than the Python one was (O114 now needs the target proven `TclType::Int`), so regenerating them would change what the profiles document. Filed as #1789. The orphaned tcl9_smoke corpus is #1790.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

```sh
make rust-check                 # EXIT=0
make smoke-p P=tcl-pkg          # ok
cargo test -p tcl-pkg -p tcl-cli
cargo xtask kcs-index-links     # KCS docs checks passed
tcl help docker                 # resolves the new feature page
```

`cargo test -p tcl-cli` also reports `explorer_gui::gui_renders_the_wasm_tab_and_settles_the_spinner` failing (Playwright: `#source` never becomes visible). It fails identically on a stashed clean tree, so it is pre-existing and unrelated to this change.

Beyond the test suite, the generated Dockerfiles were built and run against real Docker, since "the tests pass" would not have caught a broken shell layer:

| Case | Result |
|---|---|
| `debian:bookworm-slim --tcl-version 8.6`, `--no-cache` | `/usr/local/bin/tcl: OK` → `tcl 2.2.1+g45196df1` |
| `rockylinux:9 --tcl-version 8.6` | `/usr/local/bin/tcl: OK` → `tcl 2.2.1+g45196df1` |
| unpinned (`--build-arg TCL_LSP_VERSION=`) | resolves the newest release, same result |
| `--venv --entrypoint main.tcl` | `✓ created /app/.venv`, container prints `hello from the container` |
| `docker run --rm <image> command -v python3 python` | `no python in image` |
| `alpine:3.21` with `gcompat` + `libgcc` | `tcl --version` exits 127 — the evidence behind the Alpine refusal |

## Compiler / diagnostics checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? **No** — this touches `tcl-pkg`'s Dockerfile generator and the `tcl docker` CLI verbs only; no compiler, diagnostic, or analysis surface is involved.
- [x] If yes, I updated the owning design doc — n/a.
- [x] If I added or changed a diagnostic or optimisation code, I updated its page — n/a, no code added or changed.
- [x] If I added a design doc, I linked it from `docs/design/README.md` — n/a; the new docs are KCS notes, linked from `docs/kcs/README.md` and `docs/kcs/features/README.md`, and `cargo xtask kcs-index-links` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4cRmhPFo6gyCCTWQJNV6C
