### PR TITLE
fix(runtime): parse a command's words before any of them substitute (#1787)

### DIFF
--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -5945,6 +5945,19 @@ impl Interp {
 
     /// Substitute each word of a command (with `{*}` expansion), then dispatch.
     fn eval_words(&mut self, src: &[u8], words: &[parse::Word]) -> Code {
+        // C parses a command WHOLE before it substitutes any of it
+        // (`Tcl_EvalEx` → `Tcl_ParseCommand` → `TclEvalObjvInternal`), so a
+        // parse failure in a later word — or inside a later word's `[…]` —
+        // stops an earlier word's command substitution from ever running.
+        // Measured on 8.6.16 and 9.0.4: `list [sfx inner] {a}b` raises `extra
+        // characters after close-brace` with `sfx` never called. Walking the
+        // words in order and raising at the first `WordPart::ParseError` (this
+        // engine's carrier for those failures — the scanner stays infallible so
+        // the LSP can keep tokenizing) substituted word by word instead, which
+        // ran `sfx`. Issue #1787; the gap #1818's header recorded as pending.
+        if let Some(msg) = parse::first_parse_error(words, self.lexer_config()) {
+            return self.error(msg.as_bytes());
+        }
         // The command's reported line + source file (for TIP 280 argument-line
         // tracking and the LABC literal-location table), and the first word's
         // offset (to measure each word's line within the command).

--- a/runtime/rust/src/parse.rs
+++ b/runtime/rust/src/parse.rs
@@ -249,6 +249,165 @@ pub fn parse_script_with_config(src: &[u8], config: tcl_lexer::LexerConfig) -> V
         .collect()
 }
 
+// ---------------------------------------------------------------------------
+// C's script-parsing order: a command parses whole, THEN evaluates.
+// ---------------------------------------------------------------------------
+
+/// How deep a command's `[…]` nesting is pre-scanned before the scan gives up
+/// and lets the error surface the old way (during substitution).
+///
+/// Each `[…]` level of a command is one `eval_command_subst` — i.e. one
+/// `Interp::eval_depth` step — when the command actually runs, so a script
+/// nested deeper than the interpreter's own `NATIVE_EVAL_DEPTH_LIMIT` could
+/// never have evaluated anyway. Capping at the same budget keeps the scan's
+/// native recursion bounded by a constant instead of by the input.
+const MAX_PARSE_ERROR_SCAN_DEPTH: u32 = 128;
+
+/// The first parse error anywhere in `words`, in source order — `None` if the
+/// whole command parses.
+///
+/// C's `Tcl_EvalEx` calls `Tcl_ParseCommand` for **one whole command** and only
+/// then substitutes and dispatches its words, so a parse failure in *any* word
+/// is the command's failure and nothing the command would have substituted
+/// runs. Measured on tclsh 8.6.16 and 9.0.4, both identical:
+///
+/// ```text
+/// proc sfx {t} { lappend ::ran $t; return S$t }
+/// list [sfx inner] {a}b            -> extra characters after close-brace, ::ran empty
+/// list [sfx inner] "unterminated   -> missing "                          , ::ran empty
+/// list [sfx inner] [sfx two        -> missing close-bracket              , ::ran empty
+/// puts "[sfx inner]pre${abc"       -> missing close-brace for variable name, ::ran empty
+/// ```
+///
+/// The scan descends into `[…]` bodies and `$arr(index)` components because
+/// C's parse does: `Tcl_ParseCommand`'s `ParseTokens` recurses into a bracket,
+/// parsing the substituted script's own commands, so an error *inside* a later
+/// bracket also stops an earlier bracket from running —
+/// `list [sfx inner] [list "oops]` raises `missing "` with `::ran` empty on
+/// both shells. A `{braced}` word is a [`WordBody::Literal`] and holds no
+/// components, so it is not descended into — matching C, which does not parse
+/// a braced word's contents as a script either.
+///
+/// Note the deliberate non-consumer: `subst` does **not** get this treatment.
+/// It is not a command parse — C substitutes its template left to right and
+/// keeps the side effects of every `[…]` that ran before the failure
+/// (`subst {[side][b}` prints `side`'s output, then raises), which is exactly
+/// what walking [`WordPart`]s in order already does.
+#[must_use]
+pub fn first_parse_error(words: &[Word<'_>], config: LexerConfig) -> Option<&'static str> {
+    SCAN_MEMO.with(|memo| {
+        let memo = &mut *memo.borrow_mut();
+        memo.truncated = false;
+        words_parse_error(words, config, 0, memo)
+    })
+}
+
+/// The `[…]` recursion's memo, and how big it is allowed to get before it is
+/// dropped wholesale.
+///
+/// The scan's answer is a pure function of (script bytes, [`LexerConfig`]), so
+/// memoizing it is sound — and it has to be memoized, because this crate has no
+/// parse cache by design (the borrow-based tree makes one a lifetime hazard,
+/// memory-management.md MM-B.6). Without it, every execution of a command
+/// re-parses each of its `[…]` bodies once for the scan on top of the parse the
+/// substitution itself does, which on a bracket-dense loop measured ~40% slower.
+///
+/// The memo owns its keys and stores a `&'static str`, so nothing here can
+/// dangle; it is per-thread rather than per-[`crate::interp::Interp`] precisely
+/// because the function is pure — two interpreters on one thread asking the same
+/// question deserve the same answer. The cap bounds the memory an adversarial
+/// script (a fresh `[…]` body per iteration) can pin.
+const SCAN_MEMO_CAP: usize = 4096;
+
+thread_local! {
+    static SCAN_MEMO: std::cell::RefCell<ScanMemo> = std::cell::RefCell::new(ScanMemo::default());
+}
+
+#[derive(Default)]
+struct ScanMemo {
+    /// The config every entry was computed under; a different one clears it
+    /// (a version-pinned interpreter changes the grammar, issue #1462).
+    config: Option<LexerConfig>,
+    entries: std::collections::HashMap<Vec<u8>, Option<&'static str>>,
+    /// Set while a subtree's scan was cut short by
+    /// [`MAX_PARSE_ERROR_SCAN_DEPTH`]. A truncated answer is only valid at the
+    /// depth it was computed at, so it must not be memoized — the same script
+    /// reached at a shallower depth would scan further and could find an error
+    /// this run did not.
+    truncated: bool,
+}
+
+impl ScanMemo {
+    fn get(&mut self, script: &[u8], config: LexerConfig) -> Option<Option<&'static str>> {
+        if self.config != Some(config) {
+            self.config = Some(config);
+            self.entries.clear();
+            return None;
+        }
+        self.entries.get(script).copied()
+    }
+
+    fn put(&mut self, script: &[u8], answer: Option<&'static str>) {
+        if self.entries.len() >= SCAN_MEMO_CAP {
+            self.entries.clear();
+        }
+        self.entries.insert(script.to_vec(), answer);
+    }
+}
+
+fn words_parse_error(
+    words: &[Word<'_>],
+    config: LexerConfig,
+    depth: u32,
+    memo: &mut ScanMemo,
+) -> Option<&'static str> {
+    words.iter().find_map(|w| match &w.body {
+        WordBody::Literal(_) => None,
+        WordBody::Parts(parts) => parts_parse_error(parts, config, depth, memo),
+    })
+}
+
+fn parts_parse_error(
+    parts: &[WordPart<'_>],
+    config: LexerConfig,
+    depth: u32,
+    memo: &mut ScanMemo,
+) -> Option<&'static str> {
+    if depth >= MAX_PARSE_ERROR_SCAN_DEPTH {
+        memo.truncated = true;
+        return None;
+    }
+    parts.iter().find_map(|part| match part {
+        WordPart::ParseError(msg) => Some(*msg),
+        WordPart::Text(_) => None,
+        WordPart::Variable(v) => v
+            .index
+            .as_deref()
+            .and_then(|idx| parts_parse_error(idx, config, depth + 1, memo)),
+        WordPart::Command(script) => script_parse_error(script, config, depth + 1, memo),
+    })
+}
+
+fn script_parse_error(
+    script: &[u8],
+    config: LexerConfig,
+    depth: u32,
+    memo: &mut ScanMemo,
+) -> Option<&'static str> {
+    if let Some(hit) = memo.get(script, config) {
+        return hit;
+    }
+    let enclosing_truncated = std::mem::replace(&mut memo.truncated, false);
+    let answer = parse_script_with_config(script, config)
+        .iter()
+        .find_map(|cmd| words_parse_error(&cmd.words, config, depth, memo));
+    if !memo.truncated {
+        memo.put(script, answer);
+    }
+    memo.truncated |= enclosing_truncated;
+    answer
+}
+
 /// C's parse errors for the word delimiters this module owns — spelled by
 /// the shared owner, not re-typed here.
 ///

--- a/runtime/rust/tests/parser_gaps.rs
+++ b/runtime/rust/tests/parser_gaps.rs
@@ -330,14 +330,10 @@ fn regsub_writes_its_target_variable_as_an_array_element() {
 // already run, since `Tcl_EvalEx` parses one command at a time — pinned below
 // by `sfx pre`.
 //
-// One ordering nuance is deliberately NOT pinned, because this engine does not
-// yet match it: C parses every word of a command before substituting any, so
-// `list [side] {a}b` — side effect in an *earlier* word than the welded one —
-// never runs `side`, while this engine substitutes word by word and does. That
-// gap predates #1786 and is shared by every `WordPart::ParseError` (`list
-// [side] "unterminated` behaves the same way); closing it means pre-scanning a
-// command's words in `Interp::eval_words`, which is the `word_parts` module
-// doc's "C's script-parsing order" consumer note, not this lane's change.
+// The ordering nuance this header once recorded as pending — C parses every
+// word of a command before substituting any, so `list [side] {a}b` never runs
+// `side` — is closed by #1787 and pinned below by
+// `a_command_parses_whole_before_any_of_its_words_substitute`.
 //
 // Not welded, and still accepted (measured the same on 8.6.16 / 9.0.4):
 // `a{b}c`, `x{a}y`, `$a{b}c`, `[b]{c}d` — a `{` away from word start is an
@@ -413,4 +409,94 @@ fn a_brace_away_from_word_start_or_after_a_separator_is_not_a_weld() {
         assert_eq!(code, Code::Ok, "{sheet}: {result}");
         assert_eq!(result, want, "{sheet}");
     }
+}
+
+// ---------------------------------------------------------------------------
+// #1787 — C's script-parsing ORDER. `Tcl_EvalEx` parses one whole command
+// (`Tcl_ParseCommand`, every word of it) and only then substitutes and
+// dispatches, so a parse failure anywhere in a command is the *command's*
+// failure: nothing that command would have substituted runs, however early in
+// the command it sits. And `Tcl_ParseCommand`'s `ParseTokens` recurses into a
+// `[…]`, parsing the substituted script's own commands, so an error nested
+// inside a later bracket also stops an earlier bracket — and stops the earlier
+// commands *inside* the failing bracket too.
+//
+// Property (1) of the same issue — earlier commands of the script have already
+// run — this engine has had since it was written (`parse.rs`'s `next`-offset
+// `Command` and the per-command loop in `interp.rs`); every row below pins it
+// as well, through the `sfx pre` that always shows up in `ran`.
+//
+// Oracle: `PARSE_ORDER_SHEET` below, saved to a file and run as
+// `tclsh sheet.tcl` (FROM A FILE — a stdin-fed tclsh swallows the error text)
+// on tclsh 8.6.16 and tclsh 9.0.4. Both shells produced `PARSE_ORDER_ORACLE`
+// byte for byte; paste the sheet into either shell to re-derive it without this
+// harness. The sheet builds its `${abc` rows with `format` because a sheet that
+// spelled `${` inside a braced `catch`/`probe` word would itself be an
+// unbalanced brace group.
+// ---------------------------------------------------------------------------
+
+/// The oracle sheet, verbatim. `$ob` is a literal `{`.
+const PARSE_ORDER_SHEET: &str = r#"set ob "\173"
+set ::out {}
+proc sfx {t} { lappend ::ran $t; return S$t }
+proc probe {name script} {
+    set ::ran {}
+    set verb [expr {[catch {uplevel 1 $script} e] ? "error" : "ok"}]
+    lappend ::out "$name -> $verb {$e} ran {$::ran}"
+}
+probe welded        {sfx pre; list [sfx inner] {a}b}
+probe quote         {sfx pre; list [sfx inner] "unterminated}
+probe bracket       {sfx pre; list [sfx inner] [sfx two}
+probe braced-var    [format {sfx pre; list [sfx inner]pre$%sabc} $ob]
+probe nested-quote  {sfx pre; list [sfx inner] [list "oops]}
+probe nested-var    [format {sfx pre; list [sfx inner] [set y "a$%sbcd"]} $ob]
+probe nested-weld   {sfx pre; list [sfx inner] [set y {a}b]}
+probe two-cmd-brkt  [format {sfx pre; list [sfx one; set y "a$%sbcd"]} $ob]
+probe var-first     [format {sfx pre; list $nosuchvar [set y "a$%sbcd"]} $ob]
+probe runtime-err   {sfx pre; list [sfx inner] [set y $nosuchvar]}
+probe all-well      {sfx pre; list [sfx inner] [list ok]}
+join $::out \n"#;
+
+/// tclsh 8.6.16 and tclsh 9.0.4, identical.
+const PARSE_ORDER_ORACLE: &str = r#"welded -> error {extra characters after close-brace} ran {pre}
+quote -> error {missing "} ran {pre}
+bracket -> error {missing close-bracket} ran {pre}
+braced-var -> error {missing close-brace for variable name} ran {pre}
+nested-quote -> error {missing "} ran {pre}
+nested-var -> error {missing close-brace for variable name} ran {pre}
+nested-weld -> error {extra characters after close-brace} ran {pre}
+two-cmd-brkt -> error {missing close-brace for variable name} ran {pre}
+var-first -> error {missing close-brace for variable name} ran {pre}
+runtime-err -> error {can't read "nosuchvar": no such variable} ran {pre inner}
+all-well -> ok {Sinner ok} ran {pre inner}"#;
+
+/// Every row of the sheet, against the recorded shells.
+///
+/// The two rows that are *not* parse failures are the guard against
+/// over-rejecting: `runtime-err` (a well-formed later bracket that fails at run
+/// time) and `all-well` both still run the earlier `[sfx inner]`, so the
+/// pre-scan may not turn a runtime error — or a healthy command — into a
+/// parse-time abort.
+#[test]
+fn a_command_parses_whole_before_any_of_its_words_substitute() {
+    let (code, result, _) = run(PARSE_ORDER_SHEET);
+    assert_eq!(code, Code::Ok, "{result}");
+    assert_eq!(result, PARSE_ORDER_ORACLE);
+}
+
+/// `subst` is the deliberate non-consumer: it is not a command parse, so C
+/// substitutes its template left to right and keeps the side effects of every
+/// `[…]` that ran before the failure. Pinned separately above by
+/// `subst_reports_the_missing_bracket_after_running_the_earlier_one`; repeated
+/// here next to its opposite so the pair cannot drift apart.
+///
+/// Oracle (8.6.16 / 9.0.4): `1 {missing close-bracket}` — `side` ran.
+#[test]
+fn subst_is_not_a_command_parse_and_still_runs_the_earlier_bracket() {
+    let (code, result, _) = run("set ::ran 0\n\
+         proc side {} {set ::ran 1; return S}\n\
+         catch {subst {[side][b}} e\n\
+         list $::ran $e");
+    assert_eq!(code, Code::Ok);
+    assert_eq!(result, "1 {missing close-bracket}");
 }

--- a/runtime/rust/tests/parser_gaps.rs
+++ b/runtime/rust/tests/parser_gaps.rs
@@ -441,7 +441,12 @@ set ::out {}
 proc sfx {t} { lappend ::ran $t; return S$t }
 proc probe {name script} {
     set ::ran {}
-    set verb [expr {[catch {uplevel 1 $script} e] ? "error" : "ok"}]
+    # `lindex` rather than `expr`/`if`: without libtommath there is no
+    # bignum tower, so neither command is registered, and this sheet has
+    # nothing to do with arithmetic. `catch` answers 0 or 1 here, and any
+    # other completion code would surface as an empty verb rather than
+    # being silently folded into "error".
+    set verb [lindex {ok error} [catch {uplevel 1 $script} e]]
     lappend ::out "$name -> $verb {$e} ran {$::ran}"
 }
 probe welded        {sfx pre; list [sfx inner] {a}b}


### PR DESCRIPTION
The `runtime/rust` half of #1787, and a recommendation to reshape the rest of the issue — see **On the issue's shape** below, which is the part I would most like your view on.

## What this fixes

C parses every word of a command before evaluating any, so a side effect in one word does not run when a later word fails to parse. Measured from files (a stdin-fed tclsh swallows the error text) on tclsh 8.6.16 and 9.0.4, which agree:

```tcl
proc side {} { puts SIDE-RAN; return s }
puts "[side]pre${abc"
# -> missing close-brace for variable name, and SIDE-RAN is never printed
```

`runtime/rust` substituted word by word, so it ran `side` and *then* raised. #1818 recorded the gap in its test header; this closes it. `Interp::eval_words` now scans the whole command through `parse::first_parse_error` before any substitution.

**The scan recurses into `[…]` bodies and `$arr(index)` components**, which is not obvious and is load-bearing — C's `ParseTokens` parses a bracket's own commands during the outer command's parse. Measured:

| script | why it matters |
|---|---|
| `list [sfx inner] [list "oops]` | error is nested a level deeper in a *later* word, and still stops the earlier bracket |
| `list [sfx one; set y "a${bcd"]` | an *earlier command inside* the failing bracket does not run either |
| `list $nosuchvar [set y "a${bcd"]` | the parse error wins over `can't read "nosuchvar"` — parsing precedes evaluation |

A `{braced}` word is a `Literal` and is not descended into, matching C.

**Cost.** The naive recursion was +40% on a bracket-dense loop, because this crate deliberately keeps no parse cache (memory-management.md MM-B.6) and every bracket body was then parsed twice. A thread-local memo keyed by (body bytes, `LexerConfig`) — sound, the answer being a pure function of those — brings it to **+4–6%**. Capped at 4096 entries, cleared on config change, and a result truncated by the 128-deep recursion guard is deliberately not memoized.

## On the issue's shape — a recommendation, not a decision

#1787 asks for "one shared parse-then-evaluate driver below both engines". Having built the runtime half, I think that shape does not fit, and I would rather say so than quietly deliver something else:

- **`runtime/rust` already *is* that loop.** It has property (1) — earlier commands run before a later parse error — today.
- **`tcl-vm` structurally cannot be.** It has no command granularity at run time, only a CFG from a `CompileService`. Driving it command-at-a-time through `PushScript` means one compile round trip per top-level command, discarding cross-command optimisation and the reason the bytecode engine exists.
- **And property (1) in `runtime/rust` does not come from the loop.** It comes from the parse being *infallible* — errors deferred as `WordPart::ParseError` rather than aborting. A shared driver whose parse step returned `Result` would reintroduce #1603 in the engine that does not have it.

What is genuinely shareable is **the cut policy**: "which command first fails to parse, at what offset, with which message", computed once from `script::group_commands` plus the `word_parts` primitives. `runtime/rust` consumes it per command; `tcl-compiler` replaces `first_fatal_parse_error`'s lexer-warning scan with it and gains a **command index** — which is the cut the VM actually needs, so it can lower and compile the clean prefix and then emit an unconditional raise. That is a compiler change, and it leaves `PushScript` and whole-unit proc-body compilation alone, which #1787 wanted preserved anyway.

**Suggested reshape:** retitle #1787 to *one shared parse-error **cut** owner, applied twice*, and split the VM half (prefix compilation, which closes #1603) from the runtime half (this PR). They share the owner and nothing else. Happy to be overruled — say the word and I will build the driver as written.

### A correction worth recording

I had believed `first_fatal_parse_error` was confined to tcl-vm's examples and tests. **That is wrong** — my grep was scoped to `rust/tcl-vm/`. It is called from three production `CompileService` implementations: `tcl-engine-tclvm/src/lib.rs`, `tcl-vm-cli/src/main.rs` (the shipped `tclvm` binary) and `tcl-irule-test/src/live.rs`. So #1603 reproduces in a shipped binary — `puts A` followed by `puts "x${abc"` prints nothing — and the pre-check is load-bearing rather than incidental: without it the VM would execute a mis-parsed script, because `lower_to_ir` is the LSP-lenient lowering.

Two further VM divergences noticed in passing and **not** addressed here: `list [sfx inner] [list "oops]` reports `missing close-bracket` where C says `missing "`; and `set y {a}b` inside a bracket is not rejected at all, because the compiler side does not consume `welded_after_close` the way #1818 made `runtime/rust` do.

## Validation

```
make runtime-rust-test    # 595 + 22 + 28 + 10 + 3 + 2 + 22, 0 failed
make runtime-rust-lint    # fmt --check + clippy --locked --all-targets -D warnings
```

`runtime/rust` is a separate cargo workspace, so `cargo test --workspace` does not cover it. `git status` is three files, all inside that workspace, so the root-workspace suites are unaffected.

**No existing expectation changed.** Two tests added (`#[test]` in `parser_gaps.rs`: 26 → 28). The 11-row transcript is byte-identical to both shells and includes two negative rows — a well-formed later bracket failing at *run* time, and an all-well script — so an over-rejecting scan fails it too.

**Break proofs**, both run and restored:

- Neutralising the pre-scan regresses **9 of 11** rows (`ran {pre inner}` where C runs only `pre`) and correctly leaves the two negative rows alone.
- Dropping only the `[…]` recursion regresses **exactly the four nested rows** — proof the recursion is load-bearing, not gold-plating.

- [x] I ran relevant tests/checks locally and listed the exact commands.

## Compiler / diagnostics checklist

- [x] **Did this change alter a compiler fact contract?** No — `runtime/rust` only; the shared owners are unchanged.
- [x] No owning design doc needed updating; no owner row changes.
- [x] No diagnostic or optimisation code changed.
- [x] No new design doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013wqsJY5pcg8Uyk1H4e7V8y

---
_Generated by [Claude Code](https://claude.ai/code/session_013wqsJY5pcg8Uyk1H4e7V8y)_