### PR TITLE
Provision a wasm-capable C compiler for macOS builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,9 @@ jobs:
   #                    scripted LSP sessions targeted, while failing safe when
   #                    path detection is ambiguous.  Both transports sit on the
   #                    same `tcl-lsp-server` closure, so one flag gates both.
+  #   wasm_cc_changed — a wasm32-unknown-unknown crate or the shared compiler
+  #                    bootstrap changed. It gates the macOS-only proof that a
+  #                    clean stock runner provisions a capable C compiler.
   #   spectcl_compat_changed — SpecTcl or its TclVM/compiler/registry/runtime
   #                    and exact-reference-toolchain closure changed. Runs the
   #                    non-vacuous 15+3+4+2+1 compatibility lane.
@@ -120,6 +123,7 @@ jobs:
       python_changed: ${{ steps.paths.outputs.python_changed }}
       ext_changed: ${{ steps.paths.outputs.ext_changed }}
       lsp_wasm_changed: ${{ steps.paths.outputs.lsp_wasm_changed }}
+      wasm_cc_changed: ${{ steps.paths.outputs.wasm_cc_changed }}
       spectcl_compat_changed: ${{ steps.paths.outputs.spectcl_compat_changed }}
       runtime_rust_changed: ${{ steps.paths.outputs.runtime_rust_changed }}
       docs_only: ${{ steps.paths.outputs.docs_only }}
@@ -198,6 +202,7 @@ jobs:
           python_changed=false
           ext_changed=false
           lsp_wasm_changed=false
+          wasm_cc_changed=false
           spectcl_compat_changed=false
           runtime_rust_changed=false
           docs_only=true
@@ -214,6 +219,10 @@ jobs:
               case "$f" in
                 rust/f5-xc/* | rust/tcl-bigip/* | rust/tcl-bytecode/* | rust/tcl-cmd-core/* | rust/tcl-compiler/* | rust/tcl-core-types/* | rust/tcl-diagram/* | rust/tcl-dialect/* | rust/tcl-engine-api/* | rust/tcl-engine-tclvm/* | rust/tcl-explorer/* | rust/tcl-host-native/* | rust/tcl-irules/* | rust/tcl-lexer/* | rust/tcl-lsp-core/* | rust/tcl-lsp-db/* | rust/tcl-lsp-server/* | rust/tcl-lsp-server-wasm/* | rust/tcl-lsp-server-wasi/* | rust/tcl-platform/* | rust/tcl-regex/* | rust/tcl-registry/* | rust/tcl-runtime-api/* | rust/tcl-spec-hooks/* | rust/tcl-spectcl/* | rust/tcl-sslictcl/* | rust/tcl-syntax/* | rust/tcl-userdirs/* | rust/tcl-version/* | rust/tcl-vm/* | .cargo/config.toml | scripts/verify-wasm-externref.mjs | Cargo.toml | Cargo.lock | rust-toolchain.toml | Makefile | .github/workflows/ci.yml)
                   lsp_wasm_changed=true ;;
+              esac
+              case "$f" in
+                rust/tcl-explorer-wasm/* | rust/tcl-vm-wasm/* | rust/tcl-spec-studio-wasm/* | rust/tcl-lsp-server-wasm/* | rust/bigip-query-wasm/* | rust/bigip-report-gen/wasm/* | scripts/dev/ensure-test-deps.sh | scripts/dev/wasm-cc-env.sh | scripts/dev/test-wasm-cc-env.sh | Cargo.toml | Cargo.lock | rust-toolchain.toml | Makefile | .github/workflows/ci.yml)
+                  wasm_cc_changed=true ;;
               esac
               if scripts/dev/spectcl-compat-path.sh "$f"; then
                 spectcl_compat_changed=true
@@ -243,6 +252,7 @@ jobs:
             python_changed=true
             ext_changed=true
             lsp_wasm_changed=true
+            wasm_cc_changed=true
             spectcl_compat_changed=true
             runtime_rust_changed=true
             docs_only=false
@@ -251,11 +261,12 @@ jobs:
             echo "python_changed=$python_changed"
             echo "ext_changed=$ext_changed"
             echo "lsp_wasm_changed=$lsp_wasm_changed"
+            echo "wasm_cc_changed=$wasm_cc_changed"
             echo "spectcl_compat_changed=$spectcl_compat_changed"
             echo "runtime_rust_changed=$runtime_rust_changed"
             echo "docs_only=$docs_only"
           } >>"$GITHUB_OUTPUT"
-          echo "python_changed=$python_changed ext_changed=$ext_changed lsp_wasm_changed=$lsp_wasm_changed spectcl_compat_changed=$spectcl_compat_changed runtime_rust_changed=$runtime_rust_changed docs_only=$docs_only"
+          echo "python_changed=$python_changed ext_changed=$ext_changed lsp_wasm_changed=$lsp_wasm_changed wasm_cc_changed=$wasm_cc_changed spectcl_compat_changed=$spectcl_compat_changed runtime_rust_changed=$runtime_rust_changed docs_only=$docs_only"
 
   # Fast PR gate.  Runs on every PR and every push.  Covers the Rust fast
   # checks through the central `make rust-check` contract: root and standalone
@@ -313,6 +324,39 @@ jobs:
         # restores from, so pushes to rust keep it warm.
         if: needs.channel.outputs.prerelease != 'true' && !(startsWith(github.ref, 'refs/tags/') && needs.channel.outputs.already_green == 'true')
         run: make rust-check
+
+  # Apple clang deliberately omits the WebAssembly backend. Exercise the
+  # complete standalone-crate gate on a stock macOS runner whenever its owned
+  # compiler/bootstrap surface changes: ensure-rust-deps must install wasi-sdk,
+  # select it through CC_wasm32_unknown_unknown, and prove it with a real C
+  # compile before ring or another cc-rs consumer starts. This job has no
+  # dependants and is not a release gate, so a job-level path skip is safe and
+  # avoids allocating a macOS runner for unrelated changes.
+  macos-wasm-check:
+    if: ${{ github.event_name == 'pull_request' && needs.channel.outputs.wasm_cc_changed == 'true' }}
+    needs: [channel]
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+
+      - name: Set up Rust
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+        with:
+          toolchain: stable
+          components: clippy, rustfmt
+          cache-key: macos-wasm-check
+          cache-workspaces: |
+            .
+            editors/zed
+            rust/tcl-explorer-wasm
+            rust/tcl-vm-wasm
+            rust/tcl-spec-studio-wasm
+            rust/tcl-lsp-server-wasm
+
+      - name: Provision and exercise the macOS WASM compiler
+        run: make check-rust
 
   # Build the native tcl-lsp-server release binary ONCE and share it via
   # artifact with every job that just needs to *run* it rather than build it

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,10 @@ Tiers, policies, and the CI redundancy contract:
   from `.claude/hooks/session-start.sh` before the first instruction; never
   `apt install` by hand. Versions and their owners:
   [development-environment.md](docs/design/contracts/development-environment.md).
+- On macOS, run `make ensure-rust-deps` before a WASM build. It provisions the
+  pinned wasi-sdk because stock Apple clang has no WebAssembly backend; the
+  build probes and exports its clang as `CC_wasm32_unknown_unknown` before
+  Cargo can reach a C dependency.
 - **Parallel worktrees:** never share a `CARGO_TARGET_DIR` across
   concurrently-building worktrees — cargo serves a sibling branch's rlibs and
   the resulting green or red is untrustworthy (#1052). `source

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,8 @@
 #     `stable` channel pinned in rust-toolchain.toml; current stable is 1.98.0,
 #     released 2026-08-18.  `Cargo.toml` `rust-version` is authoritative.
 #   - Node.js 24+ with npm
+#   - macOS WASM builds: `make ensure-rust-deps` installs the pinned wasi-sdk;
+#     stock Apple clang has no wasm32 backend.
 #
 
 SHELL := /bin/bash
@@ -208,7 +210,7 @@ TS_SRCS  := $(shell find $(EXT_DIR)/src -name '*.ts' 2>/dev/null)
 # Tests
 .PHONY: test test-ext test-emacs test-rust rust-server rust-tcl rust-f5 rust-mcp rust-clis ensure-server-cross-deps server-cross-build server-cross-build-all mcp-cross-build-all cli-cross-build-all server-cross-test server-cross-test-build print-server-targets-all print-server-targets-jetbrains
 .PHONY: xtask-check xtask-editor-extensions xtask-kcs-index-links xtask-diag-tables xtask-diag-emission-check xtask-gen-editor-catalogs xtask-gen-bundled-environments xtask-gen-editor-dialects xtask-gen-irule-test-data xtask-gen-zed-queries xtask-gen-editor-settings xtask-gen-vscode-package xtask-gen-jetbrains-catalog xtask-gen-ai-diagnostics xtask-owner-resolution xtask-command-backing xtask-audit-option-dialects xtask-registry-oracle xtask-sslictcl-data xtask-runtime-stdlib tcltest-sweep tcltest-sweep-check xtask-f5query-builtins-doc xtask-bigip-data-schema xtask-c-api-ownership check-c-api-ownership
-.PHONY: xtask-workflow-sync xtask-resolution-drift xtask-retired-api-gate xtask-pack-goldens xtask-number-drift xtask-gen-tmlanguage-keywords xtask-option-registry-drift xtask-callback-inventory check-tcl-reference-toolchains check-spectcl-compat-paths check-runtime-rust-paths xtask-dialect-drift
+.PHONY: xtask-workflow-sync xtask-resolution-drift xtask-retired-api-gate xtask-pack-goldens xtask-number-drift xtask-gen-tmlanguage-keywords xtask-option-registry-drift xtask-callback-inventory check-tcl-reference-toolchains check-spectcl-compat-paths check-runtime-rust-paths check-wasm-cc-env xtask-dialect-drift
 # Lint / format / typecheck
 .PHONY: lint format lint-ts format-ts typecheck-ts check-rust check-rust-pr _check-rust-pr rust-deny
 .PHONY: build-report-assets build-report-pyz lint-report-ts typecheck-report-ts check-report-assets lint-spec-studio-ts typecheck-spec-studio-ts
@@ -757,7 +759,7 @@ coverage-ext: compile $(NPM_STAMP) ensure-vscode-test-deps ## Run VS Code extens
 # --- Native (cargo xtask) check gates.  These need the Rust toolchain, so CI
 # runs them in the rust-tests job (rust-gate.yml / ci.yml).  `xtask-check` is
 # the CI aggregate.
-xtask-check: check-tcl-reference-toolchains check-spectcl-compat-paths check-runtime-rust-paths xtask-workflow-sync xtask-kcs-index-links xtask-diag-tables xtask-diag-emission-check xtask-gen-editor-catalogs xtask-gen-bundled-environments xtask-gen-editor-dialects xtask-gen-irule-test-data xtask-gen-zed-queries xtask-gen-tmlanguage-keywords xtask-gen-editor-settings xtask-gen-vscode-package xtask-gen-jetbrains-catalog xtask-gen-ai-diagnostics xtask-owner-resolution xtask-resolution-drift xtask-retired-api-gate xtask-pack-goldens xtask-number-drift xtask-command-backing xtask-callback-inventory xtask-option-registry-drift xtask-sslictcl-data xtask-runtime-stdlib xtask-editor-extensions xtask-f5query-builtins-doc xtask-bigip-data-schema xtask-c-api-ownership ## Rust-side check gates (docs index coverage + generated-table/catalog drift) xtask-dialect-drift
+xtask-check: check-tcl-reference-toolchains check-spectcl-compat-paths check-runtime-rust-paths check-wasm-cc-env xtask-workflow-sync xtask-kcs-index-links xtask-diag-tables xtask-diag-emission-check xtask-gen-editor-catalogs xtask-gen-bundled-environments xtask-gen-editor-dialects xtask-gen-irule-test-data xtask-gen-zed-queries xtask-gen-tmlanguage-keywords xtask-gen-editor-settings xtask-gen-vscode-package xtask-gen-jetbrains-catalog xtask-gen-ai-diagnostics xtask-owner-resolution xtask-resolution-drift xtask-retired-api-gate xtask-pack-goldens xtask-number-drift xtask-command-backing xtask-callback-inventory xtask-option-registry-drift xtask-sslictcl-data xtask-runtime-stdlib xtask-editor-extensions xtask-f5query-builtins-doc xtask-bigip-data-schema xtask-c-api-ownership ## Rust-side check gates (docs index coverage + generated-table/catalog drift) xtask-dialect-drift
 
 check-tcl-reference-toolchains: ## Verify pinned C Tcl patchlevels across shell setup and Rust oracle discovery
 	@echo "==> Checking C Tcl reference toolchain ownership"
@@ -771,6 +773,10 @@ check-spectcl-compat-paths: ## Verify CI's SpecTcl dependency closure and centra
 check-runtime-rust-paths: ## Verify CI's standalone-runtime dependency closure and job wiring (#1768)
 	@echo "==> Checking standalone runtime CI path ownership"
 	@bash scripts/dev/test-runtime-rust-paths.sh
+
+check-wasm-cc-env: ## Verify wasm32 C-compiler selection and dependency diagnostics
+	@echo "==> Checking wasm32 C compiler bootstrap"
+	@bash scripts/dev/test-wasm-cc-env.sh
 
 xtask-runtime-stdlib: ## Verify the embedded Tcl stdlib version, provenance, hashes, and FILES table
 	@echo "==> Checking embedded Tcl standard-library provenance (cargo xtask)"
@@ -1253,6 +1259,8 @@ check-rust: ensure-rust-deps ## Rust fmt-check + clippy on the workspace and exc
 		echo "       Set SKIP_CHECK_RUST=1 to skip."; \
 		exit 1; \
 	fi; \
+	. $(ROOT)scripts/dev/wasm-cc-env.sh; \
+	wasm_cc_prepare; \
 	$(MAKE) --no-print-directory -C $(ROOT) _check-rust-pr; \
 	if [ -f "$(ZED_DIR)/Cargo.toml" ]; then \
 		echo "==> Checking Zed extension (fmt + clippy --target wasm32-wasip2 + host tests)"; \
@@ -1355,7 +1363,7 @@ ensure-tcl-deps: ## Install Tcl shells needed by Tcl/tclpkg tests and bytecode c
 ensure-tcl90-reference: ## Install the exact manifest-pinned Tcl 9.0 reference interpreter
 	@$(MAKE) TCL_LSP_TCL_RELEASES=9.0 ensure-tcl-deps
 
-ensure-rust-deps: ## Install Rust/rustup + wasm32-wasip2 target needed by check-rust
+ensure-rust-deps: ## Install Rust targets and macOS's wasm32-capable C compiler needed by check-rust
 	@if [ -n "$${SKIP_CHECK_RUST:-}" ] || [ -n "$${SKIP_RUST:-}" ]; then \
 		echo "==> Rust dependency install skipped"; \
 	else \
@@ -1371,7 +1379,7 @@ ensure-rust-deps: ## Install Rust/rustup + wasm32-wasip2 target needed by check-
 			SKIP_OPENSSL=1 \
 			SKIP_PING=1 \
 			SKIP_RGXG=1 \
-			SKIP_WASI_SDK=1 \
+			$(if $(filter Darwin,$(SERVER_UNAME_S)),,SKIP_WASI_SDK=1) \
 			SKIP_PYTHON_TK=1 \
 			SKIP_UV=1 \
 			SKIP_TCLLIB=1 \
@@ -1676,7 +1684,10 @@ explorer-wasm: ## Build the Rust → WASM compiler-explorer core into the tcl GU
 	@command -v wasm-pack >/dev/null 2>&1 || { \
 		echo "wasm-pack not found — run 'make ensure-rust-deps' or 'cargo install wasm-pack'"; \
 		exit 1; }
-	@echo "==> Building tcl-explorer-wasm (wasm-pack --target no-modules)"
+	@set -eu; \
+	. $(ROOT)scripts/dev/wasm-cc-env.sh; \
+	wasm_cc_prepare; \
+	echo "==> Building tcl-explorer-wasm (wasm-pack --target no-modules)"; \
 	cd $(EXPLORER_WASM_DIR) && wasm-pack build --target no-modules --release \
 		--out-dir $(BUILD_DIR)/explorer-wasm --out-name tcl_explorer_wasm
 	@# wasm-opt is intentionally NOT run (also disabled inside wasm-pack via
@@ -1710,7 +1721,10 @@ TCL_VM_WASM_DIR := $(ROOT)rust/tcl-vm-wasm
 tcl-vm-wasm: ## Build the bytecode VM as a self-contained wasm32 cdylib (the primary wasm compile target)
 	@rustup target list --installed 2>/dev/null | grep -q wasm32-unknown-unknown \
 		|| rustup target add wasm32-unknown-unknown
-	@echo "==> Building tcl-vm-wasm (VM + compiler → wasm32-unknown-unknown cdylib, no imports/WASI)"
+	@set -eu; \
+	. $(ROOT)scripts/dev/wasm-cc-env.sh; \
+	wasm_cc_prepare; \
+	echo "==> Building tcl-vm-wasm (VM + compiler → wasm32-unknown-unknown cdylib, no imports/WASI)"; \
 	cd $(TCL_VM_WASM_DIR) && cargo build --release --target wasm32-unknown-unknown
 	@mkdir -p $(BUILD_DIR)/tcl-vm-wasm
 	cp $(TCL_VM_WASM_DIR)/target/wasm32-unknown-unknown/release/tcl_vm_wasm.wasm \

--- a/README.md
+++ b/README.md
@@ -2023,6 +2023,10 @@ an INI file you can commit alongside the project.
 - Node.js 24+ with npm (pinned to v12 via `packageManager`; run `corepack enable npm`)
 - VS Code 1.93+
 
+On macOS, run `make ensure-rust-deps` before the Rust/WASM gates. Stock Apple
+clang has no WebAssembly backend, so this installs and selects the pinned
+wasi-sdk compiler used for `wasm32-unknown-unknown` C dependencies.
+
 ```sh
 git clone https://github.com/bitwisecook/tcl-lsp && cd tcl-lsp
 make test                  # the whole suite

--- a/docs/design/contracts/development-environment.md
+++ b/docs/design/contracts/development-environment.md
@@ -19,7 +19,12 @@ names are the executable truth.
   kotlinc, Wasmtime, Binaryen, wasi-sdk, emacs, xvfb, tshark, …) on
   Debian/Ubuntu, RHEL-family, or macOS. Idempotent; `SKIP_<TOOL>=1` skips one
   tool; `--check` reports without installing. `make ensure-rust-deps` adds
-  the `wasm32-wasip2` target.
+  the Rust WASM targets and, on macOS, installs the pinned wasi-sdk. Stock
+  Apple clang has no WebAssembly backend, so every `wasm32-unknown-unknown`
+  entry point sources `scripts/dev/wasm-cc-env.sh`: it selects the owned SDK
+  (or an explicit `CC_wasm32_unknown_unknown`) and compiles a tiny C object for
+  the exact target before Cargo starts. An executable named `clang` that fails
+  that probe is reported as missing by `ensure-test-deps.sh --check`.
 
 ## Remote agent sessions
 
@@ -88,7 +93,7 @@ publishing) and the publish-secret invariant are in
 
 - `.claude/hooks/session-start.sh`, `.claude/settings.json`
 - `scripts/dev/ensure-test-deps.sh`, `scripts/dev/agent-build-env.sh`,
-  `scripts/dev/tcl-reference-toolchains.sh`
+  `scripts/dev/wasm-cc-env.sh`, `scripts/dev/tcl-reference-toolchains.sh`
 - `.claude/skills/fetch-tcl-source/fetch_tcl_source.sh`
 - `rust-toolchain.toml`, `Cargo.toml`, `.github/workflows/ci.yml`
 

--- a/rust/bigip-query-wasm/build-wasm.sh
+++ b/rust/bigip-query-wasm/build-wasm.sh
@@ -21,15 +21,19 @@
 # Python package, so `f5report` can embed a live in-browser query console
 # without needing the wasm toolchain at report-generation time.
 #
-# Requires: rustup wasm32-unknown-unknown target, wasm-bindgen-cli (matching the
+# Requires: rustup wasm32-unknown-unknown target, a WASM-capable C compiler
+# (`make ensure-rust-deps` provisions one), wasm-bindgen-cli (matching the
 # wasm-bindgen crate version pinned in Cargo.toml), and wasm-opt (binaryen).
 set -euo pipefail
 
 here="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=../../scripts/dev/wasm-cc-env.sh
+. "$here/../../scripts/dev/wasm-cc-env.sh"
 vendor="$here/../bigip-report-gen/assets"
 out="$(mktemp -d)"
 trap 'rm -rf "$out"' EXIT
 
+wasm_cc_prepare
 echo "==> cargo build --target wasm32-unknown-unknown --release"
 ( cd "$here" && cargo build --target wasm32-unknown-unknown --release )
 wasm="$here/target/wasm32-unknown-unknown/release/bigip_query_wasm.wasm"

--- a/rust/bigip-report-gen/wasm/build-wasm.sh
+++ b/rust/bigip-report-gen/wasm/build-wasm.sh
@@ -21,17 +21,21 @@
 # hosting page (`dist/index.html`) that runs the whole pipeline in the browser —
 # upload a UCS/SCF, get a standalone HTML report, entirely client-side.
 #
-# Requires: the rustup wasm32-unknown-unknown target, wasm-bindgen-cli (matching
-# the wasm-bindgen crate version pinned in Cargo.toml), and python3 (for the
-# byte-safe asset injection). Node, if present, is used to verify the module.
+# Requires: the rustup wasm32-unknown-unknown target, a WASM-capable C compiler
+# (`make ensure-rust-deps` provisions one), wasm-bindgen-cli (matching the
+# wasm-bindgen crate version pinned in Cargo.toml), and python3 (for the byte-
+# safe asset injection). Node, if present, is used to verify the module.
 set -euo pipefail
 
 here="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=../../../scripts/dev/wasm-cc-env.sh
+. "$here/../../../scripts/dev/wasm-cc-env.sh"
 dist="$here/dist"
 out="$(mktemp -d)"
 trap 'rm -rf "$out"' EXIT
 mkdir -p "$dist"
 
+wasm_cc_prepare
 echo "==> cargo build --target wasm32-unknown-unknown --release"
 ( cd "$here" && cargo build --target wasm32-unknown-unknown --release )
 wasm="$here/target/wasm32-unknown-unknown/release/bigip_report_wasm.wasm"

--- a/rust/tcl-lsp-server-wasm/build-wasm.sh
+++ b/rust/tcl-lsp-server-wasm/build-wasm.sh
@@ -22,12 +22,15 @@
 # ties the two to `postMessage`. Three plain files, no bundler — a page loads
 # `worker.js` with `new Worker(...)` and speaks raw LSP JSON-RPC to it.
 #
-# Requires: the rustup wasm32-unknown-unknown target and wasm-bindgen-cli
-# (matching the wasm-bindgen crate version resolved in Cargo.lock). Node, if
-# present, also verifies the module.
+# Requires: the rustup wasm32-unknown-unknown target, a WASM-capable C compiler
+# (`make ensure-rust-deps` provisions one), and wasm-bindgen-cli (matching the
+# wasm-bindgen crate version resolved in Cargo.lock). Node, if present, also
+# verifies the module.
 set -euo pipefail
 
 here="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=../../scripts/dev/wasm-cc-env.sh
+. "$here/../../scripts/dev/wasm-cc-env.sh"
 dist="$here/dist"
 mkdir -p "$dist"
 
@@ -44,6 +47,7 @@ mkdir -p "$dist"
 # worse than native's. Match the native budget.
 STACK_SIZE=$((64 * 1024 * 1024))
 
+wasm_cc_prepare
 echo "==> cargo build --target wasm32-unknown-unknown --release (stack ${STACK_SIZE} bytes)"
 (
     cd "$here"

--- a/rust/tcl-spec-studio-wasm/build-wasm.sh
+++ b/rust/tcl-spec-studio-wasm/build-wasm.sh
@@ -44,8 +44,9 @@
 # remote origins for the opt-in GitHub release fetcher (which is the one
 # feature on the page that uses the network, and says so beside itself).
 #
-# Requires: the rustup wasm32-unknown-unknown target, wasm-bindgen-cli (matching
-# the wasm-bindgen crate version resolved in Cargo.lock), python3 (for the
+# Requires: the rustup wasm32-unknown-unknown target, a WASM-capable C compiler
+# (`make ensure-rust-deps` provisions one), wasm-bindgen-cli (matching the
+# wasm-bindgen crate version resolved in Cargo.lock), python3 (for the
 # byte-safe asset injection), the front-end bundles under
 # `../tcl-spec-studio/web/dist/` (`cd ../tcl-spec-studio/web && npm ci && npm run
 # build`), and the language server worker's `dist/` from
@@ -54,6 +55,8 @@
 set -euo pipefail
 
 here="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=../../scripts/dev/wasm-cc-env.sh
+. "$here/../../scripts/dev/wasm-cc-env.sh"
 web="$here/../tcl-spec-studio/web"
 assets="$here/../bigip-report-gen/assets"
 lspdist="$here/../tcl-lsp-server-wasm/dist"
@@ -68,6 +71,7 @@ mkdir -p "$dist/assets" "$dist/lsp"
 
 echo "==> Spec Studio $version"
 
+wasm_cc_prepare
 echo "==> cargo build --target wasm32-unknown-unknown --release"
 ( cd "$here" && CARGO_TARGET_DIR="$here/target" cargo build --target wasm32-unknown-unknown --release )
 wasm="$here/target/wasm32-unknown-unknown/release/tcl_spec_studio_wasm.wasm"

--- a/scripts/dev/ensure-test-deps.sh
+++ b/scripts/dev/ensure-test-deps.sh
@@ -29,17 +29,18 @@
 #   * ``kotlinc`` — the JetBrains plugin's DiagnosticCatalog.kt compile
 #     check.
 #   * ``rustup`` + Rust stable at least as new as the workspace's authoritative
-#     ``rust-version`` + the ``wasm32-wasip2`` target — the Zed
-#     extension's clippy check in ``make check-rust`` cross-compiles to
-#     WASI Preview 2 and fails without that target installed.  Installs
+#     ``rust-version`` + the ``wasm32-wasip2`` and
+#     ``wasm32-unknown-unknown`` targets — the Zed extension and standalone
+#     browser crates in ``make check-rust`` need them. Installs
 #     the latest stable toolchain (rather than a pinned version) so it
 #     tracks the same channel as the local ``cargo`` developers expect.
 #   * ``wasmtime`` — the Rust WASM codegen tests run wasm32-wasi binaries
 #     through the Wasmtime CLI.
 #   * ``wasm-merge`` / ``wasm-opt`` — Binaryen tools used by bundled WASM
 #     tests and asyncify runtime builds.
-#   * ``wasi-sdk`` — clang + WASI sysroot for the wasm cross-compile of
-#     libtommath (the numeric tower) in ``runtime/rust/build.rs``.
+#   * ``wasi-sdk`` — a wasm-capable clang for browser-crate C dependencies
+#     (required on macOS, whose Apple clang omits the backend) plus the WASI
+#     sysroot for libtommath in ``runtime/rust/build.rs``.
 #   * ``emacs`` — the headless eglot regression suite.
 #   * ``xvfb-run`` — Linux headless VS Code extension tests when DISPLAY is
 #     unset.
@@ -82,6 +83,8 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 # shellcheck source=tcl-reference-toolchains.sh
 . "$SCRIPT_DIR/tcl-reference-toolchains.sh"
+# shellcheck source=wasm-cc-env.sh
+. "$SCRIPT_DIR/wasm-cc-env.sh"
 tcl_reference_load_toolchains "$REPO_ROOT"
 
 TCL_REFERENCE_SOURCE_PARENT="${TCL_LSP_TCL_SOURCE_PARENT:-$REPO_ROOT/tmp}"
@@ -935,22 +938,29 @@ ensure_binaryen() {
 }
 
 # ---------------------------------------------------------------- wasi-sdk
-# clang + WASI sysroot for the wasm cross-compile of libtommath (the numeric
-# tower) in runtime/rust/build.rs.  Installed to /opt/wasi-sdk-<ver> and
-# symlinked /opt/wasi-sdk, which build.rs auto-discovers (or set WASI_SDK_PATH).
-# Without it, runtime/rust's wasm build drops the tower (expr/mathop/mathfunc/
-# lseq) with a warning.
+# WebAssembly-capable clang plus a WASI sysroot. Installed to
+# /opt/wasi-sdk-<ver> and symlinked /opt/wasi-sdk, which both wasm-cc-env.sh
+# and runtime/rust/build.rs discover (or set WASI_SDK_PATH). Stock Apple clang
+# has no wasm backend; without the sysroot, runtime/rust's wasm build also
+# drops the numeric tower (expr/mathop/mathfunc/lseq) with a warning.
 
 ensure_wasi_sdk() {
     if [ "${SKIP_WASI_SDK:-}" = "1" ]; then info "SKIP_WASI_SDK=1 — skipping wasi-sdk"; return 0; fi
     local link="/opt/wasi-sdk"
-    if [ -x "${WASI_SDK_PATH:-$link}/bin/clang" ]; then
-        info "wasi-sdk already present ($("${WASI_SDK_PATH:-$link}/bin/clang" --version 2>/dev/null | head -1))"
+    local sdk_root="${WASI_SDK_PATH:-$link}"
+    local sdk_clang="$sdk_root/bin/clang"
+    if [ -x "$sdk_clang" ] && wasm_cc_probe "$sdk_clang" >/dev/null 2>&1; then
+        info "wasi-sdk already present ($(wasm_cc_run "$sdk_clang" --version 2>/dev/null | head -1))"
         return 0
     fi
     if [ "$CHECK_ONLY" -eq 1 ]; then
-        note_missing "wasi-sdk ${WASI_SDK_VERSION} (would install for $OS/$ARCH → ${link})"
+        note_missing "wasi-sdk ${WASI_SDK_VERSION} with a wasm32-unknown-unknown-capable C compiler (would install for $OS/$ARCH → ${link})"
         return 0
+    fi
+    if [ -n "${WASI_SDK_PATH:-}" ]; then
+        echo "ERROR: WASI_SDK_PATH '$WASI_SDK_PATH' does not contain a clang capable of targeting wasm32-unknown-unknown." >&2
+        echo "       Fix or unset WASI_SDK_PATH so the managed SDK can be installed at $link." >&2
+        return 1
     fi
 
     local sdk_os sdk_arch
@@ -1022,7 +1032,11 @@ ensure_wasi_sdk() {
     $SUDO mkdir -p "$prefix"
     $SUDO tar -xzf "$tmpdir/$tarball" -C "$prefix" --strip-components=1
     $SUDO ln -sfn "$prefix" "$link"
-    info "Installed wasi-sdk to ${prefix} (symlinked ${link}); runtime/rust/build.rs auto-discovers it"
+    if ! wasm_cc_probe "$link/bin/clang" >/dev/null 2>&1; then
+        echo "ERROR: installed wasi-sdk clang cannot target wasm32-unknown-unknown" >&2
+        return 1
+    fi
+    info "Installed wasi-sdk to ${prefix} (symlinked ${link}); Rust WASM builds and runtime/rust/build.rs auto-discover it"
 }
 
 # ---------------------------------------------------------------- tshark

--- a/scripts/dev/test-wasm-cc-env.sh
+++ b/scripts/dev/test-wasm-cc-env.sh
@@ -102,6 +102,7 @@ run_installer_check() {
     env \
         WASI_SDK_PATH="$1" \
         WASM_CC_TEST_LOG="$probe_log" \
+        SKIP_WASI_SDK=0 \
         SKIP_TCLSH=1 \
         SKIP_PYTHON_TK=1 \
         SKIP_NODE=1 \

--- a/scripts/dev/test-wasm-cc-env.sh
+++ b/scripts/dev/test-wasm-cc-env.sh
@@ -16,7 +16,9 @@ INSTALLER="$SCRIPT_DIR/ensure-test-deps.sh"
 fixture="$(mktemp -d)"
 trap 'rm -rf "$fixture"' EXIT
 apple_clang="$fixture/apple-clang"
-sdk_root="$fixture/wasi-sdk"
+# The whitespace is intentional: custom SDK roots and target-specific compiler
+# paths on macOS must reach exec as one argument, not be split like a wrapper.
+sdk_root="$fixture/wasi sdk"
 sdk_clang="$sdk_root/bin/clang"
 probe_log="$fixture/probe.log"
 mkdir -p "$sdk_root/bin"
@@ -87,6 +89,21 @@ selected="$({
 })"
 if [ "$selected" != "$sdk_clang" ]; then
     echo "owned wasi-sdk clang was not selected (got '$selected')" >&2
+    exit 1
+fi
+
+# The same whitespace-bearing executable must also work when selected through
+# cc-rs's shell-friendly target override rather than through WASI_SDK_PATH.
+target_selected="$({
+    env -u 'CC_wasm32-unknown-unknown' \
+        CC_wasm32_unknown_unknown="$sdk_clang" \
+        WASI_SDK_PATH="$fixture/unused sdk" \
+        WASM_CC_TEST_LOG="$probe_log" \
+        /bin/bash -c '. "$1"; wasm_cc_prepare >/dev/null; printf "%s" "$CC_wasm32_unknown_unknown"' \
+            wasm-cc-test "$HELPER"
+})"
+if [ "$target_selected" != "$sdk_clang" ]; then
+    echo "whitespace-bearing target compiler was not selected (got '$target_selected')" >&2
     exit 1
 fi
 case "$(cat "$probe_log")" in

--- a/scripts/dev/test-wasm-cc-env.sh
+++ b/scripts/dev/test-wasm-cc-env.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# tcl-lsp — a language server and toolchain for Tcl
+# Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+# Hermetic regression for macOS's wasm32 C-compiler bootstrap. The fixtures
+# model stock Apple clang and the owned wasi-sdk without requiring a macOS host
+# or downloading a toolchain.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+HELPER="$SCRIPT_DIR/wasm-cc-env.sh"
+INSTALLER="$SCRIPT_DIR/ensure-test-deps.sh"
+fixture="$(mktemp -d)"
+trap 'rm -rf "$fixture"' EXIT
+apple_clang="$fixture/apple-clang"
+sdk_root="$fixture/wasi-sdk"
+sdk_clang="$sdk_root/bin/clang"
+probe_log="$fixture/probe.log"
+mkdir -p "$sdk_root/bin"
+
+{
+    printf '%s\n' '#!/bin/sh'
+    printf '%s\n' 'case " $* " in'
+    printf '%s\n' '    *" --version "*) echo "Apple clang version 17.0.0"; exit 0 ;;'
+    printf '%s\n' '    *" --target=wasm32-unknown-unknown "*)'
+    printf '%s\n' "        echo \"error: unable to create target: No available targets are compatible with triple 'wasm32-unknown-unknown'\" >&2"
+    printf '%s\n' '        exit 1 ;;'
+    printf '%s\n' 'esac'
+    printf '%s\n' 'exit 1'
+} > "$apple_clang"
+chmod 0755 "$apple_clang"
+
+{
+    printf '%s\n' '#!/bin/sh'
+    printf '%s\n' 'case " $* " in'
+    printf '%s\n' '    *" --version "*) echo "clang version 25.0.0-wasi-sdk"; exit 0 ;;'
+    printf '%s\n' '    *" --target=wasm32-unknown-unknown "*) ;;'
+    printf '%s\n' '    *) echo "missing wasm32 target" >&2; exit 1 ;;'
+    printf '%s\n' 'esac'
+    printf '%s\n' 'printf "%s\n" "$*" >> "${WASM_CC_TEST_LOG:?}"'
+    printf '%s\n' 'output=' 'previous='
+    printf '%s\n' 'for argument in "$@"; do'
+    printf '%s\n' '    if [ "$previous" = -o ]; then output="$argument"; fi'
+    printf '%s\n' '    previous="$argument"'
+    printf '%s\n' 'done'
+    printf '%s\n' '[ -n "$output" ] || exit 1'
+    printf '%s\n' 'printf wasm-object > "$output"'
+} > "$sdk_clang"
+chmod 0755 "$sdk_clang"
+
+# The exact compiler that produced #1716 must be rejected before Cargo starts,
+# even when a valid SDK is available as a fallback: explicit overrides win.
+set +e
+bad_output="$({
+    env -u 'CC_wasm32-unknown-unknown' \
+        CC_wasm32_unknown_unknown="$apple_clang" \
+        WASI_SDK_PATH="$sdk_root" \
+        /bin/bash "$HELPER"
+} 2>&1)"
+bad_status=$?
+set -e
+if [ "$bad_status" -eq 0 ]; then
+    echo "stock Apple clang unexpectedly passed the wasm32 probe" >&2
+    exit 1
+fi
+case "$bad_output" in
+    *"cannot compile for wasm32-unknown-unknown"*) ;;
+    *)
+        echo "invalid-compiler diagnostic did not name the target" >&2
+        printf '%s\n' "$bad_output" >&2
+        exit 1
+        ;;
+esac
+
+# With no target-specific override, the owned SDK is selected, exported under
+# cc-rs's target-specific name, and actually asked to compile a C translation
+# unit for the precise Rust target.
+selected="$({
+    env -u 'CC_wasm32-unknown-unknown' -u CC_wasm32_unknown_unknown \
+        WASI_SDK_PATH="$sdk_root" \
+        WASM_CC_TEST_LOG="$probe_log" \
+        /bin/bash -c '. "$1"; wasm_cc_prepare >/dev/null; printf "%s" "$CC_wasm32_unknown_unknown"' \
+            wasm-cc-test "$HELPER"
+})"
+if [ "$selected" != "$sdk_clang" ]; then
+    echo "owned wasi-sdk clang was not selected (got '$selected')" >&2
+    exit 1
+fi
+case "$(cat "$probe_log")" in
+    *"--target=wasm32-unknown-unknown"*" -c "*" -o "*) ;;
+    *)
+        echo "compiler probe did not compile for the exact target" >&2
+        cat "$probe_log" >&2
+        exit 1
+        ;;
+esac
+
+run_installer_check() {
+    env \
+        WASI_SDK_PATH="$1" \
+        WASM_CC_TEST_LOG="$probe_log" \
+        SKIP_TCLSH=1 \
+        SKIP_PYTHON_TK=1 \
+        SKIP_NODE=1 \
+        SKIP_KOTLINC=1 \
+        SKIP_RUST=1 \
+        SKIP_WASMTIME=1 \
+        SKIP_BINARYEN=1 \
+        SKIP_EMACS=1 \
+        SKIP_XVFB=1 \
+        SKIP_TSHARK=1 \
+        SKIP_OPENSSL=1 \
+        SKIP_PING=1 \
+        SKIP_RGXG=1 \
+        SKIP_TCLLIB=1 \
+        SKIP_UV=1 \
+        bash "$INSTALLER" --check
+}
+
+# Merely finding an executable named clang is not enough. --check must report
+# an installed but incapable SDK compiler as missing, then accept the proven
+# SDK fixture without mutating the host.
+broken_sdk="$fixture/broken-sdk"
+mkdir -p "$broken_sdk/bin"
+cp "$apple_clang" "$broken_sdk/bin/clang"
+set +e
+check_output="$(run_installer_check "$broken_sdk" 2>&1)"
+check_status=$?
+set -e
+if [ "$check_status" -ne 1 ]; then
+    echo "ensure-test-deps --check accepted an incapable SDK clang" >&2
+    printf '%s\n' "$check_output" >&2
+    exit 1
+fi
+case "$check_output" in
+    *"wasi-sdk 25.0 with a wasm32-unknown-unknown-capable C compiler"*) ;;
+    *)
+        echo "dependency audit did not report the missing wasm32 compiler" >&2
+        printf '%s\n' "$check_output" >&2
+        exit 1
+        ;;
+esac
+
+good_output="$(run_installer_check "$sdk_root" 2>&1)"
+case "$good_output" in
+    *"wasi-sdk already present"*"all dependencies satisfied"*) ;;
+    *)
+        echo "dependency audit rejected the working SDK fixture" >&2
+        printf '%s\n' "$good_output" >&2
+        exit 1
+        ;;
+esac
+
+echo "wasm32 C compiler bootstrap regression: ok"

--- a/scripts/dev/wasm-cc-env.sh
+++ b/scripts/dev/wasm-cc-env.sh
@@ -19,9 +19,17 @@ wasm_cc_run() {
     shift
     local -a command
 
+    # A compiler discovered below is an executable path, which may legitimately
+    # contain whitespace (for example on a named macOS volume). Try the whole
+    # value first so wrapper parsing cannot split that path apart.
+    if [ -x "$compiler" ]; then
+        "$compiler" "$@"
+        return
+    fi
+
     # cc-rs permits a wrapper plus compiler in CC (for example "sccache
-    # clang"). Preserve that convention for explicit overrides. Paths used by
-    # the owned wasi-sdk do not contain whitespace.
+    # clang"). Preserve that convention for explicit overrides that are not a
+    # directly executable path.
     read -r -a command <<< "$compiler"
     if [ "${#command[@]}" -eq 0 ] || ! command -v "${command[0]}" >/dev/null 2>&1; then
         return 127

--- a/scripts/dev/wasm-cc-env.sh
+++ b/scripts/dev/wasm-cc-env.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# tcl-lsp — a language server and toolchain for Tcl
+# Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+# Select and prove the C compiler used by cc-rs for wasm32-unknown-unknown.
+#
+# Stock Apple clang has no WebAssembly backend. Rust-only crates can therefore
+# cross-compile successfully until a dependency such as ring invokes cc-rs,
+# where the build fails much later with an opaque "No available targets"
+# diagnostic. Source this helper and call wasm_cc_prepare before Cargo so the
+# exact compiler Cargo will inherit is selected and exercised up front.
+
+WASM_CC_TARGET="wasm32-unknown-unknown"
+
+wasm_cc_run() {
+    local compiler="$1"
+    shift
+    local -a command
+
+    # cc-rs permits a wrapper plus compiler in CC (for example "sccache
+    # clang"). Preserve that convention for explicit overrides. Paths used by
+    # the owned wasi-sdk do not contain whitespace.
+    read -r -a command <<< "$compiler"
+    if [ "${#command[@]}" -eq 0 ] || ! command -v "${command[0]}" >/dev/null 2>&1; then
+        return 127
+    fi
+    "${command[@]}" "$@"
+}
+
+wasm_cc_probe() {
+    local compiler="$1"
+    local probe_dir status
+    probe_dir="$(mktemp -d "${TMPDIR:-/tmp}/tcl-lsp-wasm-cc.XXXXXX")"
+    printf '%s\n' 'int tcl_lsp_wasm_cc_probe(void) { return 0; }' > "$probe_dir/probe.c"
+
+    if wasm_cc_run "$compiler" --target="$WASM_CC_TARGET" -x c -c \
+        "$probe_dir/probe.c" -o "$probe_dir/probe.o"; then
+        status=0
+    else
+        status=$?
+    fi
+
+    if [ "$status" -eq 0 ] && [ -s "$probe_dir/probe.o" ]; then
+        rm -rf "$probe_dir"
+        return 0
+    fi
+    rm -rf "$probe_dir"
+    return 1
+}
+
+wasm_cc_export() {
+    local compiler="$1"
+    CC_wasm32_unknown_unknown="$compiler"
+    export CC_wasm32_unknown_unknown
+    printf '==> wasm32 C compiler: %s\n' "$compiler"
+}
+
+wasm_cc_prepare() {
+    local compiler candidate
+    local target_specific_hyphen
+    target_specific_hyphen="$(printenv 'CC_wasm32-unknown-unknown' 2>/dev/null || true)"
+
+    # cc-rs gives the hyphenated target variable precedence over the
+    # shell-friendly underscore spelling. Respect either explicit choice and
+    # fail on it rather than silently replacing a developer's override.
+    compiler="${target_specific_hyphen:-${CC_wasm32_unknown_unknown:-}}"
+    if [ -n "$compiler" ]; then
+        if wasm_cc_probe "$compiler"; then
+            wasm_cc_export "$compiler"
+            return 0
+        fi
+        printf "ERROR: configured wasm32 C compiler '%s' cannot compile for %s.\n" \
+            "$compiler" "$WASM_CC_TARGET" >&2
+        printf '%s\n' \
+            "       Run 'make ensure-rust-deps' or set CC_wasm32_unknown_unknown to a WASM-capable clang." >&2
+        return 1
+    fi
+
+    # An explicit SDK root is authoritative. A typo must not quietly fall back
+    # to a different host installation.
+    if [ -n "${WASI_SDK_PATH:-}" ]; then
+        candidate="$WASI_SDK_PATH/bin/clang"
+        if [ -x "$candidate" ] && wasm_cc_probe "$candidate"; then
+            wasm_cc_export "$candidate"
+            return 0
+        fi
+        printf "ERROR: WASI_SDK_PATH '%s' has no clang capable of targeting %s.\n" \
+            "$WASI_SDK_PATH" "$WASM_CC_TARGET" >&2
+        return 1
+    fi
+
+    # Prefer the project-owned SDK. Homebrew LLVM is a useful existing
+    # installation on macOS; PATH clang is last because it is normally the
+    # incapable Apple compiler there.
+    for candidate in \
+        /opt/wasi-sdk/bin/clang \
+        /opt/homebrew/opt/llvm/bin/clang \
+        /usr/local/opt/llvm/bin/clang \
+        "$(command -v clang 2>/dev/null || true)"; do
+        [ -n "$candidate" ] || continue
+        [ -x "$candidate" ] || continue
+        if wasm_cc_probe "$candidate" >/dev/null 2>&1; then
+            wasm_cc_export "$candidate"
+            return 0
+        fi
+    done
+
+    printf 'ERROR: no C compiler capable of targeting %s was found.\n' \
+        "$WASM_CC_TARGET" >&2
+    printf '%s\n' \
+        "       Run 'make ensure-rust-deps'; on macOS it installs the pinned wasi-sdk." >&2
+    return 1
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    wasm_cc_prepare
+fi


### PR DESCRIPTION
Closes #1716.

## Summary

- add one sourceable wasm C-compiler selector that validates the actual wasm32-unknown-unknown target before Cargo runs
- teach the dependency bootstrap to install and verify wasi-sdk on macOS, and export the cc-rs target compiler for every browser/WASM build entry point
- add a hermetic shell regression plus a path-scoped macOS CI job that runs the complete check-rust surface on a clean GitHub-hosted runner
- document the macOS prerequisite and troubleshooting contract

## Experimental proof

Red reproduction: a fake Apple-clang-compatible driver that accepts version discovery but rejects --target=wasm32-unknown-unknown made the Spec Studio target compile fail inside ring with: No available targets are compatible with triple wasm32-unknown-unknown. The cc-rs trace confirmed that exact target reached the compiler.

Green reproduction: with generic CC deliberately set to /bin/false, the new selector chose /opt/wasi-sdk/bin/clang; the identical Spec Studio cargo check then compiled ring and completed successfully. The probe also produced a non-empty WebAssembly object directly.

The hermetic regression separately proves that an installed but target-incapable compiler is reported as missing, an explicit bad compiler fails before Cargo, and a valid SDK compiler is exported with the exact target arguments.

## Verification

- scripts/dev/test-wasm-cc-env.sh
- make check-rust
- make rust-check
- make NPROC=1 prep-pr
- workflow YAML parsed independently

The new macos-wasm-check PR job is the final clean-host proof on stock macOS.