### PR TITLE
fix(lexer): register the reparse scanner as its own owner and gate segmentation (#1786)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -210,7 +210,7 @@ TS_SRCS  := $(shell find $(EXT_DIR)/src -name '*.ts' 2>/dev/null)
 # Tests
 .PHONY: test test-ext test-emacs test-rust rust-server rust-tcl rust-f5 rust-mcp rust-clis ensure-server-cross-deps server-cross-build server-cross-build-all mcp-cross-build-all cli-cross-build-all server-cross-test server-cross-test-build print-server-targets-all print-server-targets-jetbrains
 .PHONY: xtask-check xtask-editor-extensions xtask-kcs-index-links xtask-diag-tables xtask-diag-emission-check xtask-gen-editor-catalogs xtask-gen-bundled-environments xtask-gen-editor-dialects xtask-gen-irule-test-data xtask-gen-zed-queries xtask-gen-editor-settings xtask-gen-vscode-package xtask-gen-jetbrains-catalog xtask-gen-ai-diagnostics xtask-owner-resolution xtask-command-backing xtask-audit-option-dialects xtask-registry-oracle xtask-sslictcl-data xtask-runtime-stdlib tcltest-sweep tcltest-sweep-check xtask-f5query-builtins-doc xtask-bigip-data-schema xtask-c-api-ownership check-c-api-ownership
-.PHONY: xtask-workflow-sync xtask-resolution-drift xtask-retired-api-gate xtask-pack-goldens xtask-number-drift xtask-gen-tmlanguage-keywords xtask-option-registry-drift xtask-callback-inventory check-tcl-reference-toolchains check-spectcl-compat-paths check-runtime-rust-paths check-rust-tests-runner check-wasm-cc-env check-homebrew-ci check-sign-and-upload xtask-dialect-drift
+.PHONY: xtask-workflow-sync xtask-resolution-drift xtask-retired-api-gate xtask-pack-goldens xtask-number-drift xtask-gen-tmlanguage-keywords xtask-option-registry-drift xtask-callback-inventory check-tcl-reference-toolchains check-spectcl-compat-paths check-runtime-rust-paths check-rust-tests-runner check-wasm-cc-env check-homebrew-ci check-sign-and-upload xtask-dialect-drift xtask-segmentation-drift
 # Lint / format / typecheck
 .PHONY: lint format lint-ts format-ts typecheck-ts check-rust check-rust-pr _check-rust-pr rust-deny
 .PHONY: build-report-assets build-report-pyz lint-report-ts typecheck-report-ts check-report-assets lint-spec-studio-ts typecheck-spec-studio-ts
@@ -759,7 +759,7 @@ coverage-ext: compile $(NPM_STAMP) ensure-vscode-test-deps ## Run VS Code extens
 # --- Native (cargo xtask) check gates.  These need the Rust toolchain, so CI
 # runs them in the rust-tests job (rust-gate.yml / ci.yml).  `xtask-check` is
 # the CI aggregate.
-xtask-check: check-tcl-reference-toolchains check-spectcl-compat-paths check-runtime-rust-paths check-rust-tests-runner check-wasm-cc-env check-homebrew-ci check-sign-and-upload xtask-workflow-sync xtask-kcs-index-links xtask-diag-tables xtask-diag-emission-check xtask-gen-editor-catalogs xtask-gen-bundled-environments xtask-gen-editor-dialects xtask-gen-irule-test-data xtask-gen-zed-queries xtask-gen-tmlanguage-keywords xtask-gen-editor-settings xtask-gen-vscode-package xtask-gen-jetbrains-catalog xtask-gen-ai-diagnostics xtask-owner-resolution xtask-resolution-drift xtask-retired-api-gate xtask-pack-goldens xtask-number-drift xtask-command-backing xtask-callback-inventory xtask-option-registry-drift xtask-sslictcl-data xtask-runtime-stdlib xtask-editor-extensions xtask-f5query-builtins-doc xtask-bigip-data-schema xtask-c-api-ownership ## Rust-side check gates (docs index coverage + generated-table/catalog drift) xtask-dialect-drift
+xtask-check: check-tcl-reference-toolchains check-spectcl-compat-paths check-runtime-rust-paths check-rust-tests-runner check-wasm-cc-env check-homebrew-ci check-sign-and-upload xtask-workflow-sync xtask-kcs-index-links xtask-diag-tables xtask-diag-emission-check xtask-gen-editor-catalogs xtask-gen-bundled-environments xtask-gen-editor-dialects xtask-gen-irule-test-data xtask-gen-zed-queries xtask-gen-tmlanguage-keywords xtask-gen-editor-settings xtask-gen-vscode-package xtask-gen-jetbrains-catalog xtask-gen-ai-diagnostics xtask-owner-resolution xtask-resolution-drift xtask-retired-api-gate xtask-pack-goldens xtask-number-drift xtask-segmentation-drift xtask-command-backing xtask-callback-inventory xtask-option-registry-drift xtask-sslictcl-data xtask-runtime-stdlib xtask-editor-extensions xtask-f5query-builtins-doc xtask-bigip-data-schema xtask-c-api-ownership ## Rust-side check gates (docs index coverage + generated-table/catalog drift) xtask-dialect-drift
 
 check-tcl-reference-toolchains: ## Verify pinned C Tcl patchlevels across shell setup and Rust oracle discovery
 	@echo "==> Checking C Tcl reference toolchain ownership"
@@ -833,6 +833,10 @@ xtask-number-drift: ## Check Tcl numeral parser and expression-boundary scanner 
 xtask-dialect-drift: ## Check that document text is re-read under the ingress-resolved grammar only (dialect-grammar drift gate)
 	@echo "==> Checking for dialect-grammar drift (cargo xtask)"
 	cd $(ROOT) && cargo xtask dialect-drift
+
+xtask-segmentation-drift: ## Check that Tcl command/word boundaries come from the shared owner (segmentation drift gate)
+	@echo "==> Checking for command/word segmentation drift (cargo xtask)"
+	cd $(ROOT) && cargo xtask segmentation-drift
 
 xtask-kcs-index-links: ## Validate docs links + design/KCS index coverage
 	@echo "==> Checking docs links + index coverage (cargo xtask)"

--- a/docs/design/compiler/recursive-descent-depth-limits.md
+++ b/docs/design/compiler/recursive-descent-depth-limits.md
@@ -369,7 +369,7 @@ higher-level guard ever runs.
 | Walker | Cap | Notes |
 |---|---|---|
 | `Lexer::scan_array_index_body`/`skip_var_in_index` (nested `$a($b($c(...)))`) | `MAX_ARRAY_INDEX_DEPTH` = 64 | Empirically: SIGABRT depth 20,000-25,000 on a 2 MiB thread. Past the cap, a nested `$` is scanned as an ordinary character. |
-| `structural_index.rs`'s three scanners (`BracketIndex::scan_cmd_sub`; `BraceIndex`'s `scan_script`/`scan_quoted`; `scan_complete`/`scan_complete_quoted` behind `script_is_complete`/`command_boundaries`) | `MAX_NESTED_BRACKET_DEPTH` = 128 | The last of these backs `script_is_complete`, called directly on raw document text from `tcl-lsp-server::compute_base_analysis`. Empirically: SIGABRT depth 10,000-50,000 depending on the scanner. |
+| `structural_index.rs`'s three scanners (`BracketIndex::scan_cmd_sub`; `BraceIndex`'s `scan_script`/`scan_quoted`; `scan_complete`/`scan_complete_quoted` behind `script_is_complete`) | `MAX_NESTED_BRACKET_DEPTH` = 128 | The last of these backs `script_is_complete`, called directly on raw document text from `tcl-lsp-server::compute_base_analysis`. Empirically: SIGABRT depth 10,000-50,000 depending on the scanner. `command_boundaries` needs no cap of its own: its `[…]` skip goes through `ranges::command_substitution_end`, which is iterative. |
 | `expr_lexer.rs`'s `Inner::scan_array_index` (nested array index inside an `expr`) | `MAX_EXPR_ARRAY_INDEX_DEPTH` = 64 | Bypassed `tcl-syntax`'s already-capped Pratt parser entirely — the whole nested chain is swallowed into one `Variable` token during lexing, before the parser ever sees per-level tokens to count. Empirically: SIGABRT depth 100,000-200,000. |
 
 **`tcl-lsp-core`** — seven Scope-tree/word-nesting walkers, all sharing

--- a/docs/design/contracts/shared-utility-contracts-rust.md
+++ b/docs/design/contracts/shared-utility-contracts-rust.md
@@ -49,7 +49,8 @@ entry point, or gate moves without this contract being updated.
 | sort numeric parsing | `rust/tcl-cmd-core/src/sort.rs` | `parse_wide`; `parse_real` | `NumberSyntax` per release | none |
 | command errors | `rust/tcl-cmd-core/src/error.rs` | `CmdError`; `wrong_args`; `bad_choice` | invariant | none |
 | expression grammar / evaluation | `rust/tcl-syntax/src/expr/parser.rs`; `rust/tcl-syntax/src/expr/eval.rs`; `rust/tcl-registry/src/expr_surface.rs` | `parse_expr`; `eval`; `RuntimeExprSurface` | `RuntimeExprSurface` per release | none |
-| command / word segmentation | `rust/tcl-lexer/src/script.rs`; `rust/tcl-compiler/src/segmenter.rs`; `rust/tcl-compiler/src/parsing/syntax/build.rs`; `rust/tcl-compiler/src/parsing/syntax/segment.rs` | `group_commands`; `CommandSpan`; `WordSpan`; `WordKind`; `SegmentedCommand`; `segment_commands` | `LexerConfig` per document dialect | none |
+| command / word segmentation | `rust/tcl-lexer/src/script.rs`; `rust/tcl-compiler/src/segmenter.rs`; `rust/tcl-compiler/src/parsing/syntax/build.rs`; `rust/tcl-compiler/src/parsing/syntax/segment.rs` | `group_commands`; `CommandSpan`; `WordSpan`; `WordKind`; `SegmentedCommand`; `segment_commands` | `LexerConfig` per document dialect | `xtask-segmentation-drift` |
+| script completeness / reparse windows | `rust/tcl-lexer/src/structural_index.rs` | `script_is_complete`; `command_boundaries`; `reparse_window`; `BracketIndex`; `BraceIndex`; `ExprParenIndex`; `ParenBalance` | dialect-blind by construction: one byte scan of stock 8.6/9.x brace, quote, `${…}`-nesting, comment and terminator structure, so an editor keystroke costs no tokenise. The two grammar axes that really do move a command boundary — the F5 `BraceLineContinuation::Continues` next-line-`{` rule and the 8.x `BracedVarStyle::FirstClose` name rule — are pinned as measured divergences by `differential_boundaries`, never silently absorbed | `xtask-segmentation-drift` |
 | iRules execution boundaries and placement | `rust/tcl-syntax/src/event_handler.rs`; `rust/tcl-registry/src/events.rs`; `rust/tcl-registry/src/registry.rs`; `rust/tcl-irules/src/when_block.rs`; `rust/tcl-irules/src/executable.rs` | `event_handlers`; `event_handlers_with_head_predicate`; `script_commands`; `top_level_when_handlers_with_registry_and_head_resolver`; `IrulesDeclarationArguments`; `IrulesExecutionContext`; `IrulesCommandPlacement`; `IrulesTopLevelDeclaration`; `IrulesTopLevelEffect`; `CommandRegistry::irules_command_placement`; `CommandRegistry::irules_event_declaration`; `CommandRegistry::irules_top_level_declaration`; `CommandRegistry::irules_top_level_declaration_shape`; `CommandRegistry::irules_top_level_effect`; `when_blocks`; `irules_executable_commands` | caller-supplied `LexerConfig`; offset-keyed resolved command identity; exact single-braced declaration body; declaration-only top level; known-event roots; call-reachable procedure bodies; stateful priority (`0..=1000`, default 500) | `xtask-gen-ai-diagnostics` |
 | text similarity | `rust/tcl-compiler/src/text.rs` | `edit_distance`; `rank_suggestions`; `rank_containment_suggestions` | invariant | none |
 | per-command knowledge | `rust/tcl-registry/src/spec.rs`; `rust/tcl-registry/src/hooks.rs`; `rust/tcl-registry/src/registry.rs` | `CommandSpec`; `SubCommand`; `CommandRegistry` | per release/dialect | `xtask-command-backing` |
@@ -385,6 +386,65 @@ entry point, or gate moves without this contract being updated.
   part. The segmenter keeps owning *command* and *word* boundaries; only
   the within-word breakdown moves. Tracked in
   `docs/design/lanes/wasm-native-lowering.md` § `r10-word-parts`.
+
+- `structural_index::command_boundaries` — the byte-scanned **reparse
+  split points**, and, with `script_is_complete` and `reparse_window`, its
+  own surface rather than a fourth grouper folded onto
+  `script::group_commands` (issue #1786 item 1).
+
+  The three share one scanner family. `script_is_complete` is the
+  crate's `Tcl_CommandComplete` port — called on raw document text by
+  `tcl-lsp-server::compute_base_analysis`, `codegen::structured`, the
+  analyser's incremental gate and `tcl-vm-cli`'s REPL —
+  `command_boundaries` answers "where may an incremental reparser cut this
+  document into whole commands", and `reparse_window` snaps an edit range
+  outward to those cuts. Every boundary satisfies
+  `script_is_complete(&source[..b])`; that invariant is *why* the two
+  cannot be separated.
+
+  Folding the boundary half onto the owner was considered and rejected on
+  three measurements. **One**, it would split that family: the
+  completeness oracle is not a grouper and cannot move, so the invariant
+  above would become unprovable and the two halves free to disagree.
+  **Two**, the contracts differ — the scanner reports *terminator*
+  offsets, the owner reports command spans and discards empty,
+  comment-only and dangling-`{*}` commands, so `a\n\n\nb\n` is `[2,3,4,6]`
+  against the owner's two commands, and `reparse_window`'s minimality
+  rests on those blank-line cuts. **Three**, cost and totality: the
+  scanner is a single allocation-free pass over bytes, deliberately *not*
+  a `Vec<Token>` per keystroke, and it is total on malformed input where
+  `tokenise_all` returns a `Result`.
+
+  What the fold *would* have bought — dialect correctness — is instead
+  paid for honestly. The scanner takes no `LexerConfig`, and two grammar
+  axes really do move a command boundary: under the F5 trunk a newline
+  whose next line opens with `{` does not terminate the command
+  (`BraceLineContinuation::Continues`), and under the 8.x family
+  `${a{b}` ends at the first `}` (`BracedVarStyle::FirstClose`), so
+  `set v ${a{b}<newline>puts hi` is two commands there and one under 9.x.
+  Both are pinned with their measured answers by `tcl-lexer`'s
+  `differential_boundaries`, which also asserts containment, coverage and
+  termination against `group_commands` over `samples/` and the Tcl 9.0.4
+  library at three dialects and three nesting levels — 21.5k regions,
+  39.9k commands — with tcllib behind `--ignored`. It replaced a
+  seven-string non-straddling assertion in `tcl-compiler`'s segmenter that
+  a `command_boundaries` returning nothing but `source.len()` would have
+  passed; the coverage invariant it could not express found two live
+  defects, one per tier. Both were the same shape — a nested `[…]` whose
+  interior C rejects (`{a}$b`) makes the completeness scanner report
+  `Terminal` with its offset collapsed to end-of-input, so every later
+  boundary in the document is lost. The CI tier caught it on
+  `[a [b {*}$c]]`, written in 9.0.4's `auto.tcl`; the tcllib tier caught
+  it behind a quoted word, in `page/util_quote.tcl`. Fixed by taking the
+  lenient closes — `ranges::command_substitution_end` and, on `Terminal`
+  only, `ranges::close_quote_offset` — instead of the completeness
+  oracle's error path. Coverage is asserted only where the region is a
+  complete script, which is the scanner's documented precondition; those
+  regions are tallied and reported.
+
+  Agreement with the *compiler* segmenter follows transitively:
+  `differential_group` proves `group_commands == segment_commands`
+  command for command over the same corpora.
 
 ### `tcl-cmd-core` — portable command logic
 
@@ -790,6 +850,18 @@ helper without reading the rationale:
   the max, then the reporting tie-break), with
   `no_pack_overlay_leaves_every_floor_where_it_was` as the FN guard for
   a session that loads no packs.
+- `rust/tcl-compiler/tests/differential_group.rs` — the command / word
+  segmentation gate: `group_commands` against the shipping segmenter,
+  command for command and word for word, over `samples/` and the Tcl
+  9.0.4 library at three dialects and three nesting levels
+  (`owner_matches_segmenter_over_corpora`), with tcllib behind
+  `--ignored`. `rust/tcl-lexer/tests/differential_boundaries.rs` — the
+  other half: `command_boundaries` against that owner
+  (`scanner_agrees_with_owner_over_corpora`), plus
+  `dialect_divergences_are_pinned` for the two axes the byte scanner is
+  deliberately blind to. `make xtask-segmentation-drift` is the
+  banned-spelling gate that keeps a *new* consumer from re-deriving
+  either boundary privately.
 
 ## Discoverability
 

--- a/rust/tcl-compiler/src/optimiser/helpers/spans.rs
+++ b/rust/tcl-compiler/src/optimiser/helpers/spans.rs
@@ -135,6 +135,9 @@ pub fn statement_delete_rewrite_range(
     while cursor < next && matches!(bytes[cursor], b' ' | b'\t' | b'\r') {
         cursor += 1;
     }
+    // segmentation-drift-ok: this does not find a boundary — both ends are
+    // already the segmenter's (`cmd_span`, and the next command's start). It
+    // only decides whether the delete may swallow the terminator between them.
     if cursor < next && matches!(bytes[cursor], b'\n' | b';') {
         cursor += 1;
         while cursor < next && matches!(bytes[cursor], b' ' | b'\t' | b'\r') {

--- a/rust/tcl-compiler/src/segmenter.rs
+++ b/rust/tcl-compiler/src/segmenter.rs
@@ -1227,9 +1227,10 @@ mod tests {
 
     #[test]
     #[ignore = "seeded edit-storm oracle (3000 edit/segment pairs); the deterministic \
-                incremental gates stay in CI — segment_commands_incremental_pins, \
-                command_boundaries_agree_with_segmenter, and the \
-                *_incremental_matches_fresh* family; run explicitly with --ignored"]
+                incremental gates stay in CI — segment_commands_incremental_pins and the \
+                *_incremental_matches_fresh* family here, and tcl-lexer's \
+                differential_boundaries for the reparse split points; run explicitly \
+                with --ignored"]
     fn segment_commands_incremental_matches_full_under_fuzz() {
         // Differential acceptance gate: a random edit applied to a base
         // document, then incremental re-segmentation must byte-for-byte
@@ -1277,40 +1278,6 @@ mod tests {
             }
         }
         assert!(checked > 2000, "fuzz corpus too small: {checked}");
-    }
-
-    /// Cross-check the cheap incremental-reparse boundary scanner
-    /// (`tcl_lexer::command_boundaries`) against the production
-    /// segmenter: no segmented command may straddle a top-level
-    /// boundary, so the cheap byte-scan agrees with the full tokeniser
-    /// on where commands split.
-    #[test]
-    fn command_boundaries_agree_with_segmenter() {
-        let cases = [
-            "set x 1\nputs hi\n",
-            "if {1} {\n  puts a\n  puts b\n}\nputs done\n",
-            "set y [a; b]\nputs \"a;b\"\n",
-            "proc p {} {\n  return [expr {1 + 2}]\n}\np\n",
-            "namespace eval n {\n  variable v 1\n}\n",
-            "a; b; c\nd\n",
-            "set s {a\nb\nc}\nputs $s\n",
-        ];
-        for src in cases {
-            let bounds = tcl_lexer::command_boundaries(src);
-            for cmd in segment_commands(src) {
-                if cmd.argv.is_empty() {
-                    continue;
-                }
-                let (s, e) = (cmd.span.start(), cmd.span.end());
-                // The command must lie within a single boundary interval
-                // [prev, next): no boundary may fall strictly inside it.
-                let straddles = bounds.iter().any(|&b| b > s && b < e);
-                assert!(
-                    !straddles,
-                    "command {s}..{e} straddles a boundary in {bounds:?} for {src:?}",
-                );
-            }
-        }
     }
 
     #[test]

--- a/rust/tcl-compiler/src/value_shapes.rs
+++ b/rust/tcl-compiler/src/value_shapes.rs
@@ -271,6 +271,12 @@ pub fn parse_command_substitution_with_spans_and_config(
             (word_text, tok_end)
         };
         let abs_span = Span::new(base + tok.span.start(), base + tok_end);
+        // segmentation-drift-ok: known #1786 debt — a private word grouper over
+        // the `[...]` interior, kept because it also recovers the two orphaned
+        // closers documented above, which `WordSpan` does not yet carry. Folding
+        // it onto `group_commands` is its own change, tracked with the other
+        // `value_shapes` sweeps in the tcl-lexer owner section of
+        // shared-utility-contracts-rust.md.
         if matches!(prev_kind, TokenType::Sep | TokenType::Eol) || words.is_empty() {
             words.push((word_text, abs_span));
         } else {

--- a/rust/tcl-explorer/src/serialise.rs
+++ b/rust/tcl-explorer/src/serialise.rs
@@ -2653,6 +2653,13 @@ pub fn serialise_event_order(source: &str, line_index: &LineIndex, dialect: &str
 /// bracket/brace balance, and the inert spans where `[`/`]`/`{`/`}` are
 /// *literal* (brace words, comments, `${…}`, escapes). This acceleration
 /// layer drives incremental reparse.
+///
+/// `commandBoundaries` here is the **reparse split points**, not the
+/// segmentation view: `command_boundaries` is registered in
+/// `shared-utility-contracts-rust.md` as a dialect-blind byte scan of
+/// stock 9.x structure, so on an F5 or 8.x document it can differ from
+/// the dialect-resolved answer — which is what the `segments` and `cst`
+/// views beside it show.
 #[must_use]
 pub fn serialise_structural_index(source: &str, li: &LineIndex) -> Value {
     use tcl_lexer::{BraceIndex, BracketIndex, command_boundaries, script_is_complete};

--- a/rust/tcl-lexer/src/structural_index.rs
+++ b/rust/tcl-lexer/src/structural_index.rs
@@ -1408,10 +1408,18 @@ fn scan_var_brace(b: &[u8], brace: usize) -> (usize, bool) {
 // Incremental-reparse primitives. A cheap single byte-scan finds the top-level
 // command boundaries (the stable split points an incremental reparser snaps
 // edits to); `reparse_window` snaps a changed byte range outward to whole
-// commands so only those need re-segmenting / re-analysing. Nesting (`[…]`,
-// `"…"`, `{…}`, `${…}`, comments, escapes) is skipped via the same recursive
-// scanner that backs `script_is_complete`, so the boundaries agree with the
-// segmenter without tokenising the whole document.
+// commands so only those need re-segmenting / re-analysing. Nesting (`{…}`,
+// `${…}`, `"…"`, comments, escapes) is skipped by the same scanner that backs
+// `script_is_complete`, and `[…]` by `ranges::command_substitution_end`, so
+// the boundaries agree with the boundary owner without tokenising the whole
+// document.
+//
+// Where the two differ is *leniency*: `script_is_complete` is an oracle and
+// reports a terminal parse error, while boundary scanning must keep going the
+// way the lexer does. Each arm below says which it takes and why. Registered
+// as its own surface in `shared-utility-contracts-rust.md` (dialect-blind by
+// construction) and pinned to `script::group_commands` over the corpora by
+// `tcl-lexer`'s `differential_boundaries`.
 
 /// The byte offsets that split `source` into top-level commands — each is
 /// the position immediately after a top-level command terminator (`\n` or
@@ -1476,7 +1484,24 @@ pub fn command_boundaries(source: &str) -> Vec<u32> {
                 command_start = false;
             }
             b'"' if newword => {
-                i = scan_complete_quoted(source, b, i + 1, 0).0;
+                i = match scan_complete_quoted(source, b, i + 1, 0) {
+                    // Same leniency as the `[` arm below: a nested `[…]`
+                    // holding a weld C rejects makes the completeness
+                    // scanner report `Terminal` with its offset collapsed
+                    // to end-of-input, which would lose every later
+                    // boundary. The quote's own delimiters are fine in
+                    // that case, so take the close from the shared
+                    // close-quote owner. Caught in tcllib's
+                    // `page/util_quote.tcl` by `differential_boundaries`.
+                    (_, Completeness::Terminal) => {
+                        crate::ranges::close_quote_offset(source, i).map_or(n, |q| q + 1)
+                    }
+                    // `Closed` is past the `"`; `Incomplete` is `n`, which
+                    // is right — an unterminated quote runs to EOF, and
+                    // `scan_complete_quoted` (unlike the close-quote
+                    // owner) knows the release's `${…}` nesting rule.
+                    (end, _) => end,
+                };
                 newword = false;
                 command_start = false;
             }
@@ -1486,8 +1511,18 @@ pub fn command_boundaries(source: &str) -> Vec<u32> {
                 i += 2;
                 command_start = false;
             }
+            // The `[…]` skip goes through the shared close-bracket owner
+            // rather than `scan_complete`: the completeness scanner reports
+            // `Terminal` for a weld C rejects (`{a}$b`), and its `[` arm
+            // collapses that verdict's offset to end-of-input — so a nested
+            // `[a [b {*}$c]]` (Tcl 9.0.4's `auto.tcl` writes exactly that)
+            // used to swallow every later boundary in the document. Boundary
+            // scanning is lenient by contract, so it wants the lenient,
+            // comment-aware, iterative closer instead of the completeness
+            // oracle's error path. Caught by `differential_boundaries`'
+            // coverage invariant.
             b'[' => {
-                i = scan_complete(source, b, i + 1, true, 0).0;
+                i = crate::ranges::command_substitution_end(source, i).unwrap_or(n);
                 newword = false;
                 command_start = false;
             }

--- a/rust/tcl-lexer/tests/differential_boundaries.rs
+++ b/rust/tcl-lexer/tests/differential_boundaries.rs
@@ -1,0 +1,543 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Differential harness: the byte-scanned reparse split points against the
+//! boundary owner (issue #1786, item 1b).
+//!
+//! [`tcl_lexer::command_boundaries`] is a **byte scanner**, not a grouper.
+//! It answers one question — where may an incremental reparser cut a
+//! document into whole top-level commands — and answers it without
+//! tokenising, because it is the split-point sibling of
+//! [`tcl_lexer::script_is_complete`], the crate's `Tcl_CommandComplete`
+//! port, and shares that port's recursive `scan_complete` /
+//! `scan_complete_quoted` scanner. Both are registered in
+//! `docs/design/contracts/shared-utility-contracts-rust.md` as the
+//! *script completeness / reparse windows* surface, separate from the
+//! *command / word segmentation* surface [`group_commands`] owns.
+//!
+//! Two surfaces means the answers must be shown to agree, and until now
+//! they were cross-checked only by a seven-string non-straddling assertion
+//! in `tcl-compiler`'s segmenter (`command_boundaries_agree_with_segmenter`,
+//! removed by this file). This harness replaces it with a corpus
+//! differential against the owner itself, over the corpora the other
+//! `#1786` differentials use. Agreement with the *compiler segmenter*
+//! follows transitively: `differential_group` proves owner ==
+//! `segment_commands` command-for-command over the same corpora.
+//!
+//! # What is proven
+//!
+//! For a region and a [`LexerConfig`], with `cmds` the owner's top-level
+//! commands and `bounds` the scanner's split points:
+//!
+//! * **containment** — no split point falls strictly inside a command. A
+//!   reparse window snapped to a boundary never cuts a command in half.
+//! * **coverage** — between two consecutive commands there is a split
+//!   point. The scanner never *merges* two commands the owner separates,
+//!   which the old straddle-only invariant could not see: a
+//!   `command_boundaries` that returned nothing but `source.len()` passed
+//!   it. Asserted only where the region is a complete script, which is
+//!   the scanner's documented precondition: a split point must be a point
+//!   at which the prefix is complete, and inside an unterminated `[`, `{`
+//!   or `"` there is no such point. The owner, being a *lexer*, recovers
+//!   and keeps grouping there; the scanner, being the `Tcl_CommandComplete`
+//!   port, correctly refuses to offer a cut. tcllib's
+//!   `page/util_quote.tcl` has a `switch` clause list holding `"\\["`,
+//!   which is exactly that shape. Incomplete regions are tallied and
+//!   reported, never silently dropped.
+//! * **termination** — the last split point is `source.len()`, so the
+//!   final command is always inside a window.
+//!
+//! # The dialect axis, and why it is a *tally* rather than a skip
+//!
+//! The scanner takes no [`LexerConfig`]; it hard-codes stock Tcl 9
+//! structure. Two grammar axes really do move a command boundary, and both
+//! are measured, pinned in [`dialect_divergences_are_pinned`], and recorded
+//! in the scanner's contract row:
+//!
+//! * `BraceLineContinuation::Continues` (the F5 trunk) — a newline whose
+//!   next line opens with `{` does not terminate the command, so the
+//!   scanner splits where the owner does not;
+//! * `BracedVarStyle::FirstClose` (the 8.x family) — `${a{b}` names `a{b`
+//!   and ends at the first `}`, so the owner splits where the scanner,
+//!   nesting `{…}` inside `${…}` the Tcl 9 way, does not.
+//!
+//! So the corpus walk drives **all three** dialects and, per region, first
+//! asks whether that dialect's own grammar puts the commands anywhere
+//! other than stock Tcl does. Where it does, the region is counted as a
+//! dialect divergence and reported; everywhere else — the overwhelming
+//! majority of real corpus text, including every f5 and 8.4 file that
+//! happens not to use those two shapes — the three invariants are asserted
+//! in full. Nothing is skipped silently: the tally is printed.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use tcl_lexer::script::{CommandSpan, group_commands};
+use tcl_lexer::{Lexer, LexerConfig, SourceMap, Span, Token, TokenType, command_boundaries};
+
+/// Repo root — two directories above `CARGO_MANIFEST_DIR`.
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("..").join("..")
+}
+
+/// The three dialects `differential_group` and `differential_segment` use.
+type NamedConfig = (&'static str, fn() -> LexerConfig);
+const CONFIGS: [NamedConfig; 3] = [
+    ("default", LexerConfig::default),
+    ("tcl8.4", || LexerConfig::for_dialect("tcl8.4")),
+    ("f5-irules", || LexerConfig::for_dialect("f5-irules")),
+];
+
+/// Both engines work in the region-local (`base_offset == 0`) space.
+fn local_config(config: LexerConfig) -> LexerConfig {
+    LexerConfig {
+        base_offset: 0,
+        base_line: 0,
+        base_col: 0,
+        ..config
+    }
+}
+
+fn lex(src: &str, config: LexerConfig) -> Option<Vec<Token>> {
+    Lexer::with_source_map(SourceMap::new(src), local_config(config))
+        .tokenise_all()
+        .ok()
+}
+
+/// The owner's commands, each widened over a braced / bracketed final
+/// token's closer the way the compiler segmenter's `command_span` does —
+/// so containment is asserted against the *whole written* command, not the
+/// lexer's inner end.
+fn owner_spans(src: &str, config: LexerConfig, tokens: &[Token]) -> Vec<Span> {
+    let sm = SourceMap::new(src);
+    group_commands(tokens, src, local_config(config))
+        .iter()
+        .map(|cmd| Span::new(cmd.span.start(), widened_end(&sm, tokens, cmd)))
+        .collect()
+}
+
+fn widened_end(sm: &SourceMap<'_>, tokens: &[Token], cmd: &CommandSpan) -> u32 {
+    let last_word_end = cmd.words.last().map_or(0, |w| w.tokens.end - 1);
+    let last = cmd
+        .expand_markers
+        .last()
+        .copied()
+        .map_or(last_word_end, |m| m.max(last_word_end));
+    let tok = tokens[last];
+    if tok.kind.group_closer().is_none() {
+        tok.span.end()
+    } else {
+        tcl_lexer::word_span(sm, tok).end()
+    }
+}
+
+/// The three invariants over one region. Returns every violation.
+///
+/// `coverage` is skipped for a region that is not a complete script — see
+/// the module docs.
+fn violations(src: &str, spans: &[Span], ctx: &str) -> Vec<String> {
+    let bounds = command_boundaries(src);
+    let len = u32::try_from(src.len()).expect("region fits u32");
+    let mut out = Vec::new();
+
+    if bounds.last() != Some(&len) {
+        out.push(format!(
+            "termination [{ctx}]: last split point {:?} is not the region end {len}",
+            bounds.last()
+        ));
+    }
+    for (i, span) in spans.iter().enumerate() {
+        if let Some(&b) = bounds.iter().find(|&&b| b > span.start() && b < span.end()) {
+            out.push(format!(
+                "containment [{ctx}] cmd {i}: split point {b} falls inside command {span:?}",
+            ));
+        }
+    }
+    if !tcl_lexer::script_is_complete(src) {
+        return out;
+    }
+    for (i, pair) in spans.windows(2).enumerate() {
+        let (prev, next) = (pair[0], pair[1]);
+        if !bounds.iter().any(|&b| b >= prev.end() && b <= next.start()) {
+            out.push(format!(
+                "coverage [{ctx}] cmds {i}/{}: no split point in [{}, {}] — the scanner merges \
+                 two commands the owner separates",
+                i + 1,
+                prev.end(),
+                next.start(),
+            ));
+        }
+    }
+    out
+}
+
+// ---------------------------------------------------------------------
+// Edge cases
+// ---------------------------------------------------------------------
+
+/// Shapes the scanner and the owner must agree on under stock Tcl. The
+/// `differential_group` edge table plus the ones that are specifically
+/// about *split points*: nested separators, comments that hide a closer,
+/// blank lines, escaped newlines, unterminated delimiters.
+const EDGE_CASES: &[&str] = &[
+    "",
+    "\n",
+    "puts hi",
+    "puts hi\n",
+    "puts hi\n\n",
+    "a; b; c",
+    "a;;b\n",
+    "a\n\n\nb\n",
+    "set x 1\nputs $x\n",
+    "if {$x} {\n  puts yes\n}\n",
+    "proc f {} {\n  return [expr {1 + 2}]\n}\nf\n",
+    "namespace eval n {\n  variable v 1\n  proc q {} {}\n}\nn::q\n",
+    "set s {a\nb\nc}\nputs $s\n",
+    "puts \"a;b\"\nset y [a;b]\n",
+    "set x [\n# ] hidden\nset y 1\n]\nputs done\n",
+    "# a comment\nputs hi\n",
+    "# c1\n# c2\nproc f {} {}\n",
+    "# orphan\n\nputs hi\n",
+    "puts hi ;# dangling",
+    "list a \\\n b\n",
+    "set y \"a\\\nb\"\nputs done\n",
+    "puts {a}\n",
+    "puts {a}b\nputs c\n",
+    "puts \"a\"b\nputs c\n",
+    "foo {*}$args\n",
+    "{a}{*}$b\n",
+    "set v ${name}\nputs hi\n",
+    "set v $arr(idx)\n",
+    "switch $x {\n a {one}\n b {two}\n}\n",
+    "set x {a\\}}\nputs done\n",
+    // Unterminated / degenerate delimiters: the scanner must stay total and
+    // must not invent a split inside the run-to-EOF region.
+    "puts {a",
+    "puts \"a",
+    "puts [a",
+    "puts {a\nputs b\n",
+    "set x [foo bar\nputs done\n",
+    // tcllib `page/util_quote.tcl`: an unterminated `[` inside a quoted
+    // word of a `switch` clause list. `info complete` is false from there
+    // on, so the scanner offers no further cut and coverage does not apply.
+    "\"\\\\[\"  {return 1}\n\"b\" {return 2}\n",
+];
+
+#[test]
+fn scanner_agrees_with_owner_on_edge_cases() {
+    let config = LexerConfig::default();
+    let mut failures = Vec::new();
+    for &src in EDGE_CASES {
+        let Some(tokens) = lex(src, config) else {
+            panic!("edge case {src:?} does not lex");
+        };
+        let spans = owner_spans(src, config, &tokens);
+        failures.extend(violations(src, &spans, &format!("default:{src:?}")));
+    }
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
+}
+
+/// The two grammar axes the scanner is blind to, pinned with the exact
+/// answers both sides give today.
+///
+/// These are not bugs the harness is hiding: they are the reason
+/// `command_boundaries` is registered as its own dialect-blind surface
+/// rather than folded onto the owner. If the scanner ever takes a
+/// `LexerConfig`, these assertions fail and must be rewritten — which is
+/// the point.
+#[test]
+fn dialect_divergences_are_pinned() {
+    // 1. F5 next-line-`{` continuation (`BraceLineContinuation::Continues`).
+    //    Stock Tcl: three commands. F5: two — the newline at 7 does not
+    //    terminate. The scanner splits at 8 either way.
+    let src = "if {$x}\n{\n puts a\n}\nputs done\n";
+    assert_eq!(command_boundaries(src), vec![8, 20, 30]);
+    assert_eq!(owner_command_count(src, LexerConfig::default()), 3);
+    assert_eq!(
+        owner_command_count(src, LexerConfig::for_dialect("f5-irules")),
+        2
+    );
+    // Under F5 the scanner cuts the single `if` command in two.
+    let cfg = LexerConfig::for_dialect("f5-irules");
+    let tokens = lex(src, cfg).expect("lexes");
+    let spans = owner_spans(src, cfg, &tokens);
+    let broken = violations(src, &spans, "f5-irules");
+    assert_eq!(broken.len(), 1, "{broken:?}");
+    assert!(broken[0].starts_with("containment"), "{broken:?}");
+
+    // 2. 8.x first-close `${…}` (`BracedVarStyle::FirstClose`). Under 8.4
+    //    `${a{b}` names `a{b`, so the newline at 12 is a terminator and the
+    //    owner sees two commands; the scanner nests `{…}` inside `${…}` the
+    //    Tcl 9 way and sees one, missing the split entirely.
+    let src = "set v ${a{b}\nputs hi\n";
+    assert_eq!(command_boundaries(src), vec![21]);
+    assert_eq!(owner_command_count(src, LexerConfig::default()), 1);
+    assert_eq!(
+        owner_command_count(src, LexerConfig::for_dialect("tcl8.4")),
+        2
+    );
+    let cfg = LexerConfig::for_dialect("tcl8.4");
+    let tokens = lex(src, cfg).expect("lexes");
+    let spans = owner_spans(src, cfg, &tokens);
+    assert_eq!(spans.len(), 2);
+    // No split point anywhere in the gap between the 8.4 commands: the
+    // scanner has merged them.
+    assert!(
+        !command_boundaries(src)
+            .iter()
+            .any(|&b| b >= spans[0].end() && b <= spans[1].start()),
+        "{spans:?}",
+    );
+    // The blindness reaches the completeness oracle as well — under the
+    // Tcl 9 rule this `${…}` never closes, so the whole script reads as
+    // incomplete and `command_boundaries` is right, on its own grammar, to
+    // offer no cut. That is why the corpus walk asserts coverage only on
+    // complete scripts, and why this pin exists instead.
+    assert!(!tcl_lexer::script_is_complete(src));
+}
+
+fn owner_command_count(src: &str, config: LexerConfig) -> usize {
+    let tokens = lex(src, config).expect("lexes");
+    group_commands(&tokens, src, local_config(config)).len()
+}
+
+// ---------------------------------------------------------------------
+// Corpus walk
+// ---------------------------------------------------------------------
+
+/// How many levels of `{…}` / `[…]` the corpus walk descends below the top
+/// level — `differential_group`'s value, for the same reason: `tokenise_all`
+/// is flat, so a top-level-only walk compares almost none of the Tcl in the
+/// corpus.
+const NEST_DEPTH: usize = 3;
+
+/// Stop after this many violations so a systematic break does not print a
+/// megabyte of near-identical failures.
+const MAX_FAILURES: usize = 20;
+
+#[derive(Default, Debug, Clone, Copy)]
+struct Tally {
+    regions: usize,
+    commands: usize,
+    /// Regions whose owner command spans under this dialect differ from
+    /// stock Tcl's — the two axes the scanner is blind to. Asserted
+    /// nowhere, reported everywhere.
+    dialect_divergent: usize,
+    /// Regions that are not complete scripts, where coverage is not
+    /// asserted (containment and termination still are).
+    incomplete: usize,
+}
+
+impl Tally {
+    fn add(self, other: Self) -> Self {
+        Self {
+            regions: self.regions + other.regions,
+            commands: self.commands + other.commands,
+            dialect_divergent: self.dialect_divergent + other.dialect_divergent,
+            incomplete: self.incomplete + other.incomplete,
+        }
+    }
+}
+
+fn walk_region(
+    src: &str,
+    config: LexerConfig,
+    ctx: &str,
+    level: usize,
+    max_depth: usize,
+    tallies: &mut [Tally],
+    failures: &mut Vec<String>,
+) {
+    let Some(tokens) = lex(src, config) else {
+        return;
+    };
+    let spans = owner_spans(src, config, &tokens);
+    let tally = &mut tallies[level];
+    tally.regions += 1;
+    tally.commands += spans.len();
+    if !tcl_lexer::script_is_complete(src) {
+        tally.incomplete += 1;
+    }
+
+    // Does this dialect's grammar put the commands anywhere other than
+    // stock Tcl does? If so this region exercises one of the two axes the
+    // scanner cannot see, and only the tally records it.
+    let stock = LexerConfig::default();
+    let stock_spans = lex(src, stock)
+        .map(|t| owner_spans(src, stock, &t))
+        .unwrap_or_default();
+    if spans == stock_spans {
+        failures.extend(violations(src, &spans, ctx));
+    } else {
+        tally.dialect_divergent += 1;
+    }
+
+    if level >= max_depth || failures.len() >= MAX_FAILURES {
+        return;
+    }
+    let sm = SourceMap::new(src);
+    for &tok in &tokens {
+        if !matches!(tok.kind, TokenType::Str | TokenType::Cmd) || tok.content_offset != 1 {
+            continue;
+        }
+        let inner = sm.token_text(tok);
+        if inner.trim().is_empty() {
+            continue;
+        }
+        let child_ctx = format!(
+            "{ctx} <{}@L{} offset {}>",
+            if tok.kind == TokenType::Cmd {
+                "[…]"
+            } else {
+                "{…}"
+            },
+            level + 1,
+            tok.span.start() + 1,
+        );
+        walk_region(
+            inner,
+            config,
+            &child_ctx,
+            level + 1,
+            max_depth,
+            tallies,
+            failures,
+        );
+        if failures.len() >= MAX_FAILURES {
+            return;
+        }
+    }
+}
+
+fn gather(dir: &Path, exts: &[&str], out: &mut Vec<PathBuf>) {
+    let Ok(rd) = fs::read_dir(dir) else { return };
+    for entry in rd.flatten() {
+        let p = entry.path();
+        if p.is_dir() {
+            gather(&p, exts, out);
+        } else if p
+            .extension()
+            .and_then(|e| e.to_str())
+            .is_some_and(|e| exts.contains(&e))
+        {
+            out.push(p);
+        }
+    }
+}
+
+/// The same corpus roots `differential_group` walks; `tcllib` dominates the
+/// cost and so is descended into only by the `--ignored` tier.
+fn corpus_files(root: &Path, with_tcllib: bool) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    gather(
+        &root.join("samples"),
+        &["tcl", "irul", "bpftcl"],
+        &mut files,
+    );
+    gather(&root.join("tmp/tcl9.0.4/library"), &["tcl"], &mut files);
+    if with_tcllib {
+        gather(&root.join("tmp/tcllib-2.0/modules"), &["tcl"], &mut files);
+    }
+    files.sort();
+    files
+}
+
+fn run_corpus(files: &[PathBuf], max_depth: usize) -> (usize, Vec<Tally>) {
+    let mut checked = 0usize;
+    let mut failures: Vec<String> = Vec::new();
+    let mut tallies = vec![Tally::default(); max_depth + 1];
+    for path in files {
+        let Ok(src) = fs::read_to_string(path) else {
+            continue;
+        };
+        checked += 1;
+        for (name, make) in CONFIGS {
+            let ctx = format!("{name}:{}", path.display());
+            walk_region(
+                &src,
+                make(),
+                &ctx,
+                0,
+                max_depth,
+                &mut tallies,
+                &mut failures,
+            );
+        }
+        if failures.len() >= MAX_FAILURES {
+            break;
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "scanner/owner boundary divergence over {checked} corpus files:\n{}",
+        failures.join("\n")
+    );
+    (checked, tallies)
+}
+
+fn report(label: &str, checked: usize, tallies: &[Tally]) {
+    eprintln!(
+        "[differential_boundaries] {label}: {checked} files x 3 dialects: \
+         containment + coverage + termination hold"
+    );
+    for (i, t) in tallies.iter().enumerate() {
+        eprintln!(
+            "[differential_boundaries]   L{i}: {} regions, {} commands, \
+             {} dialect-divergent, {} incomplete (the only ones coverage skips)",
+            t.regions, t.commands, t.dialect_divergent, t.incomplete
+        );
+    }
+    let total = tallies.iter().fold(Tally::default(), |a, t| a.add(*t));
+    eprintln!(
+        "[differential_boundaries]   total: {} regions, {} commands, \
+         {} dialect-divergent, {} incomplete",
+        total.regions, total.commands, total.dialect_divergent, total.incomplete
+    );
+}
+
+/// The CI tier: `samples/` and the Tcl 9.0.4 library, three dialects,
+/// descending [`NEST_DEPTH`] levels.
+#[test]
+fn scanner_agrees_with_owner_over_corpora() {
+    let root = repo_root();
+    let files = corpus_files(&root, false);
+    if files.is_empty() {
+        eprintln!("[differential_boundaries] skipped: no corpus present");
+        return;
+    }
+    let (checked, tallies) = run_corpus(&files, NEST_DEPTH);
+    assert!(checked > 0, "corpus present but no readable files");
+    assert!(
+        tallies.iter().map(|t| t.commands).sum::<usize>() > 10_000,
+        "corpus walk compared too few commands to be a gate"
+    );
+    report("samples + tcl9.0.4", checked, &tallies);
+}
+
+/// The exhaustive tier: the same walk with tcllib included.
+/// `docs/design/contracts/test-tiers-and-ci-gates.md` rule 2 — a permanently
+/// expensive corpus sweep over `tmp/` belongs behind `--ignored`.
+#[test]
+#[ignore = "corpus sweep over tcllib; run explicitly with --ignored"]
+fn scanner_agrees_with_owner_over_corpora_deep() {
+    let files = corpus_files(&repo_root(), true);
+    if files.is_empty() {
+        eprintln!("[differential_boundaries] skipped: no corpus present");
+        return;
+    }
+    let (checked, tallies) = run_corpus(&files, NEST_DEPTH);
+    assert!(checked > 0, "corpus present but no readable files");
+    report("samples + tcl9.0.4 + tcllib", checked, &tallies);
+}

--- a/rust/tcl-lsp-core/src/expr_context.rs
+++ b/rust/tcl-lsp-core/src/expr_context.rs
@@ -222,6 +222,9 @@ pub(crate) fn word_end(source: &str, start: usize, limit: usize) -> usize {
         }
         return limit;
     }
+    // segmentation-drift-ok: known #1786 debt — a bare-word end scan inside the
+    // `expr`-context probe, which runs on half-typed source at a cursor where a
+    // full tokenise is not affordable and often not possible.
     while pos < limit && !matches!(bytes[pos], b' ' | b'\t' | b'\r' | b'\n' | b';') {
         pos += 1;
     }
@@ -240,6 +243,9 @@ fn command_start_in_region(text: &str) -> usize {
             b'\\' => idx += 1,
             b'{' | b'[' => depth += 1,
             b'}' | b']' => depth -= 1,
+            // segmentation-drift-ok: known #1786 debt — `command_start_in_region`
+            // is a private last-command splitter for the same half-typed-source
+            // probe; it is depth-tracked but dialect-blind.
             b'\n' | b';' if depth <= 0 => start = idx + 1,
             _ => {}
         }

--- a/rust/tcl-lsp-core/src/formatting/engine.rs
+++ b/rust/tcl-lsp-core/src/formatting/engine.rs
@@ -338,6 +338,9 @@ fn parse_commands(
             _ => {}
         }
 
+        // segmentation-drift-ok: known #1786 debt — the formatter's own
+        // `parse_commands` is a word grouper that must also keep the trivia
+        // (comments, blank-line runs) `WordSpan` deliberately does not carry.
         let is_start_of_new_arg = matches!(prev_type, TokenType::Sep | TokenType::Eol);
         let detected_quoted =
             is_start_of_new_arg && source.as_bytes().get(tok.span.start() as usize) == Some(&b'"');
@@ -949,6 +952,9 @@ fn count_body_commands(body_text: &str) -> usize {
                 depth = depth.saturating_sub(1);
                 in_statement = true;
             }
+            // segmentation-drift-ok: known #1786 debt — `count_body_commands` is a
+            // private top-level command counter over a body it only needs a count
+            // for, with its own brace/bracket depth and escape tracking.
             '\n' | ';' if depth == 0 => {
                 if in_statement {
                     count += 1;

--- a/rust/tcl-lsp-core/src/minify.rs
+++ b/rust/tcl-lsp-core/src/minify.rs
@@ -2788,6 +2788,9 @@ fn parse_commands(source: &str, tokens: &[Token]) -> Vec<Vec<Arg>> {
             _ => {}
         }
 
+        // segmentation-drift-ok: known #1786 debt — the minifier's own
+        // `parse_commands` is a word grouper, kept alongside the formatter's
+        // until both fold onto the owner together.
         let is_start = matches!(prev_type, TokenType::Sep | TokenType::Eol);
         let detected_quoted =
             is_start && source.as_bytes().get(tok.span.start() as usize) == Some(&b'"');

--- a/rust/xtask/src/main.rs
+++ b/rust/xtask/src/main.rs
@@ -53,6 +53,10 @@
 //!   `tcl_dialect::scan_expr_number`.
 //! - `owner-resolution` — verify that the shared semantic-owner contract
 //!   resolves to live source files and drift gates.
+//! - `segmentation-drift` — flag a hand-rolled Tcl command-terminator scan
+//!   or a private `Sep`/`Eol` word-start state machine outside the command /
+//!   word boundary owners, and verify the owner/scanner corpus differential
+//!   is still wired (issue #1786).
 
 #![forbid(unsafe_code)]
 
@@ -91,6 +95,7 @@ mod registry_oracle;
 mod resolution_drift;
 mod retired_api_gate;
 mod runtime_stdlib;
+mod segmentation_drift;
 mod sslictcl_data;
 mod tcltest_sweep;
 mod tzdata_bundle;
@@ -319,6 +324,17 @@ enum Command {
         check: bool,
     },
 
+    /// Flag a private Tcl command-terminator scan or a private word-start
+    /// state machine outside the boundary owners, and verify the
+    /// owner/scanner corpus differential is wired (segmentation-drift gate).
+    #[command(name = "segmentation-drift")]
+    SegmentationDrift {
+        /// Accepted for symmetry with the other gates (the lint always
+        /// verifies; it never rewrites).
+        #[arg(long)]
+        check: bool,
+    },
+
     /// Flag any code use of the dialect/registry APIs retired in P1-G
     /// (`DialectProfile::by_name` and kin, the string-keyed registry
     /// doors, external `ProfileQueries`) — the zero-reference gate of the
@@ -455,6 +471,7 @@ fn main() -> anyhow::Result<ExitCode> {
         Command::DialectDrift { check } => Ok(dialect_drift::run(check)),
         Command::NumberDrift { check } => Ok(number_drift::run(check)),
         Command::ResolutionDrift { check } => Ok(resolution_drift::run(check)),
+        Command::SegmentationDrift { check } => Ok(segmentation_drift::run(check)),
         Command::RetiredApiGate { check } => Ok(retired_api_gate::run(check)),
         Command::RuntimeStdlib => runtime_stdlib::run(),
         Command::OwnerResolution => owner_resolution::run(),

--- a/rust/xtask/src/owner_resolution.rs
+++ b/rust/xtask/src/owner_resolution.rs
@@ -353,6 +353,7 @@ fn entry_is_declared(source: &str, entry: &str) -> bool {
 fn xtask_dispatches(main: &str, command: &str) -> bool {
     let variant = match command {
         "resolution-drift" => "ResolutionDrift",
+        "segmentation-drift" => "SegmentationDrift",
         "number-drift" => "NumberDrift",
         "audit-option-dialects" => "AuditOptionDialects",
         "command-backing" => "WasmBacking",

--- a/rust/xtask/src/segmentation_drift.rs
+++ b/rust/xtask/src/segmentation_drift.rs
@@ -1,0 +1,578 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! `segmentation-drift` — the command / word boundary drift gate.
+//!
+//! Issue #1786 counted the answers to "where does this command end and
+//! where does each word begin" and found **four** implementations of it:
+//! `tcl-compiler`'s CST builder, `runtime/rust`'s `parse_script`, the
+//! compiler segmenter, and `tcl_lexer::structural_index`'s byte-scanned
+//! `command_boundaries`. They disagreed measurably — on `{*}` welded to a
+//! close-brace, and on where a nested `[a [b {*}$c]]` ends. Each was
+//! written by someone who needed a boundary in a hurry and did not know a
+//! shared one existed.
+//!
+//! `docs/design/contracts/shared-utility-contracts-rust.md` now names two
+//! surfaces for this, and this gate is the drift check on both:
+//!
+//! * **command / word segmentation** — `tcl_lexer::script::group_commands`
+//!   over a dialect-configured token stream, with the compiler's
+//!   `segment_commands` / CST builder as its consumers. Every question
+//!   about where a *word* starts is this owner's.
+//! * **script completeness / reparse windows** —
+//!   `tcl_lexer::script_is_complete`, `command_boundaries` and
+//!   `reparse_window`: the `Tcl_CommandComplete` port and the byte-scanned
+//!   split points an incremental reparser snaps to, deliberately
+//!   dialect-blind and cross-checked against the owner over the corpora by
+//!   `tcl-lexer`'s `differential_boundaries`.
+//!
+//! # What it flags
+//!
+//! 1. **A private command-terminator scan** — a byte or `char` match
+//!    pattern that alternates `\n` with `;` (`b'\n' | b';'`, `'\n' | ';'`,
+//!    either order). Those two bytes together are Tcl's *command
+//!    terminator set*, and a loop that tests for them is splitting a script
+//!    into commands by hand. It is the exact shape of all four
+//!    implementations #1786 collapsed, and of the three private splitters
+//!    still live in `tcl-lsp-core` and the optimiser (each waived in place,
+//!    with what it re-derives named).
+//!
+//! 2. **A private word-start state machine** — the two-variant
+//!    `TokenType::Sep | TokenType::Eol` alternation tested against a
+//!    *previous-token* binding. "A content token after a `Sep` or an `Eol`
+//!    starts a new word" is `group_commands`' word rule verbatim; a
+//!    consumer carrying its own `prev_type` across a token loop has
+//!    reimplemented it. A `Sep`/`Eol` set that also lists `Eof` or
+//!    `Comment`, or one with no `prev` binding in sight, is trivia
+//!    *skipping* — legitimate, and not flagged.
+//!
+//! 3. **A missing cross-check** — the corpus differential that keeps the
+//!    dialect-blind scanner honest against the owner must exist and must
+//!    still declare its named tests. Following `number-drift`'s precedent,
+//!    this is structural wiring evidence, not a semantic proof: the Rust
+//!    tests execute the actual corpora.
+//!
+//! # Known blind spots
+//!
+//! A grouper that matches on token kinds *arm by arm* — `TokenType::Sep =>
+//! flush_word(…)`, `TokenType::Eol => push_command(…)` — is not flagged,
+//! because a `match tok.kind` with one arm per kind is also how every
+//! legitimate token consumer (a formatter, a highlighter, a minifier) is
+//! written. `runtime/rust/src/parse.rs` is the live example, and it is the
+//! consumer PR #1818 folds onto the owner; the gate scans `rust/` only, as
+//! `dialect-drift` does.
+//!
+//! Escapes: the owners themselves are exempt (see [`SANCTIONED_FILES`]);
+//! test modules, `tests/` trees, examples and benches are skipped; and a
+//! reviewed site carries `// segmentation-drift-ok: <reason>` on the
+//! flagged line or in the comment block directly above it.
+
+use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+
+/// The files allowed to derive a command or word boundary from raw bytes
+/// or from a `Sep`/`Eol` state machine: the tokeniser that defines the
+/// terminator grammar, the boundary owner, the two registered
+/// `tcl-lexer` scanners, and the compiler's segmentation owners — i.e.
+/// exactly the source paths the two owner-manifest rows name.
+const SANCTIONED_FILES: &[&str] = &[
+    // The tokeniser: `\n` / `;` *are* its grammar.
+    "rust/tcl-lexer/src/lexer.rs",
+    // The boundary owner (#1786).
+    "rust/tcl-lexer/src/script.rs",
+    // The registered `Tcl_CommandComplete` port + reparse split points.
+    "rust/tcl-lexer/src/structural_index.rs",
+    // The registered word-span / delimiter-close scanners the two above
+    // and the segmenter all call.
+    "rust/tcl-lexer/src/ranges.rs",
+    "rust/tcl-lexer/src/word_parts.rs",
+    // The compiler's half of the segmentation row.
+    "rust/tcl-compiler/src/segmenter.rs",
+    "rust/tcl-compiler/src/parsing/syntax/build.rs",
+    "rust/tcl-compiler/src/parsing/syntax/segment.rs",
+    // This gate names the banned spellings in its own source.
+    "rust/xtask/src/segmentation_drift.rs",
+];
+
+/// The corpus differential rule 3 requires, and the tests it must declare.
+const CROSS_CHECK_FILE: &str = "rust/tcl-lexer/tests/differential_boundaries.rs";
+const CROSS_CHECK_TESTS: &[&str] = &[
+    "fn scanner_agrees_with_owner_on_edge_cases",
+    "fn scanner_agrees_with_owner_over_corpora",
+    "fn scanner_agrees_with_owner_over_corpora_deep",
+    "fn dialect_divergences_are_pinned",
+];
+/// Both engines must actually appear in the cross-check — a differential
+/// that stopped calling one of them proves nothing.
+const CROSS_CHECK_ENGINES: &[&str] = &["command_boundaries(", "group_commands("];
+
+const WAIVER: &str = "segmentation-drift-ok:";
+
+/// The command-terminator set, in every spelling a match pattern uses.
+const TERMINATOR_NEEDLES: &[&str] = &[
+    "b'\\n' | b';'",
+    "b';' | b'\\n'",
+    "'\\n' | ';'",
+    "';' | '\\n'",
+];
+
+const TERMINATOR_WHY: &str = "scans for the Tcl command-terminator set (`\\n` / `;`) by hand — \
+     that is a private top-level command splitter (#1786). Take the \
+     boundaries from tcl_lexer::script::group_commands, or, for a reparse \
+     split point, from tcl_lexer::command_boundaries";
+
+/// The word-start rule, in both orders. `tcl_lexer::` prefixes are
+/// normalised away before matching.
+const WORD_START_NEEDLES: &[&str] = &[
+    "TokenType::Sep | TokenType::Eol",
+    "TokenType::Eol | TokenType::Sep",
+];
+
+const WORD_START_WHY: &str = "carries a previous-token kind across a token loop to decide where a word starts — \
+     that is group_commands' word rule reimplemented. Group once through \
+     tcl_lexer::script::group_commands (or the compiler's segment_commands) and read \
+     WordSpan";
+
+/// How many lines after (and before, for the `prev` binding) a needle may
+/// be split across by rustfmt.
+const LOOKAHEAD: usize = 8;
+const LOOKBEHIND: usize = 4;
+
+/// Scan the workspace; exit non-zero listing every offending site.
+/// `check` is accepted for CLI symmetry with the other gates — the lint
+/// never rewrites anything, so both modes verify.
+pub fn run(_check: bool) -> ExitCode {
+    let root = crate::util::repo_root();
+    let mut files = Vec::new();
+    collect_rs_files(&root.join("rust"), &mut files);
+    files.sort();
+
+    let mut report = String::new();
+    let mut hits = 0usize;
+    for path in files {
+        let rel = path
+            .strip_prefix(&root)
+            .unwrap_or(&path)
+            .to_string_lossy()
+            .replace('\\', "/");
+        if is_exempt_path(&rel) {
+            continue;
+        }
+        let Ok(text) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        for (line_no, snippet, why) in scan(&text) {
+            hits += 1;
+            let _ = writeln!(report, "  {rel}:{line_no}: {snippet}\n      -> {why}");
+        }
+    }
+
+    for problem in cross_check_problems(&root) {
+        hits += 1;
+        let _ = writeln!(report, "  {CROSS_CHECK_FILE}: {problem}");
+    }
+
+    if hits == 0 {
+        println!(
+            "segmentation-drift: OK (no private command-terminator scan or word-start state \
+             machine outside the boundary owners; the owner/scanner corpus differential is wired)"
+        );
+        return ExitCode::SUCCESS;
+    }
+    eprintln!(
+        "segmentation-drift: {hits} site(s) derive Tcl command or word boundaries outside the \
+         owner. Where a command ends and where a word begins is answered once, by \
+         tcl_lexer::script::group_commands over a dialect-configured token stream \
+         (shared-utility-contracts-rust.md, issue #1786); a reparse split point comes from \
+         tcl_lexer::command_boundaries. If a site genuinely is not segmenting Tcl script text, \
+         mark it `// {WAIVER} <reason>`:\n{report}"
+    );
+    ExitCode::FAILURE
+}
+
+/// Rule 3: the corpus differential exists and still names both engines and
+/// its tiers.
+fn cross_check_problems(root: &Path) -> Vec<String> {
+    let Ok(text) = std::fs::read_to_string(root.join(CROSS_CHECK_FILE)) else {
+        return vec![
+            "the owner/scanner boundary differential is missing — `command_boundaries` is \
+             registered as a separate, dialect-blind surface precisely because this \
+             cross-check pins it to the owner"
+                .to_owned(),
+        ];
+    };
+    let mut problems = Vec::new();
+    for needed in CROSS_CHECK_TESTS {
+        if !text.contains(needed) {
+            problems.push(format!("the cross-check no longer declares `{needed}`"));
+        }
+    }
+    for engine in CROSS_CHECK_ENGINES {
+        if !text.contains(engine) {
+            problems.push(format!(
+                "the cross-check no longer calls `{engine}` — it must drive both engines"
+            ));
+        }
+    }
+    problems
+}
+
+fn is_exempt_path(rel: &str) -> bool {
+    SANCTIONED_FILES.contains(&rel)
+        || rel.contains("/tests/")
+        || rel.ends_with("/tests.rs")
+        || rel.contains("/examples/")
+        || rel.contains("/benches/")
+}
+
+/// Every offending `(line_number, trimmed_line, why)` in `text`.
+fn scan(text: &str) -> Vec<(usize, &str, &'static str)> {
+    let lines: Vec<&str> = text.lines().collect();
+    let test_tail = test_module_start(&lines).unwrap_or(lines.len());
+    let mut out = Vec::new();
+    for (idx, line) in lines.iter().enumerate().take(test_tail) {
+        let trimmed = line.trim();
+        if trimmed.starts_with("//") {
+            continue;
+        }
+        let code = code_only(trimmed);
+        let Some(why) = rule_for(&lines, idx, test_tail, &code) else {
+            continue;
+        };
+        if !is_waived(&lines, idx) {
+            out.push((idx + 1, trimmed, why));
+        }
+    }
+    out
+}
+
+/// The rule this line breaks, if any.
+fn rule_for(lines: &[&str], idx: usize, limit: usize, code: &str) -> Option<&'static str> {
+    // Rule 1 is single-line by construction: a match pattern's alternation
+    // of two character literals is never wrapped.
+    if TERMINATOR_NEEDLES.iter().any(|n| code.contains(n)) {
+        return Some(TERMINATOR_WHY);
+    }
+    // Rule 2 needs a window: rustfmt splits a long `matches!` across lines,
+    // and the `prev` scrutinee sits *before* the alternation.
+    if !code.contains("Sep") {
+        return None;
+    }
+    let window = joined(
+        lines,
+        idx.saturating_sub(LOOKBEHIND),
+        (idx + LOOKAHEAD).min(limit),
+    );
+    WORD_START_NEEDLES
+        .iter()
+        .filter_map(|n| exact_alternation(&window, n))
+        .any(|at| scrutinee_is_previous_token(&window[..at]))
+        .then_some(WORD_START_WHY)
+}
+
+/// Where `needle` appears in `window` as a **complete** alternation — the
+/// two-variant word rule, not the prefix of a wider trivia set
+/// (`Sep | Eol | Eof | Comment`). Returns the match offset.
+fn exact_alternation(window: &str, needle: &str) -> Option<usize> {
+    let mut from = 0;
+    while let Some(pos) = window[from..].find(needle) {
+        let at = from + pos;
+        let before = window[..at].trim_end().chars().next_back();
+        let after = window[at + needle.len()..].trim_start().chars().next();
+        if before != Some('|') && after != Some('|') {
+            return Some(at);
+        }
+        from = at + needle.len();
+    }
+    None
+}
+
+/// Whether the innermost `matches!(` / `match ` opened before the
+/// alternation is applied to a *previous-token* binding — the tell of a
+/// state machine, as against a filter over the token in hand.
+fn scrutinee_is_previous_token(before: &str) -> bool {
+    let head = before
+        .rfind("matches!(")
+        .map(|at| at + "matches!(".len())
+        .or_else(|| before.rfind("match ").map(|at| at + "match ".len()));
+    let Some(head) = head else {
+        return false;
+    };
+    mentions_prev(&before[head..])
+}
+
+/// Whether `text` contains an identifier that starts a `prev` word
+/// (`prev`, `prev_type`, `prev_kind`, `previous_token`).
+fn mentions_prev(text: &str) -> bool {
+    let bytes = text.as_bytes();
+    let mut from = 0;
+    while let Some(pos) = text[from..].find("prev") {
+        let at = from + pos;
+        if at == 0 || !is_ident_byte(bytes[at - 1]) {
+            return true;
+        }
+        from = at + 4;
+    }
+    false
+}
+
+const fn is_ident_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || byte == b'_'
+}
+
+/// Lines `[from, to)` as one whitespace-collapsed code string, with
+/// `tcl_lexer::` path prefixes normalised away.
+fn joined(lines: &[&str], from: usize, to: usize) -> String {
+    let mut out = String::new();
+    for line in &lines[from..to.min(lines.len())] {
+        out.push_str(&code_only(line.trim()));
+        out.push(' ');
+    }
+    out.split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .replace("tcl_lexer::", "")
+}
+
+/// The line of the `#[cfg(test)]` that annotates a **module**, after which
+/// nothing is production code. (Verbatim from `dialect_drift`: a
+/// `#[cfg(test)]` on a single `use` near the top must not end the scan.)
+fn test_module_start(lines: &[&str]) -> Option<usize> {
+    lines.iter().enumerate().find_map(|(i, l)| {
+        if !l.trim_start().starts_with("#[cfg(test)]") {
+            return None;
+        }
+        let next = lines[i + 1..]
+            .iter()
+            .map(|l| l.trim_start())
+            .find(|l| !l.is_empty() && !l.starts_with("#["))?;
+        let item = next.strip_prefix("pub ").unwrap_or(next);
+        let item = item.strip_prefix("(crate) ").unwrap_or(item);
+        (item.starts_with("mod ")).then_some(i)
+    })
+}
+
+/// The code part of a line: everything before a `//` that is not inside a
+/// string literal, with the *contents* of string literals elided — a needle
+/// quoted in a message or a doc string is a mention, not a call.
+fn code_only(line: &str) -> String {
+    let mut out = String::with_capacity(line.len());
+    let mut in_str = false;
+    let bytes = line.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if in_str {
+            if b == b'\\' {
+                i += 2;
+                continue;
+            }
+            if b == b'"' {
+                in_str = false;
+                out.push('"');
+            }
+            i += 1;
+            continue;
+        }
+        match b {
+            b'\'' if bytes.get(i + 1) == Some(&b'"') && bytes.get(i + 2) == Some(&b'\'') => {
+                out.push_str("'\"'");
+                i += 3;
+                continue;
+            }
+            b'"' => {
+                in_str = true;
+                out.push('"');
+            }
+            b'/' if i + 1 < bytes.len() && bytes[i + 1] == b'/' => break,
+            _ => out.push(b as char),
+        }
+        i += 1;
+    }
+    out
+}
+
+/// A waiver is honoured on the flagged line itself, or anywhere in the run
+/// of `//` comment lines directly above it. It does not leak past
+/// intervening code.
+fn is_waived(lines: &[&str], idx: usize) -> bool {
+    if lines[idx].contains(WAIVER) {
+        return true;
+    }
+    let mut i = idx;
+    while i > 0 {
+        i -= 1;
+        let t = lines[i].trim_start();
+        if !t.starts_with("//") {
+            return false;
+        }
+        if t.contains(WAIVER) {
+            return true;
+        }
+    }
+    false
+}
+
+fn collect_rs_files(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            if path.file_name().is_some_and(|n| n == "target") {
+                continue;
+            }
+            collect_rs_files(&path, out);
+        } else if path.extension().is_some_and(|e| e == "rs") {
+            out.push(path);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_hand_rolled_terminator_scan_is_flagged() {
+        let src = "fn f(b: &[u8]) {\n    while i < n {\n        match b[i] {\n            \
+                   b'\\n' | b';' => out.push(i),\n            _ => i += 1,\n        }\n    }\n}\n";
+        let hits = scan(src);
+        assert_eq!(hits.len(), 1, "{hits:?}");
+        assert_eq!(hits[0].0, 4);
+        assert!(hits[0].2.contains("command-terminator"));
+    }
+
+    #[test]
+    fn both_orders_and_both_literal_kinds_are_flagged() {
+        for src in [
+            "match c { b';' | b'\\n' => {} }\n",
+            "match c { '\\n' | ';' => {} }\n",
+            "match c { ';' | '\\n' => {} }\n",
+            "if matches!(bytes[p], b' ' | b'\\t' | b'\\n' | b';') { p += 1; }\n",
+        ] {
+            assert_eq!(scan(src).len(), 1, "{src:?}");
+        }
+    }
+
+    #[test]
+    fn a_terminator_that_is_not_a_pair_is_not_flagged() {
+        // A newline alone, or a semicolon alone, is not the terminator set.
+        assert!(scan("match c { b'\\n' => {} }\n").is_empty());
+        assert!(scan("match c { b';' => {} }\n").is_empty());
+        // A `\n` and a `;` in different patterns is not an alternation.
+        assert!(scan("match c { b'\\n' => a(), b'x' | b';' => b() }\n").is_empty());
+    }
+
+    #[test]
+    fn a_private_word_start_state_machine_is_flagged() {
+        let src = "fn f(toks: &[Token]) {\n    let mut prev_type = TokenType::Eol;\n    \
+                   for t in toks {\n        let starts = matches!(prev_type, TokenType::Sep | \
+                   TokenType::Eol);\n    }\n}\n";
+        let hits = scan(src);
+        assert_eq!(hits.len(), 1, "{hits:?}");
+        assert_eq!(hits[0].0, 4);
+        assert!(hits[0].2.contains("previous-token"));
+    }
+
+    #[test]
+    fn the_wrapped_and_path_qualified_form_is_still_flagged() {
+        let src = "fn f() {\n    let start = matches!(\n        prev_kind,\n        \
+                   tcl_lexer::TokenType::Sep\n            | tcl_lexer::TokenType::Eol,\n    );\n}\n";
+        let hits = scan(src);
+        assert_eq!(hits.len(), 1, "{hits:?}");
+        assert_eq!(hits[0].0, 4, "flagged where the alternation starts");
+    }
+
+    #[test]
+    fn trivia_skipping_is_not_a_word_start_machine() {
+        // No `prev` binding: a filter, not a state machine.
+        assert!(
+            scan(
+                "let words = toks.iter().filter(|t| !matches!(t.kind, TokenType::Sep | \
+                  TokenType::Eol));\n"
+            )
+            .is_empty()
+        );
+        // A wider trivia set is not the two-variant word rule either.
+        assert!(
+            scan(
+                "fn f() {\n let prev = x;\n if matches!(t.kind, TokenType::Sep | \
+                  TokenType::Eol | TokenType::Eof) {}\n}\n"
+            )
+            .is_empty()
+        );
+    }
+
+    #[test]
+    fn a_waiver_is_honoured_on_the_line_and_in_the_block_above() {
+        assert!(
+            scan(
+                "match c { b'\\n' | b';' => {} } // segmentation-drift-ok: BIG-IP config, not Tcl\n"
+            )
+            .is_empty()
+        );
+        let src = "// segmentation-drift-ok: trims a terminator inside an already\n\
+                   // segmented command span; the boundary came from the segmenter\n\
+                   let a = matches!(b[i], b'\\n' | b';');\n\
+                   let z = 1;\n\
+                   let c = matches!(b[i], b'\\n' | b';');\n";
+        let hits = scan(src);
+        assert_eq!(hits.len(), 1, "{hits:?}");
+        assert_eq!(
+            hits[0].0, 5,
+            "the waiver does not leak past intervening code"
+        );
+    }
+
+    #[test]
+    fn a_mention_in_a_comment_or_string_is_not_a_hit() {
+        assert!(scan("// the old shape was b'\\n' | b';'\n").is_empty());
+        assert!(scan("let m = \"b'\\\\n' | b';'\";\n").is_empty());
+    }
+
+    #[test]
+    fn the_test_tail_is_exempt() {
+        let src = "fn f() {}\n#[cfg(test)]\nmod tests {\n    fn g(c: u8) { \
+                   let _ = matches!(c, b'\\n' | b';'); }\n}\n";
+        assert!(scan(src).is_empty());
+    }
+
+    #[test]
+    fn owner_and_test_paths_are_exempt() {
+        assert!(is_exempt_path("rust/tcl-lexer/src/script.rs"));
+        assert!(is_exempt_path("rust/tcl-lexer/src/structural_index.rs"));
+        assert!(is_exempt_path("rust/tcl-compiler/src/segmenter.rs"));
+        assert!(is_exempt_path("rust/tcl-lexer/tests/lexer_depth.rs"));
+        assert!(!is_exempt_path("rust/tcl-lsp-core/src/expr_context.rs"));
+        assert!(!is_exempt_path("rust/tcl-compiler/src/lowering/mod.rs"));
+    }
+
+    #[test]
+    fn the_cross_check_is_required_to_exist_and_name_both_engines() {
+        let root = crate::util::repo_root();
+        assert!(
+            cross_check_problems(&root).is_empty(),
+            "{:?}",
+            cross_check_problems(&root)
+        );
+        assert_eq!(cross_check_problems(Path::new("/nonexistent")).len(), 1);
+    }
+}


### PR DESCRIPTION
Closes out #1786's last two items — what to do about the fourth boundary implementation, and the segmentation row's `none` drift gate. Follows #1810, #1815, #1816 and #1818.

**The new cross-check found two live defects in real Tcl 9.0.4 and tcllib code. That is the headline, not the bookkeeping.**

## `command_boundaries` is registered, not folded

The evidence said fold was wrong:

- **It is not a fourth grouper.** It is the split-point sibling of `script_is_complete`, sharing `scan_complete` / `scan_complete_quoted` / `skip_comment`. `script_is_complete` is the `Tcl_CommandComplete` port called on raw text by the LSP server, codegen, the analyser, the VM REPL and SslicTcl; it is dialect-blind and cannot become a grouper, so folding only the boundary half breaks the invariant tying them together.
- **Different contract, measured.** `command_boundaries("a\n\n\nb\n")` is `[2,3,4,6]` — terminator offsets, blank lines included — against the owner's two command spans ending `[1,5]`. `reparse_window`'s minimality rests on those blank-line cuts.
- **Different cost and totality.** One allocation-free byte pass against a whole-document `Vec<Token>` per keystroke; and it must be *total*, since its fuzz properties feed it random bytes, while `tokenise_all` returns a `Result`.

Its dialect-blindness is real, so it is now **pinned** rather than assumed away:

| source | owner | scanner |
|---|---|---|
| `if {$x}\n{\n puts a\n}\nputs done\n` | 3 commands `default`, **2** `f5-irules` | one answer — cuts an F5 command in half |
| `set v ${a{b}\nputs hi\n` | 1 command `default`, **2** `tcl8.4` | one answer — merges two |

`structural_index.rs` had **no manifest row at all**, despite owning `script_is_complete`, `reparse_window` and the bracket/brace indices. It has one now, so `owner-resolution` reports 32 rows.

## The two defects

The 7-case non-straddling invariant this replaces could not express **coverage** — a `command_boundaries` returning only `source.len()` passed it. The new `differential_boundaries` compares the scanner against `script::group_commands` over the corpora, three dialects, three nesting levels, asserting containment, coverage and termination.

Both defects are the same shape: a nested `[…]` whose interior C rejects (`{a}$b`) makes `scan_complete` report `Terminal` with its offset collapsed to end-of-input, so the scanner lost **every later boundary in the document**.

- `[lsort [glob -- {*}$args]]` — Tcl 9.0.4's `auto.tcl` (CI tier)
- the same shape behind a quoted word — tcllib's `page/util_quote.tcl` (exhaustive tier)

The `[` skip now takes the lenient, comment-aware `ranges::command_substitution_end`. The quote skip falls back to `ranges::close_quote_offset` **on `Terminal` only** — swapping that arm wholesale broke the `command_boundaries_are_complete_prefixes` fuzz property, because the close-quote owner does not know the release's `${…}` nesting rule.

`script_is_complete` is untouched: it is an oracle and should keep reporting the error. Boundary scanning is lenient by contract. Each arm now says which it takes and why.

Coverage is asserted only where the region is a complete script — the scanner's documented precondition. Incomplete regions are tallied and printed, never silently dropped (0 of them on the CI tier).

## `xtask-segmentation-drift`

`make xtask-segmentation-drift` → `cargo xtask segmentation-drift`, wired into `xtask-check` and registered as the drift gate on **both** rows. It bans:

1. a private command-terminator scan (`b'\n' | b';'`, either order);
2. a private word-start state machine — the exact `TokenType::Sep | TokenType::Eol` alternation over a `prev`-named scrutinee (a wider trivia set is filtering, not grouping, and is not flagged);
3. the corpus differential going missing or stopping driving both engines.

Waiver: `// segmentation-drift-ok: <reason>`.

**It carries 7 pre-existing waivers, recorded rather than hidden.** Six are genuine #1786 debt — private word groupers and command splitters in `value_shapes.rs`, `expr_context.rs` (×2), `formatting/engine.rs` (×2) and `minify.rs`. The seventh, in `optimiser/helpers/spans.rs`, is **not** debt: both ends there already come from the segmenter, and the scan only decides whether a delete may swallow the terminator between them.

Two blind spots are documented in the gate's own module header: an arm-by-arm `match tok.kind` grouper is indistinguishable from any legitimate token consumer and is not flagged; and, inheriting `dialect_drift`'s scan model, code after a file's `#[cfg(test)] mod tests` is not scanned.

## Validation

```
cargo xtask owner-resolution      # OK, 32 rows
cargo xtask segmentation-drift    # OK
cargo xtask dialect-drift         # OK
cargo test -p tcl-lexer           # 464 + integration, 0 failed
cargo test -p tcl-compiler --test differential_group --test differential_segment --test command_segmenter
cargo test -p tcl-explorer        # 89 ok
cargo test -p xtask               # 199 ok (11 segmentation_drift)
cargo fmt --all -- --check
cargo clippy -p tcl-lexer -p tcl-compiler -p xtask --all-targets -- -D warnings
```

The CI tier of `differential_boundaries` walks 21,555 regions / 39,881 commands in under a second (it is a byte scanner, not a tokeniser); tcllib is behind `#[ignore]` per the tier contract, matching #1816's precedent.

**Anti-vacuity, both verified by planting and removing:**

- Reverting the `[` fix fails the CI tier on `auto.tcl` with `no split point in [895, 900] — the scanner merges two commands the owner separates`, cascading through every later boundary in that region.
- A planted `matches!(*b, b'\n' | b';')` in `tcl-lsp-core/src/code_lens.rs` is caught with the file, line and a specific remedy. (Planting it *after* the file's `#[cfg(test)]` module is **not** caught — that is the documented blind spot above, and I hit it on the first attempt.)

- [x] I ran relevant tests/checks locally and listed the exact commands.

## Compiler / diagnostics checklist

- [x] **Did this change alter a compiler fact contract?** Yes — `command_boundaries` no longer loses boundaries after a rejected nested `[…]`, and the reparse scanner is now a registered owner.
- [x] **Owning design doc updated.** New `script completeness / reparse windows` row plus prose recording the fold-vs-register decision and its evidence; both segmentation rows now name a real gate.
- [x] No diagnostic or optimisation code changed.
- [x] No new design doc.

## What is left

#1786 is done after this. #1787 — one shared per-command parse-then-evaluate driver — is next, and #1818 scoped it precisely: C parses every word of a command before substituting any, so `list [side] {a}b` should raise without running `side`, and closing that is the pre-scan in `eval_words`. Then #1784 closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013wqsJY5pcg8Uyk1H4e7V8y

---
_Generated by [Claude Code](https://claude.ai/code/session_013wqsJY5pcg8Uyk1H4e7V8y)_