### PR TITLE
Restore automated Tcl 9 smoke corpus coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,10 +98,11 @@ jobs:
   #   spectcl_compat_changed — SpecTcl or its TclVM/compiler/registry/runtime
   #                    and exact-reference-toolchain closure changed. Runs the
   #                    non-vacuous 15+3+4+2+1 compatibility lane.
-  #   runtime_rust_changed — the standalone `runtime/rust` crate or one of the
-  #                    path dependencies its own cargo workspace resolves
-  #                    changed, so `runtime-rust-tests` must execute that
-  #                    crate's unit suite.  `runtime/rust` is NOT a member of
+  #   runtime_rust_changed — the standalone `runtime/rust` crate, its Tcl 9
+  #                    smoke corpus, or one of the path dependencies its own
+  #                    cargo workspace resolves changed, so
+  #                    `runtime-rust-tests` must execute that crate's suite.
+  #                    `runtime/rust` is NOT a member of
   #                    the root workspace: `cargo test --workspace` never runs
   #                    those tests, and `wasm-real-link` builds and links the
   #                    crate without running a single one of them, so before
@@ -953,9 +954,9 @@ jobs:
   # remains the real-link check, and this job never links anything.
   #
   # The step-level skip keys on `runtime_rust_changed` (see the channel job
-  # header): the crate plus the path-dependency closure its own lockfile
-  # resolves.  The job itself always runs and reports, per the redundancy
-  # contract in AGENTS.md.
+  # header): the crate, its external Tcl 9 smoke corpus, plus the path-dependency
+  # closure its own lockfile resolves. The job itself always runs and reports,
+  # per the redundancy contract in AGENTS.md.
   runtime-rust-tests:
     needs: [channel]
     runs-on: ubuntu-26.04

--- a/runtime/rust/tests/tcl9_smoke.rs
+++ b/runtime/rust/tests/tcl9_smoke.rs
@@ -1,0 +1,188 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Byte-for-byte runner for the small, primitive-oriented Tcl 9 smoke corpus.
+//!
+//! The corpus used to have only a Python driver. Keep this test in the
+//! standalone runtime workspace so the same interpreter path as the
+//! `run_script` example owns and executes the contract without another
+//! language-specific harness.
+
+use std::cell::RefCell;
+use std::path::{Path, PathBuf};
+use std::rc::Rc;
+
+use tcl_dialect::TclVersion;
+use tcl_host_native::NativeHost;
+use tcl_platform::{Capabilities, Clock, Env, Filesystem, Host, Process, StdIo};
+use tcl_runtime::interp::{Code, Interp};
+
+const BASELINE_SAMPLE_COUNT: usize = 10;
+
+/// Delegate every real native capability except stdio, which the oracle needs
+/// to capture without redirecting process-global file descriptors.
+struct CaptureHost {
+    native: NativeHost,
+    stdout: RefCell<Vec<u8>>,
+    stderr: RefCell<Vec<u8>>,
+}
+
+impl CaptureHost {
+    fn new() -> Self {
+        Self {
+            native: NativeHost::new(),
+            stdout: RefCell::new(Vec::new()),
+            stderr: RefCell::new(Vec::new()),
+        }
+    }
+
+    fn stdout(&self) -> Vec<u8> {
+        self.stdout.borrow().clone()
+    }
+
+    fn stderr(&self) -> Vec<u8> {
+        self.stderr.borrow().clone()
+    }
+}
+
+impl StdIo for CaptureHost {
+    fn write_stdout(&self, bytes: &[u8]) {
+        self.stdout.borrow_mut().extend_from_slice(bytes);
+    }
+
+    fn write_stderr(&self, bytes: &[u8]) {
+        self.stderr.borrow_mut().extend_from_slice(bytes);
+    }
+}
+
+impl Host for CaptureHost {
+    fn capabilities(&self) -> Capabilities {
+        self.native.capabilities()
+    }
+
+    fn clock(&self) -> &dyn Clock {
+        self.native.clock()
+    }
+
+    fn stdio(&self) -> &dyn StdIo {
+        self
+    }
+
+    fn env(&self) -> &dyn Env {
+        self.native.env()
+    }
+
+    fn filesystem(&self) -> Option<&dyn Filesystem> {
+        self.native.filesystem()
+    }
+
+    fn process(&self) -> Option<&dyn Process> {
+        self.native.process()
+    }
+}
+
+fn collect_paths(root: &Path, extension: &str) -> Vec<PathBuf> {
+    fn visit(directory: &Path, extension: &str, paths: &mut Vec<PathBuf>) {
+        let mut entries = std::fs::read_dir(directory)
+            .unwrap_or_else(|error| panic!("cannot read {}: {error}", directory.display()))
+            .map(|entry| entry.expect("read corpus directory entry").path())
+            .collect::<Vec<_>>();
+        entries.sort();
+
+        for path in entries {
+            if path.is_dir() {
+                visit(&path, extension, paths);
+            } else if path.extension().is_some_and(|ext| ext == extension) {
+                paths.push(path);
+            }
+        }
+    }
+
+    let mut paths = Vec::new();
+    visit(root, extension, &mut paths);
+    paths
+}
+
+fn rendered(bytes: &[u8]) -> String {
+    format!("{:?}", String::from_utf8_lossy(bytes))
+}
+
+#[test]
+fn every_tcl9_smoke_sample_matches_its_oracle() {
+    let repository = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let corpus = repository.join("samples/tcl9_smoke");
+    let samples = collect_paths(&corpus, "tcl");
+    let expectations = collect_paths(&corpus, "expected");
+
+    assert!(
+        samples.len() >= BASELINE_SAMPLE_COUNT,
+        "Tcl 9 smoke corpus shrank or became vacuous: found {}, expected at least {BASELINE_SAMPLE_COUNT}",
+        samples.len()
+    );
+
+    for expected in &expectations {
+        let sample = expected.with_extension("tcl");
+        assert!(
+            sample.is_file(),
+            "orphaned expectation has no .tcl sample: {}",
+            expected.display()
+        );
+    }
+
+    let mut failures = Vec::new();
+    for sample in samples {
+        let expected_path = sample.with_extension("expected");
+        assert!(
+            expected_path.is_file(),
+            "sample has no .expected oracle: {}",
+            sample.display()
+        );
+
+        let script = std::fs::read(&sample)
+            .unwrap_or_else(|error| panic!("cannot read {}: {error}", sample.display()));
+        let expected = std::fs::read(&expected_path)
+            .unwrap_or_else(|error| panic!("cannot read {}: {error}", expected_path.display()));
+        let source_name = sample
+            .strip_prefix(&repository)
+            .expect("corpus lives under repository root")
+            .to_string_lossy();
+
+        let host = Rc::new(CaptureHost::new());
+        let mut interp = Interp::new();
+        interp.set_runtime_version(TclVersion::V9_0);
+        interp.set_host(host.clone());
+        let code = interp.eval_sourced(&script, source_name.as_bytes());
+        let actual = host.stdout();
+
+        if code != Code::Ok || actual != expected {
+            failures.push(format!(
+                "{source_name}: code={code:?}, result={}, stderr={}\n  expected {}\n    actual {}",
+                rendered(&interp.result_bytes()),
+                rendered(&host.stderr()),
+                rendered(&expected),
+                rendered(&actual),
+            ));
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "Tcl 9 smoke corpus failures:\n{}",
+        failures.join("\n")
+    );
+}

--- a/runtime/rust/tests/tcl9_smoke.rs
+++ b/runtime/rust/tests/tcl9_smoke.rs
@@ -119,7 +119,20 @@ fn collect_paths(root: &Path, extension: &str) -> Vec<PathBuf> {
 }
 
 fn rendered(bytes: &[u8]) -> String {
-    format!("{:?}", String::from_utf8_lossy(bytes))
+    let escaped = bytes
+        .iter()
+        .flat_map(|byte| std::ascii::escape_default(*byte))
+        .map(char::from)
+        .collect::<String>();
+    format!("b\"{escaped}\"")
+}
+
+#[test]
+fn failure_rendering_preserves_every_byte() {
+    assert_eq!(
+        rendered(&[0x80, b'\n', b'"', b'\\', b'A']),
+        "b\"\\x80\\n\\\"\\\\A\""
+    );
 }
 
 #[test]
@@ -157,21 +170,22 @@ fn every_tcl9_smoke_sample_matches_its_oracle() {
             .unwrap_or_else(|error| panic!("cannot read {}: {error}", sample.display()));
         let expected = std::fs::read(&expected_path)
             .unwrap_or_else(|error| panic!("cannot read {}: {error}", expected_path.display()));
-        let source_name = sample
+        let source_path = sample
             .strip_prefix(&repository)
-            .expect("corpus lives under repository root")
-            .to_string_lossy();
+            .expect("corpus lives under repository root");
+        let source_name = source_path.as_os_str().as_encoded_bytes();
 
         let host = Rc::new(CaptureHost::new());
         let mut interp = Interp::new();
         interp.set_runtime_version(TclVersion::V9_0);
         interp.set_host(host.clone());
-        let code = interp.eval_sourced(&script, source_name.as_bytes());
+        let code = interp.eval_sourced(&script, source_name);
         let actual = host.stdout();
 
         if code != Code::Ok || actual != expected {
             failures.push(format!(
-                "{source_name}: code={code:?}, result={}, stderr={}\n  expected {}\n    actual {}",
+                "{}: code={code:?}, result={}, stderr={}\n  expected {}\n    actual {}",
+                source_path.display(),
                 rendered(&interp.result_bytes()),
                 rendered(&host.stderr()),
                 rendered(&expected),

--- a/samples/tcl9_smoke/README.md
+++ b/samples/tcl9_smoke/README.md
@@ -2,16 +2,14 @@
 
 Minimal, self-contained `.tcl` programs that exercise individual
 primitives **without** using `tcltest`.  Each sample sits next to
-a `.expected` file containing the stdout we expect the compiled
-WASM to emit when the sample runs.  The pair serves two purposes:
+a `.expected` file containing the stdout expected from Tcl 9.0.4.
+The pair serves two purposes:
 
-1. **Regression smoke** — compile a sample to WASM, run it under
-   wasmtime, and compare the captured stdout against its sibling
-   `.expected` byte-for-byte.  A failing sample pinpoints the
-   primitive the commit broke without requiring tcltest's harness to
-   be healthy.  The Python runner that did this for the whole tree
-   went with the rest of Python; there is currently no automated
-   harness, so run samples by hand (below) until one is rebuilt.
+1. **Regression smoke** — `runtime/rust/tests/tcl9_smoke.rs` evaluates every
+   sample through the Rust runtime interpreter and compares captured stdout
+   against its sibling `.expected` byte-for-byte. A failing sample pinpoints
+   the primitive the commit broke without requiring tcltest's harness to be
+   healthy. The compiled WASM path remains a separate contract (below).
 2. **Architectural signal** — the corpus is organised by
    primitive (one directory per concern), so which primitives
    drift after a compiler change is immediately visible from the
@@ -33,9 +31,15 @@ their header comment.
 
 ## Running locally
 
-Evaluate a sample through the Rust runtime and diff it against its
-expectation (`--quiet` matches `tclsh script.tcl`: only `puts` reaches
-stdout):
+Run the complete automated corpus through the standalone runtime workspace:
+
+```sh
+make runtime-rust-test
+```
+
+To isolate one sample manually, evaluate it through the Rust runtime and diff
+it against its expectation (`--quiet` matches `tclsh script.tcl`: only `puts`
+reaches stdout):
 
 ```sh
 cd runtime/rust
@@ -58,13 +62,13 @@ instantiate it.
    * Run `tclsh9.0 path/to/sample.tcl > path/to/sample.expected`
      if you have Tcl 9 installed locally.
    * Hand-author the `.expected` based on the Tcl 9 man pages.
-3. Rerun the run-and-diff above; a silent `diff` confirms our
-   implementation produces the same stdout.
+3. Rerun `make runtime-rust-test`; the harness discovers new pairs
+   automatically and reports the sample path on a mismatch.
 
 ## When a sample fails
 
-`diff` shows expected vs actual.  Treat the failure as a
-regression of the compiler or runtime, NOT of the sample —
-the `.expected` is the source of truth (pinned to Tcl 9 reference
-behaviour).  If Tcl 9 semantics change, regenerate the `.expected`
-and note the version bump in the commit.
+The harness renders expected and actual bytes together with the completion
+code, interpreter result, and stderr. Treat a failure as a runtime regression
+unless a Tcl 9.0.4 reference interpreter proves the oracle stale. If the pinned
+reference version changes, regenerate the `.expected` files and note the
+version bump in the commit.

--- a/samples/tcl9_smoke/error_info/01_caught_error_global.expected
+++ b/samples/tcl9_smoke/error_info/01_caught_error_global.expected
@@ -1,3 +1,5 @@
 boom
 boom
+    while executing
+"error boom "
 NONE

--- a/scripts/dev/runtime-rust-path.sh
+++ b/scripts/dev/runtime-rust-path.sh
@@ -15,7 +15,8 @@
 # partition green — which is exactly what #1768 was filed for.
 #
 # The case list below is the runtime's LOCAL PACKAGE CLOSURE (the crate itself
-# plus every path dependency `cargo metadata` resolves for it), not a guess.
+# plus every path dependency `cargo metadata` resolves for it), its external
+# Tcl 9 smoke corpus, and the lane's build inputs — not a guess.
 # `scripts/dev/test-runtime-rust-paths.sh` re-derives that closure from cargo
 # and fails if this list has drifted either way, so a new path dependency
 # cannot silently stop triggering the job, and an over-broad entry cannot
@@ -33,6 +34,10 @@ PATH_TO_CLASSIFY=$1
 case "$PATH_TO_CLASSIFY" in
     # The crate under test.
     runtime/rust/*)
+        exit 0
+        ;;
+    # External golden inputs executed by runtime/rust/tests/tcl9_smoke.rs.
+    samples/tcl9_smoke/*)
         exit 0
         ;;
     # Its resolved path-dependency closure. Keep in sync with

--- a/scripts/dev/runtime-rust-path.sh
+++ b/scripts/dev/runtime-rust-path.sh
@@ -37,7 +37,7 @@ case "$PATH_TO_CLASSIFY" in
         exit 0
         ;;
     # External golden inputs executed by runtime/rust/tests/tcl9_smoke.rs.
-    samples/tcl9_smoke/*)
+    samples/tcl9_smoke/*.tcl | samples/tcl9_smoke/*.expected)
         exit 0
         ;;
     # Its resolved path-dependency closure. Keep in sync with

--- a/scripts/dev/test-runtime-rust-paths.sh
+++ b/scripts/dev/test-runtime-rust-paths.sh
@@ -110,6 +110,8 @@ expect_relevant scripts/dev/test-runtime-rust-paths.sh
 
 expect_unrelated README.md
 expect_unrelated samples/hello.tcl
+expect_unrelated samples/tcl9_smoke/README.md
+expect_unrelated samples/tcl9_smoke/eval/notes.txt
 expect_unrelated docs/design/compiler/wasm-native-lowering-plan.md
 expect_unrelated editors/vscode/src/extension.ts
 

--- a/scripts/dev/test-runtime-rust-paths.sh
+++ b/scripts/dev/test-runtime-rust-paths.sh
@@ -7,9 +7,9 @@
 # Contract tests for the standalone-runtime CI lane (issue #1768):
 #
 #   1. `scripts/dev/runtime-rust-path.sh` classifies exactly the runtime's
-#      resolved local package closure as relevant — no less (a new path
-#      dependency must start triggering the job) and no more (an over-broad
-#      entry must not make every PR pay for the lane).
+#      resolved local package closure and its external Tcl 9 smoke corpus as
+#      relevant — no less (a new path dependency or oracle edit must trigger
+#      the job) and no more (an over-broad entry must not make every PR pay).
 #   2. `make runtime-rust-test` really runs the standalone suite locked, with
 #      the numeric tower explicitly enabled.
 #   3. `.github/workflows/ci.yml` wires the classifier to a step-level,
@@ -100,6 +100,8 @@ done
 
 # Build inputs and the gate's own definition.
 expect_relevant runtime/rust/Cargo.lock
+expect_relevant samples/tcl9_smoke/eval/01_braced_literal.tcl
+expect_relevant samples/tcl9_smoke/eval/01_braced_literal.expected
 expect_relevant rust-toolchain.toml
 expect_relevant Makefile
 expect_relevant .github/workflows/ci.yml
@@ -107,6 +109,7 @@ expect_relevant scripts/dev/runtime-rust-path.sh
 expect_relevant scripts/dev/test-runtime-rust-paths.sh
 
 expect_unrelated README.md
+expect_unrelated samples/hello.tcl
 expect_unrelated docs/design/compiler/wasm-native-lowering-plan.md
 expect_unrelated editors/vscode/src/extension.ts
 


### PR DESCRIPTION
Closes #1790

## Summary

- Restore a Rust integration harness that discovers and runs every `.tcl` / `.expected` pair.
- Capture stdout through the runtime `Host` seam, pin Tcl 9.0, reject orphaned files, and enforce the ten-sample baseline.
- Correct the stale `errorInfo` oracle against Tcl 9.0.4.
- Make only executed Tcl 9 corpus inputs trigger the required `runtime-rust-tests` lane.
- Preserve platform path bytes passed to the interpreter and render all result bytes losslessly on failure.
- Document the interpreter-versus-compiled-WASM boundary accurately.

## Experimental proof

Tcl 9.0.4 and the Rust `run_script` path produced byte-identical output for `error_info/01_caught_error_global`; both include the command-frame lines omitted by the old oracle.

Red: with the original oracle, the new harness ran all ten samples and failed only that case, showing the missing command-frame bytes.

Green:

- focused corpus harness: 2 passed; all ten pairs executed in 0.09s, plus a non-UTF-8 diagnostic-rendering regression
- complete standalone runtime suite: 595 unit tests plus every integration suite passed
- runtime path/classifier/CI-wiring contracts passed, including unrelated README/text sentinels
- rebased onto #1812 so every dependency graph selects `wnaf 0.14.1`
- `make rust-check` passed from a clean post-ENOSPC target
- `make NPROC=1 prep-pr` passed from the same clean isolated target; no checks or assertions were skipped

The clean gate used a unique per-worktree target and disabled test debuginfo to lower linker memory. Merge waits for the fresh hosted matrix on the rebased head.
