### PR TITLE
refactor(compiler): build WordExpr from the word-parts owner (#1785)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -888,6 +888,19 @@ jobs:
   # This is an ADDITIONAL semantic gate, not a replacement: `wasm-real-link`
   # remains the real-link check, and this job never links anything.
   #
+  # It also runs the mirror-image config: `make runtime-rust-test-no-tommath`,
+  # BEFORE the libtommath fetch step below, so the source tree genuinely does
+  # not exist yet — no hiding trick needed on this runner. Every job here
+  # fetches the Tcl 9.0.4 source before touching `runtime/rust`, so the
+  # degraded fallback build.rs takes when that source is absent (no bignum
+  # tower, and `expr`/`if`/the `mathfunc`/`mathop` ensembles un-registered)
+  # had never once been compiled in CI, let alone tested — despite two real
+  # bugs recently found in exactly that fallback by hand (a `read_double` that
+  # widened every bignum to infinity, and an `incr` that bypassed the
+  # read-trace chokepoint). Same step-level skip and shared make target as the
+  # tommath-enabled run below, so this doesn't cost a second job or a second
+  # checkout.
+  #
   # The step-level skip keys on `runtime_rust_changed` (see the channel job
   # header): the crate plus the path-dependency closure its own lockfile
   # resolves.  The job itself always runs and reports, per the redundancy
@@ -909,6 +922,16 @@ jobs:
           # target dir, so it keeps its own cache rather than racing the root
           # workspace jobs on save.
           cache-key: runtime-rust-tests
+
+      # The no-bignum fallback config, run BEFORE the fetch step below so
+      # libtommath's source tree genuinely is not present on this runner —
+      # the natural way to exercise the degraded build, no hide-and-restore
+      # dance required. See `runtime-rust-test-no-tommath` in the Makefile for
+      # why this configuration is worth gating and how it forces absence on a
+      # checkout where the tree WAS already fetched.
+      - name: make runtime-rust-test-no-tommath (standalone runtime, no libtommath)
+        if: needs.channel.outputs.runtime_rust_changed == 'true' && needs.channel.outputs.already_green != 'true'
+        run: make runtime-rust-test-no-tommath
 
       # libtommath, for the same reason `wasm-real-link` fetches it: without
       # the source `runtime/rust`'s build script prints a `cargo:warning` and

--- a/Makefile
+++ b/Makefile
@@ -229,7 +229,7 @@ TS_SRCS  := $(shell find $(EXT_DIR)/src -name '*.ts' 2>/dev/null)
 .PHONY: release release-tag release-sums
 .PHONY: release-perf release-notes-perf release-verify release-prepare release-rust-tag
 # Rust runtime port
-.PHONY: runtime-rust-test runtime-rust-lint zed-query-check vm-test vm-lint
+.PHONY: runtime-rust-test runtime-rust-test-no-tommath runtime-rust-lint zed-query-check vm-test vm-lint
 # Screenshots
 .PHONY: screenshot screenshots clean-screenshots
 # Cleanup
@@ -2343,6 +2343,46 @@ runtime-rust-test: ## Run the Rust runtime port's cargo test (leak round-trip + 
 		tommath=""; \
 	fi; \
 	cd $(RUNTIME_RUST_DIR) && TCL_TOMMATH_DIR="$$tommath" cargo test --locked
+
+# The companion no-bignum gate. `runtime-rust-test` above exists precisely
+# because CI's own fetch step means the standalone suite ALWAYS builds with
+# `have_tommath` set — the degraded fallback build.rs takes when libtommath's
+# source is absent (no bignum tower, and `expr`/`if`/the `mathfunc`/`mathop`
+# ensembles un-registered, since control flow needs `expr` to evaluate a
+# condition) had never once been compiled, let alone tested, in CI. Two real
+# bugs were found in exactly that fallback by running it by hand (a
+# `read_double` that widened every bignum to infinity, and an `incr` that
+# bypassed the read-trace chokepoint) — this target is what stops that
+# regressing silently again. Tests whose subject is `expr`/`if` are
+# `#[cfg(have_tommath)]`-gated so they compile out here; everything else runs.
+#
+# Forcing absence takes two things, per `locate_libtommath()` in build.rs:
+# unset $$TCL_TOMMATH_DIR (never pass it, unlike the target above) AND make
+# sure its fallback path — tmp/tcl9.0.4/libtommath — does not exist, since the
+# build script probes that path itself when the variable is unset. On a fresh
+# checkout that never fetched the tree (the normal CI shape: this target runs
+# BEFORE the Tcl-source fetch step) the fallback path is simply absent
+# already. On a machine where it WAS fetched (e.g. `make ensure-tcl90-reference`
+# already ran), the tree is renamed out of the way for the duration of the run
+# and restored — via a trap, so a failing `cargo test` still restores it —
+# rather than deleted, since re-fetching is neither instant nor guaranteed
+# offline.
+runtime-rust-test-no-tommath: ## Run the Rust runtime port's cargo test with libtommath deliberately absent (the no-bignum/no-expr fallback build)
+	@set -eu; \
+	tommath_dir="$(ROOT)tmp/tcl9.0.4/libtommath"; \
+	hidden="$${tommath_dir}.hidden-for-no-tommath-test"; \
+	restore() { \
+		if [ -d "$$hidden" ]; then \
+			rm -rf "$$tommath_dir"; \
+			mv "$$hidden" "$$tommath_dir"; \
+		fi; \
+	}; \
+	trap restore EXIT INT TERM HUP; \
+	if [ -d "$$tommath_dir" ]; then \
+		mv "$$tommath_dir" "$$hidden"; \
+	fi; \
+	unset TCL_TOMMATH_DIR; \
+	cd $(RUNTIME_RUST_DIR) && cargo test --locked
 
 runtime-rust-lint: ## Rust runtime port: cargo fmt --check + locked clippy -D warnings
 	cd $(RUNTIME_RUST_DIR) && cargo fmt --check && cargo clippy --locked --all-targets -- -D warnings

--- a/docs/design/contracts/shared-utility-contracts-rust.md
+++ b/docs/design/contracts/shared-utility-contracts-rust.md
@@ -42,7 +42,7 @@ entry point, or gate moves without this contract being updated.
 | boolean words | `rust/tcl-syntax/src/boolean.rs` | `parse_boolean_word`; `truthiness_with` | fixed boolean vocabulary; number axis per release | none |
 | quotes / braces / word spans | `rust/tcl-lexer/src/ranges.rs` | `close_quote_offset`; `word_closer_offset`; `word_span_at`; `braced_var_name_end` | `${...}` close rule per release (`BracedVarStyle`); tmsh brace mode per dialect | none |
 | array-index source scan | `rust/tcl-lexer/src/ranges.rs`; `rust/tcl-dialect/src/grammar.rs` | `scan_array_index`; `ArrayIndexSyntax` | `LexerGrammar::array_index` per release | none |
-| word substitution components | `rust/tcl-lexer/src/word_parts.rs` | `decompose`; `scan_var_ref`; `command_subst_close`; `quoted_word_close`; `SubstFlags`; `WordPart`; `WordBody`; `VarRef`; `RawVarRef`; `MISSING_QUOTE`; `MISSING_CLOSE_BRACKET`; `MISSING_CLOSE_BRACE`; `MISSING_PAREN` | `LexerConfig` per emulated release (`${...}` close rule, array-index source mask, escape grammar); compiled-word vs source-word `$` spelling | none |
+| word substitution components | `rust/tcl-lexer/src/word_parts.rs` | `decompose`; `decompose_spanned`; `scan_var_ref`; `command_subst_close`; `quoted_word_close`; `SubstFlags`; `WordPart`; `SpannedPart`; `WordBody`; `VarRef`; `RawVarRef`; `MISSING_QUOTE`; `MISSING_CLOSE_BRACKET`; `MISSING_CLOSE_BRACE`; `MISSING_PAREN` | `LexerConfig` per emulated release (`${...}` close rule, array-index source mask, escape grammar); compiled-word vs source-word `$` spelling | none |
 | indices | `rust/tcl-cmd-core/src/index.rs` | `resolve_with`; `drill` | grammar-parameterised, inheriting the number axis | none |
 | option words / subcommands | `rust/tcl-cmd-core/src/prefix.rs`; `rust/tcl-cmd-core/src/ensemble.rs`; `rust/tcl-registry/src/hover.rs`; `rust/tcl-registry/src/spec.rs` | `OptionTable`; `OptionSpec`; `SubCommand`; `first_positional_index`; `ensemble::EnsembleToken`; `ensemble::InvocationLayout`; `ensemble::invocation_layout`; `ensemble::UNKNOWN_DELETED_MESSAGE`; `ensemble::UNKNOWN_DELETED_ERROR_CODE`; `ensemble::CREATE_OPTIONS`; `ensemble::CONFIG_OPTIONS`; `ensemble::SUBCOMMANDS`; `ensemble::resolve_subcommand`; `ensemble::subcommand_choices`; `ensemble::unknown_subcommand_message`; `ensemble::validate_map_targets` | option surface per release/dialect; ensemble token lifecycle and invocation layout invariant | `xtask-option-registry-drift` |
 | trace argument decoding | `rust/tcl-cmd-core/src/trace.rs` | `TraceKind`; `resolve_option`; `resolve_type`; `parse_ops`; `parse_legacy_variable_ops`; `legacy_ops_letters`; `callback_op_word` | option surface per release (the 8.x-only `variable`/`vdelete`/`vinfo` forms) | none |
@@ -326,8 +326,14 @@ entry point, or gate moves without this contract being updated.
   `segmenter.rs` / `ir.rs` `WordExpr` builder. Only one raised C's `missing
   close-bracket`; only one found a `]` without being fooled by a brace,
   quote or comment in the substituted script; only one decoded a literal
-  run's escapes. `runtime/rust` and `tcl-vm` are consumers now; the
-  compiler's segmenter is the remaining adopter (see below).
+  run's escapes. All four are consumers now: `runtime/rust`, `tcl-vm`, and
+  — since #1785 — the compiler, whose `WordExpr` builder moved out of
+  `ir.rs`'s fragment walk into `word_expr.rs` over `decompose_spanned`.
+  The segmenter keeps what it owns, command and word boundaries; only the
+  within-word breakdown is the owner's. `differential_word_expr` holds a
+  frozen copy of the walk that was replaced and asserts the new production
+  against it across crafted edge cases, the sample corpus and tcllib, so
+  the adoption's behaviour changes are enumerated rather than assumed.
 
   The module sits in `tcl-lexer` because its dependencies already do —
   `braced_var_name_end`, `scan_array_index`, `command_substitution_end`,

--- a/rust/tcl-cli/tests/explorer_gui.rs
+++ b/rust/tcl-cli/tests/explorer_gui.rs
@@ -30,6 +30,11 @@
 //! `serialise_result` the WASM facade calls) and drives the shipped GUI in
 //! headless Chromium via `tests/gui/explorer-gui-smoke.mjs`.
 //!
+//! Source goes in the way the shipped UI accepts it: Monaco owns the editor
+//! and the `#source` textarea behind it is hidden state plumbing, so the
+//! driver writes through the editor host's `onChange` bridge rather than
+//! typing into an element no user can reach.
+//!
 //! It needs `node` plus a Playwright install; without them it prints why and
 //! passes, so a plain `cargo test` on a machine with no browser stack is not
 //! blocked. Point it at a non-default install with:
@@ -120,7 +125,28 @@ fn native_serve_requires_the_complete_monaco_bundle() {
     assert!(!GUI_RS.contains("make explorer-wasm && cargo build -p tcl-cli --release"));
 }
 
-fn assert_forced_compiles(report: &Value) {
+/// The other half of #1183: an edit made while the WASM module is still
+/// loading must not be dropped. The driver holds module load open (the stubbed
+/// `wasm_bindgen` parks on a gate), enters the source through the Monaco host
+/// — the only editor the shipped page shows — and only then lets the worker
+/// report ready, so this is a state the test enters on purpose rather than a
+/// timing window it has to win.
+fn assert_compile_survives_module_load(report: &Value, first: &Value, source: &str) {
+    assert_eq!(
+        report["queuedDuringLoad"], true,
+        "the GUI never queued a compile for the edit made during module load"
+    );
+    assert_eq!(
+        report["compilesDuringLoad"], 0,
+        "the worker compiled before it finished loading"
+    );
+    assert_eq!(
+        first["compiledSource"], source,
+        "the compile owed from module load never reached the compiler"
+    );
+}
+
+fn assert_compile_triggers(report: &Value) {
     let before = report["compilesBeforeButton"]
         .as_u64()
         .expect("compile count");
@@ -143,6 +169,20 @@ fn assert_forced_compiles(report: &Value) {
         after_shortcut,
         before_shortcut + 1,
         "Ctrl/Cmd+Enter in Monaco did not force compilation ({before_shortcut} -> {after_shortcut})"
+    );
+
+    // Monaco is the only editor: an ordinary edit reaches the compiler only
+    // through its `onChange` bridge into the hidden `#source` textarea.
+    let before_edit = report["compilesBeforeEdit"]
+        .as_u64()
+        .expect("edit compile count");
+    let after_edit = report["compilesAfterEdit"]
+        .as_u64()
+        .expect("edit compile count");
+    assert_eq!(
+        after_edit,
+        before_edit + 1,
+        "editing in Monaco did not recompile ({before_edit} -> {after_edit})"
     );
 }
 
@@ -211,6 +251,8 @@ fn gui_renders_the_wasm_tab_and_settles_the_spinner() {
         first["errorBoxes"]
     );
 
+    assert_compile_survives_module_load(&report, first, source);
+
     // Issue #1183: the throbber must stop once a result is in.
     assert_eq!(
         first["spinnerDisplay"], "none",
@@ -258,5 +300,5 @@ fn gui_renders_the_wasm_tab_and_settles_the_spinner() {
         "the ready-message trait reference was empty before compilation"
     );
 
-    assert_forced_compiles(&report);
+    assert_compile_triggers(&report);
 }

--- a/rust/tcl-cli/tests/gui/explorer-gui-smoke.mjs
+++ b/rust/tcl-cli/tests/gui/explorer-gui-smoke.mjs
@@ -23,7 +23,9 @@
  *   - the WASM tab actually renders a disassembly,
  *   - the compile spinner stops,
  *   - the dialect dropdown is populated before the first result,
- *   - typing before the WASM module is ready still produces a compile,
+ *   - an edit made while the WASM module is still loading still produces a
+ *     compile (the stub holds module load open, so this is a state the test
+ *     enters on purpose rather than a race it has to win),
  *   - the Compile button forces a recompile,
  *   - no uncaught page errors along the way.
  */
@@ -57,7 +59,11 @@ await writeFile(
   `self.__PAYLOAD = ${JSON.stringify(payload)};\n` +
     `self.__META = ${JSON.stringify(meta)};\n` +
     'self.__COMPILES = 0;\n' +
-    'self.wasm_bindgen = function () { return Promise.resolve(); };\n' +
+    // Module load blocks until the driver opens this gate. `worker.js` awaits
+    // `wasm_bindgen(...)` before it posts `ready`, so the driver — not a
+    // timing window — decides when the GUI leaves its "still loading" state.
+    'self.__initGate = new Promise(function (resolve) { self.__finishInit = resolve; });\n' +
+    'self.wasm_bindgen = function () { return self.__initGate; };\n' +
     'self.wasm_bindgen.meta = function () { return self.__META; };\n' +
     'self.wasm_bindgen.compile = function () { self.__COMPILES += 1; return self.__PAYLOAD; };\n',
 );
@@ -74,6 +80,13 @@ await writeFile(join(root, 'build_info.json'), '{"version":"smoke-test"}');
 // browser/native editor bundle has its own boot tests). Supply the same module
 // boundary with a tiny test surface so the production page still has exactly
 // one editor path and makes no failed asset requests here.
+//
+// The stub keeps the parts of the contract the page depends on (see
+// `Surface` in `rust/tcl-spec-studio/web/src/monacoHost.ts`): the textarea is
+// hidden state plumbing, not a second editor, and an edit writes the model
+// text into it before calling `onChange`. `__tclEditorStub.setText` is the
+// only way this driver puts source into the page, because it is the only way
+// the shipped UI has.
 await mkdir(join(root, 'editor', 'assets'), { recursive: true });
 await writeFile(
   join(root, 'editor', 'build-info.json'),
@@ -82,11 +95,16 @@ await writeFile(
 await writeFile(
   join(root, 'editor', 'assets', 'monaco-host.js'),
   'export async function mountTclEditor(options){' +
+    'options.textarea.hidden=true;' +
     'options.container.classList.add("monaco-mounted");' +
     'options.container.tabIndex=0;' +
     'options.container.addEventListener("keydown",event=>{' +
       'if(event.key==="Enter"&&(event.ctrlKey||event.metaKey)){event.preventDefault();options.onCompile?.();}' +
     '});' +
+    'globalThis.__tclEditorStub={' +
+      'setText(text){options.textarea.value=text;options.onChange(text);},' +
+      'getText(){return options.textarea.value;}' +
+    '};' +
     'return {setDialect(){},highlightRanges(){},layout(){},lspReady:true};' +
   '}',
 );
@@ -128,6 +146,7 @@ try {
   const referencePage = await browser.newPage();
   referencePage.on('pageerror', (err) => pageErrors.push(err.stack || String(err)));
   await referencePage.goto(base);
+  await finishModuleLoad(referencePage);
   await referencePage.waitForFunction(
     () => document.querySelectorAll('.trait-reference-row').length > 90,
     null,
@@ -140,10 +159,29 @@ try {
   page.on('pageerror', (err) => pageErrors.push(err.stack || String(err)));
 
   await page.goto(base);
-  // Deliberately type *before* the worker signals ready: a compile queued
-  // during module load must still happen (it used to be dropped, leaving
-  // the GUI blank forever).
-  await page.fill('#source', SOURCE);
+  // Monaco is the only editor the shipped page shows; the textarea behind it
+  // is hidden state plumbing. Put the source in through the editor host, the
+  // way a real keystroke reaches the page.
+  await page.waitForSelector('#monacoSource.monaco-mounted', { timeout: 30_000 });
+  await setEditorText(page, SOURCE);
+
+  // Deliberately edit *before* the worker signals ready — the stub's module
+  // load is still parked on its gate, so this is not a race. A compile owed
+  // from that window must still happen (it used to be dropped, leaving the
+  // GUI blank forever), so wait until the page has actually queued one.
+  await page.waitForFunction(
+    // `pendingCompile` / `workerReady` are index.html's own module-load state.
+    () => pendingCompile === true && workerReady === false,
+    null,
+    { timeout: 30_000 },
+  );
+  const queuedDuringLoad = await page.evaluate(
+    () => pendingCompile === true && workerReady === false,
+  );
+  const compilesDuringLoad = await compileCount(page);
+
+  // Now let module load finish: the queued compile must be picked up.
+  await finishModuleLoad(page);
   await page.waitForFunction(() => !!window.data, null, { timeout: 30_000 });
 
   const afterFirst = await snapshot(page);
@@ -169,14 +207,31 @@ try {
     afterShortcut = await compileCount(page);
   }
 
+  // An ordinary edit must recompile on its own. Monaco writes the model text
+  // into the hidden textarea and calls `onChange`, which index.html turns into
+  // an `input` event on `#source`; nothing else compiles once a result is in
+  // (the page's one-second safety net only fires while `data` is still null),
+  // so this isolates the editor → page bridge.
+  const beforeEdit = afterShortcut;
+  await setEditorText(page, SOURCE + 'puts [add 3 4]\n');
+  let afterEdit = beforeEdit;
+  for (let i = 0; i < 100 && afterEdit === beforeEdit; i += 1) {
+    await page.waitForTimeout(100);
+    afterEdit = await compileCount(page);
+  }
+
   report = {
     ok: true,
     first: afterFirst,
     traitRowsBeforeCompile,
+    queuedDuringLoad,
+    compilesDuringLoad,
     compilesBeforeButton: before,
     compilesAfterButton: after,
     compilesBeforeShortcut: beforeShortcut,
     compilesAfterShortcut: afterShortcut,
+    compilesBeforeEdit: beforeEdit,
+    compilesAfterEdit: afterEdit,
     pageErrors,
   };
 } finally {
@@ -200,6 +255,9 @@ async function snapshot(page) {
       wasmInstructions: wasm.querySelectorAll('.wasm-instr').length,
       asmFunctions: asm.querySelectorAll('.wasm-function').length,
       monacoMounted: !!document.querySelector('#monacoSource.monaco-mounted'),
+      // What the page actually compiled — the text that went in during
+      // module load must be what came back out.
+      compiledSource: window.compiledSource,
       stateEditorDisplay: getComputedStyle(document.querySelector('#editorContainer')).display,
       traitRows: document.querySelectorAll('.trait-reference-row').length,
       traitGroups: document.querySelectorAll('.trait-group').length,
@@ -220,4 +278,35 @@ async function compileCount(page) {
   const workers = page.workers();
   if (!workers.length) return null;
   return workers[0].evaluate(() => self.__COMPILES);
+}
+
+// Put source into the page the only way the shipped UI offers: through the
+// Monaco host, which writes the model text into the hidden `#source` textarea
+// and then calls the page's `onChange`.
+async function setEditorText(page, text) {
+  await page.evaluate((value) => {
+    if (!globalThis.__tclEditorStub) throw new Error('the editor host never mounted');
+    globalThis.__tclEditorStub.setText(value);
+  }, text);
+}
+
+// Release the stub's module-load gate, so `worker.js` finishes `init()` and
+// posts `ready`. Until this runs the page is genuinely mid-load, which is the
+// state the "compile queued during load" guard needs.
+async function finishModuleLoad(page) {
+  for (let i = 0; i < 300; i += 1) {
+    const worker = page.workers()[0];
+    if (
+      worker &&
+      (await worker.evaluate(() => {
+        if (typeof self.__finishInit !== 'function') return false;
+        self.__finishInit();
+        return true;
+      }))
+    ) {
+      return;
+    }
+    await page.waitForTimeout(50);
+  }
+  throw new Error('the compiler worker never reached its module-load gate');
 }

--- a/rust/tcl-compiler/src/codegen/wasm/leaf_invoke.rs
+++ b/rust/tcl-compiler/src/codegen/wasm/leaf_invoke.rs
@@ -561,7 +561,11 @@ fn nested_words(
     if segment.is_partial {
         return Err(WasmLeafInvokeDecline::UnmodelledCommandSubstitution);
     }
-    let tokens = CommandTokens::from_segmented(segment);
+    // The nested script is a sub-lex: its own text, segmented at the document
+    // offset it sits at, so the word model reads `inner` and still reports
+    // document spans (`SourceMap::with_base` is that sub-lexing contract).
+    let sm = tcl_lexer::SourceMap::new(inner).with_base(base, 0, 0);
+    let tokens = CommandTokens::from_segmented(&sm, config, segment);
     if tokens.word_exprs.is_empty() {
         return Err(WasmLeafInvokeDecline::MissingCommandHead);
     }
@@ -576,7 +580,9 @@ mod tests {
     /// The structured words of the first command in `source`.
     fn words(source: &str) -> Vec<WordExpr> {
         let segments = segment_commands(source);
-        CommandTokens::from_segmented(&segments[0]).word_exprs
+        let sm = tcl_lexer::SourceMap::new(source);
+        CommandTokens::from_segmented(&sm, tcl_lexer::LexerConfig::default(), &segments[0])
+            .word_exprs
     }
 
     fn plan(source: &str) -> Result<WasmLeafInvokePlan, WasmLeafInvokeDecline> {

--- a/rust/tcl-compiler/src/ir.rs
+++ b/rust/tcl-compiler/src/ir.rs
@@ -27,10 +27,10 @@
 //! [`SourceMap`](tcl_lexer::SourceMap). This mirrors the span-first
 //! design established in the lexer crate.
 
-use tcl_lexer::Span;
+use tcl_lexer::{LexerConfig, SourceMap, Span, Token};
 
 use crate::expr_ast::ExprNode;
-use crate::segmenter::{SegmentedCommand, WordFragment};
+use crate::segmenter::SegmentedCommand;
 
 // Command tokens
 
@@ -230,53 +230,6 @@ impl WordExpr {
         }
     }
 
-    fn from_fragments(
-        fragments: &[WordFragment],
-        fallback_text: &str,
-        fallback_span: Span,
-        expanded: bool,
-        expansion_span: Option<Span>,
-    ) -> Self {
-        let word = match fragments {
-            [fragment] if is_plain_bare_literal(fragment) => Self::Literal {
-                text: fragment.text.clone(),
-                source: SourceSite::source(fragment.token.span),
-            },
-            [fragment] if fragment.token.kind == tcl_lexer::TokenType::Str => Self::BracedLiteral {
-                text: fragment.text.clone(),
-                source: SourceSite::source(fragment.token.span),
-            },
-            [fragment] if fragment.token.kind == tcl_lexer::TokenType::Var => Self::Variable {
-                spelling: fragment.text.clone(),
-                source: SourceSite::source(fragment.token.span),
-            },
-            [fragment] if fragment.token.kind == tcl_lexer::TokenType::Cmd => {
-                Self::CommandSubstitution {
-                    spelling: fragment.text.clone(),
-                    source: SourceSite::source(fragment.token.span),
-                }
-            }
-            [] => Self::Opaque {
-                text: fallback_text.to_owned(),
-                source: SourceSite::opaque(fallback_span),
-                reason: WordOpacity::MissingFragments,
-            },
-            _ => Self::Template {
-                parts: fragments.iter().map(WordPart::from_fragment).collect(),
-                source: SourceSite::source(fallback_span),
-            },
-        };
-        if expanded {
-            let start = expansion_span.map_or(fallback_span.start(), Span::start);
-            Self::Expand {
-                source: SourceSite::source(Span::new(start, fallback_span.end())),
-                word: Box::new(word),
-            }
-        } else {
-            word
-        }
-    }
-
     fn from_lossy_snapshot(
         text: &str,
         span: Span,
@@ -323,19 +276,6 @@ impl WordExpr {
     }
 }
 
-/// Whether a single lexer fragment is statically a bare Tcl literal.
-///
-/// `Esc` is intentionally broader than a semantic literal: quoted fragments
-/// and fragments containing a backslash need Tcl substitution processing.
-/// This predicate only admits the demonstrably plain subset so a later
-/// resolver receives static command heads without overclaiming word meaning.
-fn is_plain_bare_literal(fragment: &WordFragment) -> bool {
-    fragment.token.kind == tcl_lexer::TokenType::Esc
-        && !fragment.token.in_quote
-        && fragment.token.content_offset == 0
-        && !fragment.text.contains('\\')
-}
-
 /// One ordered lexical component of a [`WordExpr::Template`].
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum WordPart {
@@ -371,28 +311,6 @@ pub enum WordPart {
 }
 
 impl WordPart {
-    fn from_fragment(fragment: &WordFragment) -> Self {
-        let source = SourceSite::source(fragment.token.span);
-        match fragment.token.kind {
-            tcl_lexer::TokenType::Var => Self::Variable {
-                spelling: fragment.text.clone(),
-                source,
-            },
-            tcl_lexer::TokenType::Cmd => Self::CommandSubstitution {
-                spelling: fragment.text.clone(),
-                source,
-            },
-            tcl_lexer::TokenType::Esc | tcl_lexer::TokenType::Str => Self::Text {
-                text: fragment.text.clone(),
-                source,
-            },
-            _ => Self::Opaque {
-                text: fragment.text.clone(),
-                source,
-            },
-        }
-    }
-
     fn legacy_text(&self) -> String {
         match self {
             Self::Text { text, .. } | Self::Opaque { text, .. } => text.clone(),
@@ -523,35 +441,54 @@ pub struct CommandTokens {
 
 impl CommandTokens {
     /// Build a token snapshot from the segmenter without losing word shape.
+    ///
+    /// `sm` is the buffer the segment's spans index into — the document, or a
+    /// sub-lexed slice carrying its document base
+    /// ([`SourceMap::with_base`]) — and `config` is that document's grammar,
+    /// resolved once at the ingress and threaded here so every word is
+    /// decomposed under the release it is written for.
     #[must_use]
-    pub fn from_segmented(seg: &SegmentedCommand) -> Self {
+    pub fn from_segmented(sm: &SourceMap<'_>, config: LexerConfig, seg: &SegmentedCommand) -> Self {
         let expand = seg.expand_word.as_deref();
-        let word_exprs = seg
-            .argv
-            .iter()
-            .enumerate()
-            .map(|(idx, token)| {
-                let fragments = seg.word_fragments.get(idx).map_or(&[][..], Vec::as_slice);
-                let text = seg.texts.get(idx).map_or("", String::as_str);
-                let expanded = expand
-                    .and_then(|flags| flags.get(idx))
-                    .copied()
-                    .unwrap_or(false);
-                let expansion_span = expanded
-                    .then(|| {
-                        seg.all_tokens
-                            .iter()
-                            .rev()
-                            .find(|candidate| {
-                                candidate.kind == tcl_lexer::TokenType::Expand
-                                    && candidate.span.end() <= token.span.start()
-                            })
-                            .map(|candidate| candidate.span)
-                    })
-                    .flatten();
-                WordExpr::from_fragments(fragments, text, token.span, expanded, expansion_span)
-            })
-            .collect();
+        // One reused buffer: `WordExpr::from_word` takes the word's lexer
+        // tokens, and the segmenter keeps them behind its own fragment type.
+        let mut fragments: Vec<Token> = Vec::new();
+        let mut word_exprs = Vec::with_capacity(seg.argv.len());
+        for (idx, token) in seg.argv.iter().enumerate() {
+            fragments.clear();
+            fragments.extend(
+                seg.word_fragments
+                    .get(idx)
+                    .map_or(&[][..], Vec::as_slice)
+                    .iter()
+                    .map(|fragment| fragment.token),
+            );
+            let text = seg.texts.get(idx).map_or("", String::as_str);
+            let expanded = expand
+                .and_then(|flags| flags.get(idx))
+                .copied()
+                .unwrap_or(false);
+            let expansion_span = expanded
+                .then(|| {
+                    seg.all_tokens
+                        .iter()
+                        .rev()
+                        .find(|candidate| {
+                            candidate.kind == tcl_lexer::TokenType::Expand
+                                && candidate.span.end() <= token.span.start()
+                        })
+                        .map(|candidate| candidate.span)
+                })
+                .flatten();
+            word_exprs.push(WordExpr::from_word(
+                sm,
+                config,
+                &fragments,
+                text,
+                expanded,
+                expansion_span,
+            ));
+        }
         Self {
             argv: seg.argv.iter().map(|token| token.span).collect(),
             argv_texts: seg.texts.clone(),

--- a/rust/tcl-compiler/src/ir.rs
+++ b/rust/tcl-compiler/src/ir.rs
@@ -411,6 +411,9 @@ pub enum WordOpacity {
     /// The snapshot was synthetically constructed or retained only its legacy
     /// representative-token fields.
     LossySnapshot,
+    /// C Tcl's parser rejects the word; the payload is its exact message
+    /// (`missing close-bracket`, `missing )`, …) for diagnostics.
+    ParseError(&'static str),
 }
 
 /// A statement the CFG builder **synthesised**: it models an analysis effect

--- a/rust/tcl-compiler/src/ir_helpers.rs
+++ b/rust/tcl-compiler/src/ir_helpers.rs
@@ -614,13 +614,17 @@ pub(crate) fn tokenise_command_words(source: &str, config: LexerConfig) -> Vec<V
     crate::segmenter::segment_commands_with_offset_and_config(source, 0, config)
         .iter()
         .filter(|command| !command.argv.is_empty())
-        .map(|command| command_words(&sm, command))
+        .map(|command| command_words(&sm, config, command))
         .collect()
 }
 
 /// Map one segmented command onto its per-word [`CommandWord`] facts.
-fn command_words(sm: &SourceMap<'_>, command: &SegmentedCommand) -> Vec<CommandWord> {
-    let tokens = CommandTokens::from_segmented(command);
+fn command_words(
+    sm: &SourceMap<'_>,
+    config: LexerConfig,
+    command: &SegmentedCommand,
+) -> Vec<CommandWord> {
+    let tokens = CommandTokens::from_segmented(sm, config, command);
     command
         .argv
         .iter()

--- a/rust/tcl-compiler/src/lib.rs
+++ b/rust/tcl-compiler/src/lib.rs
@@ -177,6 +177,7 @@ pub mod var_observability;
 pub mod var_refs;
 pub mod var_resolve;
 pub mod var_scoping;
+pub mod word_expr;
 pub mod world_state_ssa;
 
 // Re-export key types for convenience.

--- a/rust/tcl-compiler/src/lowering/mod.rs
+++ b/rust/tcl-compiler/src/lowering/mod.rs
@@ -853,6 +853,46 @@ pub struct Lowerer<'r> {
     /// script is lowered, which the guard reads as "nothing to compare
     /// against" and leaves every body text alone.
     source: String,
+    /// The buffer each word model is read from — see [`WordSpace`].
+    word_space: WordSpace,
+}
+
+/// The text a [`crate::ir::WordExpr`] is decomposed from, and the offset its
+/// first byte sits at in the span space the segmentation used.
+///
+/// Deliberately *not* [`Lowerer::source`]: a word is read from the very text
+/// that was segmented into it, which is not always a slice of the enclosing
+/// buffer.  A `{body}x` word's body is clamped to the part that does map
+/// (issue #1325); an `eval $const` / `eval [list …]` body is a literal
+/// materialised at lowering time and lives in a span space of its own; and
+/// the `TclOO` method extraction runs as a post-pass, after the document's
+/// span space has been restored to the (empty) enclosing one.  Reading the
+/// segmented text itself makes the word model right in all three, and the
+/// base keeps every span it reports in the space the statements' spans are
+/// in.
+struct WordSpace {
+    text: String,
+    base: u32,
+    /// `text`'s line index, held so the per-command [`tcl_lexer::SourceMap`]
+    /// is a refcount bump (`LineIndex` is `Arc`-backed) rather than a rescan.
+    lines: tcl_lexer::LineIndex,
+}
+
+impl WordSpace {
+    fn new(text: &str, base: u32) -> Self {
+        Self {
+            text: text.to_owned(),
+            base,
+            lines: tcl_lexer::LineIndex::new(text),
+        }
+    }
+
+    /// A [`tcl_lexer::SourceMap`] over this text, carrying its base so a word
+    /// built from it reports spans in the enclosing span space.
+    fn map(&self) -> tcl_lexer::SourceMap<'_> {
+        tcl_lexer::SourceMap::with_line_index(&self.text, self.lines.clone())
+            .with_base(self.base, 0, 0)
+    }
 }
 
 /// Maximum nesting depth for the recursive `lower_script` / `lower_body`
@@ -913,6 +953,7 @@ impl<'r> Lowerer<'r> {
             body_cache: None,
             nest_depth: 0,
             source: String::new(),
+            word_space: WordSpace::new("", 0),
         }
     }
 
@@ -1009,10 +1050,21 @@ impl<'r> Lowerer<'r> {
         result
     }
 
+    /// Run `body` with the words of the commands it lowers read from `text`,
+    /// segmented at `base` — see [`WordSpace`]. Restores the enclosing space
+    /// after, so a nested body does not outlive its own descent.
+    fn in_word_space<T>(&mut self, text: &str, base: u32, body: impl FnOnce(&mut Self) -> T) -> T {
+        let enclosing = std::mem::replace(&mut self.word_space, WordSpace::new(text, base));
+        let result = body(self);
+        self.word_space = enclosing;
+        result
+    }
+
     fn lower_script_inner(&mut self, source: &str, namespace: &str) -> Script {
         let commands = segment_commands_with_offset_and_config(source, 0, self.config);
         self.const_map_stack.push(HashMap::new());
-        let stmts = self.lower_segmented(&commands, namespace);
+        let stmts =
+            self.in_word_space(source, 0, |this| this.lower_segmented(&commands, namespace));
         self.const_map_stack.pop();
         Script::from_statements(stmts)
     }
@@ -1124,7 +1176,9 @@ impl<'r> Lowerer<'r> {
         let commands = segment_commands_with_offset_and_config(text, base_offset, self.config);
         let inherited = self.const_map_stack.last().cloned().unwrap_or_default();
         self.const_map_stack.push(inherited);
-        let stmts = self.lower_segmented(&commands, namespace);
+        let stmts = self.in_word_space(text, base_offset, |this| {
+            this.lower_segmented(&commands, namespace)
+        });
         self.const_map_stack.pop();
         Script::from_statements(stmts)
     }
@@ -1247,9 +1301,11 @@ impl<'r> Lowerer<'r> {
         scope.get(inner).cloned()
     }
 
-    /// Build a `CommandTokens` snapshot from a segmented command.
-    fn cmd_tokens(seg: &SegmentedCommand) -> CommandTokens {
-        CommandTokens::from_segmented(seg)
+    /// Build a `CommandTokens` snapshot from a segmented command, decomposing
+    /// each word under the document's own grammar (`self.config`) from the
+    /// text that was segmented into it (see [`WordSpace`]).
+    fn cmd_tokens(&self, seg: &SegmentedCommand) -> CommandTokens {
+        CommandTokens::from_segmented(&self.word_space.map(), self.config, seg)
     }
 
     /// Extract arg token kinds for the lowering hooks.
@@ -1358,6 +1414,7 @@ impl<'r> Lowerer<'r> {
     /// `{*}` expansion on a structured command lowers to a barrier so
     /// downstream analyses can't reason about the expanded form.
     fn structured_expand_barrier(
+        &self,
         cmd_name: &str,
         args: &[String],
         seg: &SegmentedCommand,
@@ -1368,7 +1425,7 @@ impl<'r> Lowerer<'r> {
             command: cmd_name.into(),
             canonical_command: None,
             args: args.to_vec(),
-            tokens: Some(Self::cmd_tokens(seg)),
+            tokens: Some(self.cmd_tokens(seg)),
         }
     }
 
@@ -1425,7 +1482,7 @@ impl<'r> Lowerer<'r> {
                 .as_ref()
                 .is_some_and(|ew| ew.iter().any(|&e| e))
         {
-            return Some(Self::structured_expand_barrier(cmd_name, args, seg));
+            return Some(self.structured_expand_barrier(cmd_name, args, seg));
         }
         let inline_body_error_context = resolved.semantics.operation.inline_body_error_context();
         match hook {
@@ -1764,7 +1821,7 @@ impl<'r> Lowerer<'r> {
             args,
             single_token_word: &seg.single_token_word,
             expand_word: seg.expand_word.as_deref(),
-            tokens: Some(Self::cmd_tokens(seg)),
+            tokens: Some(self.cmd_tokens(seg)),
             arg_kinds: &Self::arg_kinds(seg),
             dialect: self.dialect,
         };
@@ -1827,7 +1884,7 @@ impl<'r> Lowerer<'r> {
                 command: "proc".into(),
                 canonical_command: None,
                 args: args_borrow.to_vec(),
-                tokens: Some(Self::cmd_tokens(seg)),
+                tokens: Some(self.cmd_tokens(seg)),
             };
         }
         // Phase 2: dynamic proc name resolution.
@@ -1862,7 +1919,7 @@ impl<'r> Lowerer<'r> {
                 command: "proc".into(),
                 canonical_command: None,
                 args: seg.args().to_vec(),
-                tokens: Some(Self::cmd_tokens(seg)),
+                tokens: Some(self.cmd_tokens(seg)),
             };
         };
         let qualified = qualify_proc_name(namespace, proc_name);
@@ -1917,7 +1974,7 @@ impl<'r> Lowerer<'r> {
             reads: vec![],
             reads_own_defs: false,
             safe_on_uninit: false,
-            tokens: Some(Self::cmd_tokens(seg)),
+            tokens: Some(self.cmd_tokens(seg)),
             foreach_groups: None,
         }
     }
@@ -2012,7 +2069,7 @@ impl<'r> Lowerer<'r> {
                 command: "proc".into(),
                 canonical_command: None,
                 args: args_borrow.to_vec(),
-                tokens: Some(Self::cmd_tokens(seg)),
+                tokens: Some(self.cmd_tokens(seg)),
             }));
         };
 
@@ -2086,7 +2143,7 @@ impl<'r> Lowerer<'r> {
                 command: "proc".into(),
                 canonical_command: None,
                 args: seg.args().to_vec(),
-                tokens: Some(Self::cmd_tokens(seg)),
+                tokens: Some(self.cmd_tokens(seg)),
             }));
         }
         let body_offset = body_tok.span.start() + u32::from(body_tok.content_offset);
@@ -2161,7 +2218,7 @@ impl<'r> Lowerer<'r> {
             reads: vec![],
             reads_own_defs: false,
             safe_on_uninit: false,
-            tokens: Some(Self::cmd_tokens(seg)),
+            tokens: Some(self.cmd_tokens(seg)),
             foreach_groups: None,
         }
     }
@@ -2238,7 +2295,7 @@ impl<'r> Lowerer<'r> {
             frame_shift: level.shift,
             absolute: level.absolute,
             body,
-            tokens: Some(Self::cmd_tokens(seg)),
+            tokens: Some(self.cmd_tokens(seg)),
         })
     }
 
@@ -2370,7 +2427,7 @@ impl<'r> Lowerer<'r> {
             span: seg.span,
             body,
             namespace: namespace.to_string(),
-            tokens: Some(Self::cmd_tokens(seg)),
+            tokens: Some(self.cmd_tokens(seg)),
             error_context,
         })
     }
@@ -2550,7 +2607,7 @@ impl<'r> Lowerer<'r> {
             command: seg.name().into(),
             canonical_command: None,
             args: args.to_vec(),
-            tokens: Some(Self::cmd_tokens(seg)),
+            tokens: Some(self.cmd_tokens(seg)),
         }
     }
 
@@ -2598,7 +2655,7 @@ impl<'r> Lowerer<'r> {
                     list_arg: args[2].clone(),
                     // `array for {k v} {arr} …` — a braced array-name word
                     // is a literal name, not a substitution (issue #1260).
-                    list_braced: Self::cmd_tokens(seg).arg_is_braced_literal(2),
+                    list_braced: self.cmd_tokens(seg).arg_is_braced_literal(2),
                 }],
                 body,
                 body_span: body_tok.span,
@@ -2606,7 +2663,7 @@ impl<'r> Lowerer<'r> {
                 raw_args: args.to_vec(),
                 is_dict_iteration: false,
                 is_array_iteration: true,
-                raw_tokens: Some(Self::cmd_tokens(seg)),
+                raw_tokens: Some(self.cmd_tokens(seg)),
             };
         }
 
@@ -2640,7 +2697,7 @@ impl<'r> Lowerer<'r> {
             command: "namespace".into(),
             canonical_command: None,
             args: seg.args().to_vec(),
-            tokens: Some(Self::cmd_tokens(seg)),
+            tokens: Some(self.cmd_tokens(seg)),
         }
     }
 
@@ -2782,7 +2839,7 @@ impl<'r> Lowerer<'r> {
                 command: cmd_name.into(),
                 canonical_command: canonical.clone(),
                 args: args.to_vec(),
-                tokens: Some(Self::cmd_tokens(seg)),
+                tokens: Some(self.cmd_tokens(seg)),
             };
         }
 
@@ -2847,7 +2904,7 @@ impl<'r> Lowerer<'r> {
                 reads: var_reads,
                 reads_own_defs: reads_before_write,
                 safe_on_uninit: self.safe_on_uninit(&role_cmd, &role_args),
-                tokens: Some(Self::cmd_tokens(seg)),
+                tokens: Some(self.cmd_tokens(seg)),
                 foreach_groups: None,
             };
         }
@@ -2861,7 +2918,7 @@ impl<'r> Lowerer<'r> {
             reads: vec![],
             reads_own_defs: false,
             safe_on_uninit: false,
-            tokens: Some(Self::cmd_tokens(seg)),
+            tokens: Some(self.cmd_tokens(seg)),
             foreach_groups: None,
         }
     }

--- a/rust/tcl-compiler/src/lowering/structured.rs
+++ b/rust/tcl-compiler/src/lowering/structured.rs
@@ -194,7 +194,7 @@ impl Lowerer<'_> {
         let arg_single = seg.arg_single_token();
 
         if args.is_empty() {
-            return Self::barrier(seg, "malformed if");
+            return self.barrier(seg, "malformed if");
         }
 
         let mut clauses = Vec::new();
@@ -216,24 +216,24 @@ impl Lowerer<'_> {
                 // (`if 1 {a} elseif`) is "no expression after elseif". Defer to the
                 // runtime `if`, which reports it faithfully (if-2.3).
                 if i >= args.len() {
-                    return Self::barrier(seg, "if missing elseif expression");
+                    return self.barrier(seg, "if missing elseif expression");
                 }
                 continue;
             }
             if args[i] == "else" {
                 if i + 1 >= args.len() {
-                    return Self::barrier(seg, "malformed if else clause");
+                    return self.barrier(seg, "malformed if else clause");
                 }
                 // Exactly one body may follow `else`; trailing words
                 // (`if 0 {a} else {b} junk`) are "extra words after else" — defer to
                 // the runtime `if` (if-3.5).
                 if i + 2 < args.len() {
-                    return Self::barrier(seg, "if extra words after else");
+                    return self.barrier(seg, "if extra words after else");
                 }
                 // Only a substitution-free literal body inlines (see the
                 // clause-body note below).
                 if !super::seg_word_is_static_literal(seg, i + 2) {
-                    return Self::barrier(seg, "if with non-literal body");
+                    return self.barrier(seg, "if with non-literal body");
                 }
                 let body_tok = arg_tokens.get(i + 1);
                 let dead = later_clauses_dead;
@@ -254,7 +254,7 @@ impl Lowerer<'_> {
                 i += 1;
             }
             if i >= args.len() {
-                return Self::barrier(seg, "malformed if clause");
+                return self.barrier(seg, "malformed if clause");
             }
 
             let body_idx = i;
@@ -265,7 +265,7 @@ impl Lowerer<'_> {
             // construct to that command rather than mis-parsing the unsubstituted
             // word as a literal script at compile time.
             if !super::seg_word_is_static_literal(seg, body_idx + 1) {
-                return Self::barrier(seg, "if with non-literal body");
+                return self.barrier(seg, "if with non-literal body");
             }
             let body_tok = arg_tokens.get(body_idx);
             let cond_tok = arg_tokens.get(cond_idx);
@@ -300,12 +300,12 @@ impl Lowerer<'_> {
             // as another implicit clause. Bail to the runtime `if`, which
             // reports the error faithfully.
             if i < args.len() && args[i] != "elseif" && args[i] != "else" {
-                return Self::barrier(seg, "if with extra words");
+                return self.barrier(seg, "if with extra words");
             }
         }
 
         if clauses.is_empty() {
-            return Self::barrier(seg, "malformed if");
+            return self.barrier(seg, "malformed if");
         }
 
         Statement::If {
@@ -328,7 +328,7 @@ impl Lowerer<'_> {
         // runtime builtin, which raises `wrong # args` (for-old-1.7). Lowering a
         // ≥4 form would silently drop the extras and run arg[0] as the body.
         if args.len() != 4 || arg_tokens.len() < 4 {
-            return Self::barrier(seg, "malformed for");
+            return self.barrier(seg, "malformed for");
         }
         // `init`, `next`, and `body` are all lowered via `lower_body_from_tok`,
         // which rebases the segmenter-reconstructed word text at the token's
@@ -341,14 +341,14 @@ impl Lowerer<'_> {
             || !super::seg_word_is_static_literal(seg, 3)
             || !super::seg_word_is_static_literal(seg, 4)
         {
-            return Self::barrier(seg, "for with dynamic arguments");
+            return self.barrier(seg, "for with dynamic arguments");
         }
         // A body/next that redefines break/continue must run through the runtime
         // builtin, which dispatches them (so the redefinition is honoured) rather
         // than firing the compiled JUMP fast-path unconditionally and looping
         // forever (proc-7.3).
         if redefines_loop_control(&args[2]) || redefines_loop_control(&args[3]) {
-            return Self::barrier(seg, "for redefines break/continue");
+            return self.barrier(seg, "for redefines break/continue");
         }
 
         let init = self.lower_body_from_tok(&args[0], Some(&arg_tokens[0]), namespace);
@@ -374,7 +374,7 @@ impl Lowerer<'_> {
             body,
             body_span: arg_tokens[3].span,
             raw_args: args.to_vec(),
-            raw_tokens: Some(Self::cmd_tokens(seg)),
+            raw_tokens: Some(self.cmd_tokens(seg)),
         }
     }
 
@@ -389,7 +389,7 @@ impl Lowerer<'_> {
         // `while` takes exactly two arguments; a wrong count barriers to the
         // runtime builtin, which raises `wrong # args` (while-old-4.3).
         if args.len() != 2 || arg_tokens.len() < 2 {
-            return Self::barrier(seg, "malformed while");
+            return self.barrier(seg, "malformed while");
         }
         // The body is lowered via `lower_body_from_tok`, which rebases the
         // segmenter-reconstructed word text at the token's span — safe only
@@ -398,12 +398,12 @@ impl Lowerer<'_> {
         // dynamic body (`$body`, `[cmd]`) must barrier rather than be lowered
         // as if it were the literal text (issue #1375).
         if !arg_single[0] || !super::seg_word_is_static_literal(seg, 2) {
-            return Self::barrier(seg, "while with dynamic arguments");
+            return self.barrier(seg, "while with dynamic arguments");
         }
         // See `lower_for`: a body redefining break/continue must use the runtime
         // builtin so the redefinition is dispatched (proc-7.3).
         if redefines_loop_control(&args[1]) {
-            return Self::barrier(seg, "while redefines break/continue");
+            return self.barrier(seg, "while redefines break/continue");
         }
 
         let body = self.lower_body_from_tok(&args[1], Some(&arg_tokens[1]), namespace);
@@ -423,7 +423,7 @@ impl Lowerer<'_> {
             body,
             body_span: arg_tokens[1].span,
             raw_args: args.to_vec(),
-            raw_tokens: Some(Self::cmd_tokens(seg)),
+            raw_tokens: Some(self.cmd_tokens(seg)),
         }
     }
 
@@ -440,7 +440,7 @@ impl Lowerer<'_> {
         let arg_tokens = seg.arg_tokens();
 
         if args.len() < 3 || args.len().is_multiple_of(2) {
-            return Self::barrier(seg, "malformed foreach");
+            return self.barrier(seg, "malformed foreach");
         }
 
         let body_idx = args.len() - 1;
@@ -452,7 +452,7 @@ impl Lowerer<'_> {
         // dynamic body (`$body`, `[cmd]`) must barrier rather than be lowered
         // as if it were the literal text (issue #1375).
         if body_tok.is_none() || !super::seg_word_is_static_literal(seg, body_idx + 1) {
-            return Self::barrier(seg, "foreach with dynamic body");
+            return self.barrier(seg, "foreach with dynamic body");
         }
 
         // The value word's brace-quoting is a fact only the tokens carry:
@@ -461,7 +461,7 @@ impl Lowerer<'_> {
         // "a $b c"` substitutes. Both lower to the same `list_arg` text,
         // so the flag is what downstream read-harvesting gates on
         // (issue #1260).
-        let cmd_tokens = Self::cmd_tokens(seg);
+        let cmd_tokens = self.cmd_tokens(seg);
         let mut iterators = Vec::new();
         for i in (0..body_idx).step_by(2) {
             // A varList that is not a well-formed Tcl list binds nothing we can
@@ -469,7 +469,7 @@ impl Lowerer<'_> {
             let Some(var_names) =
                 parse_var_list_names(&args[i], WordValueRules::from_config(&self.config))
             else {
-                return Self::barrier(seg, "foreach with malformed variable list");
+                return self.barrier(seg, "foreach with malformed variable list");
             };
             iterators.push(ForeachIterator {
                 vars: var_names,
@@ -507,7 +507,7 @@ impl Lowerer<'_> {
             .any(|statement| matches!(statement, Statement::Foreach { .. }));
         let lmap_needs_runtime = is_lmap && !Self::body_is_straight_line(&body);
         if self.target.is_bytecode() && (lmap_needs_runtime || body_nests_foreach) {
-            return Self::barrier(seg, if is_lmap { "lmap" } else { "foreach" });
+            return self.barrier(seg, if is_lmap { "lmap" } else { "foreach" });
         }
 
         Statement::Foreach {
@@ -577,7 +577,7 @@ impl Lowerer<'_> {
 
         // `foreachLine varName filename body` — exactly three args.
         if args.len() != 3 {
-            return Self::barrier(seg, "malformed foreachLine");
+            return self.barrier(seg, "malformed foreachLine");
         }
 
         // Body must be a single static brace-string literal; dynamic
@@ -588,7 +588,7 @@ impl Lowerer<'_> {
         // static loop body.
         let body_tok = arg_tokens.get(2);
         if !super::seg_word_is_static_braced(seg, 3) {
-            return Self::barrier(seg, "foreachLine with dynamic body");
+            return self.barrier(seg, "foreachLine with dynamic body");
         }
 
         // Single iterator binding the loop variable.  `list_arg`
@@ -598,10 +598,10 @@ impl Lowerer<'_> {
         // dataflow doesn't care: the lattice-propagation matters,
         // not the literal value.  See the type-level doc-comment
         // above for the runtime-semantics caveat.
-        let cmd_tokens = Self::cmd_tokens(seg);
+        let cmd_tokens = self.cmd_tokens(seg);
         let Some(vars) = parse_var_list_names(&args[0], WordValueRules::from_config(&self.config))
         else {
-            return Self::barrier(seg, "foreachLine with malformed variable list");
+            return self.barrier(seg, "foreachLine with malformed variable list");
         };
         let iterators = vec![ForeachIterator {
             vars,
@@ -632,7 +632,7 @@ impl Lowerer<'_> {
         let arg_tokens = seg.arg_tokens();
 
         if args.is_empty() {
-            return Self::barrier(seg, "malformed catch");
+            return self.barrier(seg, "malformed catch");
         }
         // Body must be a single brace-literal (`Str` kind) token to
         // compile statically.  Variable references (`$cmd`) and
@@ -642,7 +642,7 @@ impl Lowerer<'_> {
         // value.  Without the kind check, ``catch $cmd res`` would
         // be compiled as "call the proc named by ``$cmd``" — wrong.
         if arg_tokens.is_empty() || !super::seg_word_is_static_braced(seg, 1) {
-            return Self::barrier(seg, "catch with dynamic body");
+            return self.barrier(seg, "catch with dynamic body");
         }
 
         let body = self.lower_body_from_tok(&args[0], Some(&arg_tokens[0]), namespace);
@@ -656,7 +656,7 @@ impl Lowerer<'_> {
             result_var,
             options_var,
             raw_args: args.to_vec(),
-            tokens: Some(Self::cmd_tokens(seg)),
+            tokens: Some(self.cmd_tokens(seg)),
         }
     }
 
@@ -669,7 +669,7 @@ impl Lowerer<'_> {
         // be compiled correctly (its handler/finally clauses would be dropped).
         // Analysis callers keep the structured form below. See `CompileTarget`.
         if self.target.is_bytecode() {
-            return Self::barrier(seg, "try");
+            return self.barrier(seg, "try");
         }
 
         let args = seg.args();
@@ -677,7 +677,7 @@ impl Lowerer<'_> {
         let arg_single = seg.arg_single_token();
 
         if args.is_empty() {
-            return Self::barrier(seg, "malformed try");
+            return self.barrier(seg, "malformed try");
         }
         // The body is lowered via `lower_body_from_tok`, which rebases the
         // segmenter-reconstructed word text at the token's span — safe only
@@ -686,7 +686,7 @@ impl Lowerer<'_> {
         // barrier rather than be lowered as if it were the literal text
         // (issue #1375).
         if arg_tokens.is_empty() || !super::seg_word_is_static_braced(seg, 1) {
-            return Self::barrier(seg, "try with dynamic body");
+            return self.barrier(seg, "try with dynamic body");
         }
 
         let body = self.lower_body_from_tok(&args[0], Some(&arg_tokens[0]), namespace);
@@ -710,7 +710,7 @@ impl Lowerer<'_> {
                 // `TCL_TOKEN_SIMPLE_WORD` is `goto failedToCompile`, deferring
                 // the whole `try` to the runtime command.
                 if fin_tok.is_none() || !super::seg_word_is_static_braced(seg, i + 2) {
-                    return Self::barrier(seg, "try with dynamic finally body");
+                    return self.barrier(seg, "try with dynamic finally body");
                 }
                 finally_body = Some(self.lower_body_from_tok(&args[i + 1], fin_tok, namespace));
                 finally_span = fin_tok.map(|t| t.span);
@@ -749,7 +749,7 @@ impl Lowerer<'_> {
                 let Some(var_names) =
                     parse_var_list_names(var_list, WordValueRules::from_config(&self.config))
                 else {
-                    return Self::barrier(seg, "try with malformed handler variable list");
+                    return self.barrier(seg, "try with malformed handler variable list");
                 };
                 let result_var = var_names.first().map(|v| normalise_var_name(v).to_owned());
                 let options_var = var_names.get(1).map(|v| normalise_var_name(v).to_owned());
@@ -788,7 +788,7 @@ impl Lowerer<'_> {
                 if !is_fallthrough
                     && (handler_tok.is_none() || !super::seg_word_is_static_braced(seg, i + 4))
                 {
-                    return Self::barrier(seg, "try with dynamic handler body");
+                    return self.barrier(seg, "try with dynamic handler body");
                 }
                 let handler_body = if is_fallthrough {
                     crate::ir::Script::new()
@@ -810,7 +810,7 @@ impl Lowerer<'_> {
                 continue;
             }
 
-            return Self::barrier(seg, "malformed try handler");
+            return self.barrier(seg, "malformed try handler");
         }
 
         Statement::Try {
@@ -908,7 +908,7 @@ impl Lowerer<'_> {
         let arg_single = seg.arg_single_token();
 
         if args.len() < 2 {
-            return Self::barrier(seg, "malformed switch");
+            return self.barrier(seg, "malformed switch");
         }
 
         let (mut i, mode, nocase, unknown) = parse_switch_options(args);
@@ -916,16 +916,16 @@ impl Lowerer<'_> {
         // An unrecognised / arg-taking option (`-foo`, `-matchvar`, …): bail to
         // the runtime `switch`, which validates options and does the var writes.
         if unknown {
-            return Self::barrier(seg, "switch with non-inlined option");
+            return self.barrier(seg, "switch with non-inlined option");
         }
         if i >= args.len() {
-            return Self::barrier(seg, "malformed switch options");
+            return self.barrier(seg, "malformed switch options");
         }
 
         let subject = args[i].clone();
         i += 1;
         if i >= args.len() {
-            return Self::barrier(seg, "switch missing arms");
+            return self.barrier(seg, "switch missing arms");
         }
 
         // Collect pattern/body pairs. Each pair carries a
@@ -954,15 +954,15 @@ impl Lowerer<'_> {
             // Not a well-formed Tcl list — bail to the runtime `switch`,
             // which reports the list error exactly as C Tcl does.
             let Some(elements) = switch_body_elements(body_text) else {
-                return Self::barrier(seg, "switch case list is not a list");
+                return self.barrier(seg, "switch case list is not a list");
             };
             // An empty arm list (`switch x {}`) is a "wrong # args" error, not a
             // no-op — bail to the runtime command, which reports it.
             if elements.is_empty() {
-                return Self::barrier(seg, "switch with no arms");
+                return self.barrier(seg, "switch with no arms");
             }
             if !elements.len().is_multiple_of(2) {
-                return Self::barrier(seg, "switch odd pattern count");
+                return self.barrier(seg, "switch odd pattern count");
             }
             let relocate = |local: Span| {
                 let start = body_base.saturating_add(local.start());
@@ -991,7 +991,7 @@ impl Lowerer<'_> {
             patterns_braced = false;
             let remaining = args.len() - i;
             if !remaining.is_multiple_of(2) {
-                return Self::barrier(seg, "switch odd pattern count");
+                return self.barrier(seg, "switch odd pattern count");
             }
             while i + 1 < args.len() {
                 let pattern = args[i].clone();
@@ -1010,7 +1010,7 @@ impl Lowerer<'_> {
                 // command word, so the body word `args[i + 1]` is index
                 // `i + 2`.).
                 if body_text_inner != "-" && !super::seg_word_is_static_literal(seg, i + 2) {
-                    return Self::barrier(seg, "switch with non-literal arm body");
+                    return self.barrier(seg, "switch with non-literal arm body");
                 }
                 let body_span_val = arg_tokens.get(body_tok_idx).map(|t| t.span);
                 pairs.push(SwitchPair {
@@ -1065,7 +1065,7 @@ impl Lowerer<'_> {
                 let Some(var_names) =
                     parse_var_list_names(&sub_args[0], WordValueRules::from_config(&self.config))
                 else {
-                    return Self::barrier(seg, &format!("dict {sub} with malformed variable list"));
+                    return self.barrier(seg, &format!("dict {sub} with malformed variable list"));
                 };
                 let body_idx = 3; // index in original args
                 let body_tok = arg_tokens.get(body_idx);
@@ -1077,7 +1077,7 @@ impl Lowerer<'_> {
                 // barrier rather than be lowered as if it were the literal
                 // text (issue #1375).
                 if body_tok.is_none() || !super::seg_word_is_static_braced(seg, body_idx + 1) {
-                    return Self::barrier(seg, &format!("dict {sub} with dynamic body"));
+                    return self.barrier(seg, &format!("dict {sub} with dynamic body"));
                 }
                 let body = self.lower_body_from_tok(&sub_args[2], body_tok, namespace);
 
@@ -1089,7 +1089,7 @@ impl Lowerer<'_> {
                         // `dict for {k v} {a $b} …` iterates the literal
                         // dictionary; the value word is `args[2]` in the
                         // full argument list (issue #1260).
-                        list_braced: Self::cmd_tokens(seg).arg_is_braced_literal(2),
+                        list_braced: self.cmd_tokens(seg).arg_is_braced_literal(2),
                     }],
                     body,
                     body_span: body_tok.map_or(seg.span, |t| t.span),
@@ -1097,7 +1097,7 @@ impl Lowerer<'_> {
                     raw_args: args.to_vec(),
                     is_dict_iteration: true,
                     is_array_iteration: false,
-                    raw_tokens: Some(Self::cmd_tokens(seg)),
+                    raw_tokens: Some(self.cmd_tokens(seg)),
                 }
             }
 
@@ -1111,7 +1111,7 @@ impl Lowerer<'_> {
                 command: seg.name().into(),
                 canonical_command: None,
                 args: args.to_vec(),
-                tokens: Some(Self::cmd_tokens(seg)),
+                tokens: Some(self.cmd_tokens(seg)),
             },
 
             // A sub-mutator (`dict set/unset/append/lappend/incr …`) tags
@@ -1130,7 +1130,7 @@ impl Lowerer<'_> {
                     reads: vec![],
                     reads_own_defs: true,
                     safe_on_uninit: self.safe_on_uninit(seg.name(), args),
-                    tokens: Some(Self::cmd_tokens(seg)),
+                    tokens: Some(self.cmd_tokens(seg)),
                     foreach_groups: None,
                 }
             }
@@ -1144,7 +1144,7 @@ impl Lowerer<'_> {
                 reads: vec![],
                 reads_own_defs: false,
                 safe_on_uninit: false,
-                tokens: Some(Self::cmd_tokens(seg)),
+                tokens: Some(self.cmd_tokens(seg)),
                 foreach_groups: None,
             },
         }
@@ -1153,14 +1153,14 @@ impl Lowerer<'_> {
     // Helpers
 
     /// Create a barrier statement from a segmented command.
-    fn barrier(seg: &SegmentedCommand, reason: &str) -> Statement {
+    fn barrier(&self, seg: &SegmentedCommand, reason: &str) -> Statement {
         Statement::Barrier {
             span: seg.span,
             reason: reason.into(),
             command: seg.name().into(),
             canonical_command: None,
             args: seg.args().to_vec(),
-            tokens: Some(Self::cmd_tokens(seg)),
+            tokens: Some(self.cmd_tokens(seg)),
         }
     }
 

--- a/rust/tcl-compiler/src/native_lowering/lower.rs
+++ b/rust/tcl-compiler/src/native_lowering/lower.rs
@@ -1967,7 +1967,11 @@ fn nested_words(
     if segment.is_partial {
         return Err(NativeLoweringDecline::UnmodelledCommandSubstitution);
     }
-    let tokens = CommandTokens::from_segmented(segment);
+    // The nested script is a sub-lex: its own text, segmented at the document
+    // offset it sits at, so the word model reads `inner` and still reports
+    // document spans (`SourceMap::with_base` is that sub-lexing contract).
+    let sm = tcl_lexer::SourceMap::new(inner).with_base(base, 0, 0);
+    let tokens = CommandTokens::from_segmented(&sm, config, segment);
     if tokens.word_exprs.is_empty() {
         return Err(NativeLoweringDecline::MissingCommandTokens);
     }

--- a/rust/tcl-compiler/src/word_expr.rs
+++ b/rust/tcl-compiler/src/word_expr.rs
@@ -1,0 +1,292 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! The compiler's adapter over the word-parts owner.
+//!
+//! [`WordExpr`] is built here from [`tcl_lexer::word_parts::decompose_spanned`]
+//! — the one owner of "split a Tcl word into its substitution components" —
+//! rather than from a private walk over lexer fragments (issue #1785). The
+//! segmenter still owns *command* and *word* boundaries: it hands this module
+//! one word's fragment tokens, and only the within-word breakdown is the
+//! owner's.
+//!
+//! What stays lexical and what moves:
+//!
+//! - **Brace and quote extents** come from the lexer's fragments and
+//!   [`tcl_lexer::quoted_word_close`]. A `{…}` fragment is a literal run with
+//!   no substitution; a `"…"` run is decomposed as one region. Real Tcl rejects
+//!   anything welded to either (`extra characters after close-brace`); the
+//!   analyser accepts it so the braced part still gets diagnosed, and that
+//!   leniency is a word-boundary rule (issue #1786), not a decomposition one.
+//! - **Substitution boundaries** — where a `$` reference or `[…]` ends, which
+//!   `$` is data, where C stops parsing — are the owner's, under the document's
+//!   [`LexerConfig`] so the `${…}` close rule, the array-index source mask and
+//!   the escape grammar follow the emulated release.
+//! - **Spellings stay compatibility spellings.** A `Text` part carries its raw,
+//!   undecoded source so the backslash rule stays explicit at this boundary; a
+//!   `Variable` part carries the argv spelling the analyser and the WASM tiers
+//!   read (`${name}` for a bare scalar, verbatim for `${…}` and for an element
+//!   whose index substitutes); a `CommandSubstitution` carries `[script]`.
+//! - **Spans keep the lexer's inner-end convention.** A `${name}` or `[script]`
+//!   part's span excludes its closer (an empty `${}` / `[]` covers it), which
+//!   is what `codegen::wasm::leaf_invoke::plan_variable` reads to tell `$a(b)`
+//!   from `${a(b)}`.
+//! - **A parse error is the whole word.** C's `Tcl_ParseCommand` rejects the
+//!   script, so the word becomes [`WordExpr::Opaque`] carrying C's message in
+//!   [`WordOpacity::ParseError`] — the same `missing …` texts the segmenter's
+//!   E200 reports — and every consumer declines it.
+
+use tcl_lexer::word_parts::{SpannedPart, SubstFlags, decompose_spanned, quoted_word_close};
+use tcl_lexer::{LexerConfig, SourceMap, Span, Token, TokenType};
+
+use crate::ir::{SourceSite, WordExpr, WordOpacity, WordPart};
+
+impl WordExpr {
+    /// Build the word model for one segmented word.
+    ///
+    /// `fragments` are the word's lexer tokens in document order (the
+    /// segmenter's word boundary); `compat_text` is the argv spelling kept on
+    /// an opaque word; `expansion_span` is the `{*}` marker when `expanded`.
+    #[must_use]
+    pub fn from_word(
+        sm: &SourceMap<'_>,
+        config: LexerConfig,
+        fragments: &[Token],
+        compat_text: &str,
+        expanded: bool,
+        expansion_span: Option<Span>,
+    ) -> Self {
+        let (Some(first), Some(last)) = (fragments.first(), fragments.last()) else {
+            return Self::Opaque {
+                text: compat_text.to_owned(),
+                source: SourceSite::opaque(Span::new(0, 0)),
+                reason: WordOpacity::LossySnapshot,
+            };
+        };
+        let word_span = Span::new(first.span.start(), last.span.end());
+        let word = match build(sm, config, fragments) {
+            Ok(word) => word,
+            Err(message) => Self::Opaque {
+                text: compat_text.to_owned(),
+                source: SourceSite::opaque(word_span),
+                reason: WordOpacity::ParseError(message),
+            },
+        };
+        if expanded {
+            let start = expansion_span.map_or(word_span.start(), Span::start);
+            Self::Expand {
+                source: SourceSite::source(Span::new(start, word_span.end())),
+                word: Box::new(word),
+            }
+        } else {
+            word
+        }
+    }
+}
+
+/// The regions a word is made of: braced literals and quoted runs are
+/// delimited by the lexer; everything between is a bare run.
+struct Regions {
+    parts: Vec<WordPart>,
+    count: usize,
+    quoted: bool,
+}
+
+fn build(
+    sm: &SourceMap<'_>,
+    config: LexerConfig,
+    fragments: &[Token],
+) -> Result<WordExpr, &'static str> {
+    let source = sm.source();
+    let bytes = source.as_bytes();
+    let first = fragments[0];
+    let last = fragments[fragments.len() - 1];
+    let word_span = Span::new(first.span.start(), last.span.end());
+    let opener_of = |tok: Token| bytes.get(tok.span.start() as usize).copied();
+
+    if fragments.len() == 1 && first.kind == TokenType::Str && opener_of(first) == Some(b'{') {
+        return Ok(WordExpr::BracedLiteral {
+            text: sm.token_text(first).to_owned(),
+            source: SourceSite::source(first.span),
+        });
+    }
+
+    let mut regions = Regions {
+        parts: Vec::new(),
+        count: 0,
+        quoted: false,
+    };
+    // Start of the bare run being accumulated, if one is open.
+    let mut run_start: Option<usize> = None;
+    let mut i = 0;
+    while i < fragments.len() {
+        let tok = fragments[i];
+        let start = tok.span.start() as usize;
+        let opener = opener_of(tok);
+        if tok.kind == TokenType::Str && opener == Some(b'{') {
+            flush_run(&mut regions, source, config, run_start.take(), start)?;
+            regions.parts.push(WordPart::Text {
+                text: sm.token_text(tok).to_owned(),
+                source: SourceSite::source(tok.span),
+            });
+            regions.count += 1;
+            i += 1;
+            continue;
+        }
+        if tok.kind == TokenType::Esc && tok.content_offset == 1 && opener == Some(b'"') {
+            flush_run(&mut regions, source, config, run_start.take(), start)?;
+            let close = quoted_word_close(source, start)?;
+            decompose_region(&mut regions, source, config, start + 1, close)?;
+            regions.quoted = true;
+            let end = close + 1;
+            // The rest of the quoted run's fragments — its `$` / `[` pieces
+            // and the (possibly empty) closing-quote fragment — are covered.
+            i += 1;
+            while i < fragments.len() && (fragments[i].span.end() as usize) <= end {
+                i += 1;
+            }
+            continue;
+        }
+        if run_start.is_none() {
+            run_start = Some(start);
+        }
+        i += 1;
+    }
+    if let Some(start) = run_start {
+        let end = tcl_lexer::word_span_at(source, last.span).end() as usize;
+        flush_run(&mut regions, source, config, Some(start), end)?;
+    }
+
+    let single_bare = regions.count == 1 && !regions.quoted;
+    let word = match regions.parts.as_mut_slice() {
+        [WordPart::Text { text, .. }] if single_bare && !text.contains('\\') => WordExpr::Literal {
+            text: std::mem::take(text),
+            source: SourceSite::source(word_span),
+        },
+        [WordPart::Variable { spelling, source }] if single_bare => WordExpr::Variable {
+            spelling: std::mem::take(spelling),
+            source: source.clone(),
+        },
+        [WordPart::CommandSubstitution { spelling, source }] if single_bare => {
+            WordExpr::CommandSubstitution {
+                spelling: std::mem::take(spelling),
+                source: source.clone(),
+            }
+        }
+        _ => WordExpr::Template {
+            parts: regions.parts,
+            source: SourceSite::source(word_span),
+        },
+    };
+    Ok(word)
+}
+
+/// Close the bare run `[start, end)`, if one is open, as one decomposed region.
+fn flush_run(
+    regions: &mut Regions,
+    source: &str,
+    config: LexerConfig,
+    start: Option<usize>,
+    end: usize,
+) -> Result<(), &'static str> {
+    match start {
+        Some(start) if end > start => decompose_region(regions, source, config, start, end),
+        _ => Ok(()),
+    }
+}
+
+/// Decompose `source[start..end]` through the owner and append its parts.
+fn decompose_region(
+    regions: &mut Regions,
+    source: &str,
+    config: LexerConfig,
+    start: usize,
+    end: usize,
+) -> Result<(), &'static str> {
+    let content = source.get(start..end).unwrap_or("");
+    regions.count += 1;
+    for spanned in decompose_spanned(content.as_bytes(), SubstFlags::default(), config) {
+        regions.parts.push(part_at(source, start, &spanned)?);
+    }
+    Ok(())
+}
+
+/// One owner part, re-anchored at `base` in `source`, as a compatibility part.
+fn part_at(source: &str, base: usize, spanned: &SpannedPart<'_>) -> Result<WordPart, &'static str> {
+    let (start, end) = (base + spanned.start, base + spanned.end);
+    let raw = source.get(start..end).unwrap_or("");
+    let span = |end: usize| Span::new(offset(start), offset(end));
+    Ok(match &spanned.part {
+        tcl_lexer::WordPart::Text(_) => WordPart::Text {
+            text: raw.to_owned(),
+            source: SourceSite::source(span(end)),
+        },
+        tcl_lexer::WordPart::Variable(_) => {
+            // The lexer's inner-end convention: a `${name}` token stops short
+            // of its closing brace unless the name is empty.
+            let braced = raw.starts_with("${");
+            let inner_end = if braced && raw.len() > 3 {
+                end - 1
+            } else {
+                end
+            };
+            WordPart::Variable {
+                spelling: variable_spelling(raw),
+                source: SourceSite::source(span(inner_end)),
+            }
+        }
+        tcl_lexer::WordPart::Command(_) => {
+            let inner_end = if raw.len() > 2 { end - 1 } else { end };
+            WordPart::CommandSubstitution {
+                spelling: raw.to_owned(),
+                source: SourceSite::source(span(inner_end)),
+            }
+        }
+        tcl_lexer::WordPart::ParseError(message) => return Err(message),
+    })
+}
+
+/// The compatibility argv spelling of the variable reference written as `raw`.
+///
+/// A `${…}` reference and a bare element whose index itself substitutes
+/// (`$arr($i)`) round-trip verbatim — wrapping the latter in braces would turn
+/// the element access into a scalar lookup of a name with parentheses in it.
+/// A bare scalar or literal-index element is normalised to `${name}` so
+/// consumers read one canonical shape; a name containing `}` cannot be
+/// braced unambiguously and stays bare.
+fn variable_spelling(raw: &str) -> String {
+    if raw.starts_with("${") {
+        return raw.to_owned();
+    }
+    let body = &raw[1..];
+    if let Some(open) = body.find('(')
+        && body.ends_with(')')
+        && body[open..].contains(['$', '['])
+    {
+        return raw.to_owned();
+    }
+    if body.contains('}') {
+        raw.to_owned()
+    } else {
+        format!("${{{body}}}")
+    }
+}
+
+fn offset(at: usize) -> u32 {
+    u32::try_from(at).expect("source offsets fit in u32")
+}

--- a/rust/tcl-compiler/src/word_expr.rs
+++ b/rust/tcl-compiler/src/word_expr.rs
@@ -62,6 +62,12 @@ impl WordExpr {
     /// `fragments` are the word's lexer tokens in document order (the
     /// segmenter's word boundary); `compat_text` is the argv spelling kept on
     /// an opaque word; `expansion_span` is the `{*}` marker when `expanded`.
+    ///
+    /// `sm` holds the buffer those spans index into. A sub-lex — the script
+    /// inside a `[…]`, segmented at the offset it sits at — carries its
+    /// document base on the map ([`SourceMap::with_base`]), so the text is
+    /// read locally and every span this returns stays in the document's
+    /// space.
     #[must_use]
     pub fn from_word(
         sm: &SourceMap<'_>,
@@ -72,10 +78,13 @@ impl WordExpr {
         expansion_span: Option<Span>,
     ) -> Self {
         let (Some(first), Some(last)) = (fragments.first(), fragments.last()) else {
+            // No ordered fragments to decompose: the argv spelling is all
+            // that survives, which is exactly what
+            // [`WordOpacity::MissingFragments`] names.
             return Self::Opaque {
                 text: compat_text.to_owned(),
                 source: SourceSite::opaque(Span::new(0, 0)),
-                reason: WordOpacity::LossySnapshot,
+                reason: WordOpacity::MissingFragments,
             };
         };
         let word_span = Span::new(first.span.start(), last.span.end());
@@ -105,6 +114,18 @@ struct Regions {
     parts: Vec<WordPart>,
     count: usize,
     quoted: bool,
+    /// The document offset the decomposed buffer's first byte sits at, so a
+    /// part built from a *local* slice offset carries its document span.
+    base: u32,
+}
+
+/// Re-anchor a token's span into the buffer `sm` holds, so
+/// [`SourceMap::token_text`] — which takes buffer-local spans — reads it.
+fn localise(tok: Token, base: u32) -> Token {
+    Token {
+        span: Span::new(tok.span.start() - base, tok.span.end() - base),
+        ..tok
+    }
 }
 
 fn build(
@@ -114,14 +135,19 @@ fn build(
 ) -> Result<WordExpr, &'static str> {
     let source = sm.source();
     let bytes = source.as_bytes();
+    // The fragments' spans are in the *document's* space; `source` may be a
+    // sub-lexed slice of it (a `[…]` substitution's script), so every index
+    // into `source` drops the base and every span emitted keeps it.
+    let base = sm.base_offset();
+    let at = |offset: u32| (offset - base) as usize;
     let first = fragments[0];
     let last = fragments[fragments.len() - 1];
     let word_span = Span::new(first.span.start(), last.span.end());
-    let opener_of = |tok: Token| bytes.get(tok.span.start() as usize).copied();
+    let opener_of = |tok: Token| bytes.get(at(tok.span.start())).copied();
 
     if fragments.len() == 1 && first.kind == TokenType::Str && opener_of(first) == Some(b'{') {
         return Ok(WordExpr::BracedLiteral {
-            text: sm.token_text(first).to_owned(),
+            text: sm.token_text(localise(first, base)).to_owned(),
             source: SourceSite::source(first.span),
         });
     }
@@ -130,18 +156,19 @@ fn build(
         parts: Vec::new(),
         count: 0,
         quoted: false,
+        base,
     };
     // Start of the bare run being accumulated, if one is open.
     let mut run_start: Option<usize> = None;
     let mut i = 0;
     while i < fragments.len() {
         let tok = fragments[i];
-        let start = tok.span.start() as usize;
+        let start = at(tok.span.start());
         let opener = opener_of(tok);
         if tok.kind == TokenType::Str && opener == Some(b'{') {
             flush_run(&mut regions, source, config, run_start.take(), start)?;
             regions.parts.push(WordPart::Text {
-                text: sm.token_text(tok).to_owned(),
+                text: sm.token_text(localise(tok, base)).to_owned(),
                 source: SourceSite::source(tok.span),
             });
             regions.count += 1;
@@ -157,7 +184,7 @@ fn build(
             // The rest of the quoted run's fragments — its `$` / `[` pieces
             // and the (possibly empty) closing-quote fragment — are covered.
             i += 1;
-            while i < fragments.len() && (fragments[i].span.end() as usize) <= end {
+            while i < fragments.len() && at(fragments[i].span.end()) <= end {
                 i += 1;
             }
             continue;
@@ -168,7 +195,7 @@ fn build(
         i += 1;
     }
     if let Some(start) = run_start {
-        let end = tcl_lexer::word_span_at(source, last.span).end() as usize;
+        let end = tcl_lexer::word_span_at(source, localise(last, base).span).end() as usize;
         flush_run(&mut regions, source, config, Some(start), end)?;
     }
 
@@ -196,7 +223,8 @@ fn build(
     Ok(word)
 }
 
-/// Close the bare run `[start, end)`, if one is open, as one decomposed region.
+/// Close the bare run `[start, end)`, if one is open, as one decomposed
+/// region. Both offsets are local to `source`.
 fn flush_run(
     regions: &mut Regions,
     source: &str,
@@ -220,17 +248,24 @@ fn decompose_region(
 ) -> Result<(), &'static str> {
     let content = source.get(start..end).unwrap_or("");
     regions.count += 1;
+    let base = regions.base;
     for spanned in decompose_spanned(content.as_bytes(), SubstFlags::default(), config) {
-        regions.parts.push(part_at(source, start, &spanned)?);
+        regions.parts.push(part_at(source, start, base, &spanned)?);
     }
     Ok(())
 }
 
-/// One owner part, re-anchored at `base` in `source`, as a compatibility part.
-fn part_at(source: &str, base: usize, spanned: &SpannedPart<'_>) -> Result<WordPart, &'static str> {
-    let (start, end) = (base + spanned.start, base + spanned.end);
+/// One owner part, re-anchored at the local offset `start` in `source` and
+/// carried out in the document space `base` anchors.
+fn part_at(
+    source: &str,
+    start: usize,
+    base: u32,
+    spanned: &SpannedPart<'_>,
+) -> Result<WordPart, &'static str> {
+    let (start, end) = (start + spanned.start, start + spanned.end);
     let raw = source.get(start..end).unwrap_or("");
-    let span = |end: usize| Span::new(offset(start), offset(end));
+    let span = |end: usize| Span::new(offset(start) + base, offset(end) + base);
     Ok(match &spanned.part {
         tcl_lexer::WordPart::Text(_) => WordPart::Text {
             text: raw.to_owned(),

--- a/rust/tcl-compiler/tests/differential_word_expr.rs
+++ b/rust/tcl-compiler/tests/differential_word_expr.rs
@@ -1,0 +1,608 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Differential harness: owner-based `WordExpr` vs the fragment-walk oracle.
+//!
+//! `CommandTokens::from_segmented` builds every word's `WordExpr` from
+//! `tcl_lexer::word_parts::decompose_spanned` (issue #1785). Before that it
+//! mapped the lexer's fragment tokens one-for-one, and that walk is frozen
+//! here as the **independent oracle** so the two can be compared forever:
+//! over a crafted edge-case table under both release axes, over `samples/`,
+//! and over `tmp/tcllib-2.0` when it is present.
+//!
+//! The comparison is exact up to the oracle's enumerated artefacts —
+//! [`canonical`] documents each one — so a new divergence is a real
+//! behavioural change, not noise.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use tcl_lexer::{LexerConfig, SourceMap, Span, Token, TokenType};
+
+use tcl_compiler::ir::{CommandTokens, SourceSite, WordExpr, WordOpacity, WordPart};
+use tcl_compiler::segmenter::{
+    SegmentedCommand, WordFragment, segment_commands_with_offset_and_config,
+};
+
+/// Repo root — two directories above `CARGO_MANIFEST_DIR`.
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("..").join("..")
+}
+
+fn nine() -> LexerConfig {
+    LexerConfig::default()
+}
+
+fn eight() -> LexerConfig {
+    LexerConfig::for_dialect("tcl8.4")
+}
+
+fn segments(src: &str, config: LexerConfig) -> Vec<SegmentedCommand> {
+    segment_commands_with_offset_and_config(src, 0, config)
+}
+
+/// The **production** builder under test: the shipping `from_segmented`.
+#[allow(dead_code)]
+fn production(seg: &SegmentedCommand) -> Vec<WordExpr> {
+    CommandTokens::from_segmented(seg).word_exprs
+}
+
+/// Pre-switch stand-in for [`production`]: the owner-based builder invoked
+/// directly, with the segmenter's word boundaries.
+fn owner_based(src: &str, config: LexerConfig, seg: &SegmentedCommand) -> Vec<WordExpr> {
+    let sm = SourceMap::new(src);
+    let expand = seg.expand_word.as_deref();
+    seg.argv
+        .iter()
+        .enumerate()
+        .map(|(idx, token)| {
+            let fragments: Vec<Token> = seg
+                .word_fragments
+                .get(idx)
+                .map_or(&[][..], Vec::as_slice)
+                .iter()
+                .map(|f| f.token)
+                .collect();
+            let text = seg.texts.get(idx).map_or("", String::as_str);
+            let expanded = expand
+                .and_then(|flags| flags.get(idx))
+                .copied()
+                .unwrap_or(false);
+            let expansion_span = expanded
+                .then(|| {
+                    seg.all_tokens
+                        .iter()
+                        .rev()
+                        .find(|candidate| {
+                            candidate.kind == TokenType::Expand
+                                && candidate.span.end() <= token.span.start()
+                        })
+                        .map(|candidate| candidate.span)
+                })
+                .flatten();
+            WordExpr::from_word(&sm, config, &fragments, text, expanded, expansion_span)
+        })
+        .collect()
+}
+
+/// The **oracle**: the frozen fragment walk (see [`frozen_oracle`]).
+fn oracle(seg: &SegmentedCommand) -> Vec<WordExpr> {
+    frozen_oracle::word_exprs(seg)
+}
+
+/// The oracle's artefacts, normalised away so the comparison is exact:
+///
+/// 1. **Empty text parts at a quote.** The lexer emits an empty `Esc` for the
+///    opening `"` when the body starts with `$` / `[`, and one for the closing
+///    `"`; the oracle kept them as empty `Text` parts. They are dropped unless
+///    the word is exactly `""`, whose one empty part is its value.
+/// 2. **The opening quote inside the first text span.** The first `Esc` of a
+///    quoted run has `content_offset = 1`, so its span covers the `"`; the
+///    owner's text extents are content only.
+/// 3. **A name-less `$` as its own part.** The lexer emits a `$` with no name
+///    behind it as a one-byte `Str`, so the oracle split `price$` into two
+///    text parts (or made a lone `$` a `BracedLiteral`). C treats that `$` as
+///    data in the surrounding run, which is what the owner reports.
+/// 4. **A bare word of one text run collapses to `Literal`** when it has no
+///    backslash — the shape the production builder reports once artefact 3
+///    is folded.
+/// 5. **Unterminated words.** The lexer tokenises an unclosed `"…`, `[…`,
+///    `${…` and `$arr(` best-effort and the oracle modelled them as ordinary
+///    parts; the owner reports C's parse error and the word is `Opaque`.
+///    The oracle side is rewritten to the same `Opaque` from the message
+///    the owner names, so a *wrong* message still fails.
+fn canonical(word: WordExpr, source: &str, production: &WordExpr) -> WordExpr {
+    if let WordExpr::Opaque {
+        reason: WordOpacity::ParseError(_),
+        ..
+    } = production
+        && !matches!(word, WordExpr::Opaque { .. })
+    {
+        return production.clone();
+    }
+    match word {
+        WordExpr::Expand { source: site, word } => WordExpr::Expand {
+            source: site,
+            word: Box::new(canonical(*word, source, expand_inner(production))),
+        },
+        WordExpr::BracedLiteral { text, source: site }
+            if text == "$" && at(source, &site) == "$" =>
+        {
+            WordExpr::Literal { text, source: site }
+        }
+        WordExpr::Template {
+            parts,
+            source: site,
+        } => canonical_template(parts, site, source),
+        other => other,
+    }
+}
+
+fn expand_inner(word: &WordExpr) -> &WordExpr {
+    match word {
+        WordExpr::Expand { word, .. } => word,
+        other => other,
+    }
+}
+
+fn at<'s>(source: &'s str, site: &SourceSite) -> &'s str {
+    source
+        .get(site.span.start() as usize..site.span.end() as usize)
+        .unwrap_or("")
+}
+
+fn canonical_template(parts: Vec<WordPart>, site: SourceSite, source: &str) -> WordExpr {
+    // Whether the *word* is a quoted one — the `""` exception below and
+    // artefact 4 are word-level rules, unlike the per-run fold in the loop.
+    let quoted = source.as_bytes().get(site.span.start() as usize) == Some(&b'"');
+    let mut out: Vec<WordPart> = Vec::with_capacity(parts.len());
+    for part in parts {
+        let WordPart::Text {
+            text,
+            source: mut part_site,
+        } = part
+        else {
+            out.push(part);
+            continue;
+        };
+        // Artefact 2. The fold is a property of the *quoted run*, not of the
+        // word: `foo {*}"a $b"` opens its quote at 7 while the word starts at
+        // the `{*}` marker, so anchoring this on the word start missed it. A
+        // text part whose span opens on a `"` the text itself does not carry
+        // is the oracle's `content_offset = 1` fold; a genuine `"` of content
+        // (inside `{"a"}`) starts the text too and is left alone.
+        if source.as_bytes().get(part_site.span.start() as usize) == Some(&b'"')
+            && !text.starts_with('"')
+        {
+            part_site = SourceSite::source(Span::new(
+                part_site.span.start() + 1,
+                part_site.span.end().max(part_site.span.start() + 1),
+            ));
+        }
+        // Artefact 1 (the `""` exception is restored below).
+        if text.is_empty() {
+            continue;
+        }
+        // Artefact 3: a `$` run welds onto its neighbours.
+        let welds =
+            text == "$" || matches!(out.last(), Some(WordPart::Text { text, .. }) if text == "$");
+        if welds
+            && let Some(WordPart::Text {
+                text: prev,
+                source: prev_site,
+            }) = out.last_mut()
+            && prev_site.span.end() == part_site.span.start()
+        {
+            prev.push_str(&text);
+            *prev_site =
+                SourceSite::source(Span::new(prev_site.span.start(), part_site.span.end()));
+            continue;
+        }
+        out.push(WordPart::Text {
+            text,
+            source: part_site,
+        });
+    }
+    if out.is_empty() && quoted {
+        let inner = Span::new(site.span.start() + 1, site.span.start() + 1);
+        out.push(WordPart::Text {
+            text: String::new(),
+            source: SourceSite::source(inner),
+        });
+    }
+    // Artefact 4.
+    if !quoted
+        && let [WordPart::Text { text, .. }] = out.as_slice()
+        && !text.contains('\\')
+        && at(source, &site) == text
+    {
+        return WordExpr::Literal {
+            text: text.clone(),
+            source: site,
+        };
+    }
+    WordExpr::Template {
+        parts: out,
+        source: site,
+    }
+}
+
+fn check(src: &str, config: LexerConfig, ctx: &str) -> Result<usize, String> {
+    let mut words = 0usize;
+    for (ci, seg) in segments(src, config).iter().enumerate() {
+        let got = owner_based(src, config, seg);
+        let want = oracle(seg);
+        if got.len() != want.len() {
+            return Err(format!(
+                "[{ctx}] cmd {ci}: word count {} vs oracle {}",
+                got.len(),
+                want.len()
+            ));
+        }
+        for (wi, (g, o)) in got.iter().zip(want).enumerate() {
+            words += 1;
+            let want = canonical(o, src, g);
+            if *g != want {
+                let raw = at(src, g.source());
+                return Err(format!(
+                    "[{ctx}] cmd {ci} word {wi} {raw:?}:\n  production: {g:#?}\n  oracle:     {want:#?}"
+                ));
+            }
+        }
+    }
+    Ok(words)
+}
+
+/// Crafted words covering every part kind, both spellings of a reference,
+/// every delimiter welded to another, and each of C's parse errors.
+const EDGE_CASES: &[&str] = &[
+    "",
+    "puts hi",
+    "set x 1\nputs $x\n",
+    "puts $x",
+    "puts ${x}",
+    "puts ${}",
+    "puts $arr(k)",
+    "puts $arr($i)",
+    "puts $arr([k])",
+    "puts $arr(a,$b)",
+    "puts $a:::b",
+    "puts $::ns::v",
+    "puts $",
+    "puts price$",
+    "puts price$ x",
+    "puts a$b",
+    "puts a${b}c",
+    "puts a[b]c",
+    "puts [b]",
+    "puts []",
+    "puts [a [b] c]",
+    "puts [list {a]b}]",
+    "puts [list \"a]b\"]",
+    "puts a\\nb",
+    "puts a\\$b",
+    "puts \\$a",
+    "puts \\[a]",
+    "puts a\\",
+    "puts \"\"",
+    "puts \"abc\"",
+    "puts \"a $b c\"",
+    "puts \"$a\"",
+    "puts \"$a [b] $c\"",
+    "puts \"[b]\"",
+    "puts \"a\\\"b\"",
+    "puts \"a[foo \"b\"]c\"",
+    "puts \"a\\\nb\"",
+    "puts \"\\\n\"",
+    "puts \"ab\"\"cd\"",
+    "puts \"a\"b",
+    "puts \"a\"$b",
+    "puts a\"b\"c",
+    "puts {a}",
+    "puts {}",
+    "puts {a}b",
+    "puts {a}$b",
+    "puts {a}{b}",
+    "puts a{b}c",
+    "puts {a\\}b}",
+    "puts {a $b [c]}",
+    "foo {*}$args",
+    "foo {*}{*}$args",
+    "foo {*}",
+    "foo {*}[cmd]",
+    "foo {*}{a b}",
+    "foo {*}\"a $b\"",
+    "foo {*}a$b",
+    "list a \\\n b",
+    "puts ${a{b}c}",
+    "puts ${a\\}b}",
+    "puts ${abc",
+    "puts ${a{b}",
+    "puts $arr({k})",
+    "puts $arr(",
+    "puts x[b",
+    "puts [side][b",
+    "puts \"abc",
+    "puts \"a $b",
+    "puts {abc",
+    "puts [set y ${a{b]",
+    "puts \\x4142",
+    "puts \\U0001F600",
+    "puts \"\\x41$b\"",
+    "if {$x} {body}",
+    "proc f {a b} { return [expr {$a + $b}] }",
+    "set s \"prefix-$name-[clock seconds]\"",
+    "puts $a($b($c(1)))",
+    "puts a;puts b",
+    "# comment\nputs hi",
+    "puts é$x",
+    "puts \"日本 $x\"",
+];
+
+#[test]
+fn owner_matches_oracle_on_edge_cases() {
+    let mut failures = Vec::new();
+    for (idx, src) in EDGE_CASES.iter().enumerate() {
+        for (label, config) in [("9.x", nine()), ("8.x", eight())] {
+            if let Err(msg) = check(src, config, &format!("edge {idx} {src:?} {label}")) {
+                failures.push(msg);
+            }
+        }
+    }
+    assert!(failures.is_empty(), "{}", failures.join("\n\n"));
+}
+
+/// Recursively collect Tcl sources under `dir`.
+fn gather(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(rd) = fs::read_dir(dir) else { return };
+    for entry in rd.flatten() {
+        let p = entry.path();
+        if p.is_dir() {
+            gather(&p, out);
+        } else if p
+            .extension()
+            .is_some_and(|e| e == "tcl" || e == "irul" || e == "irule")
+        {
+            out.push(p);
+        }
+    }
+}
+
+fn sweep(files: &[PathBuf], label: &str) {
+    let mut checked = 0usize;
+    let mut words = 0usize;
+    let mut failures: Vec<String> = Vec::new();
+    for path in files {
+        let Ok(src) = fs::read_to_string(path) else {
+            continue;
+        };
+        checked += 1;
+        let ctx = path.display().to_string();
+        match check(&src, nine(), &ctx) {
+            Ok(n) => words += n,
+            Err(msg) => {
+                failures.push(msg);
+                if failures.len() >= 20 {
+                    break;
+                }
+            }
+        }
+    }
+    assert!(checked > 0, "{label}: no readable sources");
+    assert!(
+        failures.is_empty(),
+        "owner/oracle divergence over {checked} {label} files:\n{}",
+        failures.join("\n\n")
+    );
+    eprintln!("[differential_word_expr] {label}: {checked} files, {words} words agree");
+}
+
+#[test]
+fn owner_matches_oracle_over_samples() {
+    let mut files = Vec::new();
+    gather(&repo_root().join("samples"), &mut files);
+    sweep(&files, "samples");
+}
+
+#[test]
+fn owner_matches_oracle_over_tcllib() {
+    let mut files = Vec::new();
+    gather(&repo_root().join("tmp").join("tcllib-2.0"), &mut files);
+    if files.is_empty() {
+        eprintln!("[differential_word_expr] skipped: no tmp/tcllib-2.0 corpus present");
+        return;
+    }
+    sweep(&files, "tcllib-2.0");
+}
+
+/// A parse error the owner names reaches the word as a typed opaque word
+/// carrying C's message, and the oracle side cannot fake that.
+#[test]
+fn parse_errors_carry_c_tcls_message() {
+    let cases = [
+        ("puts x[b", "missing close-bracket"),
+        ("puts $arr(", "missing )"),
+        ("puts ${abc", "missing close-brace for variable name"),
+        ("puts \"abc", "missing \""),
+        (
+            "puts [set y ${a{b]",
+            "missing close-brace for variable name",
+        ),
+    ];
+    for (src, message) in cases {
+        let segs = segments(src, nine());
+        let words = owner_based(src, nine(), &segs[0]);
+        assert!(
+            matches!(
+                &words[1],
+                WordExpr::Opaque {
+                    reason: WordOpacity::ParseError(m),
+                    ..
+                } if *m == message
+            ),
+            "{src:?}: {:?}",
+            words[1]
+        );
+    }
+    // Tcl 9 rejects a raw brace in an array index; Tcl 8 passes it through.
+    let words = owner_based(
+        "puts $arr({k})",
+        nine(),
+        &segments("puts $arr({k})", nine())[0],
+    );
+    assert!(
+        matches!(
+            &words[1],
+            WordExpr::Opaque {
+                reason: WordOpacity::ParseError("invalid character in array index"),
+                ..
+            }
+        ),
+        "{:?}",
+        words[1]
+    );
+    // Tcl 8 keeps the reference, and its compatibility spelling stays the raw
+    // source rather than the `${…}` wrap every other scalar gets. Measured on
+    // tclsh 8.6.16: `set arr({k}) hello; set v $arr({k})` yields `hello`,
+    // while `${arr({k})}` reads the *name* `arr({k` under the release's
+    // first-close rule (`can't read "arr({k": no such variable`). So the wrap
+    // is only sound while the body carries no `}` — which is exactly the
+    // guard `variable_spelling` applies. (On tclsh 9.0.4 the brace form does
+    // resolve, its close rule being nesting-aware, but the bare form there is
+    // the parse error asserted above, so this arm is 8.x-only anyway.)
+    let words = owner_based(
+        "puts $arr({k})",
+        eight(),
+        &segments("puts $arr({k})", eight())[0],
+    );
+    assert!(
+        matches!(&words[1], WordExpr::Variable { spelling, .. } if spelling == "$arr({k})"),
+        "{:?}",
+        words[1]
+    );
+}
+
+/// The frozen fragment walk: a byte-for-byte copy of the pre-#1785
+/// `WordExpr::from_fragments` / `WordPart::from_fragment` /
+/// `is_plain_bare_literal`, mapping each lexer fragment token to one part.
+mod frozen_oracle {
+    use super::*;
+
+    pub fn word_exprs(seg: &SegmentedCommand) -> Vec<WordExpr> {
+        let expand = seg.expand_word.as_deref();
+        seg.argv
+            .iter()
+            .enumerate()
+            .map(|(idx, token)| {
+                let fragments = seg.word_fragments.get(idx).map_or(&[][..], Vec::as_slice);
+                let text = seg.texts.get(idx).map_or("", String::as_str);
+                let expanded = expand
+                    .and_then(|flags| flags.get(idx))
+                    .copied()
+                    .unwrap_or(false);
+                let expansion_span = expanded
+                    .then(|| {
+                        seg.all_tokens
+                            .iter()
+                            .rev()
+                            .find(|candidate| {
+                                candidate.kind == TokenType::Expand
+                                    && candidate.span.end() <= token.span.start()
+                            })
+                            .map(|candidate| candidate.span)
+                    })
+                    .flatten();
+                from_fragments(fragments, text, token.span, expanded, expansion_span)
+            })
+            .collect()
+    }
+
+    fn from_fragments(
+        fragments: &[WordFragment],
+        fallback_text: &str,
+        fallback_span: Span,
+        expanded: bool,
+        expansion_span: Option<Span>,
+    ) -> WordExpr {
+        let word = match fragments {
+            [fragment] if is_plain_bare_literal(fragment) => WordExpr::Literal {
+                text: fragment.text.clone(),
+                source: SourceSite::source(fragment.token.span),
+            },
+            [fragment] if fragment.token.kind == TokenType::Str => WordExpr::BracedLiteral {
+                text: fragment.text.clone(),
+                source: SourceSite::source(fragment.token.span),
+            },
+            [fragment] if fragment.token.kind == TokenType::Var => WordExpr::Variable {
+                spelling: fragment.text.clone(),
+                source: SourceSite::source(fragment.token.span),
+            },
+            [fragment] if fragment.token.kind == TokenType::Cmd => WordExpr::CommandSubstitution {
+                spelling: fragment.text.clone(),
+                source: SourceSite::source(fragment.token.span),
+            },
+            [] => WordExpr::Opaque {
+                text: fallback_text.to_owned(),
+                source: SourceSite::opaque(fallback_span),
+                reason: WordOpacity::MissingFragments,
+            },
+            _ => WordExpr::Template {
+                parts: fragments.iter().map(from_fragment).collect(),
+                source: SourceSite::source(fallback_span),
+            },
+        };
+        if expanded {
+            let start = expansion_span.map_or(fallback_span.start(), Span::start);
+            WordExpr::Expand {
+                source: SourceSite::source(Span::new(start, fallback_span.end())),
+                word: Box::new(word),
+            }
+        } else {
+            word
+        }
+    }
+
+    fn is_plain_bare_literal(fragment: &WordFragment) -> bool {
+        fragment.token.kind == TokenType::Esc
+            && !fragment.token.in_quote
+            && fragment.token.content_offset == 0
+            && !fragment.text.contains('\\')
+    }
+
+    fn from_fragment(fragment: &WordFragment) -> WordPart {
+        let source = SourceSite::source(fragment.token.span);
+        match fragment.token.kind {
+            TokenType::Var => WordPart::Variable {
+                spelling: fragment.text.clone(),
+                source,
+            },
+            TokenType::Cmd => WordPart::CommandSubstitution {
+                spelling: fragment.text.clone(),
+                source,
+            },
+            TokenType::Esc | TokenType::Str => WordPart::Text {
+                text: fragment.text.clone(),
+                source,
+            },
+            _ => WordPart::Opaque {
+                text: fragment.text.clone(),
+                source,
+            },
+        }
+    }
+}

--- a/rust/tcl-compiler/tests/differential_word_expr.rs
+++ b/rust/tcl-compiler/tests/differential_word_expr.rs
@@ -18,12 +18,18 @@
 
 //! Differential harness: owner-based `WordExpr` vs the fragment-walk oracle.
 //!
-//! `CommandTokens::from_segmented` builds every word's `WordExpr` from
+//! `CommandTokens::from_segmented` — the builder every production lowering
+//! calls — builds every word's `WordExpr` from
 //! `tcl_lexer::word_parts::decompose_spanned` (issue #1785). Before that it
 //! mapped the lexer's fragment tokens one-for-one, and that walk is frozen
 //! here as the **independent oracle** so the two can be compared forever:
 //! over a crafted edge-case table under both release axes, over `samples/`,
 //! and over `tmp/tcllib-2.0` when it is present.
+//!
+//! Every comparison runs the *shipping* builder and, beside it, the owner
+//! invoked directly: they must agree word-for-word, so this harness cannot
+//! go green on a production path that quietly stopped going through the
+//! owner (the gap a reviewer caught when `from_word` shipped dead).
 //!
 //! The comparison is exact up to the oracle's enumerated artefacts —
 //! [`canonical`] documents each one — so a new divergence is a real
@@ -56,14 +62,18 @@ fn segments(src: &str, config: LexerConfig) -> Vec<SegmentedCommand> {
     segment_commands_with_offset_and_config(src, 0, config)
 }
 
-/// The **production** builder under test: the shipping `from_segmented`.
-#[allow(dead_code)]
-fn production(seg: &SegmentedCommand) -> Vec<WordExpr> {
-    CommandTokens::from_segmented(seg).word_exprs
+/// The **production** builder under test: the shipping `from_segmented`,
+/// which is what every lowering, the WASM leaf-invoke planner and the native
+/// lowerer actually call.
+fn production(src: &str, config: LexerConfig, seg: &SegmentedCommand) -> Vec<WordExpr> {
+    let sm = SourceMap::new(src);
+    CommandTokens::from_segmented(&sm, config, seg).word_exprs
 }
 
-/// Pre-switch stand-in for [`production`]: the owner-based builder invoked
-/// directly, with the segmenter's word boundaries.
+/// The owner-based builder invoked directly, with the segmenter's word
+/// boundaries — the shape [`production`] is asserted to reproduce, so a
+/// production path that stopped going through the owner fails here rather
+/// than passing on the strength of this function alone.
 fn owner_based(src: &str, config: LexerConfig, seg: &SegmentedCommand) -> Vec<WordExpr> {
     let sm = SourceMap::new(src);
     let expand = seg.expand_word.as_deref();
@@ -245,7 +255,16 @@ fn canonical_template(parts: Vec<WordPart>, site: SourceSite, source: &str) -> W
 fn check(src: &str, config: LexerConfig, ctx: &str) -> Result<usize, String> {
     let mut words = 0usize;
     for (ci, seg) in segments(src, config).iter().enumerate() {
-        let got = owner_based(src, config, seg);
+        // The shipping path is what is asserted; the direct owner call is
+        // held beside it so a divergence names which side moved.
+        let got = production(src, config, seg);
+        let owner = owner_based(src, config, seg);
+        if got != owner {
+            return Err(format!(
+                "[{ctx}] cmd {ci}: production does not go through the owner:\n  \
+                 production: {got:#?}\n  owner:      {owner:#?}"
+            ));
+        }
         let want = oracle(seg);
         if got.len() != want.len() {
             return Err(format!(
@@ -446,7 +465,7 @@ fn parse_errors_carry_c_tcls_message() {
     ];
     for (src, message) in cases {
         let segs = segments(src, nine());
-        let words = owner_based(src, nine(), &segs[0]);
+        let words = production(src, nine(), &segs[0]);
         assert!(
             matches!(
                 &words[1],
@@ -460,7 +479,7 @@ fn parse_errors_carry_c_tcls_message() {
         );
     }
     // Tcl 9 rejects a raw brace in an array index; Tcl 8 passes it through.
-    let words = owner_based(
+    let words = production(
         "puts $arr({k})",
         nine(),
         &segments("puts $arr({k})", nine())[0],
@@ -485,7 +504,7 @@ fn parse_errors_carry_c_tcls_message() {
     // guard `variable_spelling` applies. (On tclsh 9.0.4 the brace form does
     // resolve, its close rule being nesting-aware, but the bare form there is
     // the parse error asserted above, so this arm is 8.x-only anyway.)
-    let words = owner_based(
+    let words = production(
         "puts $arr({k})",
         eight(),
         &segments("puts $arr({k})", eight())[0],

--- a/rust/tcl-lexer/src/lib.rs
+++ b/rust/tcl-lexer/src/lib.rs
@@ -106,8 +106,8 @@ pub use tokens::{ByteCol, SourcePosition, Token, TokenType, Utf16Col, Utf16Posit
 // and the doc entry point.
 pub use word_parts::{
     MISSING_CLOSE_BRACE, MISSING_CLOSE_BRACKET, MISSING_PAREN, MISSING_QUOTE, RawVarRef,
-    SubstFlags, VarRef, WordBody, WordPart, command_subst_close, decompose, quoted_word_close,
-    scan_var_ref,
+    SpannedPart, SubstFlags, VarRef, WordBody, WordPart, command_subst_close, decompose,
+    decompose_spanned, quoted_word_close, scan_var_ref,
 };
 
 /// Return the physical line numbers whose first non-horizontal-whitespace

--- a/rust/tcl-lexer/src/source_map.rs
+++ b/rust/tcl-lexer/src/source_map.rs
@@ -95,6 +95,18 @@ impl<'src> SourceMap<'src> {
         self
     }
 
+    /// The document offset this map's first byte sits at — the
+    /// `base_offset` given to [`Self::with_base`], and `0` for a map over a
+    /// whole document.
+    ///
+    /// A caller that holds spans in the *parent* span space (a sub-lex
+    /// segmented at an offset) subtracts this to index [`Self::text`] /
+    /// [`Self::token_text`], which take spans local to the buffer.
+    #[must_use]
+    pub const fn base_offset(&self) -> u32 {
+        self.base_offset
+    }
+
     /// Borrow the underlying source buffer.
     #[must_use]
     pub fn source(&self) -> &'src str {

--- a/rust/tcl-lexer/src/word_parts.rs
+++ b/rust/tcl-lexer/src/word_parts.rs
@@ -272,11 +272,17 @@ const MAX_INDEX_DEPTH: u32 = 64;
 /// Decompose `src` into its substitution components under `flags`.
 ///
 /// `src` is a word's **content** (delimiters already stripped) or a `subst`
-/// template. Returns [`WordBody::Literal`] — a borrow of `src` — when no
-/// enabled substitution actually occurs.
+/// template. Returns [`WordBody::Literal`] — a borrow of `src`, with no
+/// allocation at all — when no enabled substitution actually occurs. That
+/// check ([`triggers`]) is hoisted here, ahead of [`scan_parts`]'s walk, so
+/// this fast path never builds the one-element `Vec` [`decompose_spanned`]'s
+/// contract requires; see the module docs' "zero-copy" claim.
 #[must_use]
 pub fn decompose(src: &[u8], flags: SubstFlags, config: LexerConfig) -> WordBody<'_> {
-    body_of(decompose_at_depth(src, flags, config, 0))
+    if !triggers(src, flags) {
+        return WordBody::Literal(src);
+    }
+    body_of(scan_parts(src, flags, config, 0))
 }
 
 /// [`decompose`] with each top-level component's byte extent in `src`.
@@ -417,23 +423,42 @@ fn is_var_name_byte(c: u8) -> bool {
     c.is_ascii_alphanumeric() || c == b'_' || c == b':'
 }
 
+/// Whether any byte of `src` could start a substitution `flags` has enabled —
+/// the "nothing to do" test shared by [`decompose`]'s fast path and
+/// [`decompose_at_depth`]'s.
+fn triggers(src: &[u8], flags: SubstFlags) -> bool {
+    src.iter().any(|&c| {
+        (flags.vars && c == b'$') || (flags.cmds && c == b'[') || (flags.backslashes && c == b'\\')
+    })
+}
+
 fn decompose_at_depth(
     src: &[u8],
     flags: SubstFlags,
     config: LexerConfig,
     depth: u32,
 ) -> Vec<SpannedPart<'_>> {
-    let len = src.len();
-    let triggered = src.iter().any(|&c| {
-        (flags.vars && c == b'$') || (flags.cmds && c == b'[') || (flags.backslashes && c == b'\\')
-    });
-    if !triggered {
+    if !triggers(src, flags) {
         return vec![SpannedPart {
             part: WordPart::Text(Cow::Borrowed(src)),
             start: 0,
-            end: len,
+            end: src.len(),
         }];
     }
+    scan_parts(src, flags, config, depth)
+}
+
+/// The substitution walk itself, once [`triggers`] has confirmed there is
+/// something to scan for. Shared by [`decompose`] (triggered case) and
+/// [`decompose_at_depth`] (always, including the recursive `$name(index)`
+/// call) so the walk exists exactly once.
+fn scan_parts(
+    src: &[u8],
+    flags: SubstFlags,
+    config: LexerConfig,
+    depth: u32,
+) -> Vec<SpannedPart<'_>> {
+    let len = src.len();
     // Computed once per call, not per byte: whether this call already sits at
     // the index-nesting cap, so any `$name(index)` here keeps its index as
     // literal text rather than recursing further.

--- a/rust/tcl-lexer/src/word_parts.rs
+++ b/rust/tcl-lexer/src/word_parts.rs
@@ -232,6 +232,27 @@ pub enum WordBody<'s> {
     Parts(Vec<WordPart<'s>>),
 }
 
+/// A top-level component of [`decompose_spanned`] with its byte extent in the
+/// scanned source.
+///
+/// The extent is what a consumer that keeps *positions* needs — the compiler's
+/// `WordExpr` carries a source span per part — and it is not recoverable from
+/// the part alone: a [`WordPart::Text`] whose escapes were decoded owns its
+/// bytes, and a [`WordPart::ParseError`] borrows nothing. A `Text` extent is
+/// the raw, undecoded run; a `Variable` extent covers `$` through the end of
+/// the reference (the closing `}` or `)` included); a `Command` extent covers
+/// both brackets; a `ParseError` extent runs from the construct C rejected to
+/// the end of the source, which is where C stopped parsing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SpannedPart<'s> {
+    /// The component.
+    pub part: WordPart<'s>,
+    /// Byte offset of the component's first source byte.
+    pub start: usize,
+    /// Byte offset one past the component's last source byte.
+    pub end: usize,
+}
+
 /// Cap on `$name(index)` nesting depth [`decompose`] recurses into while
 /// parsing an index's own components.
 ///
@@ -255,7 +276,40 @@ const MAX_INDEX_DEPTH: u32 = 64;
 /// enabled substitution actually occurs.
 #[must_use]
 pub fn decompose(src: &[u8], flags: SubstFlags, config: LexerConfig) -> WordBody<'_> {
+    body_of(decompose_at_depth(src, flags, config, 0))
+}
+
+/// [`decompose`] with each top-level component's byte extent in `src`.
+///
+/// A word with nothing to substitute comes back as exactly one borrowed
+/// [`WordPart::Text`] spanning all of `src` — the same span [`decompose`]
+/// collapses to [`WordBody::Literal`]. Index components of a `$arr(index)`
+/// reference are nested inside the [`WordPart::Variable`] without extents.
+#[must_use]
+pub fn decompose_spanned(
+    src: &[u8],
+    flags: SubstFlags,
+    config: LexerConfig,
+) -> Vec<SpannedPart<'_>> {
     decompose_at_depth(src, flags, config, 0)
+}
+
+/// C's `TCL_TOKEN_SIMPLE_WORD` collapse. A span whose only component is one
+/// *borrowed* text run had nothing to substitute after all — a `$` with no
+/// name behind it, a `[` that the flags left inert — so it goes back as a
+/// zero-copy `Literal`. An *owned* run (escapes were decoded) cannot: it no
+/// longer borrows the source.
+fn body_of(parts: Vec<SpannedPart<'_>>) -> WordBody<'_> {
+    if let [
+        SpannedPart {
+            part: WordPart::Text(Cow::Borrowed(b)),
+            ..
+        },
+    ] = parts.as_slice()
+    {
+        return WordBody::Literal(b);
+    }
+    WordBody::Parts(parts.into_iter().map(|spanned| spanned.part).collect())
 }
 
 /// Where the `"`-delimited word opening at `open_quote` closes, or
@@ -368,20 +422,24 @@ fn decompose_at_depth(
     flags: SubstFlags,
     config: LexerConfig,
     depth: u32,
-) -> WordBody<'_> {
+) -> Vec<SpannedPart<'_>> {
     let len = src.len();
     let triggered = src.iter().any(|&c| {
         (flags.vars && c == b'$') || (flags.cmds && c == b'[') || (flags.backslashes && c == b'\\')
     });
     if !triggered {
-        return WordBody::Literal(src);
+        return vec![SpannedPart {
+            part: WordPart::Text(Cow::Borrowed(src)),
+            start: 0,
+            end: len,
+        }];
     }
     // Computed once per call, not per byte: whether this call already sits at
     // the index-nesting cap, so any `$name(index)` here keeps its index as
     // literal text rather than recursing further.
     let past_cap = depth >= MAX_INDEX_DEPTH;
 
-    let mut parts: Vec<WordPart> = Vec::new();
+    let mut parts: Vec<SpannedPart> = Vec::new();
     let mut lit_start = 0usize;
     let mut i = 0usize;
 
@@ -395,16 +453,20 @@ fn decompose_at_depth(
                         if past_cap {
                             vec![WordPart::Text(Cow::Borrowed(idx))]
                         } else {
-                            match decompose_at_depth(idx, flags, config, depth + 1) {
+                            match body_of(decompose_at_depth(idx, flags, config, depth + 1)) {
                                 WordBody::Literal(b) => vec![WordPart::Text(Cow::Borrowed(b))],
                                 WordBody::Parts(p) => p,
                             }
                         }
                     });
-                    parts.push(WordPart::Variable(VarRef {
-                        name: raw.name,
-                        index,
-                    }));
+                    parts.push(SpannedPart {
+                        part: WordPart::Variable(VarRef {
+                            name: raw.name,
+                            index,
+                        }),
+                        start: i,
+                        end: raw.next,
+                    });
                     i = raw.next;
                 }
                 // `Ok(None)` cannot happen: `starts_var_ref` already tested
@@ -418,8 +480,12 @@ fn decompose_at_depth(
                 // scanned are kept (they run first — see the module docs) and
                 // the error terminates the walk.
                 Err(msg) => {
-                    parts.push(WordPart::ParseError(msg));
-                    return WordBody::Parts(parts);
+                    parts.push(SpannedPart {
+                        part: WordPart::ParseError(msg),
+                        start: i,
+                        end: len,
+                    });
+                    return parts;
                 }
             }
             lit_start = i;
@@ -427,7 +493,11 @@ fn decompose_at_depth(
             match command_subst_close(src, i, flags, config) {
                 Ok(end) => {
                     flush_text(&mut parts, src, lit_start, i, flags, config.escapes);
-                    parts.push(WordPart::Command(&src[i + 1..end - 1]));
+                    parts.push(SpannedPart {
+                        part: WordPart::Command(&src[i + 1..end - 1]),
+                        start: i,
+                        end,
+                    });
                     i = end;
                     lit_start = i;
                 }
@@ -438,8 +508,12 @@ fn decompose_at_depth(
                 Err(_) if flags.unclosed_bracket_is_data => i += 1,
                 Err(msg) => {
                     flush_text(&mut parts, src, lit_start, i, flags, config.escapes);
-                    parts.push(WordPart::ParseError(msg));
-                    return WordBody::Parts(parts);
+                    parts.push(SpannedPart {
+                        part: WordPart::ParseError(msg),
+                        start: i,
+                        end: len,
+                    });
+                    return parts;
                 }
             }
         } else if flags.backslashes && c == b'\\' && i + 1 < len {
@@ -454,15 +528,7 @@ fn decompose_at_depth(
         }
     }
     flush_text(&mut parts, src, lit_start, len, flags, config.escapes);
-    // C's `TCL_TOKEN_SIMPLE_WORD` collapse. A span whose only component is one
-    // *borrowed* text run had nothing to substitute after all — a `$` with no
-    // name behind it, a `[` that the flags left inert — so it goes back as a
-    // zero-copy `Literal`. An *owned* run (escapes were decoded) cannot: it no
-    // longer borrows `src`.
-    if let [WordPart::Text(Cow::Borrowed(b))] = parts.as_slice() {
-        return WordBody::Literal(b);
-    }
-    WordBody::Parts(parts)
+    parts
 }
 
 /// [`command_subst_close`]'s error choice for an unterminated `[`.
@@ -656,7 +722,7 @@ fn brace_word_close(src: &[u8], at: usize) -> Option<usize> {
 /// Push `src[start..end]` as a [`WordPart::Text`], decoding its escapes under
 /// the release's grammar when backslash substitution is on (borrowing else).
 fn flush_text<'s>(
-    parts: &mut Vec<WordPart<'s>>,
+    parts: &mut Vec<SpannedPart<'s>>,
     src: &'s [u8],
     start: usize,
     end: usize,
@@ -670,7 +736,11 @@ fn flush_text<'s>(
         } else {
             Cow::Borrowed(run)
         };
-        parts.push(WordPart::Text(text));
+        parts.push(SpannedPart {
+            part: WordPart::Text(text),
+            start,
+            end,
+        });
     }
 }
 
@@ -1056,6 +1126,40 @@ mod tests {
         assert_eq!(
             decompose(b"x\\$y", SubstFlags::compiled_word(), nine()),
             WordBody::Parts(vec![text(b"x$y")])
+        );
+    }
+
+    /// The extents [`decompose_spanned`] reports are the raw source runs:
+    /// a decoded text run keeps its undecoded width, a reference covers its
+    /// closer, and a parse error runs to the end of the source (where C
+    /// stopped). Nested index components carry no extents of their own.
+    #[test]
+    fn spanned_parts_carry_their_raw_extents() {
+        let src = b"a\\tb${x}[c]$arr($i)\\$z";
+        let spanned = decompose_spanned(src, SubstFlags::default(), nine());
+        let extents: Vec<(usize, usize)> = spanned.iter().map(|p| (p.start, p.end)).collect();
+        assert_eq!(extents, vec![(0, 4), (4, 8), (8, 11), (11, 19), (19, 22)]);
+        assert_eq!(&src[4..8], b"${x}");
+        assert_eq!(&src[8..11], b"[c]");
+        assert_eq!(&src[11..19], b"$arr($i)");
+        assert_eq!(spanned[0].part, text(b"a\tb"));
+        assert_eq!(spanned[4].part, text(b"$z"));
+        // Every extent tiles the source without gaps.
+        assert!(spanned.windows(2).all(|w| w[0].end == w[1].start));
+
+        let stopped = decompose_spanned(b"x[side][b", SubstFlags::default(), nine());
+        assert_eq!(
+            stopped.last().map(|p| (p.part.clone(), p.start, p.end)),
+            Some((WordPart::ParseError(MISSING_CLOSE_BRACKET), 7, 9))
+        );
+        // The literal fast path is one borrowed run over the whole source.
+        assert_eq!(
+            decompose_spanned(b"plain", SubstFlags::default(), nine()),
+            vec![SpannedPart {
+                part: text(b"plain"),
+                start: 0,
+                end: 5,
+            }]
         );
     }
 


### PR DESCRIPTION
## Summary

Four concerns, each its own commit. The first is #1785 proper; the other three are defects this branch's gating surfaced and that are cheaper to fix here than to leave red.

### 1. `WordExpr` construction moves to the word-parts owner (#1785)

- The compiler's `WordExpr` construction comes off its private walk over lexer fragment tokens and onto `tcl_lexer::word_parts`, the owner `runtime/rust`, `tcl-vm` and `subst` already share — closing the last of the four implementations bucket R10 found.
- `WordExpr::from_segmented(sm, config, seg)` now calls `WordExpr::from_word` for every word. `from_fragments` — the old walk — is gone from the crate; the only copy left is the frozen one inside the differential test.
- Each bare and quoted run is decomposed under the **document's** `LexerConfig`, so the `${…}` close rule, the array-index source mask and the escape grammar follow the emulated release. The old walk never saw a config and got these wrong wherever the releases disagree. All five production call sites take an ingress-resolved config (`lowering/mod.rs`, `leaf_invoke.rs`, `native_lowering/lower.rs`, `ir_helpers.rs`); `cargo xtask dialect-drift` passes.
- The segmenter keeps what it owns — command and word boundaries. Only the within-word breakdown moves. A word C rejects becomes `Opaque` carrying C's own message, the same texts the segmenter's E200 reports.
- `differential_word_expr` holds a byte-for-byte frozen copy of the pre-#1785 walk and asserts it against the new production over crafted edge cases, the sample corpus and tcllib, with the fragment walk's known artefacts normalised so a real divergence still fails.

#### Behaviour changes, settled against real shells

The differential test surfaced exactly two rows where production and the frozen walk disagreed. Both were resolved by measurement, not inspection:

- **The quote fold is a property of the quoted *run*, not of the word.** `foo {*}"a $b"` opens its quote at offset 7 while the word starts at the `{*}` marker, so a normalisation anchored on the word start missed it and the run's first text span kept the `"` delimiter. Now anchored on the run.
- **`$arr({k})`'s compatibility spelling stays the raw source.** Measured on tclsh 8.6.16: `set arr({k}) hello; set v $arr({k})` yields `hello`, while `${arr({k})}` reads the *name* `arr({k` under that release's first-close rule and fails with `can't read "arr({k"`. So the `${…}` wrap every other scalar gets is sound only while the body carries no `}` — the guard `variable_spelling` applies, and which the frozen walk already agreed with. The test row expecting the wrap was wrong; the code was not. (On tclsh 9.0.4 the brace form does resolve, its close rule being nesting-aware, but the bare form there is a parse error, so this arm is 8.x-only.)

### 2. `word_parts::decompose` keeps an allocation-free literal path

Making the compiler a consumer put `decompose` on the hot path for every word in the file, and it allocated a one-element `Vec` even for a plain literal. It now checks whether the source triggers any substitution at all and returns `WordBody::Literal` borrowed from the input when it does not; the scanning body is unchanged and still backs `decompose_spanned`.

### 3. The no-libtommath runtime configuration is now gated in CI

`runtime/rust`'s bignum tower is conditional on `have_tommath`, which `build.rs` emits only when libtommath compiles. Nothing in CI ever built the other side, so the tower-less fallback had drifted (two of the bugs fixed in #1795 lived there). `make runtime-rust-test-no-tommath` builds and tests that configuration with the vendored library moved aside — `trap`-restored, so an interrupted run cannot leave the tree half-configured — and `runtime-rust-tests` now runs it **before** the libtommath fetch, where the library is genuinely absent.

### 4. `gui_renders_the_wasm_tab_and_settles_the_spinner` is fixed, not just observed

The earlier version of this PR reported this test as broken on `rust` and worth its own issue. It is fixed here instead.

`page.fill('#source', …)` timed out: Monaco owns the editor and the `#source` textarea behind it is hidden state plumbing (`Surface` in `rust/tcl-spec-studio/web/src/monacoHost.ts` sets `textarea.hidden = true`), so the element the driver typed into is unreachable in the shipped page **by design**. The test was already self-contradictory — it asserted `stateEditorDisplay == "none"` while filling that same hidden element — and could only ever pass by winning a race against the mount IIFE.

The page is not changed. The driver now writes through the editor host, the only channel the UI has, and two guards get stronger as a result:

- **"Compile queued during module load" is deterministic instead of a race.** The stubbed `wasm_bindgen` parks on a gate the driver opens, so the page is genuinely mid-load while the edit lands. Reintroducing the historic #1183 bug in a scratch copy now fails the driver deterministically; before, it depended on winning a timing window.
- **The edit → compile bridge is covered for the first time.** `index.html`'s one-second safety net reads the textarea directly and masks a broken `onChange` while `data` is still null, so a post-ready edit is asserted to recompile. Stubbing `onChange` to a no-op passes every pre-existing assertion and fails this one.

## Validation

```
cargo fmt --all -- --check
make rust-check
cargo test -p tcl-compiler --test differential_word_expr
cargo test -p tcl-cli --test explorer_gui          # and with TCL_LSP_GUI_TESTS=strict
cargo test --workspace --no-fail-fast
cargo xtask dialect-drift
cargo xtask kcs-index-links
```

All green, the workspace run included — the one failure the earlier revision of this body reported is concern 4 above.

- [x] I ran relevant tests/checks locally and listed the exact commands.

## Compiler / diagnostics checklist

- [x] **Did this change alter a compiler fact contract?** Yes — `WordExpr` part spans and spellings now come from the owner under the document's grammar.
- [x] **Owning design doc updated.** `docs/design/contracts/shared-utility-contracts-rust.md` listed the compiler's segmenter as "the remaining adopter" of `word_parts::decompose`; it is now a consumer, and the row records the two API names the adoption added (`decompose_spanned`, `SpannedPart`).
- [x] No diagnostic or optimisation code was added or changed, so no `docs/kcs/codes/` page needed updating.
- [x] No new design doc, so nothing to link from `docs/design/README.md` (`cargo xtask kcs-index-links` passes).

## Sequencing

This is the first of the #1784 parser-convergence follow-ons, sequenced #1785 → #1786 → #1787, and #1785 is the compiler-side seam taken on its own as that sequencing asks. #1786 (move command/word *boundary* segmentation into `tcl-lexer` so `runtime/rust`'s `parse.rs` and `tcl-vm`'s script walk stop re-deriving it) and #1787 (one shared per-command parse-then-evaluate driver, the structural fix for #1603) remain open and are deliberately out of scope here — this PR shares the word-*component* half only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013wqsJY5pcg8Uyk1H4e7V8y


---
_Generated by [Claude Code](https://claude.ai/code/session_013wqsJY5pcg8Uyk1H4e7V8y)_