### PR TITLE
ci: remove unused Homebrew tap before Rust setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,7 +228,7 @@ jobs:
                   lsp_wasm_changed=true ;;
               esac
               case "$f" in
-                rust/tcl-explorer-wasm/* | rust/tcl-vm-wasm/* | rust/tcl-spec-studio-wasm/* | rust/tcl-lsp-server-wasm/* | rust/bigip-query-wasm/* | rust/bigip-report-gen/wasm/* | scripts/dev/ensure-test-deps.sh | scripts/dev/wasm-cc-env.sh | scripts/dev/test-wasm-cc-env.sh | Cargo.toml | Cargo.lock | rust-toolchain.toml | Makefile | .github/workflows/ci.yml)
+                rust/tcl-explorer-wasm/* | rust/tcl-vm-wasm/* | rust/tcl-spec-studio-wasm/* | rust/tcl-lsp-server-wasm/* | rust/bigip-query-wasm/* | rust/bigip-report-gen/wasm/* | scripts/dev/ensure-test-deps.sh | scripts/dev/wasm-cc-env.sh | scripts/dev/test-wasm-cc-env.sh | scripts/dev/prepare-homebrew-ci.sh | scripts/dev/test-prepare-homebrew-ci.sh | Cargo.toml | Cargo.lock | rust-toolchain.toml | Makefile | .github/workflows/ci.yml)
                   wasm_cc_changed=true ;;
               esac
               case "$f" in
@@ -353,6 +353,12 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
+
+      # The hosted image can retain the unused, untrusted aws/tap. The Rust
+      # setup action installs bash through Homebrew, which inspects configured
+      # taps and emits an annotation before doing any Rust work (issue #1684).
+      - name: Remove unused runner Homebrew tap
+        run: scripts/dev/prepare-homebrew-ci.sh
 
       - name: Set up Rust
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
@@ -1550,6 +1556,13 @@ jobs:
         with:
           fetch-depth: 1
           fetch-tags: ${{ !startsWith(github.ref, 'refs/tags/') }}
+
+      # Both Darwin legs share the hosted image's Homebrew state. Remove only
+      # the unused aws/tap before Rust setup invokes `brew install bash`; never
+      # trust the tap or weaken Homebrew's trust policy (issue #1684).
+      - name: Remove unused runner Homebrew tap
+        if: runner.os == 'macOS'
+        run: scripts/dev/prepare-homebrew-ci.sh
 
       - name: Set up Rust
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0

--- a/.github/workflows/report-pyz.yml
+++ b/.github/workflows/report-pyz.yml
@@ -68,6 +68,11 @@ jobs:
         shell: bash
         run: echo "TCL_LSP_VERSION=$(git describe --tags --always)" >> "$GITHUB_ENV"
 
+      - name: Remove unused runner Homebrew tap
+        if: runner.os == 'macOS'
+        shell: bash
+        run: scripts/dev/prepare-homebrew-ci.sh
+
       # The runner image ships a pinned stable (currently 1.96.1) and
       # `rust-toolchain.toml`'s `channel = "stable"` resolves to *that*, not to
       # the newest release — so cargo refuses the workspace's `rust-version`.

--- a/Makefile
+++ b/Makefile
@@ -210,7 +210,7 @@ TS_SRCS  := $(shell find $(EXT_DIR)/src -name '*.ts' 2>/dev/null)
 # Tests
 .PHONY: test test-ext test-emacs test-rust rust-server rust-tcl rust-f5 rust-mcp rust-clis ensure-server-cross-deps server-cross-build server-cross-build-all mcp-cross-build-all cli-cross-build-all server-cross-test server-cross-test-build print-server-targets-all print-server-targets-jetbrains
 .PHONY: xtask-check xtask-editor-extensions xtask-kcs-index-links xtask-diag-tables xtask-diag-emission-check xtask-gen-editor-catalogs xtask-gen-bundled-environments xtask-gen-editor-dialects xtask-gen-irule-test-data xtask-gen-zed-queries xtask-gen-editor-settings xtask-gen-vscode-package xtask-gen-jetbrains-catalog xtask-gen-ai-diagnostics xtask-owner-resolution xtask-command-backing xtask-audit-option-dialects xtask-registry-oracle xtask-sslictcl-data xtask-runtime-stdlib tcltest-sweep tcltest-sweep-check xtask-f5query-builtins-doc xtask-bigip-data-schema xtask-c-api-ownership check-c-api-ownership
-.PHONY: xtask-workflow-sync xtask-resolution-drift xtask-retired-api-gate xtask-pack-goldens xtask-number-drift xtask-gen-tmlanguage-keywords xtask-option-registry-drift xtask-callback-inventory check-tcl-reference-toolchains check-spectcl-compat-paths check-runtime-rust-paths check-rust-tests-runner check-wasm-cc-env xtask-dialect-drift
+.PHONY: xtask-workflow-sync xtask-resolution-drift xtask-retired-api-gate xtask-pack-goldens xtask-number-drift xtask-gen-tmlanguage-keywords xtask-option-registry-drift xtask-callback-inventory check-tcl-reference-toolchains check-spectcl-compat-paths check-runtime-rust-paths check-rust-tests-runner check-wasm-cc-env check-homebrew-ci xtask-dialect-drift
 # Lint / format / typecheck
 .PHONY: lint format lint-ts format-ts typecheck-ts check-rust check-rust-pr _check-rust-pr rust-deny
 .PHONY: build-report-assets build-report-pyz lint-report-ts typecheck-report-ts check-report-assets lint-spec-studio-ts typecheck-spec-studio-ts
@@ -759,7 +759,7 @@ coverage-ext: compile $(NPM_STAMP) ensure-vscode-test-deps ## Run VS Code extens
 # --- Native (cargo xtask) check gates.  These need the Rust toolchain, so CI
 # runs them in the rust-tests job (rust-gate.yml / ci.yml).  `xtask-check` is
 # the CI aggregate.
-xtask-check: check-tcl-reference-toolchains check-spectcl-compat-paths check-runtime-rust-paths check-rust-tests-runner check-wasm-cc-env xtask-workflow-sync xtask-kcs-index-links xtask-diag-tables xtask-diag-emission-check xtask-gen-editor-catalogs xtask-gen-bundled-environments xtask-gen-editor-dialects xtask-gen-irule-test-data xtask-gen-zed-queries xtask-gen-tmlanguage-keywords xtask-gen-editor-settings xtask-gen-vscode-package xtask-gen-jetbrains-catalog xtask-gen-ai-diagnostics xtask-owner-resolution xtask-resolution-drift xtask-retired-api-gate xtask-pack-goldens xtask-number-drift xtask-command-backing xtask-callback-inventory xtask-option-registry-drift xtask-sslictcl-data xtask-runtime-stdlib xtask-editor-extensions xtask-f5query-builtins-doc xtask-bigip-data-schema xtask-c-api-ownership ## Rust-side check gates (docs index coverage + generated-table/catalog drift) xtask-dialect-drift
+xtask-check: check-tcl-reference-toolchains check-spectcl-compat-paths check-runtime-rust-paths check-rust-tests-runner check-wasm-cc-env check-homebrew-ci xtask-workflow-sync xtask-kcs-index-links xtask-diag-tables xtask-diag-emission-check xtask-gen-editor-catalogs xtask-gen-bundled-environments xtask-gen-editor-dialects xtask-gen-irule-test-data xtask-gen-zed-queries xtask-gen-tmlanguage-keywords xtask-gen-editor-settings xtask-gen-vscode-package xtask-gen-jetbrains-catalog xtask-gen-ai-diagnostics xtask-owner-resolution xtask-resolution-drift xtask-retired-api-gate xtask-pack-goldens xtask-number-drift xtask-command-backing xtask-callback-inventory xtask-option-registry-drift xtask-sslictcl-data xtask-runtime-stdlib xtask-editor-extensions xtask-f5query-builtins-doc xtask-bigip-data-schema xtask-c-api-ownership ## Rust-side check gates (docs index coverage + generated-table/catalog drift) xtask-dialect-drift
 
 check-tcl-reference-toolchains: ## Verify pinned C Tcl patchlevels across shell setup and Rust oracle discovery
 	@echo "==> Checking C Tcl reference toolchain ownership"
@@ -781,6 +781,10 @@ check-rust-tests-runner: ## Verify trusted rust-tests jobs serialize on the shar
 check-wasm-cc-env: ## Verify wasm32 C-compiler selection and dependency diagnostics
 	@echo "==> Checking wasm32 C compiler bootstrap"
 	@bash scripts/dev/test-wasm-cc-env.sh
+
+check-homebrew-ci: ## Verify exact, idempotent cleanup of unused macOS runner taps (#1684)
+	@echo "==> Checking macOS runner Homebrew cleanup"
+	@bash scripts/dev/test-prepare-homebrew-ci.sh
 
 xtask-runtime-stdlib: ## Verify the embedded Tcl stdlib version, provenance, hashes, and FILES table
 	@echo "==> Checking embedded Tcl standard-library provenance (cargo xtask)"

--- a/rust/bigip-report-gen/python/deploy/report-pyz.yml
+++ b/rust/bigip-report-gen/python/deploy/report-pyz.yml
@@ -68,6 +68,11 @@ jobs:
         shell: bash
         run: echo "TCL_LSP_VERSION=$(git describe --tags --always)" >> "$GITHUB_ENV"
 
+      - name: Remove unused runner Homebrew tap
+        if: runner.os == 'macOS'
+        shell: bash
+        run: scripts/dev/prepare-homebrew-ci.sh
+
       # The runner image ships a pinned stable (currently 1.96.1) and
       # `rust-toolchain.toml`'s `channel = "stable"` resolves to *that*, not to
       # the newest release — so cargo refuses the workspace's `rust-version`.

--- a/scripts/dev/prepare-homebrew-ci.sh
+++ b/scripts/dev/prepare-homebrew-ci.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# tcl-lsp — a language server and toolchain for Tcl
+# Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+# GitHub's macOS images can retain third-party taps that this repository never
+# uses. Homebrew inspects every configured tap during a later `brew install`,
+# and an untrusted aws/tap then emits a workflow annotation before the pinned
+# Rust setup action can install bash. Remove only that exact unused tap; do not
+# trust it or weaken Homebrew's tap-trust policy (issue #1684).
+
+set -eu
+
+if ! command -v brew >/dev/null 2>&1; then
+    echo "prepare-homebrew-ci: brew is required on the macOS runner" >&2
+    exit 1
+fi
+
+if brew tap | grep -Fxq 'aws/tap'; then
+    echo "==> Removing unused runner Homebrew tap aws/tap"
+    brew untap aws/tap
+fi

--- a/scripts/dev/test-prepare-homebrew-ci.sh
+++ b/scripts/dev/test-prepare-homebrew-ci.sh
@@ -1,0 +1,145 @@
+#!/bin/sh
+# tcl-lsp — a language server and toolchain for Tcl
+# Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+# Hermetic regression for the macOS runner cleanup in issue #1684. The fake
+# brew records every call, so the test proves exact-match removal, preservation
+# of unrelated taps, and idempotence without mutating a developer machine.
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+REPO_ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/../.." && pwd)
+HELPER=$SCRIPT_DIR/prepare-homebrew-ci.sh
+fixture=$(mktemp -d)
+trap 'rm -rf "$fixture"' EXIT
+fake_bin=$fixture/bin
+state=$fixture/taps
+log=$fixture/brew.log
+mkdir -p "$fake_bin"
+
+{
+    printf '%s\n' '#!/bin/sh'
+    printf '%s\n' 'set -eu'
+    printf '%s\n' 'printf "%s\n" "$*" >> "${BREW_TEST_LOG:?}"'
+    printf '%s\n' 'case "${1:-}" in'
+    printf '%s\n' '    tap) cat "${BREW_TEST_STATE:?}" ;;'
+    printf '%s\n' '    untap)'
+    printf '%s\n' '        [ "$#" -eq 2 ] && [ "$2" = aws/tap ] || exit 97'
+    printf '%s\n' '        grep -Fvx "$2" "$BREW_TEST_STATE" > "$BREW_TEST_STATE.next"'
+    printf '%s\n' '        mv "$BREW_TEST_STATE.next" "$BREW_TEST_STATE" ;;'
+    printf '%s\n' '    *) exit 98 ;;'
+    printf '%s\n' 'esac'
+} > "$fake_bin/brew"
+chmod 0755 "$fake_bin/brew"
+
+run_helper() {
+    env \
+        PATH="$fake_bin:$PATH" \
+        BREW_TEST_LOG="$log" \
+        BREW_TEST_STATE="$state" \
+        "$HELPER"
+}
+
+printf '%s\n' aws/tap aws/tap-extra homebrew/core > "$state"
+run_helper
+run_helper
+
+if grep -Fxq aws/tap "$state"; then
+    echo "prepare-homebrew-ci left the exact unused tap installed" >&2
+    exit 1
+fi
+for preserved in aws/tap-extra homebrew/core; do
+    if ! grep -Fxq "$preserved" "$state"; then
+        echo "prepare-homebrew-ci removed unrelated tap $preserved" >&2
+        exit 1
+    fi
+done
+
+expected_log=$fixture/expected.log
+printf '%s\n' tap 'untap aws/tap' tap > "$expected_log"
+if ! cmp -s "$expected_log" "$log"; then
+    echo "prepare-homebrew-ci was not exact and idempotent" >&2
+    diff -u "$expected_log" "$log" >&2 || true
+    exit 1
+fi
+
+# A lookalike tap must not trigger an untap call.
+printf '%s\n' aws/tap-extra homebrew/core > "$state"
+: > "$log"
+run_helper
+if [ "$(cat "$log")" != tap ]; then
+    echo "prepare-homebrew-ci matched a non-exact aws/tap name" >&2
+    cat "$log" >&2
+    exit 1
+fi
+
+# The fix must never bypass or broaden Homebrew trust.
+if grep -R 'HOMEBREW_NO_REQUIRE_TAP_TRUST' \
+    "$HELPER" \
+    "$REPO_ROOT/.github/workflows/ci.yml" \
+    "$REPO_ROOT/.github/workflows/report-pyz.yml" \
+    "$REPO_ROOT/rust/bigip-report-gen/python/deploy/report-pyz.yml" \
+    >/dev/null; then
+    echo "Homebrew tap-trust bypass is forbidden" >&2
+    exit 1
+fi
+
+ci_workflow=$(cat "$REPO_ROOT/.github/workflows/ci.yml")
+case "$ci_workflow" in
+    *'scripts/dev/prepare-homebrew-ci.sh'*) ;;
+    *)
+        echo "ci.yml does not invoke the Homebrew cleanup" >&2
+        exit 1
+        ;;
+esac
+case "$ci_workflow" in
+    *'scripts/dev/prepare-homebrew-ci.sh | scripts/dev/test-prepare-homebrew-ci.sh'*) ;;
+    *)
+        echo "the macOS regression path classifier omits the cleanup scripts" >&2
+        exit 1
+        ;;
+esac
+
+macos_wasm_job=$(awk '
+    /^  macos-wasm-check:/ { in_job = 1 }
+    in_job && /^  [A-Za-z0-9_-]+:/ && $1 != "macos-wasm-check:" { exit }
+    in_job { print }
+' "$REPO_ROOT/.github/workflows/ci.yml")
+case "$macos_wasm_job" in
+    *'run: scripts/dev/prepare-homebrew-ci.sh'*'setup-rust-toolchain'*) ;;
+    *)
+        echo "macos-wasm-check must clean the tap before Rust setup" >&2
+        exit 1
+        ;;
+esac
+
+server_matrix_job=$(awk '
+    /^  build-server-matrix:/ { in_job = 1 }
+    in_job && /^  [A-Za-z0-9_-]+:/ && $1 != "build-server-matrix:" { exit }
+    in_job { print }
+' "$REPO_ROOT/.github/workflows/ci.yml")
+case "$server_matrix_job" in
+    *"if: runner.os == 'macOS'"*'run: scripts/dev/prepare-homebrew-ci.sh'*'setup-rust-toolchain'*) ;;
+    *)
+        echo "build-server-matrix must clean the tap on macOS before Rust setup" >&2
+        exit 1
+        ;;
+esac
+
+for report_workflow in \
+    "$REPO_ROOT/.github/workflows/report-pyz.yml" \
+    "$REPO_ROOT/rust/bigip-report-gen/python/deploy/report-pyz.yml"; do
+    report_job=$(cat "$report_workflow")
+    case "$report_job" in
+        *"if: runner.os == 'macOS'"*'run: scripts/dev/prepare-homebrew-ci.sh'*'setup-rust-toolchain'*) ;;
+        *)
+            echo "$(basename "$report_workflow") must clean the tap on macOS before Rust setup" >&2
+            exit 1
+            ;;
+    esac
+done
+
+echo "Homebrew macOS runner cleanup regression: ok"


### PR DESCRIPTION
Closes #1684

## Root cause

GitHub's hosted macOS image retains the unused `aws/tap`. The pinned Rust setup action installs Bash through Homebrew, which inspects every configured tap and emits an untrusted-tap annotation before any project code runs.

## Fix

- Remove only the exact unused `aws/tap` before Rust setup in `macos-wasm-check`, both Darwin release matrix legs, and both copies of the report-pyz workflow.
- Keep Homebrew's trust policy intact; do not trust the third-party tap or set a bypass variable.
- Add a hermetic fake-brew regression and wire it into `rust-check`.
- Make the cleanup idempotent and fail clearly if invoked without Homebrew.

## Experimental proof

- Before: the hosted macOS job on #1807 passed but emitted `.github#36`, reporting `aws/tap` as untrusted during Rust setup.
- After: hosted `macos-wasm-check` on this head passed, and its check-run annotations endpoint returned an empty list (`[]`).
- The hermetic regression proves one exact `untap aws/tap`, preservation of `aws/tap-extra` and `homebrew/core`, no second untap on rerun, and no trust-policy bypass.
- The contract verifies cleanup precedes Rust setup in the PR macOS lane, both Darwin release matrix legs, and both report-pyz workflow copies.
- `sh -n` passes for both scripts; `shellcheck` is not installed locally.
- `make rust-check` and `make NPROC=1 prep-pr` pass on the rebased head.

Merge waits for the remaining required matrix; the fresh review and annotation-specific hosted proof are green.
