### PR TITLE
refactor(compiler): derive CST command/word boundaries from the owner (#1786)

### DIFF
--- a/rust/tcl-compiler/src/parsing/syntax/build.rs
+++ b/rust/tcl-compiler/src/parsing/syntax/build.rs
@@ -24,11 +24,16 @@
 //! commands and words, folding `Sep` / `Eol` / `Comment` tokens into
 //! attached [`GreenTrivia`].
 //!
-//! The grouping mirrors the segmenter's `segment_commands_local`
-//! exactly — same word-merging, same `{*}` handling, same continuation
-//! handling, and the same `word_boundary` range rule (stale-boundary
-//! quirk included) — so that segments derived from the tree
-//! are byte-identical to the token-loop segmenter.
+//! **The boundaries are not decided here.**  Where one command ends and
+//! the next begins, where each word starts, what a `{*}` marker attaches
+//! to, and which comment precedes which command are all answered by
+//! [`tcl_lexer::script::group_commands`] — the single owner of Tcl command
+//! and word boundaries (issue #1786).  This module projects the owner's
+//! answers onto the token stream ([`Plan`]) and spends its own logic only
+//! on what is genuinely the compiler's: green/red CST shape, trivia
+//! attachment, start-to-start tiling, ghost-delimiter recovery, and the
+//! `word_boundary` range rule that feeds `range_end_rel` (which the owner
+//! deliberately does not carry — see [`Plan::word_end`]).
 //!
 //! Raw fragment text is recovered by *start-to-start tiling*: the lexer
 //! advances its cursor monotonically, so
@@ -40,15 +45,10 @@
 //! lexes in *local* space (base 0, exactly as `segment_commands_local`)
 //! and leaves the anchoring to the red [`super::red::SyntaxTree`].
 
+use tcl_lexer::script::{CommandSpan, group_commands};
 use tcl_lexer::{LexWarning, Lexer, LexerConfig, SourceMap, Token, TokenType};
 
 use super::green::{GreenElement, GreenNode, GreenToken, GreenTrivia, TokenTrivia, TriviaKind};
-
-/// `Sep` / `Eol` — the two trivia types the `word_boundary` rule treats
-/// as a word break.
-const fn is_sep_or_eol(t: TokenType) -> bool {
-    matches!(t, TokenType::Sep | TokenType::Eol)
-}
 
 /// Tokenise `source` with the given dialect [`LexerConfig`] and build its
 /// green `Document` node, returning `(document, warnings)`.
@@ -87,8 +87,80 @@ pub fn build_document_with_ghosts(
     let Ok((tokens, warnings)) = lexer.tokenise_all_with_warnings() else {
         return (GreenNode::document(Vec::new(), Vec::new()), Vec::new());
     };
-    let document = Builder::new(source, &sm, &tokens).run();
+    // Ask the boundary owner where the commands and words are, then shape
+    // the CST around its answer.
+    let plan = Plan::new(&group_commands(&tokens, source, config), &tokens, source);
+    let document = Builder::new(source, &sm, &tokens, plan).run();
     (document, warnings)
+}
+
+/// [`group_commands`]'s answers, projected onto the token stream so the
+/// builder can consult them token by token as it tiles.
+///
+/// Everything here is *derived* — nothing in this struct is a boundary
+/// decision of the compiler's own.
+struct Plan {
+    /// A word begins at this token index.
+    word_start: Vec<bool>,
+    /// A word ends immediately *before* this token index — i.e. some
+    /// [`WordSpan::tokens`](tcl_lexer::script::WordSpan::tokens)`.end`
+    /// equals it.  Length is `tokens.len() + 1`.
+    ///
+    /// This is what replaces the old `prev_type` state machine behind the
+    /// `word_boundary` rule.  A `Sep` advances the boundary exactly when a
+    /// word ended at it, and the terminating `Eol` supplies the boundary
+    /// exactly when a word ended at *it* — which is precisely the old
+    /// `!is_sep_or_eol(prev_type)` test, `{*}`'s stale-boundary quirk
+    /// included (a marker is in no word, so no word ends after it).
+    word_end: Vec<bool>,
+    /// This token index is a `{*}` expansion marker.
+    marker: Vec<bool>,
+    /// Preceding comment of the command the `Eol` at this index closes.
+    comment_at: Vec<Option<String>>,
+    /// Preceding comment of a command closed by end of stream.
+    comment_at_eof: Option<String>,
+}
+
+impl Plan {
+    fn new(commands: &[CommandSpan], tokens: &[Token], source: &str) -> Self {
+        let n = tokens.len();
+        let mut plan = Self {
+            word_start: vec![false; n],
+            word_end: vec![false; n + 1],
+            marker: vec![false; n],
+            comment_at: vec![None; n],
+            comment_at_eof: None,
+        };
+        let mut reported = vec![false; n];
+        for cmd in commands {
+            for word in &cmd.words {
+                plan.word_start[word.tokens.start] = true;
+                plan.word_end[word.tokens.end] = true;
+                reported[word.tokens.clone()].fill(true);
+            }
+            for &marker in &cmd.expand_markers {
+                plan.marker[marker] = true;
+                reported[marker] = true;
+            }
+            let comment = cmd.comment_text(tokens, source);
+            match cmd.terminator {
+                Some(i) => plan.comment_at[i] = comment,
+                None => plan.comment_at_eof = comment,
+            }
+        }
+        // The owner *discards* a command made of nothing but dangling `{*}`
+        // markers, so those markers reach no `CommandSpan::expand_markers`.
+        // The CST still has to place them (losslessness), and
+        // `segments_from_tree` discards that command again on the way out,
+        // so the tree stays byte-identical.  Every other content token is
+        // in some word, so this can only ever pick up such markers.
+        for (i, tok) in tokens.iter().enumerate() {
+            if !reported[i] && tok.kind == TokenType::Expand {
+                plan.marker[i] = true;
+            }
+        }
+        plan
+    }
 }
 
 /// In-flight state for the start-to-start tiling.
@@ -96,35 +168,34 @@ struct Builder<'a> {
     source: &'a str,
     sm: &'a SourceMap<'a>,
     tokens: &'a [Token],
+    plan: Plan,
 
     commands: Vec<GreenElement>,  // finished COMMAND nodes
     cur_words: Vec<GreenElement>, // finished WORD nodes of the current command
     frag: Vec<GreenToken>,        // fragments of the word currently being built
     pending: Vec<GreenTrivia>,    // leading trivia awaiting the next fragment
     markers: Vec<GreenToken>,     // {*} markers awaiting their word
-    last_comment: Option<String>, // comment(s) accumulating for the next command
-    prev_type: TokenType,
 
-    // Range tracking, mirroring the word_boundary rule.  All offsets are
-    // region-relative (local, base 0) so the stored end stays anchor-free.
+    // Range tracking for `range_end_rel`, driven by the owner's word ends.
+    // All offsets are region-relative (local, base 0) so the stored end
+    // stays anchor-free.
     first_region: Option<u32>, // region offset of the command's first token
     last_end_region: u32,      // region offset of the last content token's inner end
     word_boundary: Option<u32>, // region offset after the last word fragment
 }
 
 impl<'a> Builder<'a> {
-    fn new(source: &'a str, sm: &'a SourceMap<'a>, tokens: &'a [Token]) -> Self {
+    fn new(source: &'a str, sm: &'a SourceMap<'a>, tokens: &'a [Token], plan: Plan) -> Self {
         Self {
             source,
             sm,
             tokens,
+            plan,
             commands: Vec::new(),
             cur_words: Vec::new(),
             frag: Vec::new(),
             pending: Vec::new(),
             markers: Vec::new(),
-            last_comment: None,
-            prev_type: TokenType::Eol,
             first_region: None,
             last_end_region: 0,
             word_boundary: None,
@@ -167,14 +238,16 @@ impl<'a> Builder<'a> {
         self.word_boundary = None;
     }
 
-    fn range_end_rel(&self, eol_region: Option<u32>) -> Option<u32> {
+    /// The command's end offset relative to its first token.
+    ///
+    /// `eol_boundary` is the terminating `Eol`'s region offset when a word
+    /// ended at that `Eol` (the owner's `word_end` answer) and `None`
+    /// otherwise — a separator or a `{*}` marker came between, or the
+    /// command was closed at end of stream — in which case the last
+    /// separator's boundary stands.
+    fn range_end_rel(&self, eol_boundary: Option<u32>) -> Option<u32> {
         let first_region = self.first_region?;
-        let boundary = if eol_region.is_some() && !is_sep_or_eol(self.prev_type) {
-            eol_region // the EOL directly follows the last token
-        } else {
-            self.word_boundary
-        };
-        let end_region = match boundary {
+        let end_region = match eol_boundary.or(self.word_boundary) {
             Some(b) if b > first_region => b - 1,
             _ => self.last_end_region, // fallback: last token's inner end
         };
@@ -184,10 +257,10 @@ impl<'a> Builder<'a> {
     fn close_command(
         &mut self,
         terminator: GreenTrivia,
-        eol_region: Option<u32>,
+        eol_boundary: Option<u32>,
         pc: Option<String>,
     ) {
-        let end_rel = self.range_end_rel(eol_region);
+        let end_rel = self.range_end_rel(eol_boundary);
         // Trailing whitespace after the last token + the terminator attach
         // to the last token (document order) as trailing trivia, keeping the
         // tree lossless; the command's range comes from end_rel, not this.
@@ -250,10 +323,10 @@ impl<'a> Builder<'a> {
             let region = tok.span.start();
             // Trivia and continuation tokens fold into attached
             // GreenTrivia and never become fragments.
-            if self.handle_trivia(tok, raw, region) {
+            if self.handle_trivia(i, tok, raw, region) {
                 continue;
             }
-            self.handle_fragment(tok, raw, region);
+            self.handle_fragment(i, tok, raw, region);
         }
         self.finalise();
         GreenNode::document(self.commands, self.pending)
@@ -262,14 +335,13 @@ impl<'a> Builder<'a> {
     /// Fold a `Comment` / `Sep` / `Eol` / backslash-newline token into
     /// attached trivia (and close commands on `Eol`).  Returns `true`
     /// when the token was trivia and the caller should advance.
-    fn handle_trivia(&mut self, tok: Token, raw: &'a str, region: u32) -> bool {
+    fn handle_trivia(&mut self, i: usize, tok: Token, raw: &'a str, region: u32) -> bool {
         match tok.kind {
+            // Which command a comment attaches to, how consecutive lines
+            // join, and when a blank line detaches them are all the owner's
+            // answers (`CommandSpan::comment`); here a comment is only
+            // trivia to be tiled.
             TokenType::Comment => {
-                let line = raw.trim_start_matches('#').trim();
-                self.last_comment = Some(match self.last_comment.take() {
-                    Some(prev) => format!("{prev}\n{line}"),
-                    None => line.to_string(),
-                });
                 self.pending
                     .push(GreenTrivia::new(TriviaKind::Comment, raw));
                 true
@@ -286,17 +358,15 @@ impl<'a> Builder<'a> {
             // drop a token the lexer reports and lose the (possibly only)
             // fragment of the quoted word.
             TokenType::Sep => {
-                if !is_sep_or_eol(self.prev_type) {
+                if self.plan.word_end[i] {
                     self.word_boundary = Some(region);
                 }
                 self.pending
                     .push(GreenTrivia::new(TriviaKind::Whitespace, raw));
-                self.prev_type = TokenType::Sep;
                 true
             }
             TokenType::Eol => {
-                self.handle_eol(raw, region);
-                self.prev_type = TokenType::Eol;
+                self.handle_eol(i, raw, region);
                 true
             }
             _ => false,
@@ -304,23 +374,20 @@ impl<'a> Builder<'a> {
     }
 
     /// Close (or skip) a command on an `Eol` terminator.
-    fn handle_eol(&mut self, raw: &'a str, region: u32) {
+    fn handle_eol(&mut self, i: usize, raw: &'a str, region: u32) {
         let eol_triv = GreenTrivia::new(TriviaKind::Eol, raw);
+        // The `Eol` supplies the range boundary only when a word ended at
+        // it; otherwise the last separator's boundary stands.
+        let boundary = self.plan.word_end[i].then_some(region);
         if !self.frag.is_empty() || !self.cur_words.is_empty() {
-            // A real command closes here: it takes the accumulated comment.
-            let pc = self.last_comment.take();
-            self.close_command(eol_triv, Some(region), pc);
+            // A real command closes here: it takes the owner's comment.
+            let pc = self.plan.comment_at[i].take();
+            self.close_command(eol_triv, boundary, pc);
         } else if !self.markers.is_empty() {
-            // A dangling-{*} command closes but keeps no comment; a blank
-            // line still resets accumulation.
-            if raw.matches('\n').count() > 1 {
-                self.last_comment = None;
-            }
-            self.close_command(eol_triv, Some(region), None);
+            // A dangling-{*} command closes but keeps no comment (the owner
+            // discards the command outright, so it reports none).
+            self.close_command(eol_triv, boundary, None);
         } else {
-            if raw.matches('\n').count() > 1 {
-                self.last_comment = None;
-            }
             self.pending.push(eol_triv);
         }
     }
@@ -328,7 +395,7 @@ impl<'a> Builder<'a> {
     /// Turn a content token (`Esc` / `Str` / `Cmd` / `Var` / `Expand`)
     /// into a fragment, merging it into the current word or starting a new
     /// one.
-    fn handle_fragment(&mut self, tok: Token, raw: &'a str, region: u32) {
+    fn handle_fragment(&mut self, i: usize, tok: Token, raw: &'a str, region: u32) {
         let end_region = self.end_region(tok);
         let leaf = GreenToken::new(
             tok.kind,
@@ -344,23 +411,22 @@ impl<'a> Builder<'a> {
         }
         self.last_end_region = end_region;
 
-        if tok.kind == TokenType::Expand {
+        if self.plan.marker[i] {
             // {*} ends any word in progress and marks the *next* word for
-            // expansion; like the segmenter it advances prev_type to SEP
-            // WITHOUT touching word_boundary (the stale-boundary quirk).
+            // expansion.  It is in no word, so no word ends at it and
+            // `word_boundary` does not move — build's "stale-boundary
+            // quirk", which the owner's grouping preserves.
             self.finish_word();
             self.markers.push(leaf);
-            self.prev_type = TokenType::Sep;
             return;
         }
 
-        if is_sep_or_eol(self.prev_type) {
+        if self.plan.word_start[i] {
             self.finish_word();
             self.frag = vec![leaf];
         } else {
             self.frag.push(leaf);
         }
-        self.prev_type = tok.kind;
     }
 
     /// Close a command left open at end-of-stream (only reachable when the
@@ -370,10 +436,10 @@ impl<'a> Builder<'a> {
             return;
         }
         let end_rel = self.range_end_rel(None);
-        let pc = if !self.frag.is_empty() || !self.cur_words.is_empty() {
-            self.last_comment.take()
-        } else {
+        let pc = if self.frag.is_empty() && self.cur_words.is_empty() {
             None
+        } else {
+            self.plan.comment_at_eof.take()
         };
         self.finish_word(); // consumes frag and its leading markers
         let mut children = std::mem::take(&mut self.cur_words);
@@ -553,6 +619,58 @@ mod tests {
         assert_eq!(doc.full_text(), src);
         // One real command; the trailing `# bye` is on the document.
         assert!(!doc.trailing.is_empty());
+    }
+
+    /// `range_end_rel` across `{*}` markers.
+    ///
+    /// `{*}` is the flagged hazard of the #1786 switch-over: the marker sits
+    /// in no word, so the "a word ended here" test that drives the command
+    /// range must answer *false* at it. `range_end_rel` has no differential
+    /// harness — `differential_segment` compares `SegmentedCommand`, whose
+    /// span comes from `command_span`/`widen_word_end`, not from this — and
+    /// its only live consumer is `tcl-explorer`'s CST view
+    /// (`rust/tcl-explorer/src/cst.rs`), so a regression here is invisible to
+    /// every other gate. Each expectation below was taken from the
+    /// pre-switch-over code and re-measured after it.
+    #[test]
+    fn range_end_rel_across_expand_markers() {
+        for (src, want_end) in [
+            // The range ends on the last byte of the final word.
+            ("foo {*}$b", 8usize),
+            ("foo {*}$b\n", 8),
+            // A `{*}` welded to a preceding braced word: two words, and the
+            // range still ends on the last byte of the second.
+            ("{a}{*}$b", 7),
+            // A braced final word: the range covers its closing `}`.
+            ("foo {*}{a b}", 11),
+            // Two markers in a row.
+            ("foo {*}{*}$b", 11),
+            // Trailing separators: the last token before the `Eol` is a `Sep`,
+            // so no word ends there and the last *word* boundary must stand.
+            // These are the rows that discriminate — without them the case
+            // where `word_end` is false at the terminator is never exercised,
+            // and `range_end_rel` has no other coverage anywhere (its span
+            // does not feed `SegmentedCommand`, so `differential_segment` is
+            // blind to it).
+            ("set x 1 \n", 6),
+            ("set x 1  ", 6),
+            ("foo {*}$b  \n", 8),
+            ("foo $b \t\n", 5),
+        ] {
+            let doc = build(src);
+            let GreenElement::Node(cmd) = &doc.children[0] else {
+                unreachable!("{src:?} produced no command node")
+            };
+            let end_rel = cmd.range_end_rel.expect("a range");
+            let tree = SyntaxTree::new(doc.clone());
+            let cmd_view = match tree.root().children().next().unwrap() {
+                super::super::red::SyntaxElement::Node(n) => n,
+                super::super::red::SyntaxElement::Token(_) => unreachable!(),
+            };
+            let first_tok = cmd_view.tokens()[0];
+            let end_offset = (first_tok.raw_start() + end_rel) as usize;
+            assert_eq!(end_offset, want_end, "{src:?} range_end_rel={end_rel}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
Second step of #1786, on top of #1810. The boundary owner `tcl_lexer::script::group_commands` landed there with a differential proving it byte-equivalent to the shipping segmenter, but nothing consumed it. This makes the compiler the first consumer.

## Summary

- `build_document_with_ghosts` calls `group_commands` and projects the answer into a private `Plan` (per-token-index `word_start`, `word_end`, `marker`, `comment_at`) that the `Builder` consults while it tiles.
- Deleted from the compiler: the `prev_type` state machine, `is_sep_or_eol`, the `last_comment` accumulator with its blank-line resets, and the `Expand` marker test.
- The token walk stays, because it is the **tiling** loop, not a boundary loop — every decision it used to make is now a lookup.
- Untouched, and deliberately still compiler-owned: green/red CST construction, trivia attachment, start-to-start tiling, the leading-BOM prefix, ghost-delimiter recovery, `segment.rs`, and `merge_f5_if_else_lookahead` (`segmenter.rs` documents N5 as a lookahead `if` performs, not a lexical rule, so moving it into the lexer would apply it twice).

One file changed: `rust/tcl-compiler/src/parsing/syntax/build.rs`.

## `range_end_rel` was the hazard, and it was load-bearing

`build.rs` maintained a `word_boundary` field feeding `range_end_rel`, and the owner carries no equivalent. `segment.rs` is right that `range_end_rel` is **not** the source of `SegmentedCommand.span` (`command_span`/`widen_word_end` is) — but it does have a live consumer: `rust/tcl-explorer/src/cst.rs`, which uses it for the `Command` node's displayed range in the `tcl explore` CST view.

It is computed in `build.rs` from the owner's token indices rather than by adding a field to `WordSpan`. The identity that makes this work: the two `prev_type` tests behind the old rule are exactly *"a word ended here"*, which the owner already answers.

- old `Sep` arm `!is_sep_or_eol(prev_type)` → `plan.word_end[i]`
- old `range_end_rel` `eol_region.is_some() && !is_sep_or_eol(prev_type)` → `plan.word_end[i].then_some(region)`, then `eol_boundary.or(self.word_boundary)`

A `{*}` marker belongs to no word, so no word ends at one — the stale-boundary quirk falls out structurally instead of being mimicked by a state assignment.

## Validation

`differential_segment`, `differential_group` and `command_segmenter` pass **unchanged**. No test file is modified; the only test added lives in `build.rs`'s own `mod tests`.

```
cargo test -p tcl-compiler                  # 66 binaries, 0 failures, exit 0
cargo test -p tcl-lsp-core                  # 34 binaries, 0 failures
cargo test -p tcl-compiler --test differential_segment --test differential_group \
                           --test command_segmenter --test differential_word_expr
cargo fmt --all -- --check
cargo clippy -p tcl-lexer -p tcl-compiler --all-targets -- -D warnings
cargo xtask dialect-drift                   # OK
cargo xtask owner-resolution                # OK, 31 rows
```

- [x] I ran relevant tests/checks locally and listed the exact commands.

### The new test exists because `range_end_rel` had no coverage at all

Worth stating plainly, because it is the one place this refactor could have gone wrong silently. `range_end_rel` does not feed `SegmentedCommand`, so the corpus differential is blind to it, and its only live consumer is the explorer's CST view.

Removing the `word_end` distinction at the terminator — `plan.word_end[i].then_some(region)` → `Some(region)` — **passes `differential_segment`**, and also passes a `{*}`-only version of this test. `{*}` rows alone are vacuous here: in `foo {*}$b` a word does end before the newline either way.

The rows that discriminate are the ones whose last token is a **separator** rather than a word end, where the mutation makes `"set x 1 \n"` answer `7` instead of `6`. Every expectation was measured on the pre-switch-over code first, and the test is verified to pass there as well as here — so it pins the original behaviour rather than this refactor's.

## Coverage limit worth knowing before the next step

`differential_group`'s corpus walk only covers **top-level** grouping: `tokenise_all` does not descend into braced bodies, so the corpus contributes **zero** `Expand` tokens across all 965 files, and every `{*}` row in that harness comes from its literal edge-case table.

That matters for the `runtime/rust::parse.rs` switch, which is where the `{*}` behaviour change and C's `extra characters after close-brace` actually land — that harness would not catch a body-only regression on the compiler side. Making its corpus walk recurse into braced bodies is a cheap, real improvement; it is left alone here because this PR's contract is that the existing differentials stay green *unchanged*.

## Remaining on #1786

Switch `runtime/rust::parse.rs`; fold or register `tcl_lexer::structural_index::command_boundaries` (byte-driven, dialect-blind, and still with no manifest row); then a real drift gate on the segmentation row, which is still `none`. #1787 follows.

`runtime/rust` is a separate cargo workspace, so `cargo test --workspace` will not catch a break there — the three-way differential has to live in `tcl-lexer/tests/` or run under `make runtime-rust-test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013wqsJY5pcg8Uyk1H4e7V8y

---
_Generated by [Claude Code](https://claude.ai/code/session_013wqsJY5pcg8Uyk1H4e7V8y)_