### PR TITLE
ci: serialize Rust tests on the shared tank host

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,10 @@ jobs:
   #                    the committed lockfile by
   #                    scripts/dev/test-runtime-rust-paths.sh, so it cannot
   #                    silently narrow.
+  #   runner_policy_changed — the self-hosted runner policy or its contract
+  #                    test changed.  Such PRs prove themselves on an isolated
+  #                    GitHub-hosted runner; an unreviewed scheduling edit must
+  #                    not execute on, overload, or strand the protected host.
   channel:
     runs-on: ubuntu-24.04
     permissions:
@@ -126,6 +130,7 @@ jobs:
       wasm_cc_changed: ${{ steps.paths.outputs.wasm_cc_changed }}
       spectcl_compat_changed: ${{ steps.paths.outputs.spectcl_compat_changed }}
       runtime_rust_changed: ${{ steps.paths.outputs.runtime_rust_changed }}
+      runner_policy_changed: ${{ steps.paths.outputs.runner_policy_changed }}
       docs_only: ${{ steps.paths.outputs.docs_only }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -205,6 +210,7 @@ jobs:
           wasm_cc_changed=false
           spectcl_compat_changed=false
           runtime_rust_changed=false
+          runner_policy_changed=false
           docs_only=true
           if [ "$ok" = "true" ]; then
             while IFS= read -r f; do
@@ -223,6 +229,10 @@ jobs:
               case "$f" in
                 rust/tcl-explorer-wasm/* | rust/tcl-vm-wasm/* | rust/tcl-spec-studio-wasm/* | rust/tcl-lsp-server-wasm/* | rust/bigip-query-wasm/* | rust/bigip-report-gen/wasm/* | scripts/dev/ensure-test-deps.sh | scripts/dev/wasm-cc-env.sh | scripts/dev/test-wasm-cc-env.sh | Cargo.toml | Cargo.lock | rust-toolchain.toml | Makefile | .github/workflows/ci.yml)
                   wasm_cc_changed=true ;;
+              esac
+              case "$f" in
+                .github/workflows/ci.yml | scripts/dev/test-rust-tests-runner.sh)
+                  runner_policy_changed=true ;;
               esac
               if scripts/dev/spectcl-compat-path.sh "$f"; then
                 spectcl_compat_changed=true
@@ -255,6 +265,7 @@ jobs:
             wasm_cc_changed=true
             spectcl_compat_changed=true
             runtime_rust_changed=true
+            runner_policy_changed=true
             docs_only=false
           fi
           {
@@ -264,9 +275,10 @@ jobs:
             echo "wasm_cc_changed=$wasm_cc_changed"
             echo "spectcl_compat_changed=$spectcl_compat_changed"
             echo "runtime_rust_changed=$runtime_rust_changed"
+            echo "runner_policy_changed=$runner_policy_changed"
             echo "docs_only=$docs_only"
           } >>"$GITHUB_OUTPUT"
-          echo "python_changed=$python_changed ext_changed=$ext_changed lsp_wasm_changed=$lsp_wasm_changed wasm_cc_changed=$wasm_cc_changed spectcl_compat_changed=$spectcl_compat_changed runtime_rust_changed=$runtime_rust_changed docs_only=$docs_only"
+          echo "python_changed=$python_changed ext_changed=$ext_changed lsp_wasm_changed=$lsp_wasm_changed wasm_cc_changed=$wasm_cc_changed spectcl_compat_changed=$spectcl_compat_changed runtime_rust_changed=$runtime_rust_changed runner_policy_changed=$runner_policy_changed docs_only=$docs_only"
 
   # Fast PR gate.  Runs on every PR and every push.  Covers the Rust fast
   # checks through the central `make rust-check` contract: root and standalone
@@ -775,15 +787,23 @@ jobs:
     # `lsp-e2e` does, so shortening the test jobs cuts cost and the local
     # `make test-rust` loop rather than PR turnaround.
     #
-    # It is the ONLY job routed to the self-hosted runner, and that
-    # is deliberate: the box has one runner instance, so anything sent there
-    # executes serially and queues behind this job.
+    # It is the ONLY job routed to the self-hosted runner, and that is
+    # deliberate.  `tank` is one physical host but may have multiple runner
+    # registrations; the job-level concurrency group is therefore the source
+    # of truth that keeps these CPU- and memory-heavy suites serial on that
+    # host.  Fork PRs and PRs changing this runner policy use a run-specific
+    # group because they execute on separate GitHub-hosted machines and must
+    # retain their normal parallelism.  The latter also makes policy changes
+    # fail safely: a broken scheduler edit cannot strand the protected host.
     #
     # Untrusted code must never reach the self-hosted runner, so PRs from forks
     # stay on GitHub-hosted; everything else (push, dispatch, and PRs from
     # branches in this repo, which only collaborators can create) goes to `tank`.
     needs: [channel]
-    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'tank' || 'ubuntu-26.04' }}
+    runs-on: ${{ (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || needs.channel.outputs.runner_policy_changed == 'true')) && 'ubuntu-26.04' || 'tank' }}
+    concurrency:
+      group: rust-tests-${{ (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || needs.channel.outputs.runner_policy_changed == 'true')) && format('hosted-{0}', github.run_id) || 'tank' }}
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/Makefile
+++ b/Makefile
@@ -210,7 +210,7 @@ TS_SRCS  := $(shell find $(EXT_DIR)/src -name '*.ts' 2>/dev/null)
 # Tests
 .PHONY: test test-ext test-emacs test-rust rust-server rust-tcl rust-f5 rust-mcp rust-clis ensure-server-cross-deps server-cross-build server-cross-build-all mcp-cross-build-all cli-cross-build-all server-cross-test server-cross-test-build print-server-targets-all print-server-targets-jetbrains
 .PHONY: xtask-check xtask-editor-extensions xtask-kcs-index-links xtask-diag-tables xtask-diag-emission-check xtask-gen-editor-catalogs xtask-gen-bundled-environments xtask-gen-editor-dialects xtask-gen-irule-test-data xtask-gen-zed-queries xtask-gen-editor-settings xtask-gen-vscode-package xtask-gen-jetbrains-catalog xtask-gen-ai-diagnostics xtask-owner-resolution xtask-command-backing xtask-audit-option-dialects xtask-registry-oracle xtask-sslictcl-data xtask-runtime-stdlib tcltest-sweep tcltest-sweep-check xtask-f5query-builtins-doc xtask-bigip-data-schema xtask-c-api-ownership check-c-api-ownership
-.PHONY: xtask-workflow-sync xtask-resolution-drift xtask-retired-api-gate xtask-pack-goldens xtask-number-drift xtask-gen-tmlanguage-keywords xtask-option-registry-drift xtask-callback-inventory check-tcl-reference-toolchains check-spectcl-compat-paths check-runtime-rust-paths check-wasm-cc-env xtask-dialect-drift
+.PHONY: xtask-workflow-sync xtask-resolution-drift xtask-retired-api-gate xtask-pack-goldens xtask-number-drift xtask-gen-tmlanguage-keywords xtask-option-registry-drift xtask-callback-inventory check-tcl-reference-toolchains check-spectcl-compat-paths check-runtime-rust-paths check-rust-tests-runner check-wasm-cc-env xtask-dialect-drift
 # Lint / format / typecheck
 .PHONY: lint format lint-ts format-ts typecheck-ts check-rust check-rust-pr _check-rust-pr rust-deny
 .PHONY: build-report-assets build-report-pyz lint-report-ts typecheck-report-ts check-report-assets lint-spec-studio-ts typecheck-spec-studio-ts
@@ -759,7 +759,7 @@ coverage-ext: compile $(NPM_STAMP) ensure-vscode-test-deps ## Run VS Code extens
 # --- Native (cargo xtask) check gates.  These need the Rust toolchain, so CI
 # runs them in the rust-tests job (rust-gate.yml / ci.yml).  `xtask-check` is
 # the CI aggregate.
-xtask-check: check-tcl-reference-toolchains check-spectcl-compat-paths check-runtime-rust-paths check-wasm-cc-env xtask-workflow-sync xtask-kcs-index-links xtask-diag-tables xtask-diag-emission-check xtask-gen-editor-catalogs xtask-gen-bundled-environments xtask-gen-editor-dialects xtask-gen-irule-test-data xtask-gen-zed-queries xtask-gen-tmlanguage-keywords xtask-gen-editor-settings xtask-gen-vscode-package xtask-gen-jetbrains-catalog xtask-gen-ai-diagnostics xtask-owner-resolution xtask-resolution-drift xtask-retired-api-gate xtask-pack-goldens xtask-number-drift xtask-command-backing xtask-callback-inventory xtask-option-registry-drift xtask-sslictcl-data xtask-runtime-stdlib xtask-editor-extensions xtask-f5query-builtins-doc xtask-bigip-data-schema xtask-c-api-ownership ## Rust-side check gates (docs index coverage + generated-table/catalog drift) xtask-dialect-drift
+xtask-check: check-tcl-reference-toolchains check-spectcl-compat-paths check-runtime-rust-paths check-rust-tests-runner check-wasm-cc-env xtask-workflow-sync xtask-kcs-index-links xtask-diag-tables xtask-diag-emission-check xtask-gen-editor-catalogs xtask-gen-bundled-environments xtask-gen-editor-dialects xtask-gen-irule-test-data xtask-gen-zed-queries xtask-gen-tmlanguage-keywords xtask-gen-editor-settings xtask-gen-vscode-package xtask-gen-jetbrains-catalog xtask-gen-ai-diagnostics xtask-owner-resolution xtask-resolution-drift xtask-retired-api-gate xtask-pack-goldens xtask-number-drift xtask-command-backing xtask-callback-inventory xtask-option-registry-drift xtask-sslictcl-data xtask-runtime-stdlib xtask-editor-extensions xtask-f5query-builtins-doc xtask-bigip-data-schema xtask-c-api-ownership ## Rust-side check gates (docs index coverage + generated-table/catalog drift) xtask-dialect-drift
 
 check-tcl-reference-toolchains: ## Verify pinned C Tcl patchlevels across shell setup and Rust oracle discovery
 	@echo "==> Checking C Tcl reference toolchain ownership"
@@ -773,6 +773,10 @@ check-spectcl-compat-paths: ## Verify CI's SpecTcl dependency closure and centra
 check-runtime-rust-paths: ## Verify CI's standalone-runtime dependency closure and job wiring (#1768)
 	@echo "==> Checking standalone runtime CI path ownership"
 	@bash scripts/dev/test-runtime-rust-paths.sh
+
+check-rust-tests-runner: ## Verify trusted rust-tests jobs serialize on the shared tank host
+	@echo "==> Checking self-hosted Rust test scheduling"
+	@sh scripts/dev/test-rust-tests-runner.sh
 
 check-wasm-cc-env: ## Verify wasm32 C-compiler selection and dependency diagnostics
 	@echo "==> Checking wasm32 C compiler bootstrap"

--- a/scripts/dev/test-rust-tests-runner.sh
+++ b/scripts/dev/test-rust-tests-runner.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+# tcl-lsp — a language server and toolchain for Tcl
+# Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+# Contract test for the one-physical-host `tank` runner pool. Multiple runner
+# registrations must not turn into concurrent heavyweight workspace suites.
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+REPO_ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/../.." && pwd)
+WORKFLOW=$REPO_ROOT/.github/workflows/ci.yml
+
+rust_tests_job=$(awk '
+    /^  rust-tests:/ { in_job = 1 }
+    in_job && /^  [A-Za-z0-9_-]+:/ && $1 != "rust-tests:" { exit }
+    in_job { print }
+' "$WORKFLOW")
+
+if [ -z "$rust_tests_job" ]; then
+    echo "ci.yml must define the rust-tests job" >&2
+    exit 1
+fi
+
+case "$(cat "$WORKFLOW")" in
+    *'runner_policy_changed: ${{ steps.paths.outputs.runner_policy_changed }}'*) ;;
+    *)
+        echo "the channel job must publish its runner-policy path decision" >&2
+        exit 1
+        ;;
+esac
+
+case "$(cat "$WORKFLOW")" in
+    *'.github/workflows/ci.yml | scripts/dev/test-rust-tests-runner.sh)'*) ;;
+    *)
+        echo "runner-policy changes must classify themselves for hosted proof" >&2
+        exit 1
+        ;;
+esac
+
+hosted_condition="github.event.pull_request.head.repo.full_name != github.repository || needs.channel.outputs.runner_policy_changed == 'true'"
+
+case "$rust_tests_job" in
+    *"runs-on:"*"$hosted_condition"*"&& 'ubuntu-26.04' || 'tank'"*) ;;
+    *)
+        echo "rust-tests must keep fork and runner-policy PRs off the self-hosted tank host" >&2
+        exit 1
+        ;;
+esac
+
+case "$rust_tests_job" in
+    *"group: rust-tests-"*"$hosted_condition"*"format('hosted-{0}', github.run_id)"*"|| 'tank'"*) ;;
+    *)
+        echo "rust-tests must serialize trusted jobs in one tank group and keep hosted jobs unique" >&2
+        exit 1
+        ;;
+esac
+
+case "$rust_tests_job" in
+    *"cancel-in-progress: false"*) ;;
+    *)
+        echo "queued tank jobs must not cancel an already-running workspace suite" >&2
+        exit 1
+        ;;
+esac
+
+echo "self-hosted Rust test scheduling contract passed"


### PR DESCRIPTION
## Summary

- serialize trusted-repository `rust-tests` jobs across workflow runs in one non-cancelling `rust-tests-tank` concurrency group
- retain run-specific concurrency groups for fork PRs, which continue to execute on isolated GitHub-hosted runners
- replace the stale one-runner-instance assumption with the actual one-physical-host contract
- add a checked workflow regression that locks runner trust, group selection, and non-cancellation together

## Experimental proof

On 2026-09-03, three queued `rust-tests` jobs began at 16:35 UTC on `tank-vm`, `tank-vm-3`, and `tank-vm-4`. They all lost communication at 17:01 UTC and all four registrations went offline together. Earlier single-job runs on the same physical host completed successfully in 15-22 minutes. This isolates the failure to concurrent heavyweight jobs on shared hardware rather than any of the three PR trees.

Local verification:

- `sh scripts/dev/test-rust-tests-runner.sh`
- parsed `.github/workflows/ci.yml` with PyYAML
- `make rust-check`
- `make NPROC=1 prep-pr`

The hosted run for this PR provides the operational proof: a trusted `rust-tests` job must acquire the shared tank group, and other repository runs must queue rather than execute alongside it.

Closes #1808