### PR TITLE
ci: retain every queued tank test run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -798,10 +798,13 @@ jobs:
     # deliberate.  `tank` is one physical host but may have multiple runner
     # registrations; the job-level concurrency group is therefore the source
     # of truth that keeps these CPU- and memory-heavy suites serial on that
-    # host.  Fork PRs and PRs changing this runner policy use a run-specific
-    # group because they execute on separate GitHub-hosted machines and must
-    # retain their normal parallelism.  The latter also makes policy changes
-    # fail safely: a broken scheduler edit cannot strand the protected host.
+    # host.  `cancel-in-progress: false` protects the running job, while
+    # `queue: max` retains every pending job (the default one-pending-job queue
+    # silently displaces an older pending run when another one arrives).  Fork
+    # PRs and PRs changing this runner policy use a run-specific group because
+    # they execute on separate GitHub-hosted machines and must retain their
+    # normal parallelism.  The latter also makes policy changes fail safely: a
+    # broken scheduler edit cannot strand the protected host.
     #
     # Untrusted code must never reach the self-hosted runner, so PRs from forks
     # stay on GitHub-hosted; everything else (push, dispatch, and PRs from
@@ -810,6 +813,7 @@ jobs:
     runs-on: ${{ (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || needs.channel.outputs.runner_policy_changed == 'true')) && 'ubuntu-26.04' || 'tank' }}
     concurrency:
       group: rust-tests-${{ (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || needs.channel.outputs.runner_policy_changed == 'true')) && format('hosted-{0}', github.run_id) || 'tank' }}
+      queue: max
       cancel-in-progress: false
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/scripts/dev/test-rust-tests-runner.sh
+++ b/scripts/dev/test-rust-tests-runner.sh
@@ -5,7 +5,8 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 # Contract test for the one-physical-host `tank` runner pool. Multiple runner
-# registrations must not turn into concurrent heavyweight workspace suites.
+# registrations must not turn into concurrent heavyweight workspace suites,
+# and bursts must not displace an older suite while it is waiting for the host.
 
 set -eu
 
@@ -58,12 +59,14 @@ case "$rust_tests_job" in
         ;;
 esac
 
-case "$rust_tests_job" in
-    *"cancel-in-progress: false"*) ;;
-    *)
-        echo "queued tank jobs must not cancel an already-running workspace suite" >&2
-        exit 1
-        ;;
-esac
+if ! printf '%s\n' "$rust_tests_job" | grep -Fqx '      cancel-in-progress: false'; then
+    echo "a new tank job must not cancel an already-running workspace suite" >&2
+    exit 1
+fi
+
+if ! printf '%s\n' "$rust_tests_job" | grep -Fqx '      queue: max'; then
+    echo "the tank concurrency group must retain every pending workspace suite" >&2
+    exit 1
+fi
 
 echo "self-hosted Rust test scheduling contract passed"


### PR DESCRIPTION
## Root cause

The `rust-tests-tank` concurrency group used `cancel-in-progress: false`, which protects the running job but leaves GitHub concurrency at its default single-pending queue. A newly pending run therefore cancels and replaces the older pending run.

This happened live on 2026-09-03: job `100854406462` held the tank; PR #1786 job `100854827047` was pending and was cancelled at 23:36:16Z when #1819 job `100855175291` entered the same pending group at 23:36:15Z.

## Fix

- Set `queue: max` on the job-level concurrency group. GitHub documents this as retaining up to 100 pending jobs in FIFO waiting order.
- Keep `cancel-in-progress: false`, the required compatible setting, so the running suite is also protected.
- Strengthen the runner-policy contract to require both properties as exact YAML settings, rather than allowing their spelling in a comment to satisfy the check.
- Keep fork and runner-policy PRs on unique hosted groups, so they remain parallel and cannot strand the protected host.

Documentation: https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency#queueing-multiple-pending-runs

## Verification

- `sh scripts/dev/test-rust-tests-runner.sh`
- `make rust-check`
- `make NPROC=1 NPM="npm --no-audit --no-fund" prep-pr`
- Clean post-rebase rerun of both required pre-push gates on `61af3e7f`
