### PR TITLE
fix(spec-studio): a word left outside the block is not a program

### DIFF
--- a/docs/kcs/README.md
+++ b/docs/kcs/README.md
@@ -50,6 +50,10 @@ symptom with several possible causes worth telling apart. See rule 13 in
   — a file whose extension a SpecTcl pack claims opens as plain text with
   no language server, and what each editor needs before it will treat the
   extension as Tcl.
+- [kcs-issue-a-spec-studio-edit-does-not-reach-the-pack-document.md](kcs-issue-a-spec-studio-edit-does-not-reach-the-pack-document.md)
+  — the spec studio reports a command written and the Pack DSL pane does not
+  change, because the document is a program the studio patches rather than
+  rewrites.
 - [kcs-issue-parallel-worktree-builds-serve-stale-artefacts.md](kcs-issue-parallel-worktree-builds-serve-stale-artefacts.md)
   — builds in one git worktree fail or pass with artefacts from a
   sibling checkout because the worktrees share one cargo target

--- a/docs/kcs/kcs-issue-a-spec-studio-edit-does-not-reach-the-pack-document.md
+++ b/docs/kcs/kcs-issue-a-spec-studio-edit-does-not-reach-the-pack-document.md
@@ -1,0 +1,63 @@
+# KCS: My spec studio edit does not appear in the Pack DSL pane
+
+> **Audience:** User
+> **Type:** Issue
+
+## Applies to
+
+all-editors
+
+## Question
+
+I edited a command in the spec studio — or imported a package and pressed
+**Add all N to the pack** — the studio said it wrote, and the Pack DSL pane
+still shows the document exactly as it was. Where did the edit go?
+
+## Symptoms
+
+- The status line says the command was written, and the document text does
+  not change.
+- The command is missing from the Pack DSL pane and from the file you
+  download or save.
+- The status line adds "as a patch over this document, which is a program and
+  is not rewritten".
+
+## Answer
+
+The studio never rewrites a **programmed** pack — one that computes its
+declarations rather than stating them. Your edit is not lost: it stands as a
+patch over the document, which is what the studio and the language server
+resolve the command through. The document itself is left exactly as you
+wrote it, because rewriting it would replace your program with the commands
+it happened to produce this time.
+
+A document is a program when any of these is true:
+
+1. It asks `available?` while registering, so its surface depends on the
+   analysis target.
+2. A command it declares has no `command NAME { … }` statement of its own —
+   a `foreach`, a `proc`, or a computed name registered it.
+3. A statement in it runs rather than registers — a `set`, a `proc`, an `if`
+   around the declarations.
+
+To get the edit into the document, edit the program that produces the
+declaration, in the Pack DSL pane. There is no way to fold a patch back into
+a program: only you know which line of the program should have produced it.
+
+A patch stands for the session it was made in. Downloading or saving the
+document saves the document — the patch is not part of it — so treat a patch
+as a staging area, not a home.
+
+If the document is *not* a program and the edit still does not appear, look
+for text left outside the `speclib NAME VERSION { … }` block — a half-typed
+`command`, a stray word. The loader reads and drops it, so it is harmless to
+the pack, but tidy it up: it is the only text in the file the studio's own
+report cannot account for.
+
+## Related
+
+- [How do I write a SpecTcl pack?](kcs-howto-write-a-tclspec-pack.md)
+- [How do I create command specs without Rust?](kcs-howto-create-command-specs-without-rust.md)
+- [SpecTcl pack design](../design/spec-packs.md)
+- [KCS index](README.md)
+- [Glossary](../GLOSSARY.md)

--- a/rust/tcl-spec-studio/src/store.rs
+++ b/rust/tcl-spec-studio/src/store.rs
@@ -558,19 +558,19 @@ impl PackStore {
         (!self.straight_line()).then_some(Programmed::NonCanonicalStatement)
     }
 
-    /// Whether every top-level statement of the `speclib` body is one of the
+    /// Whether every top-level statement the document states is one of the
     /// registration calls the snapshot recorded, in the same order.
     ///
     /// True for every canonical pack — the loader records the file's own
     /// statements — and false the moment a statement runs rather than
     /// registers.
     fn straight_line(&self) -> bool {
-        let Some(body) = pack_body(&self.source) else {
+        if pack_body(&self.source).is_none() {
             // Not a pack at all: nothing was registered, and there is nothing
             // programmed about a document that declares nothing.
             return self.pack.registrations.is_empty();
-        };
-        let statements = segments(&self.source[body]);
+        }
+        let statements = self.document_statements();
         statements.len() == self.pack.registrations.len()
             && statements
                 .iter()
@@ -579,6 +579,40 @@ impl PackStore {
                     statement.words.first().map(String::as_str) == Some(registration.word())
                         && statement.words.get(1).map_or("", String::as_str) == registration.arg(1)
                 })
+    }
+
+    /// The document's own top-level statements, in the order the loader reads
+    /// them: the `speclib` call stands for the statements its body holds, and
+    /// a statement the file states *outside* that call keeps its place in the
+    /// list.
+    ///
+    /// The registration record covers the whole file rather than the block
+    /// alone, so the comparison in [`Self::straight_line`] has to be made
+    /// against the whole file too. Reading only the body counted a word left
+    /// outside the block as a statement the program had computed, and judged
+    /// an ordinary document a program: every edit after it then went silently
+    /// to a patch pack instead of into the document (E-R12).
+    ///
+    /// The discrimination survives the widening. Text the loader reads and
+    /// drops — a half-typed `command`, an unknown property — is recorded like
+    /// any other statement and pairs off; a statement that *runs* is recorded
+    /// as nothing at all, so the counts still disagree and the document is
+    /// still a program.
+    fn document_statements(&self) -> Vec<Segmented> {
+        let body = pack_body(&self.source);
+        let mut seen_pack = false;
+        let mut out = Vec::new();
+        for statement in segments(&self.source) {
+            if !seen_pack && statement.words.first().map(String::as_str) == Some("speclib") {
+                seen_pack = true;
+                if let Some(body) = body.clone() {
+                    out.extend(segments(&self.source[body]));
+                }
+            } else {
+                out.push(statement);
+            }
+        }
+        out
     }
 
     /// The canonical patch pack standing over this document, when form edits
@@ -1522,15 +1556,28 @@ impl<'a> Resolution<'a> {
     /// This is `tcl_spectcl::pack::installs_over`'s rule — *shipped wins unless
     /// the pack says `-override`* — restated as a four-way answer so a surface
     /// can show the author which of the two definitions is live.
+    ///
+    /// The **effective** draft decides, patch pack included (E-R12): an edit
+    /// to a programmed document lands in the patch, the patch is what the
+    /// installed registry answers with, and a command the patch alone
+    /// declares is therefore a command the pack has. Asking the document
+    /// alone made every such write invisible the moment it was made — the
+    /// surface that had just written it was told the name is in neither the
+    /// pack nor the registry.
     #[must_use]
     pub fn origin(&self, name: &str) -> Option<Origin> {
-        let in_pack = self.store.draft(name).is_some();
+        let in_pack = self.store.effective_draft(name).is_some();
         let in_builtins = self.builtins.contains(name);
+        // A patch declaration is written `-override` whatever the form asked
+        // for — a patch that does not override is inert — so a standing patch
+        // over a shipped name is an override of it.
+        let overrides =
+            self.store.overrides_shipped(name) || self.store.patch_draft(name).is_some();
         match (in_pack, in_builtins) {
             (false, false) => None,
             (false, true) => Some(Origin::Builtin),
             (true, false) => Some(Origin::Pack),
-            (true, true) if self.store.overrides_shipped(name) => Some(Origin::Override),
+            (true, true) if overrides => Some(Origin::Override),
             (true, true) => Some(Origin::Shadowed),
         }
     }

--- a/rust/tcl-spec-studio/src/store.rs
+++ b/rust/tcl-spec-studio/src/store.rs
@@ -576,8 +576,10 @@ impl PackStore {
                 .iter()
                 .zip(&self.pack.registrations)
                 .all(|(statement, registration)| {
-                    statement.words.first().map(String::as_str) == Some(registration.word())
-                        && statement.words.get(1).map_or("", String::as_str) == registration.arg(1)
+                    let paired = statement.words.first().map(String::as_str)
+                        == Some(registration.word())
+                        && statement.words.get(1).map_or("", String::as_str) == registration.arg(1);
+                    paired && (statement.inside_pack || stated_verbatim(statement, registration))
                 })
     }
 
@@ -593,22 +595,29 @@ impl PackStore {
     /// an ordinary document a program: every edit after it then went silently
     /// to a patch pack instead of into the document (E-R12).
     ///
-    /// The discrimination survives the widening. Text the loader reads and
-    /// drops — a half-typed `command`, an unknown property — is recorded like
-    /// any other statement and pairs off; a statement that *runs* is recorded
-    /// as nothing at all, so the counts still disagree and the document is
-    /// still a program.
+    /// The discrimination survives the widening. A statement that *runs* is
+    /// recorded as nothing at all, so the counts still disagree and the
+    /// document is still a program; text the loader reads and drops — a
+    /// half-typed `command`, an unknown property — is recorded like any other
+    /// statement and pairs off. A statement outside the block that registers
+    /// is held to [`stated_verbatim`] as well, because outside is exactly
+    /// where the head-and-first-argument comparison is too weak to tell a
+    /// declaration from the program that computed it.
     fn document_statements(&self) -> Vec<Segmented> {
         let body = pack_body(&self.source);
         let mut seen_pack = false;
         let mut out = Vec::new();
-        for statement in segments(&self.source) {
+        for mut statement in segments(&self.source) {
             if !seen_pack && statement.words.first().map(String::as_str) == Some("speclib") {
                 seen_pack = true;
                 if let Some(body) = body.clone() {
-                    out.extend(segments(&self.source[body]));
+                    out.extend(segments(&self.source[body]).into_iter().map(|mut inner| {
+                        inner.inside_pack = true;
+                        inner
+                    }));
                 }
             } else {
+                statement.inside_pack = false;
                 out.push(statement);
             }
         }
@@ -2008,6 +2017,30 @@ struct Segmented {
     words: Vec<String>,
     span: std::ops::Range<usize>,
     spans: Vec<WordSpan>,
+    /// Whether the statement is one the `speclib` block holds, rather than
+    /// one the file states outside it. Set by
+    /// [`PackStore::document_statements`]; `false` for a bare body read on
+    /// its own, which is the shape every other caller reads.
+    inside_pack: bool,
+}
+
+/// Whether `statement` states, word for word, what `registration` recorded.
+///
+/// The [`PackStore::straight_line`] pairing reads the head and the first
+/// argument, which is enough for a declaration inside the block: the loader
+/// records that block's statements, so a computed one shows up as a count
+/// that does not match. Outside the block there is no such backstop —
+/// `default dialects [list tcl9.0]` registers `default dialects tcl9.0` and
+/// pairs on both words it compares — so the rest of the words have to be
+/// read. A word that was substituted differs from the value it evaluated to,
+/// and the document is a program after all.
+fn stated_verbatim(statement: &Segmented, registration: &Registration) -> bool {
+    statement
+        .words
+        .iter()
+        .enumerate()
+        .all(|(index, word)| word == registration.arg(index))
+        && registration.arg(statement.words.len()).is_empty()
 }
 
 /// A word's byte ranges: `outer` includes any `{ }` / `" "` delimiters,
@@ -2048,6 +2081,7 @@ fn segments(source: &str) -> Vec<Segmented> {
                 words: segment.texts.clone(),
                 span: segment.span.start() as usize..segment.span.end() as usize,
                 spans,
+                inside_pack: false,
             }
         })
         .collect()

--- a/rust/tcl-spec-studio/tests/pack_store.rs
+++ b/rust/tcl-spec-studio/tests/pack_store.rs
@@ -349,3 +349,113 @@ fn every_hand_written_pack_is_canonical() {
         );
     }
 }
+
+/// A word left at top level — the half-typed `command` an author has on screen
+/// the moment before they name it — is a malformed statement, not a program.
+///
+/// The registration record covers the whole file, so that stray word is
+/// recorded like any other statement; comparing it against the `speclib`
+/// body alone made the counts disagree and judged the document programmed.
+/// Every edit then went to a patch pack the document never shows: the write
+/// reported success, the document did not change, and reading the command
+/// back said it was in neither the pack nor the registry.
+#[test]
+fn a_stray_word_outside_the_block_is_not_a_program() {
+    let base = PackStore::empty("mylib").source().to_owned();
+    for stray in ["command", "foo bar", "command\nfoo bar"] {
+        let source = format!("{base}\n{stray}\n");
+        let store = PackStore::from_source(&source);
+        assert_eq!(
+            store.programmed(),
+            None,
+            "a stray `{stray}` outside the block was judged a program"
+        );
+    }
+
+    // The discrimination this rests on: a statement the loader *runs* is not
+    // recorded as a registration, so it still fails to pair and still marks
+    // the document a program. Only inert text — a word the loader read and
+    // dropped — pairs off and stays editable.
+    for program in ["set version 1.2", "proc helper {} { return 1 }"] {
+        let source = format!("{program}\n{base}");
+        assert!(
+            PackStore::from_source(&source).programmed().is_some(),
+            "a `{program}` outside the block is a program and must not be rewritten"
+        );
+    }
+
+    let mut store = PackStore::from_source(format!("{base}\ncommand\n"));
+    let write = store.set_command("widget::paint", &draft_named("widget::paint"), false);
+    assert_eq!(
+        write.how,
+        WriteBack::Spliced,
+        "the write did not reach the document"
+    );
+    assert!(
+        store.source().contains("command widget::paint"),
+        "the document does not declare the written command: {}",
+        store.source()
+    );
+    assert_eq!(store.patch_source(), None, "the write became a patch");
+    assert!(
+        store.source().trim_end().ends_with("command"),
+        "the splice ate the author's stray word: {}",
+        store.source()
+    );
+
+    let builtins = Builtins::for_dialect("spectcl");
+    assert!(
+        Resolution::new(builtins, &store)
+            .view("widget::paint")
+            .is_some(),
+        "the written command is invisible to the surface that wrote it"
+    );
+}
+
+/// A genuinely programmed document still refuses the rewrite (E-R12) — and the
+/// patch that takes the write's place is a definition the surface can read
+/// back. A patch-only command used to resolve nowhere, so the studio crashed
+/// on the command it had just written.
+#[test]
+fn a_patched_command_resolves_through_the_patch() {
+    let source = "\
+speclib mylib 2.0 {
+    foreach name {alpha beta} {
+        command $name {
+            arity 1
+        }
+    }
+}
+";
+    let mut store = PackStore::from_source(source);
+    assert!(
+        store.programmed().is_some(),
+        "a `foreach` that registers is a program"
+    );
+
+    let write = store.set_command("widget::paint", &draft_named("widget::paint"), false);
+    assert_eq!(write.how, WriteBack::Patched, "the write rewrote a program");
+    assert_eq!(store.source(), source, "the author's program was rewritten");
+
+    let builtins = Builtins::for_dialect("spectcl");
+    let merged = Resolution::new(builtins, &store);
+    let view = merged
+        .view("widget::paint")
+        .expect("the patched command resolves");
+    assert_eq!(view["patched"], json!(true), "{view:#}");
+    assert_eq!(view["origin"], json!("pack"), "{view:#}");
+
+    // One the shipped registry holds too: the patch always overrides, so that
+    // is what the surface must say is live.
+    store.set_command("lsort", &draft_named("lsort"), false);
+    let merged = Resolution::new(builtins, &store);
+    let view = merged.view("lsort").expect("the patched builtin resolves");
+    assert_eq!(view["origin"], json!("override"), "{view:#}");
+}
+
+/// The smallest draft the store accepts: a command by name.
+fn draft_named(name: &str) -> tcl_spec_studio::draft::Draft {
+    let mut draft = tcl_spec_studio::draft::default_command_draft();
+    draft.insert("name".to_owned(), json!(name));
+    draft
+}

--- a/rust/tcl-spec-studio/tests/pack_store.rs
+++ b/rust/tcl-spec-studio/tests/pack_store.rs
@@ -372,17 +372,30 @@ fn a_stray_word_outside_the_block_is_not_a_program() {
         );
     }
 
-    // The discrimination this rests on: a statement the loader *runs* is not
+    // The discrimination this rests on. A statement the loader *runs* is not
     // recorded as a registration, so it still fails to pair and still marks
-    // the document a program. Only inert text — a word the loader read and
-    // dropped — pairs off and stays editable.
-    for program in ["set version 1.2", "proc helper {} { return 1 }"] {
+    // the document a program. One that registers but computes a word — the
+    // head and the first argument pair with the value it evaluated to — is
+    // caught by reading the rest of the words: outside the block there is no
+    // count mismatch to fall back on, and a re-render would drop the line.
+    for program in [
+        "set version 1.2",
+        "proc helper {} { return 1 }",
+        "default dialects [list tcl9.0]",
+    ] {
         let source = format!("{program}\n{base}");
         assert!(
             PackStore::from_source(&source).programmed().is_some(),
             "a `{program}` outside the block is a program and must not be rewritten"
         );
     }
+
+    // Its static twin states what it registers, so it stays editable.
+    assert_eq!(
+        PackStore::from_source(format!("default dialects tcl9.0\n{base}")).programmed(),
+        None,
+        "a statement outside the block that states what it registers is not a program"
+    );
 
     let mut store = PackStore::from_source(format!("{base}\ncommand\n"));
     let write = store.set_command("widget::paint", &draft_named("widget::paint"), false);

--- a/rust/tcl-spec-studio/web/src/studio.ts
+++ b/rust/tcl-spec-studio/web/src/studio.ts
@@ -602,6 +602,12 @@ function writeBackOpenCommand(): void {
       );
     } else if (written.upgraded_from) {
       setStatus("dslStatus", vocabularyUpgradeMessage(written) ?? "", "ok");
+    } else if (written.writeback === "patched") {
+      setStatus(
+        "dslStatus",
+        "this document is a program, so it was not rewritten — the edit stands as a patch over it and will not appear in this pane",
+        "ok",
+      );
     } else if (written.writeback === "rerendered") {
       setStatus(
         "dslStatus",
@@ -1212,9 +1218,11 @@ function writeDraftsToPack(commands: { name: string; draft: Draft }[]): {
   written: number;
   failed: string[];
   firstWritten: string | null;
+  patched: number;
 } {
   let source = state.pack.source;
   let written = 0;
+  let patched = 0;
   const failed: string[] = [];
   let firstWritten: string | null = null;
   for (const found of commands) {
@@ -1224,6 +1232,7 @@ function writeDraftsToPack(commands: { name: string; draft: Draft }[]): {
       );
       source = out.source;
       written += 1;
+      if (out.writeback === "patched") patched += 1;
       firstWritten ??= found.name;
     } catch {
       failed.push(found.name);
@@ -1231,28 +1240,43 @@ function writeDraftsToPack(commands: { name: string; draft: Draft }[]): {
   }
   state.pack.open = null;
   setPackSource(source);
-  return { written, failed, firstWritten };
+  return { written, failed, firstWritten, patched };
 }
 
 function addImportedToPack(): void {
   if (!state.imported.length) return;
-  const { written, failed, firstWritten } = writeDraftsToPack(state.imported);
+  const { written, failed, firstWritten, patched } = writeDraftsToPack(state.imported);
   // The generated-code panes render the active draft, not the pack as a
   // whole. Import used to write a perfectly good `.tclspec` and leave the
   // boot-time `mycommand` placeholder active, so Rust and stub output looked
   // as though generation had failed. Make the first successfully imported
   // command the active pack draft while leaving the author on the Import tab.
+  //
+  // Reading it back can still fail — the store is the authority on what it
+  // holds — and a throw out of a click handler leaves the page half-updated
+  // with nothing said. Report it in the panel instead.
+  let unreadable: string | null = null;
   if (firstWritten) {
-    const view = unwrap<PackCommandView>(
-      wasm.pack_command(state.pack.source, firstWritten, state.dialect),
-    );
-    if (view.pack) loadDraft(view.pack, packOrigin(view), firstWritten);
+    try {
+      const view = unwrap<PackCommandView>(
+        wasm.pack_command(state.pack.source, firstWritten, state.dialect),
+      );
+      if (view.pack) loadDraft(view.pack, packOrigin(view), firstWritten);
+    } catch (e) {
+      unreadable = message(e);
+    }
   }
   setStatus(
     "importStatus",
     `${written} command(s) written into pack ${state.pack.view?.pack ?? ""}` +
-      (failed.length ? ` — ${failed.length} could not be written: ${failed.join(", ")}` : ""),
-    failed.length ? "err" : "ok",
+      // E-R12: a programmed document is never rewritten, so the write stands
+      // in a patch pack over it. Say so — the DSL pane will not show it.
+      (patched
+        ? ` — ${patched} of them as a patch over this document, which is a program and is not rewritten`
+        : "") +
+      (failed.length ? ` — ${failed.length} could not be written: ${failed.join(", ")}` : "") +
+      (unreadable ? ` — could not reopen ${firstWritten ?? ""}: ${unreadable}` : ""),
+    failed.length || unreadable ? "err" : "ok",
   );
 }
 

--- a/rust/tcl-spec-studio/web/src/types.ts
+++ b/rust/tcl-spec-studio/web/src/types.ts
@@ -273,8 +273,16 @@ export interface PackCommandView {
 /** The reply to a write-back: the new document, and how it was reached. */
 export interface PackWrite {
   source: string;
-  /** How the store wrote the edit: byte splice, full render, or vocabulary upgrade. */
-  writeback?: "spliced" | "rerendered" | "vocabulary-upgraded";
+  /**
+   * How the store wrote the edit: byte splice, full render, vocabulary
+   * upgrade — or `patched`, which did not touch `source` at all.
+   *
+   * A `patched` write is the E-R12 answer to a **programmed** document: the
+   * author's program is never rewritten, so the edit stands in a patch pack
+   * over it instead. The document pane therefore will not show it, which is
+   * the one thing the author has to be told.
+   */
+  writeback?: "spliced" | "rerendered" | "vocabulary-upgraded" | "patched";
   /** Previous SpecTcl vocabulary when this edit required newer DSL words. */
   upgraded_from?: string;
   /** New declared SpecTcl vocabulary paired with `upgraded_from`. */


### PR DESCRIPTION
## Summary

- Every **Deploy GitHub Pages** run since 2026-08-30 has failed at the same step — *Boot the assembled spec studio in headless chromium* — with `` `widget::paint` is in neither the pack nor the spectcl registry ``, a command the page had just written. The two v2.2.1 tag runs failed the same way, so no Pages deployment has shipped since 29 Aug.
- **Root cause.** `PackStore::straight_line()` compared the `speclib` **body's** statements against `Pack::registrations`, but that record covers the **whole file**: a word the loader reads at top level and drops is recorded like any other statement. The boot check types `command` into the DSL pane (to prove the language server publishes a diagnostic), which leaves exactly such a word after the closing brace. The counts then disagreed, the document was judged a **program**, and E-R12 routed every later edit into a patch pack the studio neither persists nor shows: the write reported success, the document did not change, and reading the command back said it did not exist.
- **The fix.** Compare like with like — the document's own top-level statements, the `speclib` call standing for the statements its body holds. The discrimination survives the widening: text the loader reads and drops pairs off and stays editable, while a statement that *runs* is recorded as nothing, still fails to pair, and is still a program (a `set` or `proc` outside the block is covered by a test).
- Two further links in the same chain, each able to break the page on its own:
  - `Resolution::origin` asked the document alone, so a command declared only by a patch resolved nowhere — `view` reads the *effective* draft and reports `patched`, but never got the chance. A genuinely programmed pack had the same crash waiting for it. It now consults the effective draft, and treats a standing patch over a shipped name as an override (a patch declaration is always written `-override`).
  - The import handler let that lookup throw out of a click handler. It now reports in the panel, and says when a write landed as a patch rather than in the document — which the DSL pane cannot show. `PackWrite.writeback` gained the `"patched"` case it always could return.
- Docs: a KCS issue note, *My spec studio edit does not appear in the Pack DSL pane*, indexed from `docs/kcs/README.md`.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

- `cargo test -p tcl-spec-studio` — green, including `every_hand_written_pack_is_canonical` (the guard on this predicate) and the two new regression tests in `tests/pack_store.rs`.
- `make rust-check` — green (fmt, clippy, every xtask drift gate, `kcs-index-links`).
- `npm test`, `npm run typecheck`, `npm run lint` in `rust/tcl-spec-studio/web` — green.
- End to end, the failing CI step itself: `make spec-studio-wasm` then `NODE_PATH=… node rust/tcl-spec-studio-wasm/test/boot.mjs` under headless chromium — **boot check passed**, through the import step that was failing.

Note: the boot check was the first failing step, so the steps after it (the maturin/`f5report` render and the explorer `pages-boot.mjs`) have not run in CI since 29 Aug either. They are unchanged by this PR and were not verified locally; if something else has rotted behind the blockage it will surface on this run.

## Compiler / diagnostics checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [ ] Did this change alter a compiler fact contract? — No. It corrects a studio-local predicate over pack documents; no diagnostic, optimisation code, or compiler fact contract changes.
- [x] If I added a design doc, I linked it from `docs/design/README.md` — no design doc added; the new KCS note is linked from `docs/kcs/README.md` and `cargo xtask kcs-index-links` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017XKQA2W97wDXK9oX2YuKv3

---
_Generated by [Claude Code](https://claude.ai/code/session_017XKQA2W97wDXK9oX2YuKv3)_