### PR TITLE
ci: migrate SBOM attestations to actions/attest

### DIFF
--- a/.github/actions/sign-and-upload/action.yml
+++ b/.github/actions/sign-and-upload/action.yml
@@ -48,24 +48,25 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Attest build provenance
-      uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
-      with:
-        subject-path: ${{ inputs.artefact-glob }}
-
     - name: Resolve artefact path
       id: artefact_path
       shell: bash
+      env:
+        ARTEFACT_GLOB: ${{ inputs.artefact-glob }}
       run: |
         set -euo pipefail
-        artefact=$(ls ${{ inputs.artefact-glob }} | head -1)
-        [ -n "$artefact" ]
+        artefact=$(scripts/release/resolve-release-artefact.sh "$ARTEFACT_GLOB")
         echo "artefact=$artefact" >> "$GITHUB_OUTPUT"
         echo "sbom=${artefact}.sbom.spdx.json" >> "$GITHUB_OUTPUT"
         # Default upload-artifact name = basename minus version suffix
         # so concurrent matrix entries don't clash on a single name.
         default_name=$(basename "$artefact" | sed -E 's/-[0-9].*$//')
         echo "name=${default_name}" >> "$GITHUB_OUTPUT"
+
+    - name: Attest build provenance
+      uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+      with:
+        subject-path: ${{ steps.artefact_path.outputs.artefact }}
 
     - name: Generate SBOM
       uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
@@ -77,7 +78,7 @@ runs:
         upload-release-assets: false
 
     - name: Attest SBOM
-      uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+      uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
       with:
         subject-path: ${{ steps.artefact_path.outputs.artefact }}
         sbom-path: ${{ steps.artefact_path.outputs.sbom }}
@@ -86,16 +87,16 @@ runs:
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ inputs.artefact-name != '' && inputs.artefact-name || steps.artefact_path.outputs.name }}
-        path: ${{ inputs.artefact-glob }}
+        path: ${{ steps.artefact_path.outputs.artefact }}
         retention-days: 7
 
     - name: Upload to GitHub Release
       shell: bash
       env:
         GH_TOKEN: ${{ github.token }}
-        ARTEFACT_GLOB: ${{ inputs.artefact-glob }}
+        ARTEFACT_PATH: ${{ steps.artefact_path.outputs.artefact }}
         SBOM_PATH: ${{ steps.artefact_path.outputs.sbom }}
       run: |
         set -euo pipefail
         tag="${GITHUB_REF#refs/tags/}"
-        gh release upload "$tag" $ARTEFACT_GLOB "$SBOM_PATH" --clobber
+        gh release upload "$tag" "$ARTEFACT_PATH" "$SBOM_PATH" --clobber

--- a/Makefile
+++ b/Makefile
@@ -210,7 +210,7 @@ TS_SRCS  := $(shell find $(EXT_DIR)/src -name '*.ts' 2>/dev/null)
 # Tests
 .PHONY: test test-ext test-emacs test-rust rust-server rust-tcl rust-f5 rust-mcp rust-clis ensure-server-cross-deps server-cross-build server-cross-build-all mcp-cross-build-all cli-cross-build-all server-cross-test server-cross-test-build print-server-targets-all print-server-targets-jetbrains
 .PHONY: xtask-check xtask-editor-extensions xtask-kcs-index-links xtask-diag-tables xtask-diag-emission-check xtask-gen-editor-catalogs xtask-gen-bundled-environments xtask-gen-editor-dialects xtask-gen-irule-test-data xtask-gen-zed-queries xtask-gen-editor-settings xtask-gen-vscode-package xtask-gen-jetbrains-catalog xtask-gen-ai-diagnostics xtask-owner-resolution xtask-command-backing xtask-audit-option-dialects xtask-registry-oracle xtask-sslictcl-data xtask-runtime-stdlib tcltest-sweep tcltest-sweep-check xtask-f5query-builtins-doc xtask-bigip-data-schema xtask-c-api-ownership check-c-api-ownership
-.PHONY: xtask-workflow-sync xtask-resolution-drift xtask-retired-api-gate xtask-pack-goldens xtask-number-drift xtask-gen-tmlanguage-keywords xtask-option-registry-drift xtask-callback-inventory check-tcl-reference-toolchains check-spectcl-compat-paths check-runtime-rust-paths check-rust-tests-runner check-wasm-cc-env check-homebrew-ci xtask-dialect-drift
+.PHONY: xtask-workflow-sync xtask-resolution-drift xtask-retired-api-gate xtask-pack-goldens xtask-number-drift xtask-gen-tmlanguage-keywords xtask-option-registry-drift xtask-callback-inventory check-tcl-reference-toolchains check-spectcl-compat-paths check-runtime-rust-paths check-rust-tests-runner check-wasm-cc-env check-homebrew-ci check-sign-and-upload xtask-dialect-drift
 # Lint / format / typecheck
 .PHONY: lint format lint-ts format-ts typecheck-ts check-rust check-rust-pr _check-rust-pr rust-deny
 .PHONY: build-report-assets build-report-pyz lint-report-ts typecheck-report-ts check-report-assets lint-spec-studio-ts typecheck-spec-studio-ts
@@ -759,7 +759,7 @@ coverage-ext: compile $(NPM_STAMP) ensure-vscode-test-deps ## Run VS Code extens
 # --- Native (cargo xtask) check gates.  These need the Rust toolchain, so CI
 # runs them in the rust-tests job (rust-gate.yml / ci.yml).  `xtask-check` is
 # the CI aggregate.
-xtask-check: check-tcl-reference-toolchains check-spectcl-compat-paths check-runtime-rust-paths check-rust-tests-runner check-wasm-cc-env check-homebrew-ci xtask-workflow-sync xtask-kcs-index-links xtask-diag-tables xtask-diag-emission-check xtask-gen-editor-catalogs xtask-gen-bundled-environments xtask-gen-editor-dialects xtask-gen-irule-test-data xtask-gen-zed-queries xtask-gen-tmlanguage-keywords xtask-gen-editor-settings xtask-gen-vscode-package xtask-gen-jetbrains-catalog xtask-gen-ai-diagnostics xtask-owner-resolution xtask-resolution-drift xtask-retired-api-gate xtask-pack-goldens xtask-number-drift xtask-command-backing xtask-callback-inventory xtask-option-registry-drift xtask-sslictcl-data xtask-runtime-stdlib xtask-editor-extensions xtask-f5query-builtins-doc xtask-bigip-data-schema xtask-c-api-ownership ## Rust-side check gates (docs index coverage + generated-table/catalog drift) xtask-dialect-drift
+xtask-check: check-tcl-reference-toolchains check-spectcl-compat-paths check-runtime-rust-paths check-rust-tests-runner check-wasm-cc-env check-homebrew-ci check-sign-and-upload xtask-workflow-sync xtask-kcs-index-links xtask-diag-tables xtask-diag-emission-check xtask-gen-editor-catalogs xtask-gen-bundled-environments xtask-gen-editor-dialects xtask-gen-irule-test-data xtask-gen-zed-queries xtask-gen-tmlanguage-keywords xtask-gen-editor-settings xtask-gen-vscode-package xtask-gen-jetbrains-catalog xtask-gen-ai-diagnostics xtask-owner-resolution xtask-resolution-drift xtask-retired-api-gate xtask-pack-goldens xtask-number-drift xtask-command-backing xtask-callback-inventory xtask-option-registry-drift xtask-sslictcl-data xtask-runtime-stdlib xtask-editor-extensions xtask-f5query-builtins-doc xtask-bigip-data-schema xtask-c-api-ownership ## Rust-side check gates (docs index coverage + generated-table/catalog drift) xtask-dialect-drift
 
 check-tcl-reference-toolchains: ## Verify pinned C Tcl patchlevels across shell setup and Rust oracle discovery
 	@echo "==> Checking C Tcl reference toolchain ownership"
@@ -785,6 +785,10 @@ check-wasm-cc-env: ## Verify wasm32 C-compiler selection and dependency diagnost
 check-homebrew-ci: ## Verify exact, idempotent cleanup of unused macOS runner taps (#1684)
 	@echo "==> Checking macOS runner Homebrew cleanup"
 	@bash scripts/dev/test-prepare-homebrew-ci.sh
+
+check-sign-and-upload: ## Verify release artefact resolution, attestation pin, and permissions (#1685)
+	@echo "==> Checking release attestation action"
+	@bash scripts/release/test-sign-and-upload-action.sh
 
 xtask-runtime-stdlib: ## Verify the embedded Tcl stdlib version, provenance, hashes, and FILES table
 	@echo "==> Checking embedded Tcl standard-library provenance (cargo xtask)"

--- a/scripts/release/resolve-release-artefact.sh
+++ b/scripts/release/resolve-release-artefact.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# tcl-lsp — a language server and toolchain for Tcl
+# Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+# Resolve the maintained release glob to exactly one path before provenance,
+# SBOM generation, or upload. This keeps every stage bound to the same subject
+# and turns accidental zero/multiple matches into a loud release failure.
+
+set -euo pipefail
+
+if [[ $# -ne 1 || -z $1 ]]; then
+    echo "usage: scripts/release/resolve-release-artefact.sh ARTEFACT_GLOB" >&2
+    exit 2
+fi
+
+pattern=$1
+matches=()
+while IFS= read -r match; do
+    matches+=("$match")
+done < <(compgen -G "$pattern" || true)
+
+if [[ ${#matches[@]} -ne 1 ]]; then
+    printf 'release artefact glob %q matched %d files; expected exactly one\n' \
+        "$pattern" "${#matches[@]}" >&2
+    if [[ ${#matches[@]} -gt 0 ]]; then
+        printf '  %s\n' "${matches[@]}" >&2
+    fi
+    exit 1
+fi
+
+printf '%s\n' "${matches[0]}"

--- a/scripts/release/test-sign-and-upload-action.sh
+++ b/scripts/release/test-sign-and-upload-action.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# tcl-lsp — a language server and toolchain for Tcl
+# Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+# Offline contract test for the shared release attestation action (issue
+# #1685). It exercises representative release shapes and guards the action pin,
+# subject binding, SBOM inputs, and least-privilege workflow permissions.
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
+RESOLVER=$SCRIPT_DIR/resolve-release-artefact.sh
+ACTION=$REPO_ROOT/.github/actions/sign-and-upload/action.yml
+WORKFLOW=$REPO_ROOT/.github/workflows/ci.yml
+fixture=$(mktemp -d)
+trap 'rm -rf "$fixture"' EXIT
+mkdir -p "$fixture/build"
+
+zip=$fixture/build/tcl-lsp-claude-skills-2.2.0.zip
+vsix=$fixture/build/tcl-lsp-vscode-2.2.0-universal.vsix
+sublime=$fixture/build/TclLsp.sublime-package
+: > "$zip"
+: > "$vsix"
+: > "$sublime"
+
+assert_resolves() {
+    local pattern=$1 expected=$2 actual
+    actual=$($RESOLVER "$pattern")
+    if [[ $actual != "$expected" ]]; then
+        printf 'resolver returned %q, expected %q\n' "$actual" "$expected" >&2
+        exit 1
+    fi
+}
+
+# Representative glob shapes from the shared action's real callers.
+assert_resolves "$fixture/build/tcl-lsp-claude-skills-*.zip" "$zip"
+assert_resolves "$fixture/build/tcl-lsp-vscode-*-universal.vsix" "$vsix"
+assert_resolves "$fixture/build/TclLsp*.sublime-package" "$sublime"
+
+if $RESOLVER "$fixture/build/missing-*.zip" >/dev/null 2>&1; then
+    echo "resolver accepted a zero-match release glob" >&2
+    exit 1
+fi
+: > "$fixture/build/tcl-lsp-claude-skills-2.2.1.zip"
+if $RESOLVER "$fixture/build/tcl-lsp-claude-skills-*.zip" >/dev/null 2>&1; then
+    echo "resolver silently selected one of multiple release artefacts" >&2
+    exit 1
+fi
+
+action=$(cat "$ACTION")
+if grep -q 'actions/attest-sbom@' "$ACTION"; then
+    echo "deprecated actions/attest-sbom remains in the shared action" >&2
+    exit 1
+fi
+case "$action" in
+    *'uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2'*) ;;
+    *)
+        echo "SBOM attestation must use the reviewed actions/attest v4.2.2 commit" >&2
+        exit 1
+        ;;
+esac
+case "$action" in
+    *'Resolve artefact path'*'Attest build provenance'*'Generate SBOM'*'Attest SBOM'*) ;;
+    *)
+        echo "the exact subject must be resolved before either attestation" >&2
+        exit 1
+        ;;
+esac
+case "$action" in
+    *'subject-path: ${{ steps.artefact_path.outputs.artefact }}'*'sbom-path: ${{ steps.artefact_path.outputs.sbom }}'*) ;;
+    *)
+        echo "actions/attest is not bound to the resolved subject and generated SBOM" >&2
+        exit 1
+        ;;
+esac
+case "$action" in
+    *'path: ${{ steps.artefact_path.outputs.artefact }}'*) ;;
+    *)
+        echo "workflow upload is not bound to the single resolved subject" >&2
+        exit 1
+        ;;
+esac
+case "$action" in
+    *'ARTEFACT_PATH: ${{ steps.artefact_path.outputs.artefact }}'*'gh release upload "$tag" "$ARTEFACT_PATH" "$SBOM_PATH" --clobber'*) ;;
+    *)
+        echo "release upload is not bound to the single resolved subject" >&2
+        exit 1
+        ;;
+esac
+
+# Find every job that consumes the composite and prove it retains precisely the
+# token writes file attestations need. artifact-metadata is registry-only and
+# must not be broadened onto these release jobs.
+permission_rows=$(awk '
+    function emit() {
+        if (uses_action) {
+            print job "|" contents "|" oidc "|" attestations "|" metadata
+        }
+    }
+    /^  [A-Za-z0-9_-]+:$/ {
+        emit()
+        job = $1
+        sub(/:$/, "", job)
+        contents = oidc = attestations = metadata = uses_action = 0
+        next
+    }
+    /contents: write/ { contents = 1 }
+    /id-token: write/ { oidc = 1 }
+    /attestations: write/ { attestations = 1 }
+    /artifact-metadata: write/ { metadata = 1 }
+    /uses: \.\/\.github\/actions\/sign-and-upload/ { uses_action = 1 }
+    END { emit() }
+' "$WORKFLOW")
+
+if [[ -z $permission_rows ]]; then
+    echo "no sign-and-upload consumers found; permission check is vacuous" >&2
+    exit 1
+fi
+while IFS='|' read -r job contents oidc attestations metadata; do
+    if [[ $contents != 1 || $oidc != 1 || $attestations != 1 || $metadata != 0 ]]; then
+        echo "job $job has incorrect release-attestation permissions" >&2
+        exit 1
+    fi
+done <<< "$permission_rows"
+
+echo "release sign-and-upload action regression: ok"


### PR DESCRIPTION
## Root cause

The shared release composite still used deprecated `actions/attest-sbom`. It also passed the release glob independently to provenance and upload steps while selecting the first `ls` result for the SBOM, so an accidental multi-match could attest and upload a different subject set from the generated SBOM.

## Fix

- resolve each release glob once and fail closed unless it names exactly one artefact;
- bind provenance, SBOM generation, `actions/attest`, workflow upload, and GitHub Release upload to that exact path;
- use commit-pinned `actions/attest` v4.2.2 with its supported `subject-path` and `sbom-path` inputs;
- add an offline contract covering ZIP, VSIX, and Sublime artefact shapes, zero/multiple-match rejection, the reviewed action pin, exact subject binding, and least-privilege permissions for every composite consumer.

## Experimental proof

- `bash scripts/release/test-sign-and-upload-action.sh` — passes, including all representative artefact shapes and both fail-closed cases.
- official `actions/attest` source at the pinned SHA confirms `subject-path` plus `sbom-path` is the supported SPDX/CycloneDX SBOM interface.
- `gh attestation verify --repo bitwisecook/tcl-lsp --predicate-type https://spdx.dev/Document` succeeds for the released v2.2.0 Sublime, Claude skills, and Linux x64 VSIX artefacts. The verified predicate subjects exactly match their local SHA-256 values: `3ca8b1baa4b1c1dd0bfa4f68143fa843e0a964491e21a13941875b6e91167ea6`, `a275b0bcd1e291fb3589251409f5bdd45a2d69ff017ff4968f0990d143435747`, and `13dfae197c37f011eaa4a18bc46cd3a8f8e1537743021806b65d63a842a59fbd`.
- `make rust-check` — passes.
- `make NPROC=1 prep-pr` — passes.

Fixes #1685.