### PR TITLE
perf(build): stop rebuilding xtask in linked worktrees

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4521,7 +4521,6 @@ dependencies = [
  "tcl-sandbox",
  "tcl-syntax",
  "tcl-userdirs",
- "tcl-version",
  "toml",
  "ureq",
  "zip",

--- a/rust/tcl-cli/src/commands/docker.rs
+++ b/rust/tcl-cli/src/commands/docker.rs
@@ -84,7 +84,9 @@ fn run_create(action: &DockerCommand) -> anyhow::Result<u8> {
         install_packages: !*no_packages,
         create_venv: *venv,
         entrypoint: entrypoint.clone(),
-        cli_version: cli_version.clone(),
+        cli_version: cli_version
+            .clone()
+            .or_else(|| default_cli_version(tcl_version::VERSION)),
         extra_packages: extra_package.clone(),
         ..Default::default()
     };
@@ -160,9 +162,15 @@ fn run_recipe(
 ) -> anyhow::Result<u8> {
     // `--cli` prints what installs the tcl CLI itself (prerequisites plus the
     // verified release-asset fetch); the default prints what installs Tcl.
+    let defaulted_cli_version = cli_version
+        .map(str::to_owned)
+        .or_else(|| default_cli_version(tcl_version::VERSION));
     let recipe = if cli {
         match cli_prereq_recipe(image) {
-            Ok(prereq) => format!("{prereq}\n\n{}", tcl_cli_install_recipe(cli_version)),
+            Ok(prereq) => format!(
+                "{prereq}\n\n{}",
+                tcl_cli_install_recipe(defaulted_cli_version.as_deref())
+            ),
             Err(e) => {
                 eprintln!("error: {e}");
                 return Ok(1);
@@ -195,7 +203,7 @@ fn run_recipe(
 
 fn run_info(json: bool) -> anyhow::Result<u8> {
     let recipes = available_recipes();
-    let cli_version = default_cli_version();
+    let cli_version = default_cli_version(tcl_version::VERSION);
     let triples: Vec<&str> = RELEASE_TRIPLES.iter().map(|(_, _, t)| *t).collect();
     let cli_families = cli_capable_families();
     if json {

--- a/rust/tcl-pkg/Cargo.toml
+++ b/rust/tcl-pkg/Cargo.toml
@@ -32,7 +32,6 @@ tcl-lexer = { path = "../tcl-lexer" }
 tcl-syntax = { path = "../tcl-syntax" }
 tcl-sandbox = { path = "../tcl-sandbox" }
 tcl-userdirs = { path = "../tcl-userdirs" }
-tcl-version = { path = "../tcl-version" }
 regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/rust/tcl-pkg/src/docker.rs
+++ b/rust/tcl-pkg/src/docker.rs
@@ -203,10 +203,11 @@ pub fn cli_capable_families() -> Vec<String> {
     CLI_PREREQS.iter().map(|(f, _)| (*f).to_string()).collect()
 }
 
-/// The release version a generated Dockerfile pins by default.
+/// Reduce an application's stamped version to the release a Dockerfile should
+/// pin by default.
 ///
-/// Derived from the version stamped into this binary, so a generated image
-/// installs the CLI line that generated it. Build metadata (`+g<hash>`,
+/// The application supplies its own version so this reusable package library
+/// does not depend on the build-provenance crate. Build metadata (`+g<hash>`,
 /// `.dirty`) and the `git describe` distance (`-<n>`) are stripped, leaving the
 /// tag the build descends from: `2.2.1-7+gc1a17793` pins `2.2.1`.
 ///
@@ -215,8 +216,8 @@ pub fn cli_capable_families() -> Vec<String> {
 /// generated Dockerfile then resolves the newest release at build time instead
 /// of pinning a tag that was never published.
 #[must_use]
-pub fn default_cli_version() -> Option<String> {
-    release_base(tcl_version::VERSION)
+pub fn default_cli_version(application_version: &str) -> Option<String> {
+    release_base(application_version)
 }
 
 /// Reduce a stamped version to the release tag it descends from.
@@ -245,10 +246,11 @@ fn normalise_cli_version(version: &str) -> String {
 /// build's target architecture and verifies it against the release's
 /// `SHA256SUMS` before installing it at `/usr/local/bin/tcl`.
 ///
-/// `cli_version` pins a release; `None` defers to [`default_cli_version`], and
-/// when that is also `None` the emitted `TCL_LSP_VERSION` build argument is
-/// empty and the snippet resolves the newest release itself. Either way the
-/// version stays overridable at build time with
+/// `cli_version` pins a release. With `None`, the emitted `TCL_LSP_VERSION`
+/// build argument is empty and the snippet resolves the newest release itself.
+/// Applications that want to default to their own release should pass
+/// [`default_cli_version`] as the explicit value. Either way the version stays
+/// overridable at build time with
 /// `docker build --build-arg TCL_LSP_VERSION=…`.
 ///
 /// The trust model mirrors `scripts/tcl-mcp`: an asset missing from
@@ -256,10 +258,7 @@ fn normalise_cli_version(version: &str) -> String {
 /// landing an unverified binary in the image.
 #[must_use]
 pub fn tcl_cli_install_recipe(cli_version: Option<&str>) -> String {
-    let pinned = cli_version
-        .map(normalise_cli_version)
-        .or_else(default_cli_version)
-        .unwrap_or_default();
+    let pinned = cli_version.map(normalise_cli_version).unwrap_or_default();
 
     let arch_cases = RELEASE_TRIPLES
         .iter()
@@ -548,17 +547,26 @@ mod tests {
 
     #[test]
     fn default_version_strips_describe_and_build_metadata() {
-        assert_eq!(release_base("2.2.1+gc1a17793").as_deref(), Some("2.2.1"));
-        assert_eq!(release_base("2.2.1-7+gc1a17793").as_deref(), Some("2.2.1"));
         assert_eq!(
-            release_base("2.2.1+gc1a17793.dirty").as_deref(),
+            default_cli_version("2.2.1+gc1a17793").as_deref(),
             Some("2.2.1")
         );
-        assert_eq!(release_base("2.2.1-dirty").as_deref(), Some("2.2.1"));
+        assert_eq!(
+            default_cli_version("2.2.1-7+gc1a17793").as_deref(),
+            Some("2.2.1")
+        );
+        assert_eq!(
+            default_cli_version("2.2.1+gc1a17793.dirty").as_deref(),
+            Some("2.2.1")
+        );
+        assert_eq!(default_cli_version("2.2.1-dirty").as_deref(), Some("2.2.1"));
         // A real pre-release segment is part of the tag, not a describe count.
-        assert_eq!(release_base("2.3.0-rc1").as_deref(), Some("2.3.0-rc1"));
+        assert_eq!(
+            default_cli_version("2.3.0-rc1").as_deref(),
+            Some("2.3.0-rc1")
+        );
         // The manifest placeholder names no release, so nothing is pinned.
-        assert_eq!(release_base("0.1.0+gc1a17793"), None);
+        assert_eq!(default_cli_version("0.1.0+gc1a17793"), None);
     }
 
     #[test]
@@ -587,9 +595,7 @@ mod tests {
 
     #[test]
     fn cli_install_recipe_without_a_pin_resolves_the_latest_release() {
-        // `tcl_cli_install_recipe(None)` follows the build's own version, which
-        // varies; drive the empty-pin shape through the shared formatter.
-        let recipe = tcl_cli_install_recipe(Some(""));
+        let recipe = tcl_cli_install_recipe(None);
         assert!(recipe.starts_with("ARG TCL_LSP_VERSION=\n"));
         assert!(recipe.contains("api.github.com/repos/bitwisecook/tcl-lsp/releases?per_page=1"));
     }

--- a/rust/tcl-version/build.rs
+++ b/rust/tcl-version/build.rs
@@ -32,18 +32,36 @@
 //! Releases are tag-only: no version literal is bumped in the tree, so the tag
 //! is the single source of truth. See `scripts/release/tag.sh`.
 
+#[path = "src/git_inputs.rs"]
+mod git_inputs;
+
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 fn main() {
+    let stamped = env_version();
+
     // A change to either input must re-run this script, or the binary keeps a
     // stale version baked in from a previous build.
     println!("cargo:rerun-if-env-changed=TCL_LSP_VERSION");
     println!("cargo:rerun-if-env-changed=GIT_HASH");
-    for p in [".git/HEAD", ".git/refs/tags", ".git/packed-refs"] {
-        println!("cargo:rerun-if-changed=../../{p}");
+    for path in git_inputs::dependency_paths(Path::new(env!("CARGO_MANIFEST_DIR"))) {
+        println!("cargo:rerun-if-changed={}", path.display());
+    }
+    if stamped.is_none() {
+        // There is no complete, portable set of filesystem mtimes that models
+        // `git status`: an unstaged root-level deletion has no existing child
+        // to watch, and a chmod-only change alters neither size nor mtime.
+        // Re-run this tiny stamp crate on every unstamped binary build instead.
+        // It is intentionally absent from the xtask dependency graph, so the
+        // repeated code-generation commands this repository runs stay fresh.
+        let out_dir = PathBuf::from(
+            std::env::var_os("OUT_DIR").expect("Cargo always supplies a build-script OUT_DIR"),
+        );
+        let probe = git_inputs::worktree_probe_path(&out_dir);
+        println!("cargo:rerun-if-changed={}", probe.display());
     }
 
-    let stamped = env_version();
     let base = stamped
         .clone()
         .or_else(git_describe)

--- a/rust/tcl-version/src/git_inputs.rs
+++ b/rust/tcl-version/src/git_inputs.rs
@@ -1,0 +1,238 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Git metadata inputs that can change the version embedded by `build.rs`.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Resolve every repository input that can move the version stamp.
+///
+/// `../../.git/...` is correct only in the primary checkout. In a linked
+/// worktree `.git` is a file pointing into the common repository, so those
+/// literal children do not exist. Cargo treats a missing `rerun-if-changed`
+/// path as perpetually dirty and rebuilds this crate (and every dependent
+/// binary) before every command. `git rev-parse --git-path` knows both layouts.
+pub(crate) fn dependency_paths(manifest_dir: &Path) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+
+    // HEAD covers detached checkouts and changes between symbolic/detached
+    // state. The exact symbolic ref covers ordinary commits, because HEAD's
+    // own contents stay `ref: refs/heads/<branch>` while that branch advances.
+    for name in ["HEAD", "refs/tags", "packed-refs"] {
+        if let Some(path) = git_path(manifest_dir, name) {
+            paths.push(path);
+        }
+    }
+
+    if let Some(symbolic_ref) = git_output(manifest_dir, &["symbolic-ref", "-q", "HEAD"]) {
+        // Do not watch the whole refs/heads directory: in a shared repository,
+        // commits on unrelated worktree branches would then rebuild this crate.
+        // The exact loose ref is the primary input; its reflog also exists for
+        // ordinary non-bare repositories and covers a currently packed ref.
+        for name in [&symbolic_ref, &format!("logs/{symbolic_ref}")] {
+            if let Some(path) = git_path(manifest_dir, name) {
+                paths.push(path);
+            }
+        }
+    }
+
+    paths.sort();
+    paths.dedup();
+    paths
+}
+
+/// A deliberately absent Cargo input used to recompute unstamped provenance.
+///
+/// Cargo's change detector cannot represent every state that `git status`
+/// observes (notably chmod-only changes and missing root-level files). Keeping
+/// the probe under Cargo's private output directory avoids watching the source
+/// or target directory recursively. The build script never creates it, so an
+/// unstamped build always re-evaluates the working-tree state.
+pub(crate) fn worktree_probe_path(out_dir: &Path) -> PathBuf {
+    out_dir.join("tcl-version-worktree-state-probe")
+}
+
+fn git_path(manifest_dir: &Path, name: &str) -> Option<PathBuf> {
+    let path = git_output_path(manifest_dir, &["rev-parse", "--git-path", name])?;
+    let path = if path.is_absolute() {
+        path
+    } else {
+        manifest_dir.join(path)
+    };
+
+    // Only emit live paths. Besides avoiding Cargo's perpetual-dirty behavior,
+    // this lets a fresh repository legitimately omit packed-refs or refs/tags.
+    path.canonicalize().ok()
+}
+
+fn git_output(manifest_dir: &Path, args: &[&str]) -> Option<String> {
+    let output = git_output_bytes(manifest_dir, args)?;
+    let output = String::from_utf8(output).ok()?;
+    let output = output.trim();
+    (!output.is_empty()).then(|| output.to_owned())
+}
+
+fn git_output_path(manifest_dir: &Path, args: &[&str]) -> Option<PathBuf> {
+    git_output(manifest_dir, args).map(PathBuf::from)
+}
+
+fn git_output_bytes(manifest_dir: &Path, args: &[&str]) -> Option<Vec<u8>> {
+    let output = Command::new("git")
+        .args(["-c", "core.quotePath=false"])
+        .args(args)
+        .current_dir(manifest_dir)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    Some(output.stdout)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{dependency_paths, git_path, worktree_probe_path};
+    use std::path::{Path, PathBuf};
+    use std::process::Command;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static NEXT_TEMP: AtomicU64 = AtomicU64::new(0);
+
+    struct TempRepo {
+        root: PathBuf,
+        primary: PathBuf,
+        linked: PathBuf,
+    }
+
+    impl TempRepo {
+        fn new() -> Self {
+            let serial = NEXT_TEMP.fetch_add(1, Ordering::Relaxed);
+            let nanos = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system clock is after the Unix epoch")
+                .as_nanos();
+            let root = std::env::temp_dir().join(format!(
+                "tcl-version-git-inputs-{}-{nanos}-{serial}",
+                std::process::id()
+            ));
+            let primary = root.join("primary");
+            let linked = root.join("linked");
+
+            std::fs::create_dir_all(&root).expect("create temporary repository root");
+            git(&root, &["init", "--initial-branch=base", path(&primary)]);
+            git(&primary, &["config", "user.name", "tcl-version test"]);
+            git(
+                &primary,
+                &["config", "user.email", "tcl-version@example.invalid"],
+            );
+            git(&primary, &["config", "commit.gpgsign", "false"]);
+            let hooks = root.join("empty-hooks");
+            std::fs::create_dir_all(&hooks).expect("create empty hooks directory");
+            git(&primary, &["config", "core.hooksPath", path(&hooks)]);
+            std::fs::write(primary.join("tracked"), "first\n").expect("write tracked file");
+            git(&primary, &["add", "tracked"]);
+            git(&primary, &["commit", "-m", "first"]);
+            git(
+                &primary,
+                &["worktree", "add", "-b", "linked-test", path(&linked)],
+            );
+
+            Self {
+                root,
+                primary,
+                linked,
+            }
+        }
+    }
+
+    impl Drop for TempRepo {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.root);
+        }
+    }
+
+    #[test]
+    fn linked_worktree_dependencies_exist_and_follow_its_branch() {
+        let repo = TempRepo::new();
+        let manifest_dir = repo.linked.join("rust/tcl-version");
+        std::fs::create_dir_all(&manifest_dir).expect("create nested manifest directory");
+
+        let paths = dependency_paths(&manifest_dir);
+        assert!(!paths.is_empty());
+        assert!(
+            paths.iter().all(|candidate| candidate.exists()),
+            "all emitted Cargo dependencies must exist: {paths:#?}"
+        );
+
+        let head = git_path(&manifest_dir, "HEAD").expect("resolve worktree HEAD");
+        let branch = git_path(&manifest_dir, "refs/heads/linked-test")
+            .expect("resolve linked worktree branch");
+        let branch_log = git_path(&manifest_dir, "logs/refs/heads/linked-test")
+            .expect("resolve linked worktree branch reflog");
+        let all_heads = git_path(&manifest_dir, "refs/heads").expect("resolve heads directory");
+        assert!(paths.contains(&head), "missing worktree HEAD: {paths:#?}");
+        assert!(
+            paths.contains(&branch),
+            "missing exact branch ref: {paths:#?}"
+        );
+        assert!(
+            paths.contains(&branch_log),
+            "missing exact branch reflog: {paths:#?}"
+        );
+        assert!(
+            !paths.contains(&all_heads),
+            "unrelated branches must not invalidate the build: {paths:#?}"
+        );
+        assert!(
+            head.starts_with(repo.primary.join(".git/worktrees")),
+            "linked HEAD must resolve through the common repository: {head:?}"
+        );
+
+        let before = std::fs::read_to_string(&branch).expect("read initial branch ref");
+        let log_before = std::fs::read_to_string(&branch_log).expect("read initial branch reflog");
+        std::fs::write(repo.linked.join("tracked"), "second\n").expect("update tracked file");
+        git(&repo.linked, &["add", "tracked"]);
+        git(&repo.linked, &["commit", "-m", "second"]);
+        let after = std::fs::read_to_string(&branch).expect("read advanced branch ref");
+        let log_after = std::fs::read_to_string(&branch_log).expect("read advanced branch reflog");
+        assert_ne!(before, after, "the watched exact ref must move on commit");
+        assert_ne!(
+            log_before, log_after,
+            "the watched exact reflog must move on commit"
+        );
+    }
+
+    #[test]
+    fn worktree_probe_is_absent_and_scoped_to_cargo_output() {
+        let repo = TempRepo::new();
+        let out_dir = repo.root.join("cargo-out");
+        std::fs::create_dir(&out_dir).expect("create mock Cargo output directory");
+        let probe = worktree_probe_path(&out_dir);
+        assert_eq!(probe.parent(), Some(out_dir.as_path()));
+        assert!(!probe.exists(), "the worktree probe must remain absent");
+    }
+
+    fn git(cwd: &Path, args: &[&str]) -> String {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(cwd)
+            .output()
+            .expect("run git");
+        assert!(
+            output.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8(output.stdout)
+            .expect("git output is UTF-8")
+            .trim()
+            .to_owned()
+    }
+
+    fn path(path: &Path) -> &str {
+        path.to_str().expect("temporary path is UTF-8")
+    }
+}

--- a/rust/tcl-version/src/lib.rs
+++ b/rust/tcl-version/src/lib.rs
@@ -41,3 +41,9 @@ pub const VERSION: &str = env!("TCL_LSP_RESOLVED_VERSION");
 /// Already embedded in [`VERSION`]; exposed separately for callers that want to
 /// show it in its own field rather than parse it back out.
 pub const COMMIT: &str = env!("TCL_LSP_RESOLVED_COMMIT");
+
+// Compile the build-script support into this crate only for its regression
+// tests. `build.rs` includes the same source directly, keeping the resolver's
+// tested implementation and the one Cargo executes identical.
+#[cfg(test)]
+mod git_inputs;


### PR DESCRIPTION
## Summary

- resolve Git metadata through `git rev-parse --git-path`, so primary checkouts and linked worktrees use their real paths
- watch the exact symbolic HEAD ref and reflog, without watching all sibling-worktree branches
- deliberately re-evaluate `git status` on every unstamped user-facing binary build, covering ordinary edits, root-level deletions, mode-only changes, sparse files, and non-UTF-8 filenames without trying to serialize the tracked tree into Cargo directives
- remove the reusable `tcl-pkg` library's dependency on the application build stamp; the `tcl` CLI now supplies its own version when selecting the default Docker release
- thereby remove `tcl-version` from xtask's dependency graph, eliminating the repeated generator rebuild while retaining exact development-build provenance

## Root cause

`tcl-version/build.rs` watched hard-coded `../../.git/...` children. In a linked worktree, `.git` is a file rather than the repository directory, so every watched path was missing. Cargo treats a missing `rerun-if-changed` input as perpetually dirty, rebuilding `tcl-version` and the `tcl-pkg` / `tcl-cli-support` / `xtask` dependency chain before every drift command.

There is also no sound portable set of ordinary Cargo filesystem inputs equivalent to `git status`: a root-level unstaged deletion has no existing leaf to watch without recursively watching the worktree and its `target/`, a chmod-only change need not alter size or mtime, and Unix filenames need not be UTF-8. The final design therefore makes that recheck explicit for the small provenance crate, then removes the accidental library dependency that put it in xtask's graph.

Release-stamped builds still omit the worktree probe because they intentionally suppress `.dirty`; real Git metadata paths continue to invalidate commit/tag changes.

## Experimental proof

Before this change in a linked worktree, consecutive independent `cargo xtask` invocations rebuilt `tcl-version` and its dependent chain every time and took 4.2–4.7 seconds.

After the complete fix:

- `cargo tree -p xtask` contains no `tcl-version`
- an unchanged `cargo xtask workflow-sync --check` completes fresh in 0.15 seconds
- a clean binary reported `2.2.1-32+g13b87909`
- changing only a tracked fixture's executable bit rebuilt it as `2.2.1-32+g13b87909.dirty`; restoring the mode rebuilt it without `.dirty`
- moving root-level `README.md` out of the worktree made two consecutive builds report `.dirty`; restoring it rebuilt cleanly, without watching the worktree or `target/` recursively
- direct unstamped binary rebuilds take about 2.6–2.8 seconds, the deliberate cost of exact build provenance; repeated generator commands no longer pay it

The regression creates a real repository and linked worktree. It verifies every metadata dependency exists; linked HEAD resolves through the common repository; the exact branch ref and reflog are watched; broad `refs/heads` is not; both exact branch inputs change after a commit; and the always-missing worktree probe is confined to Cargo's private output directory.

## Validation

- `cargo test -p tcl-version`
- `cargo test -p tcl-pkg docker`
- `cargo check -p tcl-cli`
- `cargo clippy -p tcl-version -p tcl-pkg -p tcl-cli --all-targets -- -D warnings`
- clean → chmod-only edit → restore binary-version experiment
- clean → root-level deletion → second deleted build → restore binary-version experiment
- xtask dependency-graph and consecutive-timing experiment
- `make NPROC=1 rust-check`
- `make NPROC=1 NPM='npm --no-audit --no-fund' prep-pr`

All final gates used the worktree's isolated Cargo target.
