### PR TITLE
Default Docker generation to Debian and discover source packages

### DIFF
--- a/.claude/skills/dockerfile-generate/SKILL.md
+++ b/.claude/skills/dockerfile-generate/SKILL.md
@@ -26,10 +26,15 @@ mismatch, or a binary that cannot start fails the build. The release is an
 `docker build --build-arg TCL_LSP_VERSION=2.2.1 .` (empty resolves the newest
 release).
 
-**Alpine cannot carry the CLI.** Every published Linux asset is glibc-linked
-and `gcompat` re-exports neither `fcntl64` nor `__res_init`, so
-`tcl docker create alpine:…` errors as soon as a CLI verb is wanted. Use a
-glibc base, or `--no-packages` (and no `--venv`) for a Tcl-only Alpine image.
+**Default to Debian.** `tcl docker create` uses `debian:bookworm-slim` when no
+image is supplied and records why in the generated file: published Linux
+binaries require glibc. If Alpine/musl is required, compile tcl-lsp from source
+inside that image.
+
+**Alpine cannot carry a release CLI.** Every published Linux asset is
+glibc-linked and `gcompat` re-exports neither `fcntl64` nor `__res_init`, so
+`tcl docker create alpine:…` errors as soon as a CLI verb is wanted. A Tcl-only
+Alpine image may use `--no-packages` (and no `--venv`).
 
 ## CLI
 
@@ -37,16 +42,16 @@ glibc base, or `--no-packages` (and no `--venv`) for a Tcl-only Alpine image.
 tcl docker info                              # families, Tcl versions, CLI targets
 tcl docker recipe IMAGE --tcl-version V      # the Tcl install recipe it would use
 tcl docker recipe IMAGE --cli                # the native tcl CLI install layer
-tcl docker create IMAGE [--tcl-version 8.6] [-o Dockerfile] [--workdir /app]
+tcl docker create [IMAGE] [--tcl-version 8.6] [-o Dockerfile] [--workdir /app]
     [--entrypoint main.tcl] [--venv] [--no-copy] [--no-packages]
     [--extra-package PKG]... [--label k=v]... [--env k=v]...
     [--cli-version X.Y.Z] [--force] [--json]
 ```
 
 Defaults: `debian:bookworm-slim`, Tcl 8.6, and the release the `tcl` running
-the command was built from. An unknown image falls back to Debian recipes —
-say so. Confirm the `--cli-version` asset exists on GitHub Releases before
-shipping the file.
+the command was built from. Prefer the default Debian base. An unknown image
+falls back to Debian recipes — say so. Confirm the `--cli-version` asset exists
+on GitHub Releases before shipping the file.
 
 ## Steps
 

--- a/README.md
+++ b/README.md
@@ -1798,6 +1798,12 @@ tcl pkg tree                     # show dependency tree
 tcl pkg verify                   # check integrity hashes
 ```
 
+`tcl pkg discover` scans source with the full analyser and optimiser. It
+auto-adds only statically resolved, straight-line requirements that the
+manifest can express; dynamic, guarded, loop-contained, exact, bounded, and
+alternative requirements stay visible as review findings for explicit
+`tcl pkg add` decisions.
+
 The manifest is a native Tcl file (`tclpkg.tcl`) evaluated in a sandboxed
 interpreter.  The lockfile (`tclpkg.lock`) is canonical JSON — two runs against
 the same manifest produce byte-identical output (aside from the

--- a/README.md
+++ b/README.md
@@ -1791,7 +1791,8 @@ isolated virtual environments that pin a specific tclsh version.
 tcl venv create .venv            # create a virtual environment
 source .venv/bin/activate        # activate it
 tcl pkg init                     # create tclpkg.tcl manifest
-tcl pkg add json 1.0             # add a dependency
+tcl pkg discover --add           # find safe package requires in source
+tcl pkg add optional 1.0         # supplement discovery explicitly
 tcl pkg install                  # resolve, fetch, and lock
 tcl pkg tree                     # show dependency tree
 tcl pkg verify                   # check integrity hashes

--- a/docs/design/tclpkg-architecture.md
+++ b/docs/design/tclpkg-architecture.md
@@ -109,9 +109,22 @@ tclpkg.tcl (manifest)
     works without activation.
 23. Activation scripts are provided for bash/zsh and fish.
 
+### Source discovery
+
+24. `tcl pkg discover` is read-only by default and never accesses the network.
+    It inventories `package require` through the full registry-dispatched
+    analyser, then uses the optimiser's constant propagation and pure builtin
+    folds to refine dynamic words while retaining original file/line
+    provenance.
+25. `discover --add` changes only `tclpkg.tcl`. It adds deterministic,
+    unconditional requirements which the manifest's minimum-version model can
+    represent; ambiguous, guarded, exact, and bounded requirements remain
+    review findings. Installed, vendored, virtual-environment, build, and
+    generated trees are not scanned as direct project source.
+
 ## CLI surface
 
-`tcl pkg` — `init`, `install`, `list`, `tree`, `verify`, `info`, `add`,
+`tcl pkg` — `init`, `discover`, `install`, `list`, `tree`, `verify`, `info`, `add`,
 `remove`, `update`, `sync`, `outdated`, `why`, `vendor`, `run`, `freeze`,
 `search`, `show`, plus the security verbs `policy`, `hooks`, `audit`,
 `trust`, and `build` documented in

--- a/docs/design/tclpkg-architecture.md
+++ b/docs/design/tclpkg-architecture.md
@@ -118,7 +118,8 @@ tclpkg.tcl (manifest)
     provenance.
 25. `discover --add` changes only `tclpkg.tcl`. It adds deterministic,
     unconditional requirements which the manifest's minimum-version model can
-    represent; ambiguous, guarded, exact, and bounded requirements remain
+    represent; unresolved words, guarded or loop-contained calls, exact and
+    bounded requirements, and Tcl's alternative requirement lists remain
     review findings. Installed, vendored, virtual-environment, build, and
     generated trees are not scanned as direct project source.
 

--- a/docs/kcs/features/kcs-feature-tcl-docker.md
+++ b/docs/kcs/features/kcs-feature-tcl-docker.md
@@ -24,15 +24,17 @@ What does `tcl docker` do, and how do I use it?
 tcl docker info                          # families, Tcl versions, CLI targets
 tcl docker recipe debian:bookworm-slim --tcl-version 9.0   # the Tcl install layer
 tcl docker recipe debian:bookworm-slim --cli               # the tcl CLI install layer
-tcl docker create debian:bookworm-slim --tcl-version 8.6   # write a Dockerfile
+tcl docker create --tcl-version 8.6                         # Debian Dockerfile
 tcl docker create alpine:3.21 --tcl-version 8.6 --no-packages   # Tcl only
 tcl docker create ubuntu:24.04 --venv --entrypoint main.tcl --force
 ```
 
-`create` writes a Dockerfile that installs Tcl (the OS package manager for 8.6
-on Debian, Alpine, and RHEL families, a source build otherwise), downloads the
-`tcl` binary built for the image's architecture, checks it against the
-release's `SHA256SUMS`, and runs `tcl pkg install --frozen` when a
+`create` defaults to `debian:bookworm-slim`, because published Linux tcl-lsp
+binaries require glibc. The generated Dockerfile records that reason and tells
+Alpine/musl users to build tcl-lsp from source. It installs Tcl (the OS package
+manager for 8.6 on Debian, Alpine, and RHEL families, a source build otherwise),
+downloads the `tcl` binary built for the image's architecture, checks it
+against the release's `SHA256SUMS`, and runs `tcl pkg install --frozen` when a
 `tclpkg.lock` is present. No Python interpreter is installed or needed.
 
 ### Choosing the release
@@ -54,11 +56,13 @@ until something above it changes or you build with `--no-cache`.
 `tcl docker create alpine:…` fails as soon as it would install the CLI. Every
 published Linux `tcl` asset is glibc-linked, and Alpine's `gcompat` shim
 re-exports neither `fcntl64` nor `__res_init`, so the binary cannot start.
-Either use a glibc base image, or pass `--no-packages` (and no `--venv`) for a
+Use the default Debian image, or build tcl-lsp from source for musl if Alpine is
+required. Passing `--no-packages` (and no `--venv`) remains available for a
 Tcl-only image. `tcl docker info` lists which families can carry the CLI.
 
 ## Options
 
+- `[IMAGE]` — optional base image; defaults to `debian:bookworm-slim` for glibc.
 - `--tcl-version 8.4|8.5|8.6|9.0` — the Tcl to install (default 8.6).
 - `-o PATH` / `--force` — output path; overwrite an existing file.
 - `--workdir DIR` — container `WORKDIR` (default `/app`).
@@ -75,7 +79,7 @@ Tcl-only image. `tcl docker info` lists which families can carry the CLI.
 ## Example
 
 ```sh
-$ tcl docker create debian:bookworm-slim --tcl-version 8.6
+$ tcl docker create --tcl-version 8.6
   ✓ wrote Dockerfile
   base: debian:bookworm-slim  tcl: 8.6
   docker build -t myapp .

--- a/docs/kcs/features/kcs-feature-tcl-pkg.md
+++ b/docs/kcs/features/kcs-feature-tcl-pkg.md
@@ -51,11 +51,13 @@ package require $dependency 1.3
 ```
 
 The default is read-only. `--add` appends only deterministic, unconditional
-requirements that the minimum-version manifest can represent. Dynamic names,
-dynamic versions, guarded optional requirements, `-exact`, and bounded ranges
-are reported for review instead of guessed. Installed and generated trees such
-as `lib/`, `vendor/`, `.venv/`, and `target/` are excluded. Add anything the
-analysis cannot prove with `tcl pkg add NAME VERSION`.
+requirements that the minimum-version manifest can represent. Dynamic names or
+versions, guarded or loop-contained requirements, `-exact`, bounded ranges, and
+multiple alternative requirements are reported for review instead of guessed.
+The JSON report preserves every original alternative and every value the
+optimiser can resolve. Installed and generated trees such as `lib/`, `vendor/`,
+`.venv/`, and `target/` are excluded. Add anything the analysis cannot prove
+with `tcl pkg add NAME VERSION`.
 
 ### VS Code
 

--- a/docs/kcs/features/kcs-feature-tcl-pkg.md
+++ b/docs/kcs/features/kcs-feature-tcl-pkg.md
@@ -22,6 +22,8 @@ What does `tcl pkg` do, and how do I use it?
 
 ```sh
 tcl pkg init                     # create a tclpkg.tcl manifest
+tcl pkg discover                 # analyse source and report requirements
+tcl pkg discover --add           # add safe undeclared requirements
 tcl pkg add json 1.0             # add a dependency
 tcl pkg install                  # resolve + fetch + lock
 tcl pkg list                     # show installed packages
@@ -38,6 +40,23 @@ tcl pkg run                      # run the manifest entry point
 tcl pkg remove json              # remove a dependency
 ```
 
+`discover` recursively analyses the project beside `tclpkg.tcl`. It uses the
+full Tcl analyser so requirements inside procedures, methods, namespaces, and
+nested scripts are included, then applies the optimiser's constant propagation
+and registry-declared pure folds to resolve names such as:
+
+```tcl
+set dependency [string cat j son]
+package require $dependency 1.3
+```
+
+The default is read-only. `--add` appends only deterministic, unconditional
+requirements that the minimum-version manifest can represent. Dynamic names,
+dynamic versions, guarded optional requirements, `-exact`, and bounded ranges
+are reported for review instead of guessed. Installed and generated trees such
+as `lib/`, `vendor/`, `.venv/`, and `target/` are excluded. Add anything the
+analysis cannot prove with `tcl pkg add NAME VERSION`.
+
 ### VS Code
 
 When a `tclpkg.tcl` file is present in the workspace root, the LSP
@@ -51,6 +70,9 @@ for hover, completion, and diagnostics. On a missing-package diagnostic
 - `--json` — emit machine-readable JSON output (all subcommands).
 - `--manifest PATH` — override `tclpkg.tcl` location.
 - `--offline` — never touch the network; use cached data only.
+- `--add` — append safe `discover` findings without installing or locking.
+- `--no-recursive` — scan only immediate files (`discover` only).
+- `--dialect NAME` — override per-file dialect detection (`discover` only).
 - `--no-dev` — skip dev-require packages (install only).
 - `--frozen` — refuse to change the lockfile (install only).
 

--- a/docs/kcs/features/kcs-feature-tcl-verb-cli.md
+++ b/docs/kcs/features/kcs-feature-tcl-verb-cli.md
@@ -40,6 +40,7 @@ tcl help taint --json
 
 # Package management and virtual environments (tclpkg)
 tcl pkg init --name myapp --version 1.0.0
+tcl pkg discover --add
 tcl pkg install
 tcl pkg list --json
 tcl pkg tree

--- a/docs/kcs/kcs-howto-containerise-a-tcl-project.md
+++ b/docs/kcs/kcs-howto-containerise-a-tcl-project.md
@@ -19,6 +19,16 @@ version and the same locked packages I develop against?
   downloads the `tcl` release binary during the build.
 - A `tclpkg.lock` in the project, if you want packages installed for you.
 
+To derive that lockfile from literal and statically-resolvable `package
+require` calls, run:
+
+```sh
+tcl pkg discover --add
+tcl pkg install
+```
+
+Review any dynamic or optional findings and supplement them with `tcl pkg add`.
+
 ## Answer
 
 `tcl docker create` writes a Dockerfile that installs Tcl, installs the

--- a/docs/kcs/kcs-howto-containerise-a-tcl-project.md
+++ b/docs/kcs/kcs-howto-containerise-a-tcl-project.md
@@ -26,26 +26,31 @@ version and the same locked packages I develop against?
 `tcl pkg install --frozen` against your lockfile. No Python interpreter is
 installed or needed — the 1.x-era zipapp is gone.
 
-### 1. Pick a base image and Tcl version
+### 1. Pick a Tcl version
 
 ```sh
 tcl docker info
 ```
 
-Lists the Tcl versions with install recipes (8.4, 8.5, 8.6, 9.0), the
-base-image families they cover, the release the CLI is pinned to by default,
-and the architectures a release asset exists for.
+Lists the Tcl versions with install recipes (8.4, 8.5, 8.6, 9.0), the release
+the CLI is pinned to by default, and the architectures a release asset exists
+for. Generated Dockerfiles use `debian:bookworm-slim` by default because the
+published Linux binaries require glibc.
 
 ### 2. Generate the Dockerfile
 
 ```sh
-tcl docker create debian:bookworm-slim --tcl-version 8.6 --entrypoint main.tcl
+tcl docker create --tcl-version 8.6 --entrypoint main.tcl
 ```
+
+The generated file includes a comment explaining the Debian/glibc choice and
+the source-build alternative for Alpine/musl.
 
 Useful flags:
 
 | Flag | Effect |
 |---|---|
+| `[IMAGE]` | override the default `debian:bookworm-slim` base |
 | `--venv` | create a `tcl venv` inside the image and install into it |
 | `--no-packages` | skip the CLI download and `pkg install` entirely |
 | `--no-copy` | omit `COPY . .` (for multi-stage builds) |
@@ -114,7 +119,8 @@ image with --no-packages and no --venv.
 
 Every published Linux `tcl` asset is glibc-linked, and `gcompat` re-exports
 neither `fcntl64` nor `__res_init`, so the binary dies in the dynamic loader.
-Either move to a glibc base image, or keep Alpine and drop the CLI:
+Use the default Debian base. If Alpine is required, compile tcl-lsp from source
+for musl inside the image. A Tcl-only Alpine image can instead drop the CLI:
 
 ```sh
 tcl docker create alpine:3.21 --tcl-version 8.6 --no-packages

--- a/docs/kcs/kcs-howto-containerise-a-tcl-project.md
+++ b/docs/kcs/kcs-howto-containerise-a-tcl-project.md
@@ -27,7 +27,8 @@ tcl pkg discover --add
 tcl pkg install
 ```
 
-Review any dynamic or optional findings and supplement them with `tcl pkg add`.
+Review any dynamic, optional, loop-contained, or alternative findings and
+supplement them with `tcl pkg add`.
 
 ## Answer
 

--- a/docs/kcs/kcs-howto-manage-tcl-packages.md
+++ b/docs/kcs/kcs-howto-manage-tcl-packages.md
@@ -36,8 +36,8 @@ tcl pkg discover --add
 The first command is read-only. The second adds requirements whose names and
 minimum versions the analyser and optimiser can prove. It scans procedure and
 nested-script bodies, resolves constant variables, interpolations, and safe
-builtin command substitutions, and reports dynamic, conditional, `-exact`, or
-bounded requirements for review.
+builtin command substitutions, and reports dynamic, conditional,
+loop-contained, `-exact`, bounded, or alternative requirements for review.
 
 ### 3. Add or override dependencies explicitly
 

--- a/docs/kcs/kcs-howto-manage-tcl-packages.md
+++ b/docs/kcs/kcs-howto-manage-tcl-packages.md
@@ -26,7 +26,20 @@ tcl pkg init --name myapp --version 1.0.0
 
 This writes `tclpkg.tcl` in the current directory.
 
-### 2. Add dependencies
+### 2. Discover dependencies from source
+
+```sh
+tcl pkg discover
+tcl pkg discover --add
+```
+
+The first command is read-only. The second adds requirements whose names and
+minimum versions the analyser and optimiser can prove. It scans procedure and
+nested-script bodies, resolves constant variables, interpolations, and safe
+builtin command substitutions, and reports dynamic, conditional, `-exact`, or
+bounded requirements for review.
+
+### 3. Add or override dependencies explicitly
 
 ```sh
 tcl pkg add json 1.0
@@ -34,9 +47,12 @@ tcl pkg add http 2.9 --source https://example.org/http.tar.gz
 tcl pkg add tcltest 2.5 --dev
 ```
 
-Each call appends a `require` (or `dev-require`) line to the manifest.
+Use `add` for optional/dynamic requirements discovery cannot prove, packages
+which do not appear in source, explicit source URLs, and development-only
+dependencies. Each call appends a `require` (or `dev-require`) line to the
+manifest.
 
-### 3. Resolve and install
+### 4. Resolve and install
 
 ```sh
 tcl pkg install
@@ -46,7 +62,7 @@ The resolver picks the highest version that satisfies every minimum in
 the graph (Go-style MVS). Results are written to `tclpkg.lock` and
 materialised into `./lib/<pkg>-<ver>/`.
 
-### 4. Verify
+### 5. Verify
 
 ```sh
 tcl pkg verify
@@ -54,7 +70,7 @@ tcl pkg verify
 
 Re-checks SHA-256 hashes of every package against the lockfile.
 
-### 5. Reproduce in CI
+### 6. Reproduce in CI
 
 ```sh
 tcl pkg sync
@@ -63,7 +79,7 @@ tcl pkg sync
 Installs from the lockfile without re-resolving — refuses to change the
 lock. Use this in CI and production builds.
 
-### 6. (Optional) Use a virtual environment
+### 7. (Optional) Use a virtual environment
 
 ```sh
 tcl venv create .venv

--- a/editors/zed/languages/expect/highlights.scm
+++ b/editors/zed/languages/expect/highlights.scm
@@ -54,7 +54,7 @@
 (command
   name: (simple_word) @keyword.control
   (#any-of? @keyword.control
-    "case" "foreachLine" "lfilter" "lmap"))
+    "case" "foreachLine" "lfilter" "lmap" "timerate"))
 
 ; --- generated from tcl-registry: language keywords ---
 (command
@@ -95,9 +95,9 @@
     "send_user" "sleep" "socket" "spawn" "split" "strace"
     "string" "stty" "subst" "system" "tclLog" "tclPkgSetup"
     "tclPkgUnknown" "tcl_endOfWord" "tcl_findLibrary" "tcl_startOfNextWord" "tcl_startOfPreviousWord" "tcl_wordBreakAfter"
-    "tcl_wordBreakBefore" "tell" "time" "timer" "timerate" "timestamp"
-    "trace" "trap" "unicode" "unknown" "unload" "unset"
-    "update" "vwait" "wait" "writeFile" "zipfs" "zlib"))
+    "tcl_wordBreakBefore" "tell" "time" "timer" "timestamp" "trace"
+    "trap" "unicode" "unknown" "unload" "unset" "update"
+    "vwait" "wait" "writeFile" "zipfs" "zlib"))
 
 ; Highlight unset / variable arguments as variables
 (command

--- a/editors/zed/languages/iapps/highlights.scm
+++ b/editors/zed/languages/iapps/highlights.scm
@@ -54,7 +54,7 @@
 (command
   name: (simple_word) @keyword.control
   (#any-of? @keyword.control
-    "case" "foreachLine" "lfilter" "lmap"))
+    "case" "foreachLine" "lfilter" "lmap" "timerate"))
 
 ; --- generated from tcl-registry: language keywords ---
 (command
@@ -92,14 +92,14 @@
     "script::help" "script::init" "script::run" "script::tabc" "seek" "socket"
     "split" "string" "subst" "tclLog" "tclPkgSetup" "tclPkgUnknown"
     "tcl_endOfWord" "tcl_findLibrary" "tcl_startOfNextWord" "tcl_startOfPreviousWord" "tcl_wordBreakAfter" "tcl_wordBreakBefore"
-    "tell" "time" "timer" "timerate" "tmsh::add_help" "tmsh::add_tabc"
-    "tmsh::begin_transaction" "tmsh::builtin_help" "tmsh::builtin_tabc" "tmsh::cancel_transaction" "tmsh::cd" "tmsh::clear_screen"
-    "tmsh::commit_transaction" "tmsh::create" "tmsh::delete" "tmsh::display" "tmsh::display_threshold" "tmsh::get_config"
-    "tmsh::get_field_names" "tmsh::get_field_value" "tmsh::get_name" "tmsh::get_status" "tmsh::get_type" "tmsh::include"
-    "tmsh::list" "tmsh::log" "tmsh::log_dest" "tmsh::log_level" "tmsh::modify" "tmsh::pwd"
-    "tmsh::reset_stats" "tmsh::show" "tmsh::stateless" "tmsh::version" "trace" "unicode"
-    "unknown" "unload" "unset" "update" "vwait" "writeFile"
-    "zipfs" "zlib"))
+    "tell" "time" "timer" "tmsh::add_help" "tmsh::add_tabc" "tmsh::begin_transaction"
+    "tmsh::builtin_help" "tmsh::builtin_tabc" "tmsh::cancel_transaction" "tmsh::cd" "tmsh::clear_screen" "tmsh::commit_transaction"
+    "tmsh::create" "tmsh::delete" "tmsh::display" "tmsh::display_threshold" "tmsh::get_config" "tmsh::get_field_names"
+    "tmsh::get_field_value" "tmsh::get_name" "tmsh::get_status" "tmsh::get_type" "tmsh::include" "tmsh::list"
+    "tmsh::log" "tmsh::log_dest" "tmsh::log_level" "tmsh::modify" "tmsh::pwd" "tmsh::reset_stats"
+    "tmsh::show" "tmsh::stateless" "tmsh::version" "trace" "unicode" "unknown"
+    "unload" "unset" "update" "vwait" "writeFile" "zipfs"
+    "zlib"))
 
 ; Highlight unset / variable arguments as variables
 (command

--- a/editors/zed/languages/tcl/highlights.scm
+++ b/editors/zed/languages/tcl/highlights.scm
@@ -54,7 +54,7 @@
 (command
   name: (simple_word) @keyword.control
   (#any-of? @keyword.control
-    "case" "foreachLine" "lfilter" "lmap"))
+    "case" "foreachLine" "lfilter" "lmap" "timerate"))
 
 ; --- generated from tcl-registry: language keywords ---
 (command
@@ -90,9 +90,9 @@
     "regexp::quote" "registry" "regsub" "remquo" "scan" "seek"
     "socket" "split" "string" "subst" "tclLog" "tclPkgSetup"
     "tclPkgUnknown" "tcl_endOfWord" "tcl_findLibrary" "tcl_startOfNextWord" "tcl_startOfPreviousWord" "tcl_wordBreakAfter"
-    "tcl_wordBreakBefore" "tell" "time" "timer" "timerate" "trace"
-    "unicode" "unknown" "unload" "unset" "update" "vwait"
-    "writeFile" "zipfs" "zlib"))
+    "tcl_wordBreakBefore" "tell" "time" "timer" "trace" "unicode"
+    "unknown" "unload" "unset" "update" "vwait" "writeFile"
+    "zipfs" "zlib"))
 
 ; Highlight unset / variable arguments as variables
 (command

--- a/rust/tcl-cli/src/cli.rs
+++ b/rust/tcl-cli/src/cli.rs
@@ -761,6 +761,24 @@ pub enum PkgCommand {
         #[arg(long)]
         json: bool,
     },
+    /// Discover package requirements in project Tcl source.
+    #[command(visible_alias = "scan")]
+    Discover {
+        /// Files or directories to scan (default: the manifest directory).
+        #[arg(value_name = "INPUT")]
+        inputs: Vec<PathBuf>,
+        /// Add safe, previously undeclared findings to tclpkg.tcl.
+        #[arg(long)]
+        add: bool,
+        /// Do not recurse into input directories.
+        #[arg(long = "no-recursive")]
+        no_recursive: bool,
+        /// Dialect profile override (default: detect per file).
+        #[arg(long, value_name = "DIALECT", value_parser = dialect_parser())]
+        dialect: Option<String>,
+        #[command(flatten)]
+        common: PkgCommon,
+    },
     /// Resolve + fetch + materialise packages.
     Install {
         #[command(flatten)]

--- a/rust/tcl-cli/src/cli.rs
+++ b/rust/tcl-cli/src/cli.rs
@@ -1017,7 +1017,9 @@ pub enum VenvCommand {
 pub enum DockerCommand {
     /// Generate a Dockerfile for a Tcl project.
     Create {
-        /// Base Docker image (e.g. debian:bookworm-slim, alpine:3.19).
+        /// Base Docker image. Defaults to Debian because release binaries
+        /// require glibc.
+        #[arg(default_value = tcl_pkg::docker::DEFAULT_BASE_IMAGE)]
         image: String,
         /// Tcl version to install.
         #[arg(long = "tcl-version", default_value = "8.6", value_parser = ["8.4", "8.5", "8.6", "9.0"])]

--- a/rust/tcl-cli/src/commands/mod.rs
+++ b/rust/tcl-cli/src/commands/mod.rs
@@ -36,6 +36,7 @@ pub mod lookup;
 pub mod minimize;
 pub mod misc;
 pub mod pkg;
+pub mod pkg_discover;
 pub mod registry;
 pub mod spec;
 pub mod transform;

--- a/rust/tcl-cli/src/commands/pkg.rs
+++ b/rust/tcl-cli/src/commands/pkg.rs
@@ -141,14 +141,14 @@ pub fn run(action: &PkgCommand) -> anyhow::Result<u8> {
             no_recursive,
             dialect,
             common,
-        } => super::pkg_discover::run(
+        } => super::pkg_discover::run(&super::pkg_discover::DiscoverOptions {
             inputs,
-            *add,
-            !*no_recursive,
-            dialect.as_deref(),
+            add: *add,
+            recursive: !*no_recursive,
+            dialect: dialect.as_deref(),
             common,
-            &manifest_path(common),
-        ),
+            manifest_path: &manifest_path(common),
+        }),
         PkgCommand::Install {
             common,
             no_dev,

--- a/rust/tcl-cli/src/commands/pkg.rs
+++ b/rust/tcl-cli/src/commands/pkg.rs
@@ -135,6 +135,20 @@ pub fn run(action: &PkgCommand) -> anyhow::Result<u8> {
             *force,
             *json,
         ),
+        PkgCommand::Discover {
+            inputs,
+            add,
+            no_recursive,
+            dialect,
+            common,
+        } => super::pkg_discover::run(
+            inputs,
+            *add,
+            !*no_recursive,
+            dialect.as_deref(),
+            common,
+            &manifest_path(common),
+        ),
         PkgCommand::Install {
             common,
             no_dev,

--- a/rust/tcl-cli/src/commands/pkg_discover.rs
+++ b/rust/tcl-cli/src/commands/pkg_discover.rs
@@ -1,0 +1,623 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Project-source dependency discovery for `tcl pkg discover`.
+//!
+//! The full analyser owns the occurrence inventory: unlike the lightweight
+//! signature scan it reaches ordinary procedure, method, namespace, and
+//! nested-substitution bodies.  A standard optimiser pass then refines the
+//! same source without dead-code elimination, allowing SCCP, constant
+//! propagation, interpolation folding, and registry-declared pure builtin
+//! folds to turn otherwise-dynamic package words into constants.  Findings
+//! retain their original analyser spans; if the two inventories ever cease to
+//! align, discovery conservatively falls back to the original one.
+
+use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
+
+use anyhow::Context;
+use serde::Serialize;
+use tcl_compiler::analyser::Analyser;
+use tcl_compiler::optimiser::optimise_source_multipass_filtered;
+use tcl_compiler::optimiser::profiles::{OptimisationProfile, profile_to_disabled};
+use tcl_pkg::manifest::{ManifestAst, load_manifest, load_manifest_text};
+use tcl_pkg::version::Version;
+
+use crate::cli::PkgCommon;
+
+/// Directories which contain generated, installed, or vendored code rather
+/// than the root project's own direct dependency declarations.
+const SKIP_DIRECTORIES: &[&str] = &[
+    ".git",
+    ".hg",
+    ".svn",
+    ".venv",
+    ".tclpkg-build-home",
+    "__pycache__",
+    "build",
+    "dist",
+    "lib",
+    "node_modules",
+    "target",
+    "tmp",
+    "vendor",
+];
+
+#[derive(Debug, Clone, Serialize)]
+struct RequirementReport {
+    name: Option<String>,
+    minimum: Option<String>,
+    expression: String,
+    version_expression: Option<String>,
+    file: String,
+    line: usize,
+    conditional: bool,
+    exact: bool,
+    resolution: &'static str,
+    status: &'static str,
+    reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct AddedRequirement {
+    name: String,
+    minimum: String,
+}
+
+#[derive(Debug, Serialize)]
+struct DiscoveryOutput {
+    manifest: String,
+    scanned_files: usize,
+    requirements: Vec<RequirementReport>,
+    added: Vec<AddedRequirement>,
+    warnings: Vec<String>,
+}
+
+struct ResolvedRequirement {
+    name: Option<String>,
+    minimum: Option<String>,
+    expression: String,
+    version_expression: Option<String>,
+    conditional: bool,
+    exact: bool,
+    resolution: &'static str,
+    line: usize,
+}
+
+/// Run `tcl pkg discover`.
+#[allow(clippy::too_many_arguments)]
+pub fn run(
+    inputs: &[PathBuf],
+    add: bool,
+    recursive: bool,
+    dialect: Option<&str>,
+    common: &PkgCommon,
+    manifest_path: &Path,
+) -> anyhow::Result<u8> {
+    let manifest = match load_manifest(manifest_path) {
+        Ok(manifest) => manifest,
+        Err(error) => {
+            eprintln!("error: {error}");
+            return Ok(1);
+        }
+    };
+    let project_dir = manifest_path
+        .parent()
+        .map_or_else(|| PathBuf::from("."), Path::to_path_buf);
+    let project_dir = std::fs::canonicalize(&project_dir).unwrap_or(project_dir);
+    let roots = if inputs.is_empty() {
+        vec![project_dir.clone()]
+    } else {
+        inputs.to_vec()
+    };
+    let source_paths = match collect_source_paths(&roots, recursive, manifest_path) {
+        Ok(paths) => paths,
+        Err(error) => {
+            eprintln!("error: {error:#}");
+            return Ok(1);
+        }
+    };
+
+    let explicit_dialect = tcl_cli_support::resolve_dialect(dialect)?;
+    let documents = if source_paths.is_empty() {
+        Vec::new()
+    } else {
+        tcl_cli_support::read_input_documents(&source_paths, &[], false)?
+    };
+
+    let declared: BTreeSet<String> = manifest
+        .requires
+        .iter()
+        .chain(&manifest.dev_requires)
+        .map(|requirement| requirement.name.clone())
+        .collect();
+    let mut reports = Vec::new();
+    let mut warnings = Vec::new();
+    let mut scanned_files = 0;
+
+    for document in &documents {
+        if document.abstains_on_encoding() {
+            warnings.push(format!(
+                "{} is not UTF-8 text; package discovery skipped it",
+                display_path(document.path.as_deref(), &project_dir, &document.label)
+            ));
+            continue;
+        }
+        scanned_files += 1;
+        let profile = document.effective_dialect(explicit_dialect);
+        let registry = tcl_cli_support::registry_for_dialect(profile.name);
+        let file = display_path(document.path.as_deref(), &project_dir, &document.label);
+        let (requirements, warning) = discover_document_requirements(
+            &document.source,
+            &file,
+            profile,
+            &registry,
+            tcl_cli_support::spec_pack_key(profile.name),
+        );
+        if let Some(warning) = warning {
+            warnings.push(warning);
+        }
+        for requirement in requirements {
+            reports.push(classify(requirement, &file, &manifest, &declared));
+        }
+    }
+
+    reports.sort_by(|left, right| {
+        left.file
+            .cmp(&right.file)
+            .then(left.line.cmp(&right.line))
+            .then_with(|| left.expression.cmp(&right.expression))
+    });
+
+    let additions = collect_additions(&reports);
+    let added = if add && !additions.is_empty() {
+        match append_requirements(manifest_path, &additions) {
+            Ok(()) => additions
+                .into_iter()
+                .map(|(name, (_, minimum))| AddedRequirement { name, minimum })
+                .collect(),
+            Err(error) => {
+                eprintln!("error: {error:#}");
+                return Ok(1);
+            }
+        }
+    } else {
+        Vec::new()
+    };
+
+    let output = DiscoveryOutput {
+        manifest: manifest_path.display().to_string(),
+        scanned_files,
+        requirements: reports,
+        added,
+        warnings,
+    };
+    if common.json {
+        println!("{}", serde_json::to_string_pretty(&output)?);
+    } else {
+        print_text(&output, add);
+    }
+    Ok(0)
+}
+
+fn discover_document_requirements(
+    source: &str,
+    file: &str,
+    profile: &'static tcl_dialect::DialectProfile,
+    registry: &tcl_registry::CommandRegistry,
+    pack_overlay: u64,
+) -> (Vec<ResolvedRequirement>, Option<String>) {
+    let original = Analyser::new()
+        .with_file_path(Some(file.to_owned()))
+        .with_pack_overlay(pack_overlay)
+        .analyse(source, profile.name)
+        .package_requires;
+
+    // `standard` enables the optimiser's constant-analysis family while
+    // leaving DCE and code motion off. One pass preserves the analyser's
+    // occurrence order and count, which lets the refined values retain the
+    // original source spans below.
+    let disabled: HashSet<String> = profile_to_disabled(OptimisationProfile::Standard)
+        .into_iter()
+        .map(str::to_owned)
+        .collect();
+    let (optimised, _, _) = optimise_source_multipass_filtered(
+        source,
+        registry,
+        Some(profile),
+        OptimisationProfile::Standard.max_iterations(),
+        &disabled,
+    );
+    let refined = Analyser::new()
+        .with_file_path(Some(file.to_owned()))
+        .with_pack_overlay(pack_overlay)
+        .analyse(&optimised, profile.name)
+        .package_requires;
+
+    let aligned = original.len() == refined.len();
+    let warning = (!aligned).then(|| {
+        format!(
+            "{file}: optimiser changed the package-require inventory; dynamic refinement was skipped"
+        )
+    });
+    let refined = aligned.then_some(refined);
+
+    let requirements = original
+        .into_iter()
+        .enumerate()
+        .map(|(index, raw)| {
+            let candidate = refined
+                .as_ref()
+                .and_then(|items| items.get(index))
+                .unwrap_or(&raw);
+            let raw_name = static_word(&raw.name);
+            let refined_name = static_word(&candidate.name);
+            let raw_version = raw.version.as_deref().and_then(static_word);
+            let refined_version = candidate.version.as_deref().and_then(static_word);
+            let name = raw_name.clone().or(refined_name);
+            let version = match raw.version.as_deref() {
+                None => Some("0.0.1".to_owned()),
+                Some(_) => raw_version.clone().or(refined_version),
+            };
+            let unresolved = name.is_none() || (raw.version.is_some() && version.is_none());
+            let optimised_resolution = !unresolved
+                && (raw_name.is_none()
+                    || (raw.version.is_some() && raw_version.is_none())
+                    || name.as_deref() != raw_name.as_deref()
+                    || version.as_deref() != raw_version.as_deref());
+            ResolvedRequirement {
+                name,
+                minimum: version,
+                expression: raw.name,
+                version_expression: raw.version,
+                conditional: raw.conditional,
+                exact: raw.exact,
+                resolution: if unresolved {
+                    "unresolved"
+                } else if optimised_resolution {
+                    "optimiser"
+                } else {
+                    "literal"
+                },
+                line: line_number(source, raw.range.start()),
+            }
+        })
+        .collect();
+    (requirements, warning)
+}
+
+fn classify(
+    requirement: ResolvedRequirement,
+    file: &str,
+    manifest: &ManifestAst,
+    declared: &BTreeSet<String>,
+) -> RequirementReport {
+    let mut report = RequirementReport {
+        name: requirement.name,
+        minimum: requirement.minimum,
+        expression: requirement.expression,
+        version_expression: requirement.version_expression,
+        file: file.to_owned(),
+        line: requirement.line,
+        conditional: requirement.conditional,
+        exact: requirement.exact,
+        resolution: requirement.resolution,
+        status: "candidate",
+        reason: None,
+    };
+
+    let Some(name) = report.name.as_deref() else {
+        report.status = "unresolved";
+        report.reason = Some("package name is not statically resolvable".to_owned());
+        return report;
+    };
+    if !manifest_atom(name) {
+        report.status = "unresolved";
+        report.reason = Some("resolved name cannot be represented safely in tclpkg.tcl".to_owned());
+        return report;
+    }
+    if name == "Tcl" {
+        report.status = "runtime";
+        report.reason = Some("core Tcl is represented by the manifest's tcl directive".to_owned());
+        return report;
+    }
+    if name == manifest.name {
+        report.status = "self";
+        report.reason = Some("the project cannot depend on itself".to_owned());
+        return report;
+    }
+    if declared.contains(name) {
+        report.status = "declared";
+        report.reason = Some("already present in require or dev-require".to_owned());
+        return report;
+    }
+    if report.conditional {
+        report.status = "review";
+        report.reason = Some(
+            "guarded requirement may be an optional dependency; add it explicitly if needed"
+                .to_owned(),
+        );
+        return report;
+    }
+    if report.exact {
+        report.status = "review";
+        report.reason = Some("tclpkg.tcl requirements cannot express -exact".to_owned());
+        return report;
+    }
+    let Some(requirement_text) = report.minimum.as_deref() else {
+        report.status = "unresolved";
+        report.reason = Some("version requirement is not statically resolvable".to_owned());
+        return report;
+    };
+    if tcl_registry::version::requirement_upper_bound(requirement_text).is_some() {
+        report.status = "review";
+        report.reason = Some("tclpkg.tcl requirements cannot express an upper bound".to_owned());
+        return report;
+    }
+    let minimum = tcl_registry::version::requirement_lower_bound(requirement_text);
+    if Version::parse(minimum).is_err() {
+        report.status = "unresolved";
+        report.reason = Some(format!(
+            "invalid or unsupported version requirement: {requirement_text}"
+        ));
+        return report;
+    }
+    report.minimum = Some(minimum.to_owned());
+    report
+}
+
+fn collect_additions(reports: &[RequirementReport]) -> BTreeMap<String, (Version, String)> {
+    let mut additions: BTreeMap<String, (Version, String)> = BTreeMap::new();
+    for report in reports.iter().filter(|report| report.status == "candidate") {
+        let (Some(name), Some(minimum)) = (&report.name, &report.minimum) else {
+            continue;
+        };
+        let Ok(parsed) = Version::parse(minimum) else {
+            continue;
+        };
+        match additions.get(name) {
+            Some((current, _)) if current >= &parsed => {}
+            _ => {
+                additions.insert(name.clone(), (parsed, minimum.clone()));
+            }
+        }
+    }
+    additions
+}
+
+fn append_requirements(
+    path: &Path,
+    additions: &BTreeMap<String, (Version, String)>,
+) -> anyhow::Result<()> {
+    let original = std::fs::read_to_string(path)
+        .with_context(|| format!("cannot read manifest {}", path.display()))?;
+    let mut proposed = original.trim_end_matches(['\r', '\n']).to_owned();
+    for (name, (_, minimum)) in additions {
+        proposed.push('\n');
+        write!(&mut proposed, "require {name} {minimum}").expect("writing to a String cannot fail");
+    }
+    proposed.push('\n');
+    load_manifest_text(&proposed, Some(&path.to_string_lossy()))
+        .context("discovered requirements would produce an invalid manifest")?;
+    std::fs::write(path, proposed)
+        .with_context(|| format!("cannot update manifest {}", path.display()))
+}
+
+fn print_text(output: &DiscoveryOutput, add: bool) {
+    println!(
+        "Scanned {} Tcl source file(s); found {} package requirement(s).",
+        output.scanned_files,
+        output.requirements.len()
+    );
+    for requirement in &output.requirements {
+        let name = requirement
+            .name
+            .as_deref()
+            .unwrap_or(requirement.expression.as_str());
+        let minimum = requirement.minimum.as_deref().unwrap_or("?");
+        println!(
+            "  {name} {minimum}  [{}; {}]  {}:{}",
+            requirement.status, requirement.resolution, requirement.file, requirement.line
+        );
+        if let Some(reason) = &requirement.reason {
+            println!("    {reason}");
+        }
+    }
+    for warning in &output.warnings {
+        eprintln!("warning: {warning}");
+    }
+    if !output.added.is_empty() {
+        println!("Added to {}:", output.manifest);
+        for requirement in &output.added {
+            println!("  {} {}", requirement.name, requirement.minimum);
+        }
+        println!("Run 'tcl pkg install' to resolve and update tclpkg.lock.");
+    } else if add {
+        println!("No safe undeclared requirements to add.");
+    } else if output
+        .requirements
+        .iter()
+        .any(|requirement| requirement.status == "candidate")
+    {
+        println!("Run 'tcl pkg discover --add' to add safe findings.");
+    }
+    if output
+        .requirements
+        .iter()
+        .any(|requirement| matches!(requirement.status, "review" | "unresolved"))
+    {
+        println!("Use 'tcl pkg add NAME VERSION' for review-needed dependencies.");
+    }
+}
+
+fn static_word(word: &str) -> Option<String> {
+    (!tcl_compiler::naming::is_dynamic_word(word)).then(|| word.to_owned())
+}
+
+fn manifest_atom(value: &str) -> bool {
+    !value.is_empty()
+        && !value.chars().any(|character| {
+            character.is_whitespace()
+                || matches!(
+                    character,
+                    ';' | '$' | '[' | ']' | '{' | '}' | '"' | '\\' | '#'
+                )
+        })
+}
+
+fn line_number(source: &str, offset: u32) -> usize {
+    source
+        .get(
+            ..usize::try_from(offset)
+                .unwrap_or(source.len())
+                .min(source.len()),
+        )
+        .map_or(1, |prefix| {
+            prefix.bytes().filter(|byte| *byte == b'\n').count() + 1
+        })
+}
+
+fn display_path(path: Option<&Path>, project_dir: &Path, fallback: &str) -> String {
+    path.and_then(|path| path.strip_prefix(project_dir).ok())
+        .filter(|path| !path.as_os_str().is_empty())
+        .map_or_else(|| fallback.to_owned(), |path| path.display().to_string())
+}
+
+fn collect_source_paths(
+    roots: &[PathBuf],
+    recursive: bool,
+    manifest_path: &Path,
+) -> anyhow::Result<Vec<PathBuf>> {
+    let manifest = std::fs::canonicalize(manifest_path).unwrap_or_else(|_| manifest_path.into());
+    let mut paths = BTreeSet::new();
+    for root in roots {
+        collect_source_path(root, recursive, true, &manifest, &mut paths)?;
+    }
+    Ok(paths.into_iter().collect())
+}
+
+fn collect_source_path(
+    path: &Path,
+    recursive: bool,
+    explicit: bool,
+    manifest_path: &Path,
+    paths: &mut BTreeSet<PathBuf>,
+) -> anyhow::Result<()> {
+    let metadata = std::fs::symlink_metadata(path)
+        .with_context(|| format!("cannot inspect source input {}", path.display()))?;
+    if metadata.file_type().is_symlink() {
+        return Ok(());
+    }
+    if metadata.is_file() {
+        if !is_tcl_source(path) {
+            if explicit {
+                anyhow::bail!("unsupported source file: {}", path.display());
+            }
+            return Ok(());
+        }
+        let canonical = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+        if canonical != manifest_path {
+            paths.insert(canonical);
+        }
+        return Ok(());
+    }
+    if !metadata.is_dir() {
+        anyhow::bail!("unsupported source input: {}", path.display());
+    }
+
+    let mut entries = std::fs::read_dir(path)
+        .with_context(|| format!("cannot read source directory {}", path.display()))?
+        .collect::<Result<Vec<_>, _>>()?;
+    entries.sort_by_key(std::fs::DirEntry::path);
+    for entry in entries {
+        let child = entry.path();
+        let file_type = entry.file_type()?;
+        if file_type.is_symlink() {
+            continue;
+        }
+        if file_type.is_dir() {
+            if !recursive || should_skip_directory(&child) {
+                continue;
+            }
+            collect_source_path(&child, true, false, manifest_path, paths)?;
+        } else if file_type.is_file() {
+            collect_source_path(&child, false, false, manifest_path, paths)?;
+        }
+    }
+    Ok(())
+}
+
+fn should_skip_directory(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.starts_with('.') || SKIP_DIRECTORIES.contains(&name))
+}
+
+fn is_tcl_source(path: &Path) -> bool {
+    if path.file_name().is_some_and(|name| name == "pkgIndex.tcl") {
+        return true;
+    }
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .map(str::to_ascii_lowercase)
+        .is_some_and(|extension| {
+            tcl_registry::dialects::TCL_SOURCE_EXTENSIONS.contains(&extension.as_str())
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn additions_choose_the_highest_minimum() {
+        let reports = [
+            report("json", "1.2"),
+            report("json", "1.10"),
+            report("http", "2.9"),
+        ];
+        let additions = collect_additions(&reports);
+        assert_eq!(additions["json"].1, "1.10");
+        assert_eq!(additions["http"].1, "2.9");
+    }
+
+    #[test]
+    fn unsafe_manifest_atoms_are_rejected() {
+        assert!(manifest_atom("json::write"));
+        assert!(!manifest_atom("$package"));
+        assert!(!manifest_atom("two words"));
+        assert!(!manifest_atom("bad;command"));
+    }
+
+    fn report(name: &str, minimum: &str) -> RequirementReport {
+        RequirementReport {
+            name: Some(name.to_owned()),
+            minimum: Some(minimum.to_owned()),
+            expression: name.to_owned(),
+            version_expression: Some(minimum.to_owned()),
+            file: "main.tcl".to_owned(),
+            line: 1,
+            conditional: false,
+            exact: false,
+            resolution: "literal",
+            status: "candidate",
+            reason: None,
+        }
+    }
+}

--- a/rust/tcl-cli/src/commands/pkg_discover.rs
+++ b/rust/tcl-cli/src/commands/pkg_discover.rs
@@ -63,11 +63,14 @@ const SKIP_DIRECTORIES: &[&str] = &[
 struct RequirementReport {
     name: Option<String>,
     minimum: Option<String>,
+    requirements: Vec<Option<String>>,
     expression: String,
     version_expression: Option<String>,
+    requirement_expressions: Vec<String>,
     file: String,
     line: usize,
     conditional: bool,
+    control_flow: bool,
     exact: bool,
     resolution: &'static str,
     status: &'static str,
@@ -92,24 +95,38 @@ struct DiscoveryOutput {
 struct ResolvedRequirement {
     name: Option<String>,
     minimum: Option<String>,
+    requirements: Vec<Option<String>>,
     expression: String,
     version_expression: Option<String>,
+    requirement_expressions: Vec<String>,
     conditional: bool,
+    control_flow: bool,
     exact: bool,
     resolution: &'static str,
     line: usize,
 }
 
+/// Inputs for one `tcl pkg discover` invocation.
+#[derive(Clone, Copy)]
+pub struct DiscoverOptions<'a> {
+    pub inputs: &'a [PathBuf],
+    pub add: bool,
+    pub recursive: bool,
+    pub dialect: Option<&'a str>,
+    pub common: &'a PkgCommon,
+    pub manifest_path: &'a Path,
+}
+
 /// Run `tcl pkg discover`.
-#[allow(clippy::too_many_arguments)]
-pub fn run(
-    inputs: &[PathBuf],
-    add: bool,
-    recursive: bool,
-    dialect: Option<&str>,
-    common: &PkgCommon,
-    manifest_path: &Path,
-) -> anyhow::Result<u8> {
+pub fn run(options: &DiscoverOptions<'_>) -> anyhow::Result<u8> {
+    let DiscoverOptions {
+        inputs,
+        add,
+        recursive,
+        dialect,
+        common,
+        manifest_path,
+    } = *options;
     let manifest = match load_manifest(manifest_path) {
         Ok(manifest) => manifest,
         Err(error) => {
@@ -170,9 +187,7 @@ pub fn run(
             &registry,
             tcl_cli_support::spec_pack_key(profile.name),
         );
-        if let Some(warning) = warning {
-            warnings.push(warning);
-        }
+        warnings.extend(warning);
         for requirement in requirements {
             reports.push(classify(requirement, &file, &manifest, &declared));
         }
@@ -208,12 +223,17 @@ pub fn run(
         added,
         warnings,
     };
-    if common.json {
-        println!("{}", serde_json::to_string_pretty(&output)?);
-    } else {
-        print_text(&output, add);
-    }
+    render_output(&output, common.json, add)?;
     Ok(0)
+}
+
+fn render_output(output: &DiscoveryOutput, json: bool, add: bool) -> anyhow::Result<()> {
+    if json {
+        println!("{}", serde_json::to_string_pretty(output)?);
+    } else {
+        print_text(output, add);
+    }
+    Ok(())
 }
 
 fn discover_document_requirements(
@@ -250,7 +270,11 @@ fn discover_document_requirements(
         .analyse(&optimised, profile.name)
         .package_requires;
 
-    let aligned = original.len() == refined.len();
+    let aligned = original.len() == refined.len()
+        && original
+            .iter()
+            .zip(&refined)
+            .all(|(raw, candidate)| raw.requirements.len() == candidate.requirements.len());
     let warning = (!aligned).then(|| {
         format!(
             "{file}: optimiser changed the package-require inventory; dynamic refinement was skipped"
@@ -268,25 +292,45 @@ fn discover_document_requirements(
                 .unwrap_or(&raw);
             let raw_name = static_word(&raw.name);
             let refined_name = static_word(&candidate.name);
-            let raw_version = raw.version.as_deref().and_then(static_word);
-            let refined_version = candidate.version.as_deref().and_then(static_word);
+            let raw_requirements = raw.requirements.clone();
+            let refined_requirements = &candidate.requirements;
+            let requirements: Vec<Option<String>> = raw_requirements
+                .iter()
+                .enumerate()
+                .map(|(requirement_index, requirement)| {
+                    static_word(requirement).or_else(|| {
+                        refined_requirements
+                            .get(requirement_index)
+                            .and_then(|requirement| static_word(requirement))
+                    })
+                })
+                .collect();
             let name = raw_name.clone().or(refined_name);
-            let version = match raw.version.as_deref() {
-                None => Some("0.0.1".to_owned()),
-                Some(_) => raw_version.clone().or(refined_version),
+            let minimum = match requirements.as_slice() {
+                [] => Some("0.0.1".to_owned()),
+                [Some(requirement)] => Some(requirement.clone()),
+                _ => None,
             };
-            let unresolved = name.is_none() || (raw.version.is_some() && version.is_none());
+            let unresolved = name.is_none() || requirements.iter().any(Option::is_none);
             let optimised_resolution = !unresolved
                 && (raw_name.is_none()
-                    || (raw.version.is_some() && raw_version.is_none())
+                    || raw_requirements
+                        .iter()
+                        .any(|requirement| static_word(requirement).is_none())
                     || name.as_deref() != raw_name.as_deref()
-                    || version.as_deref() != raw_version.as_deref());
+                    || requirements
+                        .iter()
+                        .zip(&raw_requirements)
+                        .any(|(resolved, raw)| resolved.as_deref() != Some(raw.as_str())));
             ResolvedRequirement {
                 name,
-                minimum: version,
+                minimum,
+                requirements,
                 expression: raw.name,
                 version_expression: raw.version,
+                requirement_expressions: raw_requirements,
                 conditional: raw.conditional,
+                control_flow: raw.control_flow,
                 exact: raw.exact,
                 resolution: if unresolved {
                     "unresolved"
@@ -311,11 +355,14 @@ fn classify(
     let mut report = RequirementReport {
         name: requirement.name,
         minimum: requirement.minimum,
+        requirements: requirement.requirements,
         expression: requirement.expression,
         version_expression: requirement.version_expression,
+        requirement_expressions: requirement.requirement_expressions,
         file: file.to_owned(),
         line: requirement.line,
         conditional: requirement.conditional,
+        control_flow: requirement.control_flow,
         exact: requirement.exact,
         resolution: requirement.resolution,
         status: "candidate",
@@ -355,9 +402,25 @@ fn classify(
         );
         return report;
     }
+    if report.control_flow {
+        report.status = "review";
+        report.reason = Some(
+            "requirement is inside skippable or repeatable control flow; add it explicitly if needed"
+                .to_owned(),
+        );
+        return report;
+    }
     if report.exact {
         report.status = "review";
         report.reason = Some("tclpkg.tcl requirements cannot express -exact".to_owned());
+        return report;
+    }
+    if report.requirement_expressions.len() > 1 {
+        report.status = "review";
+        report.reason = Some(
+            "multiple alternative requirements cannot be represented by one manifest minimum"
+                .to_owned(),
+        );
         return report;
     }
     let Some(requirement_text) = report.minimum.as_deref() else {
@@ -609,11 +672,14 @@ mod tests {
         RequirementReport {
             name: Some(name.to_owned()),
             minimum: Some(minimum.to_owned()),
+            requirements: vec![Some(minimum.to_owned())],
             expression: name.to_owned(),
             version_expression: Some(minimum.to_owned()),
+            requirement_expressions: vec![minimum.to_owned()],
             file: "main.tcl".to_owned(),
             line: 1,
             conditional: false,
+            control_flow: false,
             exact: false,
             resolution: "literal",
             status: "candidate",

--- a/rust/tcl-cli/tests/pkg_verbs.rs
+++ b/rust/tcl-cli/tests/pkg_verbs.rs
@@ -76,6 +76,9 @@ fn pkg_discover_uses_analysis_and_optimisation() {
              package require $dep $minimum\n\
          }\n\
          if {$optional} { package require Tk 8.6 }\n\
+         set alternative 2.0-2.5\n\
+         package require alternatives 1.0 $alternative\n\
+         package require partial 1.0 $runtime_requirement\n\
          package require $runtime_package\n",
     )
     .unwrap();
@@ -104,6 +107,22 @@ fn pkg_discover_uses_analysis_and_optimisation() {
             && requirement["status"] == "review"
     }));
     assert!(requirements.iter().any(|requirement| {
+        requirement["name"] == "alternatives"
+            && requirement["requirements"] == serde_json::json!(["1.0", "2.0-2.5"])
+            && requirement["requirement_expressions"]
+                == serde_json::json!(["1.0", "${alternative}"])
+            && requirement["resolution"] == "optimiser"
+            && requirement["status"] == "review"
+    }));
+    assert!(requirements.iter().any(|requirement| {
+        requirement["name"] == "partial"
+            && requirement["requirements"] == serde_json::json!(["1.0", null])
+            && requirement["requirement_expressions"]
+                == serde_json::json!(["1.0", "${runtime_requirement}"])
+            && requirement["resolution"] == "unresolved"
+            && requirement["status"] == "review"
+    }));
+    assert!(requirements.iter().any(|requirement| {
         requirement["expression"] == "${runtime_package}"
             && requirement["name"].is_null()
             && requirement["status"] == "unresolved"
@@ -126,6 +145,8 @@ fn pkg_discover_add_is_idempotent_and_skips_dependency_trees() {
          package require tls 1.7\n\
          package require -exact pinned 2.0\n\
          package require ranged 1.0-2.0\n\
+         package require alternatives 1.0 2.0-2.5\n\
+         while {$optional} { package require looped 3.0 }\n\
          package require Tcl 8.6\n\
          package require demo 1.0\n",
     )
@@ -150,6 +171,19 @@ fn pkg_discover_add_is_idempotent_and_skips_dependency_trees() {
     assert!(requirements.iter().any(|requirement| {
         requirement["name"] == "ranged" && requirement["status"] == "review"
     }));
+    assert!(requirements.iter().any(|requirement| {
+        requirement["name"] == "alternatives"
+            && requirement["requirement_expressions"] == serde_json::json!(["1.0", "2.0-2.5"])
+            && requirement["requirements"] == serde_json::json!(["1.0", "2.0-2.5"])
+            && requirement["minimum"].is_null()
+            && requirement["resolution"] == "literal"
+            && requirement["status"] == "review"
+    }));
+    assert!(requirements.iter().any(|requirement| {
+        requirement["name"] == "looped"
+            && requirement["control_flow"] == true
+            && requirement["status"] == "review"
+    }));
     assert!(
         requirements.iter().any(|requirement| {
             requirement["name"] == "Tcl" && requirement["status"] == "runtime"
@@ -166,6 +200,8 @@ fn pkg_discover_add_is_idempotent_and_skips_dependency_trees() {
     assert_eq!(manifest.matches("require tls").count(), 1);
     assert!(!manifest.contains("require pinned"));
     assert!(!manifest.contains("require ranged"));
+    assert!(!manifest.contains("require alternatives"));
+    assert!(!manifest.contains("require looped"));
     assert!(!manifest.contains("require Tcl"));
     assert!(!manifest.contains("require demo"));
     assert!(!manifest.contains("should_not_be_direct"));

--- a/rust/tcl-cli/tests/pkg_verbs.rs
+++ b/rust/tcl-cli/tests/pkg_verbs.rs
@@ -114,18 +114,13 @@ fn docker_create_writes_dockerfile() {
     let dir = temp_dir("docker-create");
     let (_stdout, _stderr, code) = run_in(
         &dir,
-        &[
-            "docker",
-            "create",
-            "debian:bookworm-slim",
-            "--tcl-version",
-            "8.6",
-            "--no-packages",
-        ],
+        &["docker", "create", "--tcl-version", "8.6", "--no-packages"],
     );
     assert_eq!(code, 0);
     let content = std::fs::read_to_string(dir.join("Dockerfile")).unwrap();
-    assert!(content.starts_with("FROM debian:bookworm-slim\n"));
+    assert!(content.contains("require glibc, so Debian is the safe default"));
+    assert!(content.contains("Alpine/musl is required, build tcl-lsp from source"));
+    assert!(content.contains("FROM debian:bookworm-slim\n"));
     assert!(content.contains("# Install Tcl 8.6"));
     assert!(content.contains("WORKDIR /app"));
     assert!(content.trim_end().ends_with("CMD [\"tclsh\"]"));
@@ -168,6 +163,7 @@ fn docker_create_rejects_the_cli_on_musl() {
     let (_stdout, stderr, code) = run_in(&dir, &["docker", "create", "alpine:3.19"]);
     assert_eq!(code, 1);
     assert!(stderr.contains("musl"), "{stderr}");
+    assert!(stderr.contains("build tcl-lsp from source"), "{stderr}");
     assert!(!dir.join("Dockerfile").exists());
 
     // Without the CLI verbs an alpine image is still generated.

--- a/rust/tcl-cli/tests/pkg_verbs.rs
+++ b/rust/tcl-cli/tests/pkg_verbs.rs
@@ -60,6 +60,125 @@ fn temp_dir(tag: &str) -> PathBuf {
 }
 
 #[test]
+fn pkg_discover_uses_analysis_and_optimisation() {
+    let dir = temp_dir("pkg-discover-analysis");
+    std::fs::write(
+        dir.join("tclpkg.tcl"),
+        "package demo\nversion 1.0.0\nlicense MIT\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("main.tcl"),
+        "proc load_json {} { package require json 1.2 }\n\
+         proc load_tls {} {\n\
+             set dep [string cat t l s]\n\
+             set minimum 1.7\n\
+             package require $dep $minimum\n\
+         }\n\
+         if {$optional} { package require Tk 8.6 }\n\
+         package require $runtime_package\n",
+    )
+    .unwrap();
+
+    let (stdout, stderr, code) = run_in(&dir, &["pkg", "discover", "--json"]);
+    assert_eq!(code, 0, "{stderr}");
+    let output: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(output["scanned_files"], 1);
+    let requirements = output["requirements"].as_array().unwrap();
+    assert!(requirements.iter().any(|requirement| {
+        requirement["name"] == "json"
+            && requirement["minimum"] == "1.2"
+            && requirement["resolution"] == "literal"
+            && requirement["status"] == "candidate"
+    }));
+    assert!(requirements.iter().any(|requirement| {
+        requirement["name"] == "tls"
+            && requirement["minimum"] == "1.7"
+            && requirement["version_expression"] == "${minimum}"
+            && requirement["resolution"] == "optimiser"
+            && requirement["status"] == "candidate"
+    }));
+    assert!(requirements.iter().any(|requirement| {
+        requirement["name"] == "Tk"
+            && requirement["conditional"] == true
+            && requirement["status"] == "review"
+    }));
+    assert!(requirements.iter().any(|requirement| {
+        requirement["expression"] == "${runtime_package}"
+            && requirement["name"].is_null()
+            && requirement["status"] == "unresolved"
+    }));
+    assert!(output["added"].as_array().unwrap().is_empty());
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pkg_discover_add_is_idempotent_and_skips_dependency_trees() {
+    let dir = temp_dir("pkg-discover-add");
+    std::fs::write(
+        dir.join("tclpkg.tcl"),
+        "package demo\nversion 1.0.0\nlicense MIT\nrequire json 1.0\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("main.tcl"),
+        "package require json 1.2\n\
+         package require tls 1.7\n\
+         package require -exact pinned 2.0\n\
+         package require ranged 1.0-2.0\n\
+         package require Tcl 8.6\n\
+         package require demo 1.0\n",
+    )
+    .unwrap();
+    std::fs::create_dir_all(dir.join("vendor/dep")).unwrap();
+    std::fs::write(
+        dir.join("vendor/dep/dep.tcl"),
+        "package require should_not_be_direct 9.0\n",
+    )
+    .unwrap();
+
+    let (stdout, stderr, code) = run_in(&dir, &["pkg", "discover", "--add", "--json"]);
+    assert_eq!(code, 0, "{stderr}");
+    let output: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(output["added"].as_array().unwrap().len(), 1);
+    assert_eq!(output["added"][0]["name"], "tls");
+    assert_eq!(output["added"][0]["minimum"], "1.7");
+    let requirements = output["requirements"].as_array().unwrap();
+    assert!(requirements.iter().any(|requirement| {
+        requirement["name"] == "pinned" && requirement["status"] == "review"
+    }));
+    assert!(requirements.iter().any(|requirement| {
+        requirement["name"] == "ranged" && requirement["status"] == "review"
+    }));
+    assert!(
+        requirements.iter().any(|requirement| {
+            requirement["name"] == "Tcl" && requirement["status"] == "runtime"
+        })
+    );
+    assert!(
+        requirements.iter().any(|requirement| {
+            requirement["name"] == "demo" && requirement["status"] == "self"
+        })
+    );
+
+    let manifest = std::fs::read_to_string(dir.join("tclpkg.tcl")).unwrap();
+    assert_eq!(manifest.matches("require json").count(), 1);
+    assert_eq!(manifest.matches("require tls").count(), 1);
+    assert!(!manifest.contains("require pinned"));
+    assert!(!manifest.contains("require ranged"));
+    assert!(!manifest.contains("require Tcl"));
+    assert!(!manifest.contains("require demo"));
+    assert!(!manifest.contains("should_not_be_direct"));
+    assert!(!dir.join("tclpkg.lock").exists());
+
+    let (_stdout, stderr, code) = run_in(&dir, &["pkg", "discover", "--add"]);
+    assert_eq!(code, 0, "{stderr}");
+    let manifest = std::fs::read_to_string(dir.join("tclpkg.tcl")).unwrap();
+    assert_eq!(manifest.matches("require tls").count(), 1);
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn docker_recipe_alpine_86() {
     let dir = temp_dir("docker-recipe");
     let (stdout, _stderr, code) = run_in(

--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -347,6 +347,19 @@ impl Analyser {
         self.body_depth -= 1;
     }
 
+    /// Analyse one registry-declared control-flow body while recording that
+    /// facts inside it may execute zero or multiple times.
+    pub(super) fn analyse_control_flow_body(
+        &mut self,
+        body_text: &str,
+        body_tok: Token,
+        scope_path: &[usize],
+    ) {
+        self.control_flow_body_depth += 1;
+        self.analyse_body(body_text, body_tok, scope_path);
+        self.control_flow_body_depth -= 1;
+    }
+
     /// Walk a script argument that was **built** with `list` instead of
     /// written as a literal `{…}` block.
     ///
@@ -2156,9 +2169,11 @@ impl Analyser {
         // the first argument. `conditional_depth` rises for a command whose
         // bodies are branch-selected (`BRANCH_SELECTED_BODY` — `if` / `try`),
         // which is what makes a `package require` inside one conditional.
-        let spec_traits = registry
-            .get(cmd_name)
-            .map_or_else(tcl_registry::Traits::empty, |s| s.traits);
+        let spec_traits = registry.invocation_traits(
+            body_cmd,
+            &body_args,
+            Some(self.analysis_context().context().authoring_query()),
+        );
         // iRules event handlers are a file-level declaration surface.  A
         // handler-shaped command reached while already walking any body is
         // invalid (IRULE5006) and must not manufacture or replace event

--- a/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
@@ -10310,9 +10310,11 @@ fn analyse_w123_package_require_gate_suppresses_when_recorded() {
     a.result.package_requires.push(SignaturePackageRequire {
         name: "Tcl".to_string(),
         version: Some("8.6".to_string()),
+        requirements: vec!["8.6".to_string()],
         exact: false,
         range: Span::new(0, 24),
         conditional: false,
+        control_flow: false,
     });
     // Seed an invocation that would otherwise trip W123.
     a.result

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -4207,10 +4207,12 @@ impl Analyser {
         // The body is always the last argument; recurse so vars
         // defined inside the loop land in the enclosing scope.
         if let (Some(body_text), Some(body_tok)) = (args.last(), arg_tokens.last().copied()) {
+            self.control_flow_body_depth += 1;
             self.analyse_body(body_text, body_tok, scope_path);
             if let Some((var, elements)) = &literal_binding {
                 self.simulate_remaining_foreach_iterations(var, elements, body_tok, scope_path);
             }
+            self.control_flow_body_depth -= 1;
         }
         true
     }
@@ -4407,11 +4409,11 @@ impl Analyser {
         }
         // next body
         if let Some(tok) = arg_tokens.get(2).copied() {
-            self.analyse_body(&args[2], tok, scope_path);
+            self.analyse_control_flow_body(&args[2], tok, scope_path);
         }
         // main body
         if let Some(tok) = arg_tokens.get(3).copied() {
-            self.analyse_body(&args[3], tok, scope_path);
+            self.analyse_control_flow_body(&args[3], tok, scope_path);
         }
         true
     }
@@ -4509,7 +4511,7 @@ impl Analyser {
                     );
                 }
                 if case.fallthrough_body != Some(body_text.as_str()) {
-                    self.analyse_body(body_text, *body_tok, scope_path);
+                    self.analyse_control_flow_body(body_text, *body_tok, scope_path);
                 }
             }
         } else if let Some(i) = invocation.inline_clause_start {
@@ -4541,7 +4543,7 @@ impl Analyser {
                 if let Some(body_tok) = arg_tokens.get(body_index).copied()
                     && case.fallthrough_body != Some(body_text.as_str())
                 {
-                    self.analyse_body(body_text, body_tok, scope_path);
+                    self.analyse_control_flow_body(body_text, body_tok, scope_path);
                 }
             }
         }
@@ -5876,11 +5878,11 @@ impl Analyser {
     ///
     /// Two shapes are recognised:
     ///
-    /// - ``package require ?-exact? NAME ?VERSION?`` — appends a
+    /// - ``package require ?-exact? NAME ?requirement ...?`` — appends a
     ///   ``SignaturePackageRequire`` record to
     ///   ``result.package_requires`` (carrying ``exact`` when the
-    ///   flag is present, which narrows the version to the
-    ///   degenerate range ``V-V`` for the resolver — issue #1090)
+    ///   flag is present, which narrows each requirement to an exact
+    ///   version for the resolver — issue #1090)
     ///   and flips ``has_dynamic_providers`` when the name argument
     ///   is a ``$``-substitution / ``[…]``-substitution token.
     /// - ``package provide NAME ?VERSION?`` — consumed silently;
@@ -5910,7 +5912,7 @@ impl Analyser {
         if args.len() < 2 {
             return;
         }
-        // ``package require -exact NAME ?VERSION?`` —
+        // ``package require -exact NAME ?requirement ...?`` —
         // record the flag and shift the name index.
         let exact = args[1] == "-exact" && args.len() >= 3;
         let (name_idx, name_text) = if exact {
@@ -5919,11 +5921,8 @@ impl Analyser {
             (1usize, args[1].clone())
         };
         let version_idx = name_idx + 1;
-        let version = if version_idx < args.len() {
-            Some(args[version_idx].clone())
-        } else {
-            None
-        };
+        let requirements = args[version_idx..].to_vec();
+        let version = requirements.first().cloned();
 
         // Dynamic-provider detection — non-literal package
         // name suppresses W123 unknown-command emission
@@ -5942,9 +5941,11 @@ impl Analyser {
             .push(crate::signature_scan::types::SignaturePackageRequire {
                 name: name_text,
                 version,
+                requirements,
                 exact,
                 range: cmd_tok.span,
                 conditional: self.conditional_depth > 0,
+                control_flow: self.control_flow_body_depth > 0,
             });
     }
 
@@ -15815,8 +15816,108 @@ mod tests {
         let p = &r.package_requires[0];
         assert_eq!(p.name, "Tcl");
         assert_eq!(p.version.as_deref(), Some("8.6"));
+        assert_eq!(p.requirements, ["8.6"]);
         assert!(!p.conditional);
+        assert!(!p.control_flow);
         assert!(!p.exact, "no `-exact` word means the ranged requirement");
+    }
+
+    #[test]
+    fn analyse_records_every_package_requirement_alternative() {
+        let mut a = crate::analyser::Analyser::new();
+        let r = a.analyse("package require Foo 1.0 2.0-2.5", "tcl8.6");
+        let p = &r.package_requires[0];
+        assert_eq!(p.version.as_deref(), Some("1.0"));
+        assert_eq!(p.requirements, ["1.0", "2.0-2.5"]);
+    }
+
+    #[test]
+    fn analyse_marks_package_requires_in_control_flow() {
+        let cases = [
+            (
+                "while {$enabled} { package require WhileDep 1.0 }",
+                "tcl8.6",
+                "WhileDep",
+            ),
+            (
+                "foreach item $items { package require ForeachDep 1.0 }",
+                "tcl8.6",
+                "ForeachDep",
+            ),
+            (
+                "lmap item $items { package require LmapDep 1.0 }",
+                "tcl8.6",
+                "LmapDep",
+            ),
+            (
+                "dict for {key value} {} { package require DictForDep 1.0 }",
+                "tcl8.6",
+                "DictForDep",
+            ),
+            (
+                "dict map {key value} {} { package require DictMapDep 1.0 }",
+                "tcl8.6",
+                "DictMapDep",
+            ),
+            (
+                "::tcl::dict::for {key value} {} { package require QualifiedDictForDep 1.0 }",
+                "tcl8.6",
+                "QualifiedDictForDep",
+            ),
+            (
+                "array for {key value} values { package require ArrayForDep 1.0 }",
+                "tcl9.0",
+                "ArrayForDep",
+            ),
+            (
+                "switch $kind a { package require SwitchDep 1.0 }",
+                "tcl8.6",
+                "SwitchDep",
+            ),
+            (
+                "timerate { package require TimerateDep 1.0 } 10 1",
+                "tcl9.0",
+                "TimerateDep",
+            ),
+        ];
+        for (source, dialect, name) in cases {
+            let mut a = crate::analyser::Analyser::new();
+            let r = a.analyse(source, dialect);
+            let p = r
+                .package_requires
+                .iter()
+                .find(|p| p.name == name)
+                .unwrap_or_else(|| panic!("missing {name} from {source:?}"));
+            assert!(
+                p.control_flow,
+                "{name} is inside a skippable or repeatable body: {source:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn analyse_marks_only_the_repeatable_for_scripts_as_control_flow() {
+        let mut a = crate::analyser::Analyser::new();
+        let r = a.analyse(
+            "for {package require InitDep 1.0} {$enabled} \
+             {package require NextDep 1.0} {package require BodyDep 1.0}\n\
+             package require TailDep 1.0",
+            "tcl8.6",
+        );
+        let flags: Vec<_> = r
+            .package_requires
+            .iter()
+            .map(|p| (p.name.as_str(), p.control_flow))
+            .collect();
+        assert_eq!(
+            flags,
+            [
+                ("InitDep", false),
+                ("NextDep", true),
+                ("BodyDep", true),
+                ("TailDep", false),
+            ],
+        );
     }
 
     #[test]

--- a/rust/tcl-compiler/src/signature_scan/handlers.rs
+++ b/rust/tcl-compiler/src/signature_scan/handlers.rs
@@ -407,12 +407,12 @@ pub(super) fn handle_namespace_import(
     }
 }
 
-/// Handler for `package require ?-exact? NAME ?VERSION?`.
+/// Handler for `package require ?-exact? NAME ?requirement ...?`.
 ///
 /// Records a `SignaturePackageRequire`: the optional `-exact` flag is
 /// captured on the record's `exact` field (it turns the version into
 /// the degenerate range `V-V`, which selects a different release —
-/// issue #1090), and the optional `VERSION` is captured when present.
+/// issue #1090), and every alternative requirement is captured when present.
 /// The subcommand word resolves through the registry's ensemble rule,
 /// so C Tcl's accepted abbreviation (`package req Tcl`) records the
 /// requirement too.
@@ -433,17 +433,16 @@ pub(super) fn handle_package_require(
         return;
     }
     let pkg_name = texts[idx].clone();
-    let version = if texts.len() > idx + 1 {
-        Some(texts[idx + 1].clone())
-    } else {
-        None
-    };
+    let requirements = texts[idx + 1..].to_vec();
+    let version = requirements.first().cloned();
     result.package_requires.push(SignaturePackageRequire {
         name: pkg_name,
         version,
+        requirements,
         exact,
         range: argv[idx].span,
         conditional,
+        control_flow: conditional,
     });
 }
 

--- a/rust/tcl-compiler/src/signature_scan/types.rs
+++ b/rust/tcl-compiler/src/signature_scan/types.rs
@@ -113,7 +113,7 @@ pub struct SignatureClass {
 
 /// A `package require` invocation recorded by the signature scanner.
 ///
-/// `version` is `None` when the call supplied no version constraint.
+/// `version` is `None` when the call supplied no version requirement.
 /// `conditional` is `true` when the call lives inside a guarded
 /// branch (an `if`/`elseif`/`else` body, a `catch` script, or a
 /// `try`/`on`/`trap`/`finally` clause) so workspace-level Tcl-version
@@ -123,12 +123,15 @@ pub struct SignatureClass {
 pub struct SignaturePackageRequire {
     /// Package name (the `NAME` argument to `package require`).
     pub name: String,
-    /// Optional version constraint (the `VERSION` argument); `None`
-    /// when no version is supplied.
+    /// First requirement, retained as a compatibility view for existing
+    /// consumers; `None` when no requirement is supplied.
     pub version: Option<String>,
-    /// `true` when the call carried the `-exact` flag, which turns
-    /// `version` from the ranged requirement `V` (`[V, next major)`)
-    /// into the degenerate range `V-V` — see
+    /// Every alternative requirement word supplied after the package name.
+    /// Tcl 8.5+ accepts more than one and succeeds when any is satisfied.
+    pub requirements: Vec<String>,
+    /// `true` when the call carried the `-exact` flag, which turns every
+    /// ranged requirement `V` (`[V, next major)`) into the degenerate range
+    /// `V-V` — see
     /// [`tcl_dialect::exact_requirement`].  Meaningless without a
     /// `version`: `package require -exact NAME` is a syntax error in
     /// real Tcl, and consumers treat the pair as unconstrained.
@@ -137,6 +140,9 @@ pub struct SignaturePackageRequire {
     pub range: Span,
     /// `true` when the call is inside a guarded branch.
     pub conditional: bool,
+    /// `true` when the call is nested in a registry-declared control-flow
+    /// body which may run zero or multiple times.
+    pub control_flow: bool,
 }
 
 /// A `package prefer latest` invocation — the one form of `package

--- a/rust/tcl-compiler/tests/signature_scan.rs
+++ b/rust/tcl-compiler/tests/signature_scan.rs
@@ -448,6 +448,13 @@ fn top_level_require_not_conditional() {
     assert!(!r.package_requires[0].conditional);
 }
 
+#[test]
+fn package_require_keeps_every_alternative_requirement() {
+    let r = run("package require Foo 1.0 2.0-2.5");
+    assert_eq!(r.package_requires[0].version.as_deref(), Some("1.0"));
+    assert_eq!(r.package_requires[0].requirements, ["1.0", "2.0-2.5"]);
+}
+
 // Command invocations
 
 #[test]

--- a/rust/tcl-pkg/src/docker.rs
+++ b/rust/tcl-pkg/src/docker.rs
@@ -34,6 +34,19 @@ pub const SUPPORTED_TCL_VERSIONS: [&str; 4] = ["8.4", "8.5", "8.6", "9.0"];
 pub const DEFAULT_TCL_VERSION: &str = "8.6";
 pub const DEFAULT_BASE_IMAGE: &str = "debian:bookworm-slim";
 
+const DEFAULT_BASE_IMAGE_COMMENT: [&str; 2] = [
+    "# Published tcl-lsp Linux binaries require glibc, so Debian is the safe default.",
+    "# If Alpine/musl is required, build tcl-lsp from source inside the image.",
+];
+const MUSL_BASE_IMAGE_COMMENT: [&str; 2] = [
+    "# Published tcl-lsp Linux binaries cannot run here because Alpine uses musl.",
+    "# Build tcl-lsp from source inside the image if its tools are required.",
+];
+const ALTERNATE_GLIBC_BASE_IMAGE_COMMENT: [&str; 2] = [
+    "# Published tcl-lsp Linux binaries require a glibc-compatible base image.",
+    "# Debian bookworm-slim is the default; Alpine/musl requires a source build.",
+];
+
 /// The GitHub repository the release assets are published from.
 pub const RELEASE_REPO: &str = "bitwisecook/tcl-lsp";
 
@@ -160,7 +173,8 @@ pub fn tcl_install_recipe(image: &str, tcl_version: &str) -> Result<String, TclP
 /// Alpine is rejected. Every published Linux `tcl` asset is glibc-linked — the
 /// release matrix has no musl leg — and `gcompat` does not close the gap
 /// (`fcntl64` and `__res_init` are not among the symbols it re-exports, so the
-/// binary dies in the dynamic loader). A Tcl-only Alpine image is still fine:
+/// binary dies in the dynamic loader). An Alpine image that needs the CLI must
+/// build tcl-lsp from source for musl. A Tcl-only Alpine image is still fine:
 /// drop the CLI verbs (`--no-packages`, no `--venv`) and nothing is fetched.
 pub fn cli_prereq_recipe(image: &str) -> Result<String, TclPkgError> {
     let family = detect_image_family(image);
@@ -170,9 +184,10 @@ pub fn cli_prereq_recipe(image: &str) -> Result<String, TclPkgError> {
     if family == "alpine" {
         return Err(docker_error(
             "the native tcl CLI has no musl release asset, so it cannot run on \
-             alpine (its glibc shim is missing fcntl64 and __res_init). Use a \
-             glibc base image (debian, ubuntu, fedora, rockylinux, …), or build \
-             a Tcl-only alpine image with --no-packages and no --venv.",
+             alpine (its glibc shim is missing fcntl64 and __res_init). Use the \
+             default Debian image, or if Alpine is required, build tcl-lsp from \
+             source for musl inside the image. A Tcl-only Alpine image can still \
+             use --no-packages and no --venv.",
         ));
     }
     Err(docker_error(format!(
@@ -344,6 +359,12 @@ pub fn generate_dockerfile(spec: &DockerfileSpec) -> Result<String, TclPkgError>
     let family = detect_image_family(&spec.base_image);
     let needs_cli = spec.install_packages || spec.create_venv;
 
+    let base_comment = match (spec.base_image.as_str(), family.as_str()) {
+        (DEFAULT_BASE_IMAGE, _) => DEFAULT_BASE_IMAGE_COMMENT,
+        (_, "alpine") => MUSL_BASE_IMAGE_COMMENT,
+        _ => ALTERNATE_GLIBC_BASE_IMAGE_COMMENT,
+    };
+    lines.extend(base_comment.map(str::to_string));
     lines.push(format!("FROM {}", spec.base_image));
     lines.push(String::new());
 
@@ -604,8 +625,8 @@ mod tests {
         let err = cli_prereq_recipe("alpine:3.19").unwrap_err().to_string();
         assert!(err.contains("musl"), "unhelpful alpine error: {err}");
         assert!(
-            err.contains("--no-packages"),
-            "no escape hatch named: {err}"
+            err.contains("build tcl-lsp from source"),
+            "no source-build alternative named: {err}"
         );
 
         // Asking for the CLI on alpine fails ...
@@ -621,6 +642,11 @@ mod tests {
             ..with_cli
         };
         let out = generate_dockerfile(&tcl_only).unwrap();
+        assert!(out.starts_with(
+            "# Published tcl-lsp Linux binaries cannot run here because Alpine uses musl.\n\
+             # Build tcl-lsp from source inside the image if its tools are required.\n\
+             FROM alpine:3.19\n"
+        ));
         assert!(out.contains("RUN apk add --no-cache tcl"));
         assert!(!out.contains("ARG TCL_LSP_VERSION"));
     }
@@ -645,7 +671,11 @@ mod tests {
             ..Default::default()
         };
         let out = generate_dockerfile(&spec).unwrap();
-        assert!(out.starts_with("FROM debian:bookworm-slim\n"));
+        assert!(out.starts_with(
+            "# Published tcl-lsp Linux binaries require glibc, so Debian is the safe default.\n\
+             # If Alpine/musl is required, build tcl-lsp from source inside the image.\n\
+             FROM debian:bookworm-slim\n"
+        ));
         assert!(out.contains("# Install Tcl 8.6"));
         assert!(out.contains("WORKDIR /app"));
         assert!(out.contains("COPY . ."));

--- a/rust/tcl-registry/src/commands/tcl/array_.rs
+++ b/rust/tcl-registry/src/commands/tcl/array_.rs
@@ -156,6 +156,7 @@ static SUBCOMMANDS: &[SubCommand] = &[
     },
     SubCommand {
         name: "for",
+        traits: Traits::CONTROL_FLOW.union(Traits::HAS_LOOP_BODY),
         arity: Arity::exact(3),
         detail: "Iterates over array entries. The first argument is a two-element list of variable names for the key and value of each entry.",
         synopsis: "array for {keyVariable valueVariable} arrayName body",
@@ -359,5 +360,22 @@ pub fn spec() -> CommandSpec {
         inline_codegen_hook: Some(InlineCodegenHookId::Array),
         forms: FORMS,
         ..CommandSpec::DEFAULT
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn array_for_carries_loop_traits() {
+        let for_ = SUBCOMMANDS
+            .iter()
+            .find(|sub| sub.name == "for")
+            .expect("array for subcommand");
+        assert!(
+            for_.traits
+                .contains(Traits::CONTROL_FLOW | Traits::HAS_LOOP_BODY),
+        );
     }
 }

--- a/rust/tcl-registry/src/commands/tcl/dict.rs
+++ b/rust/tcl-registry/src/commands/tcl/dict.rs
@@ -185,6 +185,7 @@ static SUBCOMMANDS: &[SubCommand] = &[
     },
     SubCommand {
         name: "for",
+        traits: Traits::CONTROL_FLOW.union(Traits::HAS_LOOP_BODY),
         arity: Arity::exact(3),
         detail: "Iterate over dictionary key/value pairs.",
         synopsis: "dict for {keyVar valueVar} dictionaryValue body",
@@ -294,6 +295,7 @@ static SUBCOMMANDS: &[SubCommand] = &[
     },
     SubCommand {
         name: "map",
+        traits: Traits::CONTROL_FLOW.union(Traits::HAS_LOOP_BODY),
         arity: Arity::exact(3),
         detail: "Apply a transformation to each dictionary entry.",
         synopsis: "dict map {keyVar valueVar} dictionaryValue body",
@@ -812,11 +814,12 @@ pub fn qualified_specs() -> Vec<CommandSpec> {
             let &(_, summary, synopsis) = QUALIFIED_HOVER.iter().find(|&&(n, _, _)| n == bare)?;
             Some(CommandSpec {
                 name: qualified,
-                traits: if sub.pure {
-                    Traits::PURE
-                } else {
-                    Traits::empty()
-                },
+                traits: sub.traits
+                    | if sub.pure {
+                        Traits::PURE
+                    } else {
+                        Traits::empty()
+                    },
                 surface: sub.surface.or(parent_surface),
                 arity: sub.arity,
                 return_type: sub.return_type,
@@ -905,6 +908,17 @@ mod tests {
         assert!(
             for_.analyser_hook.is_some(),
             "::tcl::dict::for must carry the DictFor analyser hook",
+        );
+        assert!(
+            for_.traits
+                .contains(Traits::CONTROL_FLOW | Traits::HAS_LOOP_BODY),
+            "::tcl::dict::for must carry its loop traits",
+        );
+        let map = get("::tcl::dict::map");
+        assert!(
+            map.traits
+                .contains(Traits::CONTROL_FLOW | Traits::HAS_LOOP_BODY),
+            "::tcl::dict::map must carry its loop traits",
         );
     }
 

--- a/rust/tcl-registry/src/commands/tcl/timerate.rs
+++ b/rust/tcl-registry/src/commands/tcl/timerate.rs
@@ -192,7 +192,10 @@ pub fn spec() -> CommandSpec {
         // Tcl 8.6+ only — see the doc comment above. Narrower than the
         // sibling `time`'s `surface: Some(SpecSurface::ALL_TCL)`.
         surface: Some(SpecSurface::TCL86_PLUS),
-        traits: Traits::BYTE_COMPILED | Traits::DYNAMIC_EVAL_BODY,
+        traits: Traits::BYTE_COMPILED
+            | Traits::CONTROL_FLOW
+            | Traits::DYNAMIC_EVAL_BODY
+            | Traits::HAS_LOOP_BODY,
         // The body's position varies with the leading options, so we
         // don't pin a fixed BODY index beyond arg 0; the option /
         // positional mix makes the upper arity bound unbounded (mirrors


### PR DESCRIPTION
## Summary

- default generated Dockerfiles to Debian so the published native binaries run on the generated image
- explain the glibc requirement in generated output and retain an explicit source-build path for Alpine
- add `tcl pkg discover` (`scan`) to inventory `package require` calls through the analyser
- refine dynamic package names and versions using optimiser constant propagation and safe builtin folds
- add an idempotent `--add` mode while leaving conditional, dynamic, exact, and bounded requirements for review

## Validation

- `cargo test -p tcl-cli`
- `make rust-check`
- `make prep-pr`

Closes #1791