### PR TITLE
Own the parse-error cut, and stop classifying it from lexer warnings

### DIFF
--- a/docs/design/contracts/shared-utility-contracts-rust.md
+++ b/docs/design/contracts/shared-utility-contracts-rust.md
@@ -50,6 +50,7 @@ entry point, or gate moves without this contract being updated.
 | command errors | `rust/tcl-cmd-core/src/error.rs` | `CmdError`; `wrong_args`; `bad_choice` | invariant | none |
 | expression grammar / evaluation | `rust/tcl-syntax/src/expr/parser.rs`; `rust/tcl-syntax/src/expr/eval.rs`; `rust/tcl-registry/src/expr_surface.rs` | `parse_expr`; `eval`; `RuntimeExprSurface` | `RuntimeExprSurface` per release | none |
 | command / word segmentation | `rust/tcl-lexer/src/script.rs`; `rust/tcl-compiler/src/segmenter.rs`; `rust/tcl-compiler/src/parsing/syntax/build.rs`; `rust/tcl-compiler/src/parsing/syntax/segment.rs` | `group_commands`; `CommandSpan`; `WordSpan`; `WordKind`; `SegmentedCommand`; `segment_commands` | `LexerConfig` per document dialect | `xtask-segmentation-drift` |
+| parse-error cut | `rust/tcl-lexer/src/parse_cut.rs` | `first_parse_cut`; `first_parse_cut_in`; `ParseCut`; `EXTRA_AFTER_CLOSE_QUOTE` | `LexerConfig` per emulated release, inherited from the segmentation and word-component owners it walks | `xtask-segmentation-drift` |
 | script completeness / reparse windows | `rust/tcl-lexer/src/structural_index.rs` | `script_is_complete`; `command_boundaries`; `reparse_window`; `BracketIndex`; `BraceIndex`; `ExprParenIndex`; `ParenBalance` | dialect-blind by construction: one byte scan of stock 8.6/9.x brace, quote, `${…}`-nesting, comment and terminator structure, so an editor keystroke costs no tokenise. The two grammar axes that really do move a command boundary — the F5 `BraceLineContinuation::Continues` next-line-`{` rule and the 8.x `BracedVarStyle::FirstClose` name rule — are pinned as measured divergences by `differential_boundaries`, never silently absorbed | `xtask-segmentation-drift` |
 | iRules execution boundaries and placement | `rust/tcl-syntax/src/event_handler.rs`; `rust/tcl-registry/src/events.rs`; `rust/tcl-registry/src/registry.rs`; `rust/tcl-irules/src/when_block.rs`; `rust/tcl-irules/src/executable.rs` | `event_handlers`; `event_handlers_with_head_predicate`; `script_commands`; `top_level_when_handlers_with_registry_and_head_resolver`; `IrulesDeclarationArguments`; `IrulesExecutionContext`; `IrulesCommandPlacement`; `IrulesTopLevelDeclaration`; `IrulesTopLevelEffect`; `CommandRegistry::irules_command_placement`; `CommandRegistry::irules_event_declaration`; `CommandRegistry::irules_top_level_declaration`; `CommandRegistry::irules_top_level_declaration_shape`; `CommandRegistry::irules_top_level_effect`; `when_blocks`; `irules_executable_commands` | caller-supplied `LexerConfig`; offset-keyed resolved command identity; exact single-braced declaration body; declaration-only top level; known-event roots; call-reachable procedure bodies; stateful priority (`0..=1000`, default 500) | `xtask-gen-ai-diagnostics` |
 | text similarity | `rust/tcl-compiler/src/text.rs` | `edit_distance`; `rank_suggestions`; `rank_containment_suggestions` | invariant | none |
@@ -314,6 +315,17 @@ entry point, or gate moves without this contract being updated.
   rather than answering wrongly. Do not read this entry as claiming the
   codebase has one `${...}` decoder — it has one *for the surfaces named
   above*.
+
+- `parse_cut::first_parse_cut` — the one answer to *where a script stops
+  parsing*: which command C rejects, at what offset, with which message.
+  It walks `group_commands` and `word_parts` in C's own order — commands,
+  then words, then components, descending into `[…]` bodies and
+  `$arr(index)` — rather than filtering the lexer's flat warning stream,
+  which is what made `list [sfx one] [list "oops]` answer
+  `missing close-bracket` where C says `missing "`. The command index is
+  the part a message alone cannot carry, and it is what a bytecode
+  front-end needs to compile the prefix that runs before the raise
+  (#1603).
 
 - `word_parts::decompose` — the one splitter of a Tcl word (or a `subst`
   template) into its substitution components: C's `ParseTokens` breakdown
@@ -861,7 +873,21 @@ helper without reading the rationale:
   `dialect_divergences_are_pinned` for the two axes the byte scanner is
   deliberately blind to. `make xtask-segmentation-drift` is the
   banned-spelling gate that keeps a *new* consumer from re-deriving
-  either boundary privately.
+  either boundary privately — including, since #1787, by collecting C's
+  parse-error messages into a private list instead of asking
+  `tcl_lexer::first_parse_cut`.
+- `runtime/rust/tests/parse_cut_agreement.rs` — the parse-error cut gate.
+  The cut is applied twice on purpose: `first_parse_cut` answers it from
+  source, for a compile front-end that needs the index of the command the
+  clean prefix ends at, and `runtime/rust` answers it per command from the
+  borrowed tree it has already built, for an evaluator that must not
+  substitute a word of a command that does not parse. One shared driver
+  was considered and rejected — it would make `runtime/rust` re-lex every
+  command it evaluates, and its parse is infallible by design where the
+  owner's returns an `Option`. This differential is what keeps the two
+  applications one policy; it runs under `make runtime-rust-test`, and it
+  pins the close-quote weld (`"a"b`) as the one shape they still answer
+  differently.
 
 ## Discoverability
 

--- a/runtime/rust/src/parse.rs
+++ b/runtime/rust/src/parse.rs
@@ -418,12 +418,32 @@ fn script_parse_error(
 /// (issues #1576, #1586).
 use tcl_lexer::word_parts::{EXTRA_AFTER_CLOSE_BRACE, MISSING_CLOSE_BRACE, MISSING_QUOTE};
 
-/// Whether a `Str` (brace-delimited) token never found its closing `}` before
-/// end of input. Delegates to [`tcl_lexer::word_closer_offset`] — the one
-/// owner of "does this delimited word's span actually reach its closer" —
+/// Whether a `Str` token that **opens a brace** never found its closing `}`
+/// before end of input. Delegates to [`tcl_lexer::word_closer_offset`] — the
+/// one owner of "does this delimited word's span actually reach its closer" —
 /// rather than re-deriving the answer from span arithmetic here.
+///
+/// The opening-byte test is load-bearing, not defensive. `Str` is the lexer's
+/// *literal-fragment* class, not its brace class: a `$` that starts no
+/// variable reference is one too. Without the test, `word_closer_offset`
+/// answers "no closer" for that `$` and every one of these — all accepted by
+/// 8.4.20, 8.5.19, 8.6.16, 9.0.4 and 9.1b0 — raised `missing close-brace`:
+///
+/// ```text
+/// puts "$"           -> $
+/// puts "50% of $"    -> 50% of $
+/// puts "a$ b"        -> a$ b
+/// puts a$%b          -> a$%b
+/// ```
+///
+/// C reads a `$` that no name follows as the text `$` and keeps parsing
+/// (`Tcl_ParseVarName` form 3, `justADollarSign`,
+/// tmp/tcl9.0.4/generic/tclParse.c:1454). Found by
+/// `tests/parse_cut_agreement.rs` against `tcl_lexer::first_parse_cut`, on
+/// tcllib's `markdown.test`.
 fn brace_token_unterminated(sm: &SourceMap<'_>, tok: Token) -> bool {
-    tcl_lexer::word_closer_offset(sm, tok).is_none()
+    sm.source().as_bytes().get(tok.span.start() as usize) == Some(&b'{')
+        && tcl_lexer::word_closer_offset(sm, tok).is_none()
 }
 
 fn build_word<'s>(

--- a/runtime/rust/src/parse.rs
+++ b/runtime/rust/src/parse.rs
@@ -511,17 +511,18 @@ fn build_word<'s>(
     // raises on 8.6.16 and 9.0.4 rather than reading `b` as the word. The
     // lexer's recovery reads to end of input instead, so the close is
     // re-derived from the shared owner, exactly as the braced word above does.
+    //
+    // It is a *fallback*, not a verdict: `quoted_word_close` steps over
+    // complete `[…]` substitutions to find the closer, so an **incomplete**
+    // one makes it give up here while C, parsing the word's tokens left to
+    // right, has already failed inside the bracket. Measured on 8.6.16 and
+    // 9.0.4, `puts "[foo"` is `missing close-bracket`, not `missing "`. So
+    // the word's parts are still built below and this error is appended
+    // after them, where the first-error rule reaches it only if nothing
+    // inside the word failed first.
     let unterminated_quote = kind == WordKind::Quoted
         && core::str::from_utf8(src)
             .is_ok_and(|text| tcl_lexer::word_parts::quoted_word_close(text, start).is_err());
-    if unterminated_quote {
-        return Word {
-            kind,
-            expand,
-            body: WordBody::Parts(vec![WordPart::ParseError(MISSING_QUOTE)]),
-            start,
-        };
-    }
     let mut parts: Vec<WordPart> = Vec::new();
     for &t in toks {
         let bytes = token_content(sm, src, t);
@@ -599,6 +600,9 @@ fn build_word<'s>(
             }
             _ => {}
         }
+    }
+    if unterminated_quote {
+        parts.push(WordPart::ParseError(MISSING_QUOTE));
     }
     // SIMPLE_WORD fast path: an empty word, or a lone *borrowed* `Text` (its run
     // had no escapes to decode — `plainword` / the no-subst quoted `"hi there"`),

--- a/runtime/rust/tests/parse_cut_agreement.rs
+++ b/runtime/rust/tests/parse_cut_agreement.rs
@@ -60,6 +60,10 @@ const SHEET: &[&str] = &[
     "puts pre; puts $a(",
     "puts pre; puts \"a\"b",
     "puts pre; set y {unclosed",
+    // An unterminated quote whose word already failed inside a bracket:
+    // C reports the bracket, not the quote.
+    "puts pre; puts \"[foo\"",
+    "puts pre; puts \"a[foo b\"",
     // The two the flat warning stream got wrong.
     "puts pre; list [sfx one] [list \"oops]",
     "puts pre; puts $a([set q \"x)",

--- a/runtime/rust/tests/parse_cut_agreement.rs
+++ b/runtime/rust/tests/parse_cut_agreement.rs
@@ -1,0 +1,194 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! The cross-check that keeps the parse-error cut policy *one* policy
+//! (issue #1787).
+//!
+//! `tcl_lexer::first_parse_cut` answers the cut from source, for a compile
+//! front-end that must know which commands run before the error. This crate
+//! answers it per command, from the borrowed tree it has already built, for
+//! an evaluator that must not substitute a word of a command that does not
+//! parse. Two applications of one rule, deliberately not one call site: a
+//! shared driver would make this crate re-lex every command it evaluates,
+//! and its parse is infallible by design (errors ride as
+//! `WordPart::ParseError`) where the owner's is a `Option<ParseCut>`.
+//!
+//! Two implementations of one rule drift. This is the test that says so.
+
+use tcl_lexer::LexerConfig;
+use tcl_runtime::parse::{first_parse_error, parse_script_with_config};
+
+/// The cut this crate's per-command walk reports: the index of the first
+/// command that fails to parse, and its message.
+fn runtime_cut(src: &str, config: LexerConfig) -> Option<(usize, &'static str)> {
+    parse_script_with_config(src.as_bytes(), config)
+        .iter()
+        .enumerate()
+        .find_map(|(index, command)| {
+            first_parse_error(&command.words, config).map(|message| (index, message))
+        })
+}
+
+/// The cut the owner reports, in the same shape.
+fn owner_cut(src: &str, config: LexerConfig) -> Option<(usize, &'static str)> {
+    tcl_lexer::first_parse_cut(src, config).map(|cut| (cut.command, cut.message))
+}
+
+/// The malformed shapes, one per message C can raise, plus the two the
+/// warning-stream scan the owner replaced answered wrongly and the one it
+/// could not see at all.
+const SHEET: &[&str] = &[
+    "puts pre; puts \"x${abc\"",
+    "puts pre; puts \"unterminated",
+    "puts pre; puts [foo",
+    "puts pre; set y {a}b",
+    "puts pre; puts $a(",
+    "puts pre; puts \"a\"b",
+    "puts pre; set y {unclosed",
+    // The two the flat warning stream got wrong.
+    "puts pre; list [sfx one] [list \"oops]",
+    "puts pre; puts $a([set q \"x)",
+    // The one it could not see.
+    "puts pre; sfx {a}{*}$b",
+    // Nested a level down, where only a descent finds it.
+    "puts pre; list [sfx one] [set y {a}b]",
+    // Several clean commands before the cut.
+    "puts one; puts two; puts \"x${abc\"",
+    "sfx a; sfx b; puts $c(",
+    // Clean.
+    "puts pre; puts done",
+    "puts \"a[foo \\\"b\\\"]c\"",
+    "puts [list $ $x]",
+    "lappend ev pre-[lindex $args end]",
+];
+
+/// The one shape the two engines still answer differently, pinned rather
+/// than hidden: a word welded onto its **closing quote**.
+///
+/// C rejects `set y "a"b` with `extra characters after close-quote` on all
+/// five shells; the owner reports it, and this crate silently concatenates
+/// to `ab`. It is the exact sibling of the welded *close-brace* #1818
+/// taught this crate to raise, and the boundary owner says so in as many
+/// words — `WordSpan::welded_after_close` "is deliberately brace-only —
+/// the analogous close-quote weld (`"a"b`) is a different C error and is
+/// not reported here."
+///
+/// Raising a new error from the evaluator is a behaviour change with its
+/// own oracle sheet, so it is a follow-up, not a rider on the owner. Until
+/// then this row is the record that the divergence is known and measured,
+/// not that the two engines agree.
+const KNOWN_DIVERGENCES: &[&str] = &["puts pre; puts \"a\"b"];
+
+#[test]
+fn the_two_engines_agree_on_the_sheet() {
+    for src in SHEET {
+        for dialect in ["tcl8.4", "tcl8.6", "tcl9.0"] {
+            let config = LexerConfig::for_dialect(dialect);
+            let (runtime, owner) = (runtime_cut(src, config), owner_cut(src, config));
+            if KNOWN_DIVERGENCES.contains(src) {
+                assert_ne!(
+                    runtime, owner,
+                    "{dialect}: {src:?} no longer diverges — \
+                     drop it from KNOWN_DIVERGENCES"
+                );
+                continue;
+            }
+            assert_eq!(runtime, owner, "{dialect}: {src:?}");
+        }
+    }
+}
+
+/// The pinned divergence is exactly one shape, and it is the one described.
+#[test]
+fn the_close_quote_weld_is_the_only_pinned_divergence() {
+    let config = LexerConfig::default();
+    assert_eq!(
+        KNOWN_DIVERGENCES
+            .iter()
+            .map(|src| (runtime_cut(src, config), owner_cut(src, config)))
+            .collect::<Vec<_>>(),
+        vec![(None, Some((1, "extra characters after close-quote")))],
+    );
+}
+
+/// Real Tcl, where the two must agree that there is nothing to cut.
+///
+/// Walks every `.tcl` / `.test` / `.tm` under the corpora the boundary
+/// differential already uses. A file the harness cannot read as UTF-8 is
+/// skipped rather than failed — this is an agreement check, not an encoding
+/// one.
+#[test]
+fn the_two_engines_agree_over_the_corpus() {
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(2)
+        .expect("repository root");
+    let mut files = Vec::new();
+    for corpus in ["samples", "tmp/tcl9.0.4/library", "tmp/tcllib-2.0/modules"] {
+        collect(&root.join(corpus), &mut files);
+    }
+    assert!(
+        files.len() > 100,
+        "corpus is missing — found only {} file(s); run `make fetch-tcl-source`",
+        files.len()
+    );
+    let config = LexerConfig::default();
+    let mut disagreements = Vec::new();
+    for file in &files {
+        let Ok(src) = std::fs::read_to_string(file) else {
+            continue;
+        };
+        let (runtime, owner) = (runtime_cut(&src, config), owner_cut(&src, config));
+        // The pinned close-quote weld: `samples/tcl/05_warning_examples.tcl`
+        // is a deliberate demonstration file and carries one.
+        if runtime.is_none()
+            && owner.is_some_and(|(_, m)| m == "extra characters after close-quote")
+        {
+            continue;
+        }
+        if runtime != owner {
+            disagreements.push(format!(
+                "{}: runtime {runtime:?} owner {owner:?}",
+                file.display()
+            ));
+        }
+    }
+    assert!(
+        disagreements.is_empty(),
+        "{} file(s) disagree:\n{}",
+        disagreements.len(),
+        disagreements.join("\n")
+    );
+}
+
+fn collect(dir: &std::path::Path, out: &mut Vec<std::path::PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect(&path, out);
+        } else if path
+            .extension()
+            .is_some_and(|ext| ext == "tcl" || ext == "test" || ext == "tm")
+        {
+            out.push(path);
+        }
+    }
+}

--- a/runtime/rust/tests/parser_gaps.rs
+++ b/runtime/rust/tests/parser_gaps.rs
@@ -538,6 +538,37 @@ fn a_dollar_that_starts_no_reference_is_literal_text() {
     assert_eq!(result, "$|50% of $|a$ b|a$%b|a$%^&b|a$%b|2");
 }
 
+/// An unterminated quoted word reports what failed *inside* it first.
+///
+/// `quoted_word_close` steps over complete `[…]` substitutions to find the
+/// closer, so an incomplete one makes it give up — but C, parsing the word's
+/// tokens left to right, has already failed in the bracket. Oracle, one
+/// script per `tclsh` run on 8.6.16 and 9.0.4:
+///
+/// ```text
+/// puts "[foo"        -> missing close-bracket
+/// puts "a[foo b"     -> missing close-bracket
+/// puts "unterminated -> missing "
+/// list a "b          -> missing "
+/// ```
+#[test]
+fn an_unterminated_quote_reports_the_failure_inside_it_first() {
+    for (script, want) in [
+        ("puts \"[foo\"", "missing close-bracket"),
+        ("puts \"a[foo b\"", "missing close-bracket"),
+        ("puts \"unterminated", "missing \""),
+        ("list a \"b", "missing \""),
+    ] {
+        let (code, result, _) = run(script);
+        assert_eq!((code, result.as_str()), (Code::Error, want), "{script}");
+    }
+    // A *complete* bracket in an unterminated quote still reaches evaluation
+    // before the quote's own error, exactly as C does.
+    let (code, result, _) = run("puts \"a[nosuchcmd]b\"");
+    assert_eq!(code, Code::Error);
+    assert!(result.contains("nosuchcmd"), "{result}");
+}
+
 /// The fix must not blunt the real one. Oracle, measured one script per
 /// `tclsh` run on 8.6.16 and 9.0.4:
 ///

--- a/runtime/rust/tests/parser_gaps.rs
+++ b/runtime/rust/tests/parser_gaps.rs
@@ -505,3 +505,62 @@ fn subst_is_not_a_command_parse_and_still_runs_the_earlier_bracket() {
     assert_eq!(code, Code::Ok);
     assert_eq!(result, "1 {missing close-bracket}");
 }
+
+// ---------------------------------------------------------------------------
+// A `$` that starts no variable reference is the text `$`, not an unterminated
+// brace (#1787). C reads it as `justADollarSign` and keeps parsing
+// (`Tcl_ParseVarName` form 3, tmp/tcl9.0.4/generic/tclParse.c:1454); this
+// parser classified it as a brace-delimited fragment, because `Str` is the
+// lexer's literal-fragment class and not its brace class, and raised `missing
+// close-brace` for ordinary source. Oracle: every row below is the plain text
+// on 8.4.20, 8.5.19, 8.6.16, 9.0.4 and 9.1b0.
+// ---------------------------------------------------------------------------
+
+/// `$` alone, `$` before punctuation, `$` before a space, `$` at end of a
+/// word — bare and quoted, since the two take different paths through
+/// `build_word`.
+const BARE_DOLLAR_SHEET: &str = r#"
+set out {}
+lappend out [string cat "$"]
+lappend out [string cat "50% of $"]
+lappend out [string cat "a$ b"]
+lappend out [string cat a$%b]
+lappend out [string cat "a$%^&b"]
+lappend out [string cat {a$%b}]
+lappend out [llength [list $ x]]
+join $out |
+"#;
+
+#[test]
+fn a_dollar_that_starts_no_reference_is_literal_text() {
+    let (code, result, _) = run(BARE_DOLLAR_SHEET);
+    assert_eq!(code, Code::Ok, "{result}");
+    assert_eq!(result, "$|50% of $|a$ b|a$%b|a$%^&b|a$%b|2");
+}
+
+/// The fix must not blunt the real one. Oracle, measured one script per
+/// `tclsh` run on 8.6.16 and 9.0.4:
+///
+/// ```text
+/// set y {unclosed  -> missing close-brace
+/// list a {b {c     -> missing close-brace
+/// set y {a}b       -> extra characters after close-brace
+/// set y x{a}{b     -> ok, y is x{a}{b
+/// ```
+///
+/// The last row is the one the opening-byte test has to keep right: a `{`
+/// that is not at word start is ordinary data, so `x{a}{b` has nothing to
+/// close and must not be read as a brace-delimited fragment at all.
+#[test]
+fn a_brace_that_really_is_one_still_raises() {
+    for (script, want) in [
+        ("set y {unclosed", "missing close-brace"),
+        ("list a {b {c", "missing close-brace"),
+        ("set y {a}b", "extra characters after close-brace"),
+    ] {
+        let (code, result, _) = run(script);
+        assert_eq!((code, result.as_str()), (Code::Error, want), "{script}");
+    }
+    let (code, result, _) = run("set y x{a}{b");
+    assert_eq!((code, result.as_str()), (Code::Ok, "x{a}{b"));
+}

--- a/rust/tcl-compiler/src/lowering/mod.rs
+++ b/rust/tcl-compiler/src/lowering/mod.rs
@@ -3983,27 +3983,6 @@ pub fn lower_to_ir_traced_with_dialect(
     )
 }
 
-/// Lexer warning messages that correspond to a hard `Tcl_ParseCommand`
-/// failure in C Tcl — i.e. a malformed word that C Tcl reports as a parse
-/// error rather than tokenising leniently.
-///
-/// The lexer detects these but only *raises* them under `strict_quoting`
-/// (off by default); in the VM compile path it records them as warnings and
-/// recovers. C Tcl, however, aborts compilation of the script and defers the
-/// error to a bytecode instruction that raises it at runtime — so a parse
-/// error inside a `catch {…}` body (re-compiled at runtime) is catchable. See
-/// [`first_fatal_parse_error`].
-const FATAL_PARSE_MESSAGES: &[&str] = &[
-    "extra characters after close-quote",
-    "extra characters after close-brace",
-    "missing close-brace",
-    "missing close-brace for variable name",
-    "invalid character in array index",
-    "missing \"",
-    "missing )",
-    "missing close-bracket",
-];
-
 /// Return the first hard parse-error message in `source`, in source order, or
 /// `None` if `source` parses cleanly.
 ///
@@ -4015,8 +3994,7 @@ const FATAL_PARSE_MESSAGES: &[&str] = &[
 /// IR / bytecode never sees them.
 ///
 /// Lexes with the default (Tcl-8.5+) dialect config — the same one
-/// [`lower_to_ir_for_bytecode`] uses. Only the messages in
-/// [`FATAL_PARSE_MESSAGES`] count; benign warnings are ignored.
+/// [`lower_to_ir_for_bytecode`] uses.
 #[must_use]
 pub fn first_fatal_parse_error(source: &str) -> Option<String> {
     first_fatal_parse_error_with_config(source, tcl_lexer::LexerConfig::default())
@@ -4032,13 +4010,33 @@ pub fn first_fatal_parse_error_with_config(
     source: &str,
     config: tcl_lexer::LexerConfig,
 ) -> Option<String> {
-    let lexer = tcl_lexer::Lexer::with_source_map(tcl_lexer::SourceMap::new(source), config);
-    let (_tokens, warnings) = lexer.tokenise_all_with_warnings().ok()?;
-    warnings
-        .into_iter()
-        .filter(|w| FATAL_PARSE_MESSAGES.contains(&w.message.as_str()))
-        .min_by_key(|w| w.offset)
-        .map(|w| w.message)
+    first_fatal_parse_cut(source, config).map(|cut| cut.message.to_owned())
+}
+
+/// The full [`tcl_lexer::ParseCut`] for `source` — the message *and* the
+/// index of the top-level command it was found under.
+///
+/// The command index is what separates this from
+/// [`first_fatal_parse_error_with_config`]: C runs every command before the
+/// cut and only then raises, so a front-end that wants C's behaviour has to
+/// know where the clean prefix ends (issue #1603). The message alone cannot
+/// say.
+///
+/// This is a thin re-export of [`tcl_lexer::first_parse_cut`] — the shared
+/// owner — and exists so `tcl-compiler`'s consumers have one import for the
+/// whole parse-error question rather than reaching past it into the lexer.
+/// Until #1810 this crate filtered the lexer's flat **warning stream**
+/// against a private list of eight message strings and took the
+/// lowest-offset hit, which disagreed with C whenever the failure was
+/// nested: `list [sfx one] [list "oops]` warned `missing close-bracket`
+/// where C reports `missing "`, and a welded close-brace (`set y {a}b`)
+/// was invisible to a warning stream entirely.
+#[must_use]
+pub fn first_fatal_parse_cut(
+    source: &str,
+    config: tcl_lexer::LexerConfig,
+) -> Option<tcl_lexer::ParseCut> {
+    tcl_lexer::first_parse_cut(source, config)
 }
 
 /// Drive a configured [`Lowerer`] to a finished [`Module`] (the shared tail of

--- a/rust/tcl-lexer/src/lib.rs
+++ b/rust/tcl-lexer/src/lib.rs
@@ -62,6 +62,7 @@ mod expr_lexer;
 mod highlight;
 mod lexer;
 mod line_index;
+pub mod parse_cut;
 mod ranges;
 pub mod script;
 mod source_map;
@@ -83,6 +84,7 @@ pub use highlight::{
 };
 pub use lexer::{LeadingBom, LexError, LexWarning, Lexer, LexerConfig, UTF8_BOM};
 pub use line_index::{LineIndex, normalise_lone_cr};
+pub use parse_cut::{EXTRA_AFTER_CLOSE_QUOTE, ParseCut, first_parse_cut, first_parse_cut_in};
 pub use ranges::{
     ArrayIndexEnd, ArrayIndexScan, BracedVarEnd, INVALID_CHARACTER_IN_ARRAY_INDEX,
     MISSING_CLOSE_BRACE_FOR_VAR, braced_var_name_end, close_quote_offset, command_substitution_end,

--- a/rust/tcl-lexer/src/parse_cut.rs
+++ b/rust/tcl-lexer/src/parse_cut.rs
@@ -1,0 +1,618 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! The one owner of **where a script stops parsing** — the *cut* (issue
+//! #1787).
+//!
+//! C Tcl parses a script one command at a time and evaluates each before
+//! parsing the next, so a malformed command does not erase what preceded
+//! it: `puts pre; puts "x${abc"` prints `pre` and *then* raises `missing
+//! close-brace for variable name`.  Two Rust consumers need to know where
+//! that boundary falls, and both used to work it out privately:
+//!
+//! * `runtime/rust` walks the words of the command it is about to evaluate
+//!   (`parse::first_parse_error`) and defers the failure to the word that
+//!   carries it;
+//! * `tcl-compiler` filtered the [`Lexer`](crate::Lexer)'s **warning
+//!   stream** against a private list of eight message strings and took the
+//!   one with the lowest offset, so a VM front-end could turn a malformed
+//!   script into a catchable runtime error.
+//!
+//! The second answer was wrong in two measurable ways, because a warning
+//! stream is flat and C's parse is not.  For
+//! `list [sfx one] [list "oops]` the lexer warns `missing close-bracket`
+//! at the end of the script while C — which parses the bracket's own
+//! script during the outer command's parse — reports `missing "`.  For
+//! `puts $a([set q "x)` the lexer warns `missing )` at the `(` while C
+//! again reports `missing "` from inside the bracket.  And a warning
+//! stream cannot see [`WordSpan::welded_after_close`] at all, so
+//! `set y {a}b` was accepted as three words where C rejects it.
+//!
+//! # What the cut is
+//!
+//! [`first_parse_cut`] walks [`group_commands`] in source order, then each
+//! command's words in source order, then each word's components in source
+//! order, descending into `[…]` bodies and `$arr(index)` components
+//! exactly as C's `ParseTokens` does.  The first construct C rejects wins,
+//! and the answer carries the **top-level command index** it was found
+//! under — which is what a bytecode front-end needs in order to compile
+//! the clean prefix and raise only after it has run.
+//!
+//! Nothing here is a new scanner.  Each class of failure is delegated to
+//! the primitive that already owns its spelling:
+//! [`quoted_word_close`](crate::word_parts::quoted_word_close) for
+//! `missing "` and the close-quote position,
+//! [`word_closer_offset_at`](crate::word_closer_offset_at) for an
+//! unterminated brace, [`decompose_spanned`] for everything inside a word,
+//! and [`group_commands`] for `{*}` and the welded close-brace.  This
+//! module only decides the **order** they are asked in.
+//!
+//! # Not an evaluator's parse
+//!
+//! A cut says *where* a script stops being parseable, not what to do about
+//! it.  `runtime/rust` keeps its own per-command walk over the borrowed
+//! tree it has already built — re-deriving the cut from source there would
+//! re-lex every command it evaluates — and `runtime/rust`'s
+//! `parse_cut_owner_agrees` test is what keeps the two applications of this
+//! policy honest.
+
+use crate::script::{CommandSpan, WordKind, group_commands};
+use crate::word_parts::{
+    EXTRA_AFTER_CLOSE_BRACE, MISSING_CLOSE_BRACE, SpannedPart, SubstFlags, WordPart,
+    decompose_spanned, quoted_word_close,
+};
+use crate::{Lexer, LexerConfig, SourceMap, Token, word_closer_offset_at, word_span_at};
+
+/// C's message for content that follows a word's closing `"`.
+///
+/// Spelled here rather than in [`word_parts`](crate::word_parts) because
+/// only a *word in a command* can have anything after its closer — the
+/// content scan that module owns never sees past one.  The lexer raises the
+/// same text under `strict_quoting`; this is the shared constant both now
+/// name.
+pub const EXTRA_AFTER_CLOSE_QUOTE: &str = "extra characters after close-quote";
+
+/// How deep a `[…]` chain is followed before the walk gives up and reports
+/// no cut for the remainder.
+///
+/// Mirrors `runtime/rust`'s `MAX_PARSE_ERROR_SCAN_DEPTH` and for the same
+/// reason: each level is one `eval_command_subst` when the script actually
+/// runs, so a script nested deeper than an interpreter's own eval-depth
+/// limit could never have evaluated anyway.  Capping keeps this walk's
+/// native recursion bounded by a constant instead of by the input.
+const MAX_CUT_SCAN_DEPTH: u32 = 128;
+
+/// Where a script stops parsing, in C's order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ParseCut {
+    /// Index into [`group_commands`]'s result for the **top-level** script
+    /// of the command the failure was found under.
+    ///
+    /// Commands before this one parse cleanly and, in C, run before the
+    /// error is raised.  A failure inside a `[…]` body reports the
+    /// top-level command that contains the bracket, not the inner command
+    /// index — the inner script is not separately evaluable.
+    pub command: usize,
+    /// Byte offset in the scanned source of the construct C rejected.
+    ///
+    /// Exact for a failure in a word or in a `[…]` body.  For one found
+    /// inside a `$arr(index)` the offset is the reference's `$`:
+    /// [`decompose_spanned`] does not carry extents for index components,
+    /// and the `$` is the nearest position that is certainly correct.
+    ///
+    /// An *unterminated* construct — a brace or quote that never closes —
+    /// cuts where the parse ran out of input, so the offset is one past the
+    /// last byte scanned and can equal the length of the scanned source.
+    /// Slice with it only after bounds-checking.
+    pub offset: u32,
+    /// C's exact message for the construct.
+    pub message: &'static str,
+}
+
+/// The first parse cut in `src`, or `None` when the whole script parses.
+///
+/// Lexes `src` under `config` and delegates to [`first_parse_cut_in`]; a
+/// caller that already holds the token stream should use that instead of
+/// paying for a second lex.
+///
+/// ```
+/// use tcl_lexer::{LexerConfig, first_parse_cut};
+/// let cut = first_parse_cut("puts pre\nputs \"x${abc\"", LexerConfig::default()).unwrap();
+/// assert_eq!(cut.command, 1);
+/// assert_eq!(cut.message, "missing close-brace for variable name");
+/// // Nothing to cut.
+/// assert!(first_parse_cut("puts pre\nputs done", LexerConfig::default()).is_none());
+/// ```
+#[must_use]
+pub fn first_parse_cut(src: &str, config: LexerConfig) -> Option<ParseCut> {
+    let (tokens, commands) = lex_and_group(src, config)?;
+    first_parse_cut_in(&commands, &tokens, src, config)
+}
+
+/// [`first_parse_cut`] over a token stream and grouping the caller already
+/// has.
+///
+/// `commands` must come from [`group_commands`] over `tokens`, and
+/// `tokens` from a [`Lexer`] run over `src` under `config`.
+#[must_use]
+pub fn first_parse_cut_in(
+    commands: &[CommandSpan],
+    tokens: &[Token],
+    src: &str,
+    config: LexerConfig,
+) -> Option<ParseCut> {
+    commands.iter().enumerate().find_map(|(index, command)| {
+        command_cut(command, tokens, src, config, 0).map(|(offset, message)| ParseCut {
+            command: index,
+            offset,
+            message,
+        })
+    })
+}
+
+/// Lex and group `src`, or `None` when the lexer could not produce a stream
+/// at all.
+///
+/// A hard [`LexError`](crate::LexError) is not a cut: it is the lexer
+/// refusing the input outright (a malformed encoding), which no consumer of
+/// this module models as a Tcl parse error.
+fn lex_and_group(src: &str, config: LexerConfig) -> Option<(Vec<Token>, Vec<CommandSpan>)> {
+    let lexer = Lexer::with_source_map(SourceMap::new(src), config);
+    let tokens = lexer.tokenise_all().ok()?;
+    let commands = group_commands(&tokens, src, config);
+    Some((tokens, commands))
+}
+
+/// The first cut among one command's words, in source order.
+fn command_cut(
+    command: &CommandSpan,
+    tokens: &[Token],
+    src: &str,
+    config: LexerConfig,
+    depth: u32,
+) -> Option<(u32, &'static str)> {
+    command
+        .words
+        .iter()
+        .find_map(|word| word_cut(word, tokens, src, config, depth))
+}
+
+/// The first cut in one word: its own delimiters first, then its
+/// components in source order.
+fn word_cut(
+    word: &crate::script::WordSpan,
+    tokens: &[Token],
+    src: &str,
+    config: LexerConfig,
+    depth: u32,
+) -> Option<(u32, &'static str)> {
+    // A brace group that closed but has content welded to it — `{a}b`,
+    // `{a}{b}`, `{a}{*}$b` — is C's first complaint about the word, and
+    // the grouping owner is the only thing that can see it.
+    if word.welded_after_close {
+        return Some((weld_offset(word, tokens, src), EXTRA_AFTER_CLOSE_BRACE));
+    }
+    let written = written_span(word, tokens, src);
+    let (start, end) = (written.start() as usize, written.end() as usize);
+    match word.kind {
+        // A braced word is C's `TCL_TOKEN_SIMPLE_WORD`: its content is not
+        // parsed as anything, so the only thing that can fail is the brace
+        // itself failing to close.
+        //
+        // Two traps in that one test.  [`WordKind::Braced`] means *one `Str`
+        // token* — the lexer's literal-word class — not *brace-delimited*: a
+        // word that is a lone `$` is also one `Str` token, so the opening
+        // byte has to be checked before a closer is demanded.  And the
+        // closer test takes the **lexer's** span, not the widened one:
+        // widening already consumed the `}`, so asking
+        // [`word_closer_offset_at`](crate::word_closer_offset_at) about the
+        // widened span asks whether the byte *after* the `}` is a `}`.
+        WordKind::Braced => (src.as_bytes().get(start) == Some(&b'{')
+            && word_closer_offset_at(src, word.span).is_none())
+        .then(|| (written.end(), MISSING_CLOSE_BRACE)),
+        WordKind::Quoted => match quoted_word_close(src, start) {
+            Err(message) => Some((written.end(), message)),
+            // Anything written between the closing `"` and the end of the
+            // word is C's `extra characters after close-quote`.
+            Ok(close) if end > close + 1 => Some((offset_of(close + 1), EXTRA_AFTER_CLOSE_QUOTE)),
+            Ok(close) => content_cut(src, start + 1, close, config, depth),
+        },
+        WordKind::Bare => content_cut(src, start, end, config, depth),
+    }
+}
+
+/// The whole written word, closing delimiter included.
+///
+/// Widening is the **last token's** job, not the word's: the lexer's
+/// inner-end convention leaves a braced or bracketed final fragment's `}` /
+/// `]` one byte past the token span, and
+/// [`word_span_at`](crate::word_span_at) can only widen a span that *opens*
+/// with a delimiter.  Asking it about the whole word instead leaves
+/// `lappend x pre-[cmd arg]` a byte short and the trailing `]` invisible,
+/// which reads as an unterminated bracket.  This is `build.rs`'s
+/// `widen_word_end` policy, which the boundary owner documents on
+/// [`CommandSpan::span`](crate::CommandSpan::span).
+fn written_span(word: &crate::script::WordSpan, tokens: &[Token], src: &str) -> crate::Span {
+    let end = word
+        .tokens
+        .end
+        .checked_sub(1)
+        .and_then(|last| tokens.get(last))
+        .map_or(word.span.end(), |last| word_span_at(src, last.span).end());
+    crate::Span::new(word.span.start(), end.max(word.span.end()))
+}
+
+/// Byte offset of the content welded to a word's closing brace.
+///
+/// [`WordSpan::welded_after_close`] marks the word, not the position; the
+/// offset is where the *next* fragment of the word starts, which is the
+/// byte after the `}` that C stopped at.  Falls back to the word's own end
+/// if the word somehow holds a single token (it cannot: welding needs two).
+fn weld_offset(word: &crate::script::WordSpan, tokens: &[Token], src: &str) -> u32 {
+    let after_first = word
+        .tokens
+        .clone()
+        .find(|&i| {
+            tokens
+                .get(i)
+                .is_some_and(|t| t.span.start() > word.span.start())
+        })
+        .and_then(|i| tokens.get(i))
+        .map(|t| t.span.start());
+    after_first.unwrap_or_else(|| word_span_at(src, word.span).end())
+}
+
+/// The first cut among the substitution components of `src[start..end]`.
+fn content_cut(
+    src: &str,
+    start: usize,
+    end: usize,
+    config: LexerConfig,
+    depth: u32,
+) -> Option<(u32, &'static str)> {
+    let content = src.get(start..end)?;
+    let parts = decompose_spanned(content.as_bytes(), SubstFlags::default(), config);
+    parts_cut(&parts, start, config, depth)
+}
+
+/// The first cut among `parts`, whose extents are relative to `base`.
+fn parts_cut(
+    parts: &[SpannedPart<'_>],
+    base: usize,
+    config: LexerConfig,
+    depth: u32,
+) -> Option<(u32, &'static str)> {
+    parts.iter().find_map(|spanned| {
+        let at = offset_of(base + spanned.start);
+        match &spanned.part {
+            WordPart::Text(_) => None,
+            WordPart::ParseError(message) => Some((at, *message)),
+            // The `[` is one byte, so the body begins one past the part.
+            WordPart::Command(body) => body_cut(body, config, depth + 1)
+                .map(|(inner, message)| (at.saturating_add(inner).saturating_add(1), message)),
+            // Index components carry no extents of their own, so anything
+            // found inside one is reported at the reference's `$`.
+            WordPart::Variable(var) => var
+                .index
+                .as_deref()
+                .and_then(|index| index_cut(index, at, config, depth + 1)),
+        }
+    })
+}
+
+/// The first cut inside a complete `[…]` body, relative to the body.
+///
+/// A body that failed to *close* never reaches here — [`decompose_spanned`]
+/// reports that as a [`WordPart::ParseError`] on the enclosing word — so
+/// this is the descent C performs while parsing an outer command whose
+/// bracket is well-formed but whose inner script is not: `list [set y {a}b]`
+/// is `extra characters after close-brace`, found one level down.
+fn body_cut(body: &[u8], config: LexerConfig, depth: u32) -> Option<(u32, &'static str)> {
+    if depth >= MAX_CUT_SCAN_DEPTH {
+        return None;
+    }
+    let body = std::str::from_utf8(body).ok()?;
+    let (tokens, commands) = lex_and_group(body, config)?;
+    commands
+        .iter()
+        .find_map(|command| command_cut(command, &tokens, body, config, depth))
+}
+
+/// The first cut among a `$arr(index)` reference's own components, reported
+/// at `at` (the reference's `$`).
+///
+/// [`decompose`](crate::word_parts::decompose) nests index components
+/// without extents, so every position inside one collapses to the
+/// reference's own — see [`ParseCut::offset`].
+fn index_cut(
+    parts: &[WordPart<'_>],
+    at: u32,
+    config: LexerConfig,
+    depth: u32,
+) -> Option<(u32, &'static str)> {
+    if depth >= MAX_CUT_SCAN_DEPTH {
+        return None;
+    }
+    parts.iter().find_map(|part| match part {
+        WordPart::Text(_) => None,
+        WordPart::ParseError(message) => Some((at, *message)),
+        WordPart::Variable(var) => var
+            .index
+            .as_deref()
+            .and_then(|index| index_cut(index, at, config, depth + 1)),
+        WordPart::Command(body) => body_cut(body, config, depth + 1).map(|(_, m)| (at, m)),
+    })
+}
+
+/// A source offset as the `u32` every span in this crate uses.
+///
+/// Offsets past `u32::MAX` cannot occur: the lexer already refuses a source
+/// that large, so saturating is unreachable rather than lossy.
+fn offset_of(at: usize) -> u32 {
+    u32::try_from(at).unwrap_or(u32::MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{EXTRA_AFTER_CLOSE_QUOTE, ParseCut, first_parse_cut};
+    use crate::LexerConfig;
+
+    /// Measured on tclsh 8.4.20, 8.5.19, 8.6.16, 9.0.4 and 9.1b0 — byte
+    /// identical on all five — by running each script in a fresh child
+    /// interpreter whose `puts` appends to a list, then reporting the error
+    /// and what had already run:
+    ///
+    /// ```text
+    /// prefix-var      error missing close-brace for variable name   ran=pre
+    /// prefix-quote    error missing "                               ran=pre
+    /// prefix-bracket  error missing close-bracket                   ran=pre
+    /// prefix-brace    error extra characters after close-brace      ran=pre
+    /// prefix-paren    error missing )                               ran=pre
+    /// prefix-quotex   error extra characters after close-quote      ran=pre
+    /// bracket-inner-q error missing "                               ran=pre
+    /// bracket-inner-b error extra characters after close-brace      ran=pre
+    /// two-before      error missing close-brace for variable name   ran=one two
+    /// welded-expand   error extra characters after close-brace      ran=pre
+    /// arr-index-err   error missing "                               ran=pre
+    /// semicolon-run   error missing )                               ran=a b
+    /// ```
+    ///
+    /// The `ran=` column is what the command index has to reproduce: it is
+    /// exactly the count of commands before the cut.  `bracket-inner-q` and
+    /// `arr-index-err` are the two rows the warning-stream scan this owner
+    /// replaced got *wrong* — it answered `missing close-bracket` and
+    /// `missing )`, because a flat stream cannot see that C parses a
+    /// bracket's own script during the enclosing command's parse.
+    const CUT_SHEET: &[(&str, &str, usize, &str)] = &[
+        (
+            "prefix-var",
+            "puts pre; puts \"x${abc\"",
+            1,
+            crate::MISSING_CLOSE_BRACE_FOR_VAR,
+        ),
+        (
+            "prefix-quote",
+            "puts pre; puts \"unterminated",
+            1,
+            crate::word_parts::MISSING_QUOTE,
+        ),
+        (
+            "prefix-bracket",
+            "puts pre; puts [foo",
+            1,
+            crate::word_parts::MISSING_CLOSE_BRACKET,
+        ),
+        (
+            "prefix-brace",
+            "puts pre; set y {a}b",
+            1,
+            crate::word_parts::EXTRA_AFTER_CLOSE_BRACE,
+        ),
+        (
+            "prefix-paren",
+            "puts pre; puts $a(",
+            1,
+            crate::word_parts::MISSING_PAREN,
+        ),
+        (
+            "prefix-quotex",
+            "puts pre; puts \"a\"b",
+            1,
+            EXTRA_AFTER_CLOSE_QUOTE,
+        ),
+        (
+            "bracket-inner-q",
+            "puts pre; list [sfx one] [list \"oops]",
+            1,
+            crate::word_parts::MISSING_QUOTE,
+        ),
+        (
+            "bracket-inner-b",
+            "puts pre; list [sfx one] [set y {a}b]",
+            1,
+            crate::word_parts::EXTRA_AFTER_CLOSE_BRACE,
+        ),
+        (
+            "two-before",
+            "puts one; puts two; puts \"x${abc\"",
+            2,
+            crate::MISSING_CLOSE_BRACE_FOR_VAR,
+        ),
+        (
+            "welded-expand",
+            "puts pre; sfx {a}{*}$b",
+            1,
+            crate::word_parts::EXTRA_AFTER_CLOSE_BRACE,
+        ),
+        (
+            "arr-index-err",
+            "puts pre; puts $a([set q \"x)",
+            1,
+            crate::word_parts::MISSING_QUOTE,
+        ),
+        (
+            "semicolon-run",
+            "sfx a; sfx b; puts $c(",
+            2,
+            crate::word_parts::MISSING_PAREN,
+        ),
+    ];
+
+    #[test]
+    fn cut_sheet_matches_c() {
+        for (label, script, command, message) in CUT_SHEET {
+            let cut = first_parse_cut(script, LexerConfig::default())
+                .unwrap_or_else(|| panic!("{label}: expected a cut in {script:?}"));
+            assert_eq!(
+                (cut.command, cut.message),
+                (*command, *message),
+                "{label}: {script:?}"
+            );
+        }
+    }
+
+    /// The offset points at the construct C stopped on, not at the start of
+    /// the command or the end of the script.
+    #[test]
+    fn cut_offset_lands_on_the_rejected_construct() {
+        for (script, want) in [
+            // The byte after the `}` that closed.
+            ("puts pre; set y {a}b", 19),
+            // The byte after the `"` that closed.
+            ("puts pre; puts \"a\"b", 18),
+            // The `{` of the `${` that never closed.
+            ("puts pre; puts \"x${abc\"", 17),
+            // The `[` that never closed.
+            ("puts pre; puts [foo", 15),
+            // One level down: the byte after the inner `}`.
+            ("puts pre; list [sfx one] [set y {a}b]", 35),
+            // Inside an array index, which carries no extents — the `$`.
+            ("puts pre; puts $a([set q \"x)", 15),
+        ] {
+            let cut = first_parse_cut(script, LexerConfig::default()).expect("a cut");
+            assert_eq!(cut.offset as usize, want, "{script:?}");
+        }
+    }
+
+    /// An unterminated construct cuts where the parse ran out of input, so
+    /// the offset is allowed to be one past the last byte — but never more.
+    #[test]
+    fn cut_offset_never_exceeds_the_source() {
+        for script in [
+            "puts pre; puts \"unterminated",
+            "puts pre; set y {unclosed",
+            "puts pre; puts [foo",
+        ] {
+            let cut = first_parse_cut(script, LexerConfig::default()).expect("a cut");
+            assert!(
+                cut.offset as usize <= script.len(),
+                "{script:?}: offset {} past len {}",
+                cut.offset,
+                script.len()
+            );
+        }
+    }
+
+    /// A braced word is not a script.  C does not parse one while parsing
+    /// the command that contains it, so a `catch`/`eval`/`proc` body that is
+    /// itself malformed is *not* a cut of the enclosing script — it is a cut
+    /// of the body, found when that body is compiled in its own right.
+    /// Measured: `puts pre; catch {set y "a"b} e; puts after` runs all three
+    /// commands on every shell, catching the parse error inside.
+    #[test]
+    fn a_braced_body_is_not_descended_into() {
+        for script in [
+            "puts pre; catch {set y \"a\"b} e; puts after",
+            "puts pre; catch {puts $a(} e; puts after",
+            "puts pre; eval {set y \"a\"b}",
+            "proc p {} {set y \"a\"b}",
+        ] {
+            assert_eq!(
+                first_parse_cut(script, LexerConfig::default()),
+                None,
+                "{script:?}"
+            );
+        }
+    }
+
+    /// Words that *look* like a delimiter problem and are not.  Every one of
+    /// these is accepted by all five shells; the first three are the shapes
+    /// that broke while this owner was being written.
+    #[test]
+    fn valid_scripts_have_no_cut() {
+        for script in [
+            // A `{` mid-word is ordinary data — C only opens a braced word
+            // at word start.
+            "set y hi\nputs $={y}",
+            "puts a{b}c",
+            // A lone `$` is a literal dollar, and lexes as one `Str` token —
+            // the same token shape a braced word has.
+            "puts [list $ $x]",
+            "set z $",
+            // A bracketed *final* fragment's `]` sits past the token span.
+            "lappend ev pre-[lindex $args end]",
+            // Nested, quoted, and escaped delimiters that do close.
+            "puts \"a[foo \\\"b\\\"]c\"",
+            "puts {$x eq {}}",
+            "set x [list \"a b\" {c d}]",
+            "puts pre\nputs done",
+        ] {
+            assert_eq!(
+                first_parse_cut(script, LexerConfig::default()),
+                None,
+                "{script:?}"
+            );
+        }
+    }
+
+    /// The cut is dialect-aware: `{*}` is an ordinary word under 8.4, where
+    /// `{*}{a b}` is a welded close-brace rather than an expansion (#1462).
+    #[test]
+    fn cut_follows_the_configured_dialect() {
+        let script = "puts pre; foo {*}{a b}";
+        assert_eq!(
+            first_parse_cut(script, LexerConfig::for_dialect("tcl8.4")),
+            Some(ParseCut {
+                command: 1,
+                offset: 17,
+                message: crate::word_parts::EXTRA_AFTER_CLOSE_BRACE,
+            }),
+        );
+        assert_eq!(
+            first_parse_cut(script, LexerConfig::for_dialect("tcl8.6")),
+            None,
+        );
+    }
+
+    /// Deep `[…]` nesting terminates instead of overflowing the stack, and
+    /// still finds a cut that sits above the cap.
+    #[test]
+    fn deep_bracket_nesting_is_bounded() {
+        let deep = format!("puts {}x{}", "[foo ".repeat(400), "]".repeat(400));
+        assert_eq!(first_parse_cut(&deep, LexerConfig::default()), None);
+        let shallow_error = format!(
+            "puts \"a\"b; puts {}x{}",
+            "[foo ".repeat(400),
+            "]".repeat(400)
+        );
+        assert_eq!(
+            first_parse_cut(&shallow_error, LexerConfig::default()).map(|c| c.message),
+            Some(EXTRA_AFTER_CLOSE_QUOTE),
+        );
+    }
+}

--- a/rust/tcl-lexer/src/parse_cut.rs
+++ b/rust/tcl-lexer/src/parse_cut.rs
@@ -87,16 +87,6 @@ use crate::{Lexer, LexerConfig, SourceMap, Token, word_closer_offset_at, word_sp
 /// name.
 pub const EXTRA_AFTER_CLOSE_QUOTE: &str = "extra characters after close-quote";
 
-/// How deep a `[…]` chain is followed before the walk gives up and reports
-/// no cut for the remainder.
-///
-/// Mirrors `runtime/rust`'s `MAX_PARSE_ERROR_SCAN_DEPTH` and for the same
-/// reason: each level is one `eval_command_subst` when the script actually
-/// runs, so a script nested deeper than an interpreter's own eval-depth
-/// limit could never have evaluated anyway.  Capping keeps this walk's
-/// native recursion bounded by a constant instead of by the input.
-const MAX_CUT_SCAN_DEPTH: u32 = 128;
-
 /// Where a script stops parsing, in C's order.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ParseCut {
@@ -157,7 +147,7 @@ pub fn first_parse_cut_in(
     config: LexerConfig,
 ) -> Option<ParseCut> {
     commands.iter().enumerate().find_map(|(index, command)| {
-        command_cut(command, tokens, src, config, 0).map(|(offset, message)| ParseCut {
+        command_cut(command, tokens, src, config).map(|(offset, message)| ParseCut {
             command: index,
             offset,
             message,
@@ -178,37 +168,119 @@ fn lex_and_group(src: &str, config: LexerConfig) -> Option<(Vec<Token>, Vec<Comm
     Some((tokens, commands))
 }
 
+/// One level of the walk's explicit stack.
+///
+/// The descent is iterative, and deliberately **unbounded**: C's parser has
+/// no nesting limit of its own.  Measured on 8.6.16 and 9.0.4,
+/// `puts [list [list … set y {a}b …]]` nested 5000 deep still reports
+/// `extra characters after close-brace`, while the *well-formed* script at
+/// the same depth gets that far and fails only later, at evaluation, with
+/// `too many nested evaluations`.  A parse-depth cap here would answer
+/// `None` — "the whole script parses" — for a script C rejects, which is the
+/// one answer this owner must never give.  Depth costs heap frames rather
+/// than native stack, so the walk is O(input) like the parse it mirrors and
+/// needs no limit of its own; the lexer's source-size limit bounds it.
+enum Frame<'s> {
+    /// A grouped script's words, flattened in document order.
+    Words {
+        jobs: Vec<WordJob<'s>>,
+        next: usize,
+        report_at: Option<u32>,
+    },
+    /// A decomposed word's components.
+    Parts {
+        parts: Vec<SpannedPart<'s>>,
+        base: u32,
+        next: usize,
+        report_at: Option<u32>,
+        /// The word's own delimiter failure, reported if — and only if —
+        /// nothing *inside* the word fails first.  This is how an
+        /// unterminated quoted word yields C's answer: `puts "[foo"` is
+        /// `missing close-bracket`, not `missing "`.
+        fallback: Option<(u32, &'static str)>,
+    },
+    /// A `$arr(index)`'s components, which carry no extents of their own, so
+    /// everything found inside one reports at the reference's `$`.
+    Index {
+        parts: Vec<WordPart<'s>>,
+        at: u32,
+        next: usize,
+    },
+}
+
+/// One word of a script, resolved to what the walk must do with it.
+///
+/// Resolving every word of a body up front keeps a [`Frame`] free of borrows
+/// into the token stream it was grouped from, which is what lets a nested
+/// body be pushed without the enclosing frame still holding it.
+enum WordJob<'s> {
+    /// The word fails here, whatever its content holds.
+    Cut(u32, &'static str),
+    /// Walk this content; if nothing in it fails, report `fallback`.
+    Content {
+        content: &'s [u8],
+        base: u32,
+        fallback: Option<(u32, &'static str)>,
+    },
+    /// A braced word: C does not parse its content as anything.
+    Literal,
+}
+
 /// The first cut among one command's words, in source order.
 fn command_cut(
     command: &CommandSpan,
     tokens: &[Token],
     src: &str,
     config: LexerConfig,
-    depth: u32,
 ) -> Option<(u32, &'static str)> {
-    command
-        .words
-        .iter()
-        .find_map(|word| word_cut(word, tokens, src, config, depth))
+    let jobs = word_jobs(&command.words, tokens, src, 0);
+    let mut stack = vec![Frame::Words {
+        jobs,
+        next: 0,
+        report_at: None,
+    }];
+    drain(&mut stack, config)
 }
 
-/// The first cut in one word: its own delimiters first, then its
-/// components in source order.
-fn word_cut(
+/// Resolve every word of a grouped script into its [`WordJob`], with offsets
+/// already rebased onto the enclosing source.
+fn word_jobs<'s>(
+    words: &[crate::script::WordSpan],
+    tokens: &[Token],
+    src: &'s str,
+    base: u32,
+) -> Vec<WordJob<'s>> {
+    words
+        .iter()
+        .map(|word| word_job(word, tokens, src, base))
+        .collect()
+}
+
+/// Check one word's own delimiters.
+fn word_job<'s>(
     word: &crate::script::WordSpan,
     tokens: &[Token],
-    src: &str,
-    config: LexerConfig,
-    depth: u32,
-) -> Option<(u32, &'static str)> {
+    src: &'s str,
+    base: u32,
+) -> WordJob<'s> {
+    let at = |offset: u32| offset.saturating_add(base);
     // A brace group that closed but has content welded to it — `{a}b`,
-    // `{a}{b}`, `{a}{*}$b` — is C's first complaint about the word, and
-    // the grouping owner is the only thing that can see it.
+    // `{a}{b}`, `{a}{*}$b` — is C's first complaint about the word, and the
+    // grouping owner is the only thing that can see it.
     if word.welded_after_close {
-        return Some((weld_offset(word, tokens, src), EXTRA_AFTER_CLOSE_BRACE));
+        return WordJob::Cut(at(weld_offset(word, tokens, src)), EXTRA_AFTER_CLOSE_BRACE);
     }
     let written = written_span(word, tokens, src);
     let (start, end) = (written.start() as usize, written.end() as usize);
+    let content =
+        |from: usize, to: usize, fallback: Option<(u32, &'static str)>| match src.get(from..to) {
+            Some(text) => WordJob::Content {
+                content: text.as_bytes(),
+                base: at(offset_of(from)),
+                fallback,
+            },
+            None => WordJob::Literal,
+        };
     match word.kind {
         // A braced word is C's `TCL_TOKEN_SIMPLE_WORD`: its content is not
         // parsed as anything, so the only thing that can fail is the brace
@@ -222,18 +294,163 @@ fn word_cut(
         // widening already consumed the `}`, so asking
         // [`word_closer_offset_at`](crate::word_closer_offset_at) about the
         // widened span asks whether the byte *after* the `}` is a `}`.
-        WordKind::Braced => (src.as_bytes().get(start) == Some(&b'{')
-            && word_closer_offset_at(src, word.span).is_none())
-        .then(|| (written.end(), MISSING_CLOSE_BRACE)),
+        WordKind::Braced => {
+            if src.as_bytes().get(start) == Some(&b'{')
+                && word_closer_offset_at(src, word.span).is_none()
+            {
+                WordJob::Cut(at(written.end()), MISSING_CLOSE_BRACE)
+            } else {
+                WordJob::Literal
+            }
+        }
         WordKind::Quoted => match quoted_word_close(src, start) {
-            Err(message) => Some((written.end(), message)),
+            // The quote never closed — but that is not necessarily why C
+            // stopped.  `quoted_word_close` steps over complete `[…]`
+            // substitutions to find the closer, so an *incomplete* one makes
+            // it give up here while C, parsing the word's tokens left to
+            // right, has already failed inside the bracket:
+            // `puts "[foo"` is `missing close-bracket` on 8.6.16 and 9.0.4.
+            // Walk the content first and keep `missing "` as the fallback.
+            Err(message) => content(start + 1, end, Some((at(written.end()), message))),
             // Anything written between the closing `"` and the end of the
             // word is C's `extra characters after close-quote`.
-            Ok(close) if end > close + 1 => Some((offset_of(close + 1), EXTRA_AFTER_CLOSE_QUOTE)),
-            Ok(close) => content_cut(src, start + 1, close, config, depth),
+            Ok(close) if end > close + 1 => {
+                WordJob::Cut(at(offset_of(close + 1)), EXTRA_AFTER_CLOSE_QUOTE)
+            }
+            Ok(close) => content(start + 1, close, None),
         },
-        WordKind::Bare => content_cut(src, start, end, config, depth),
+        WordKind::Bare => content(start, end, None),
     }
+}
+
+/// Run the stack down to empty, or to the first cut.
+fn drain(stack: &mut Vec<Frame<'_>>, config: LexerConfig) -> Option<(u32, &'static str)> {
+    while let Some(frame) = stack.last_mut() {
+        match frame {
+            Frame::Words {
+                jobs,
+                next,
+                report_at,
+            } => {
+                let report_at = *report_at;
+                let Some(job) = jobs.get(*next) else {
+                    stack.pop();
+                    continue;
+                };
+                *next += 1;
+                match job {
+                    WordJob::Literal => {}
+                    WordJob::Cut(offset, message) => {
+                        return Some((report_at.unwrap_or(*offset), message));
+                    }
+                    WordJob::Content {
+                        content,
+                        base,
+                        fallback,
+                    } => {
+                        let pushed = Frame::Parts {
+                            parts: decompose_spanned(content, SubstFlags::default(), config),
+                            base: *base,
+                            next: 0,
+                            report_at,
+                            fallback: fallback
+                                .map(|(offset, message)| (report_at.unwrap_or(offset), message)),
+                        };
+                        stack.push(pushed);
+                    }
+                }
+            }
+            Frame::Parts {
+                parts,
+                base,
+                next,
+                report_at,
+                fallback,
+            } => {
+                let (base, report_at) = (*base, *report_at);
+                let Some(part) = parts.get(*next) else {
+                    let fallback = *fallback;
+                    stack.pop();
+                    if let Some(found) = fallback {
+                        return Some(found);
+                    }
+                    continue;
+                };
+                *next += 1;
+                let at = report_at.unwrap_or(base.saturating_add(offset_of(part.start)));
+                match &part.part {
+                    WordPart::Text(_) => {}
+                    WordPart::ParseError(message) => return Some((at, message)),
+                    WordPart::Variable(var) => {
+                        if let Some(index) = var.index.clone() {
+                            stack.push(Frame::Index {
+                                parts: index,
+                                at,
+                                next: 0,
+                            });
+                        }
+                    }
+                    // The `[` is one byte, so the body begins one past the part.
+                    WordPart::Command(body) => {
+                        let pushed = body_frame(body, at.saturating_add(1), report_at, config);
+                        stack.extend(pushed);
+                    }
+                }
+            }
+            Frame::Index { parts, at, next } => {
+                let at = *at;
+                let Some(part) = parts.get(*next) else {
+                    stack.pop();
+                    continue;
+                };
+                *next += 1;
+                match part {
+                    WordPart::Text(_) => {}
+                    WordPart::ParseError(message) => return Some((at, message)),
+                    WordPart::Variable(var) => {
+                        if let Some(index) = var.index.clone() {
+                            stack.push(Frame::Index {
+                                parts: index,
+                                at,
+                                next: 0,
+                            });
+                        }
+                    }
+                    WordPart::Command(body) => {
+                        let pushed = body_frame(body, at, Some(at), config);
+                        stack.extend(pushed);
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+/// A complete `[…]` body as a script frame to walk.
+///
+/// A body that failed to *close* never reaches here — [`decompose_spanned`]
+/// reports that as a [`WordPart::ParseError`] on the enclosing word — so this
+/// is the descent C performs while parsing an outer command whose bracket is
+/// well-formed but whose inner script is not: `list [set y {a}b]` is
+/// `extra characters after close-brace`, found one level down.
+fn body_frame(
+    body: &[u8],
+    base: u32,
+    report_at: Option<u32>,
+    config: LexerConfig,
+) -> Option<Frame<'_>> {
+    let body = std::str::from_utf8(body).ok()?;
+    let (tokens, commands) = lex_and_group(body, config)?;
+    let jobs = commands
+        .iter()
+        .flat_map(|command| word_jobs(&command.words, &tokens, body, base))
+        .collect();
+    Some(Frame::Words {
+        jobs,
+        next: 0,
+        report_at,
+    })
 }
 
 /// The whole written word, closing delimiter included.
@@ -275,88 +492,6 @@ fn weld_offset(word: &crate::script::WordSpan, tokens: &[Token], src: &str) -> u
         .and_then(|i| tokens.get(i))
         .map(|t| t.span.start());
     after_first.unwrap_or_else(|| word_span_at(src, word.span).end())
-}
-
-/// The first cut among the substitution components of `src[start..end]`.
-fn content_cut(
-    src: &str,
-    start: usize,
-    end: usize,
-    config: LexerConfig,
-    depth: u32,
-) -> Option<(u32, &'static str)> {
-    let content = src.get(start..end)?;
-    let parts = decompose_spanned(content.as_bytes(), SubstFlags::default(), config);
-    parts_cut(&parts, start, config, depth)
-}
-
-/// The first cut among `parts`, whose extents are relative to `base`.
-fn parts_cut(
-    parts: &[SpannedPart<'_>],
-    base: usize,
-    config: LexerConfig,
-    depth: u32,
-) -> Option<(u32, &'static str)> {
-    parts.iter().find_map(|spanned| {
-        let at = offset_of(base + spanned.start);
-        match &spanned.part {
-            WordPart::Text(_) => None,
-            WordPart::ParseError(message) => Some((at, *message)),
-            // The `[` is one byte, so the body begins one past the part.
-            WordPart::Command(body) => body_cut(body, config, depth + 1)
-                .map(|(inner, message)| (at.saturating_add(inner).saturating_add(1), message)),
-            // Index components carry no extents of their own, so anything
-            // found inside one is reported at the reference's `$`.
-            WordPart::Variable(var) => var
-                .index
-                .as_deref()
-                .and_then(|index| index_cut(index, at, config, depth + 1)),
-        }
-    })
-}
-
-/// The first cut inside a complete `[…]` body, relative to the body.
-///
-/// A body that failed to *close* never reaches here — [`decompose_spanned`]
-/// reports that as a [`WordPart::ParseError`] on the enclosing word — so
-/// this is the descent C performs while parsing an outer command whose
-/// bracket is well-formed but whose inner script is not: `list [set y {a}b]`
-/// is `extra characters after close-brace`, found one level down.
-fn body_cut(body: &[u8], config: LexerConfig, depth: u32) -> Option<(u32, &'static str)> {
-    if depth >= MAX_CUT_SCAN_DEPTH {
-        return None;
-    }
-    let body = std::str::from_utf8(body).ok()?;
-    let (tokens, commands) = lex_and_group(body, config)?;
-    commands
-        .iter()
-        .find_map(|command| command_cut(command, &tokens, body, config, depth))
-}
-
-/// The first cut among a `$arr(index)` reference's own components, reported
-/// at `at` (the reference's `$`).
-///
-/// [`decompose`](crate::word_parts::decompose) nests index components
-/// without extents, so every position inside one collapses to the
-/// reference's own — see [`ParseCut::offset`].
-fn index_cut(
-    parts: &[WordPart<'_>],
-    at: u32,
-    config: LexerConfig,
-    depth: u32,
-) -> Option<(u32, &'static str)> {
-    if depth >= MAX_CUT_SCAN_DEPTH {
-        return None;
-    }
-    parts.iter().find_map(|part| match part {
-        WordPart::Text(_) => None,
-        WordPart::ParseError(message) => Some((at, *message)),
-        WordPart::Variable(var) => var
-            .index
-            .as_deref()
-            .and_then(|index| index_cut(index, at, config, depth + 1)),
-        WordPart::Command(body) => body_cut(body, config, depth + 1).map(|(_, m)| (at, m)),
-    })
 }
 
 /// A source offset as the `u32` every span in this crate uses.
@@ -599,8 +734,69 @@ mod tests {
         );
     }
 
-    /// Deep `[…]` nesting terminates instead of overflowing the stack, and
-    /// still finds a cut that sits above the cap.
+    /// An unterminated quoted word is not automatically `missing "`.
+    ///
+    /// `quoted_word_close` steps over *complete* `[…]` substitutions to find
+    /// the closer, so an incomplete one makes it give up — but C, parsing the
+    /// word's tokens left to right, has already failed inside the bracket.
+    /// Measured one script per `tclsh` run on 8.6.16 and 9.0.4, identical:
+    ///
+    /// ```text
+    /// puts "[foo"        -> missing close-bracket
+    /// puts "a[foo b"     -> missing close-bracket
+    /// list "[foo"        -> missing close-bracket
+    /// puts "unterminated -> missing "
+    /// ```
+    #[test]
+    fn an_unterminated_quote_yields_the_error_inside_it_first() {
+        for (script, want) in [
+            ("puts \"[foo\"", crate::word_parts::MISSING_CLOSE_BRACKET),
+            ("puts \"a[foo b\"", crate::word_parts::MISSING_CLOSE_BRACKET),
+            ("list \"[foo\"", crate::word_parts::MISSING_CLOSE_BRACKET),
+            ("puts \"unterminated", crate::word_parts::MISSING_QUOTE),
+            // The quote's own error still wins when the word holds nothing
+            // that failed earlier.
+            ("puts \"a${b}c", crate::word_parts::MISSING_QUOTE),
+        ] {
+            assert_eq!(
+                first_parse_cut(script, LexerConfig::default()).map(|c| c.message),
+                Some(want),
+                "{script:?}"
+            );
+        }
+    }
+
+    /// C's parser has no nesting limit, so neither can this one.
+    ///
+    /// Measured on 8.6.16 and 9.0.4: `puts [list [list … set y {a}b …]]`
+    /// nested 1000 and 5000 deep both report `extra characters after
+    /// close-brace`, while the *well-formed* script at the same depth parses
+    /// and fails only at evaluation (`too many nested evaluations`). A
+    /// depth-capped walk answered `None` for the malformed one — "the whole
+    /// script parses" — which is the one answer this owner must never give.
+    #[test]
+    fn nesting_past_any_cap_still_finds_the_cut() {
+        for depth in [64usize, 129, 400] {
+            let malformed = format!(
+                "puts {}set y {{a}}b{}",
+                "[list ".repeat(depth),
+                "]".repeat(depth)
+            );
+            assert_eq!(
+                first_parse_cut(&malformed, LexerConfig::default()).map(|c| c.message),
+                Some(crate::word_parts::EXTRA_AFTER_CLOSE_BRACE),
+                "depth {depth}"
+            );
+            let well_formed = format!("puts {}ok{}", "[list ".repeat(depth), "]".repeat(depth));
+            assert_eq!(
+                first_parse_cut(&well_formed, LexerConfig::default()),
+                None,
+                "depth {depth}"
+            );
+        }
+    }
+
+    /// Deep `[…]` nesting terminates instead of overflowing the stack.
     #[test]
     fn deep_bracket_nesting_is_bounded() {
         let deep = format!("puts {}x{}", "[foo ".repeat(400), "]".repeat(400));

--- a/rust/xtask/src/segmentation_drift.rs
+++ b/rust/xtask/src/segmentation_drift.rs
@@ -83,19 +83,24 @@
 //! flagged line or in the comment block directly above it.
 
 use std::fmt::Write as _;
+use std::ops::Range;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
-/// The files allowed to derive a command or word boundary from raw bytes
-/// or from a `Sep`/`Eol` state machine: the tokeniser that defines the
-/// terminator grammar, the boundary owner, the two registered
-/// `tcl-lexer` scanners, and the compiler's segmentation owners — i.e.
-/// exactly the source paths the two owner-manifest rows name.
+/// The files allowed to derive a command or word boundary from raw bytes,
+/// from a `Sep`/`Eol` state machine, or from a list of C's parse failures:
+/// the tokeniser that defines the terminator grammar, the boundary and cut
+/// owners, the two registered `tcl-lexer` scanners, and the compiler's
+/// segmentation owners — i.e. exactly the source paths the three
+/// owner-manifest rows name.
 const SANCTIONED_FILES: &[&str] = &[
     // The tokeniser: `\n` / `;` *are* its grammar.
     "rust/tcl-lexer/src/lexer.rs",
     // The boundary owner (#1786).
     "rust/tcl-lexer/src/script.rs",
+    // The parse-error cut owner (#1787), which classifies the failures
+    // rule 4 bans a private list of.
+    "rust/tcl-lexer/src/parse_cut.rs",
     // The registered `Tcl_CommandComplete` port + reparse split points.
     "rust/tcl-lexer/src/structural_index.rs",
     // The registered word-span / delimiter-close scanners the two above
@@ -149,6 +154,33 @@ const WORD_START_WHY: &str = "carries a previous-token kind across a token loop 
      tcl_lexer::script::group_commands (or the compiler's segment_commands) and read \
      WordSpan";
 
+/// C's hard `Tcl_ParseCommand` failures, in the spelling a Rust string
+/// literal uses.  A *list* of two or more of these is a private fatal-parse
+/// classifier — the shape `tcl-compiler` carried as `FATAL_PARSE_MESSAGES`
+/// until the cut owner replaced it, and the shape that made
+/// `list [sfx one] [list "oops]` answer `missing close-bracket` where C says
+/// `missing "` (#1787).  A single message is not flagged: raising one, or
+/// asserting one, is ordinary.
+const PARSE_MESSAGE_NEEDLES: &[&str] = &[
+    "extra characters after close-quote",
+    "extra characters after close-brace",
+    "missing close-brace for variable name",
+    "missing close-brace",
+    "invalid character in array index",
+    "missing \\\"",
+    "missing )",
+    "missing close-bracket",
+];
+
+/// How many lines after an array opener the messages may be spread over.
+const MESSAGE_LIST_LOOKAHEAD: usize = 12;
+
+const PARSE_MESSAGE_WHY: &str = "collects C's parse-error messages into a private list — \
+     that is the parse-error cut classifier reimplemented, and a flat list cannot see that C \
+     parses a bracket's own script during the enclosing command's parse (#1787). Ask \
+     tcl_lexer::first_parse_cut, which walks the boundary and word-component owners in C's \
+     order and answers with the command index as well as the message";
+
 /// How many lines after (and before, for the `prev` binding) a needle may
 /// be split across by rustfmt.
 const LOOKAHEAD: usize = 8;
@@ -190,18 +222,20 @@ pub fn run(_check: bool) -> ExitCode {
 
     if hits == 0 {
         println!(
-            "segmentation-drift: OK (no private command-terminator scan or word-start state \
-             machine outside the boundary owners; the owner/scanner corpus differential is wired)"
+            "segmentation-drift: OK (no private command-terminator scan, word-start state \
+             machine, or parse-failure classifier outside the boundary and cut owners; the \
+             owner/scanner corpus differential is wired)"
         );
         return ExitCode::SUCCESS;
     }
     eprintln!(
-        "segmentation-drift: {hits} site(s) derive Tcl command or word boundaries outside the \
-         owner. Where a command ends and where a word begins is answered once, by \
-         tcl_lexer::script::group_commands over a dialect-configured token stream \
-         (shared-utility-contracts-rust.md, issue #1786); a reparse split point comes from \
-         tcl_lexer::command_boundaries. If a site genuinely is not segmenting Tcl script text, \
-         mark it `// {WAIVER} <reason>`:\n{report}"
+        "segmentation-drift: {hits} site(s) derive Tcl command or word boundaries, or classify \
+         a Tcl parse failure, outside the owners. Where a command ends and where a word begins \
+         is answered once, by tcl_lexer::script::group_commands over a dialect-configured token \
+         stream (shared-utility-contracts-rust.md, issue #1786); a reparse split point comes \
+         from tcl_lexer::command_boundaries; where a script stops parsing comes from \
+         tcl_lexer::first_parse_cut (#1787). If a site genuinely is not segmenting Tcl script \
+         text, mark it `// {WAIVER} <reason>`:\n{report}"
     );
     ExitCode::FAILURE
 }
@@ -244,15 +278,18 @@ fn is_exempt_path(rel: &str) -> bool {
 /// Every offending `(line_number, trimmed_line, why)` in `text`.
 fn scan(text: &str) -> Vec<(usize, &str, &'static str)> {
     let lines: Vec<&str> = text.lines().collect();
-    let test_tail = test_module_start(&lines).unwrap_or(lines.len());
+    let tests = test_module_ranges(&lines);
     let mut out = Vec::new();
-    for (idx, line) in lines.iter().enumerate().take(test_tail) {
+    for (idx, line) in lines.iter().enumerate() {
+        if tests.iter().any(|range| range.contains(&idx)) {
+            continue;
+        }
         let trimmed = line.trim();
         if trimmed.starts_with("//") {
             continue;
         }
         let code = code_only(trimmed);
-        let Some(why) = rule_for(&lines, idx, test_tail, &code) else {
+        let Some(why) = rule_for(&lines, idx, lines.len(), &code) else {
             continue;
         };
         if !is_waived(&lines, idx) {
@@ -269,6 +306,9 @@ fn rule_for(lines: &[&str], idx: usize, limit: usize, code: &str) -> Option<&'st
     if TERMINATOR_NEEDLES.iter().any(|n| code.contains(n)) {
         return Some(TERMINATOR_WHY);
     }
+    if let Some(why) = message_list_rule(lines, idx, limit, code) {
+        return Some(why);
+    }
     // Rule 2 needs a window: rustfmt splits a long `matches!` across lines,
     // and the `prev` scrutinee sits *before* the alternation.
     if !code.contains("Sep") {
@@ -284,6 +324,39 @@ fn rule_for(lines: &[&str], idx: usize, limit: usize, code: &str) -> Option<&'st
         .filter_map(|n| exact_alternation(&window, n))
         .any(|at| scrutinee_is_previous_token(&window[..at]))
         .then_some(WORD_START_WHY)
+}
+
+/// Rule 4: an array or slice literal that names two or more of C's parse
+/// failures.
+///
+/// Keyed on the opener rather than on the strings so that the messages a
+/// module raises one at a time — the owner's own constants, a lexer warning
+/// site, an analyser's diagnostic mapping — stay untouched; only a
+/// *classifier* trips it.
+fn message_list_rule(lines: &[&str], idx: usize, limit: usize, code: &str) -> Option<&'static str> {
+    if !code.contains("&[") && !code.contains("= [") {
+        return None;
+    }
+    let window = joined_literals(lines, idx, (idx + MESSAGE_LIST_LOOKAHEAD).min(limit));
+    let distinct = PARSE_MESSAGE_NEEDLES
+        .iter()
+        .filter(|needle| window.contains(&format!("\"{needle}\"")))
+        .count();
+    (distinct >= 2).then_some(PARSE_MESSAGE_WHY)
+}
+
+/// `lines[from..to]` joined with **string contents kept** — the opposite of
+/// [`joined`], which blanks them so a match pattern is never found inside a
+/// string.  Rule 4 is about the strings themselves, so it needs them; line
+/// comments are still dropped, which is what keeps a doc comment that
+/// *names* the messages (this module's own, and the cut owner's) from
+/// reading as a classifier.
+fn joined_literals(lines: &[&str], from: usize, to: usize) -> String {
+    lines[from..to.min(lines.len())]
+        .iter()
+        .map(|line| line.split("//").next().unwrap_or(line).trim())
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 /// Where `needle` appears in `window` as a **complete** alternation — the
@@ -353,19 +426,36 @@ fn joined(lines: &[&str], from: usize, to: usize) -> String {
 /// The line of the `#[cfg(test)]` that annotates a **module**, after which
 /// nothing is production code. (Verbatim from `dialect_drift`: a
 /// `#[cfg(test)]` on a single `use` near the top must not end the scan.)
-fn test_module_start(lines: &[&str]) -> Option<usize> {
-    lines.iter().enumerate().find_map(|(i, l)| {
-        if !l.trim_start().starts_with("#[cfg(test)]") {
-            return None;
+fn test_module_ranges(lines: &[&str]) -> Vec<Range<usize>> {
+    let mut out = Vec::new();
+    for (i, line) in lines.iter().enumerate() {
+        if !line.trim_start().starts_with("#[cfg(test)]") {
+            continue;
         }
-        let next = lines[i + 1..]
-            .iter()
-            .map(|l| l.trim_start())
-            .find(|l| !l.is_empty() && !l.starts_with("#["))?;
-        let item = next.strip_prefix("pub ").unwrap_or(next);
+        let Some((at, decl)) = lines[i + 1..].iter().enumerate().find_map(|(n, l)| {
+            let t = l.trim_start();
+            (!t.is_empty() && !t.starts_with("#[")).then_some((i + 1 + n, *l))
+        }) else {
+            continue;
+        };
+        let trimmed = decl.trim_start();
+        let item = trimmed.strip_prefix("pub ").unwrap_or(trimmed);
         let item = item.strip_prefix("(crate) ").unwrap_or(item);
-        (item.starts_with("mod ")).then_some(i)
-    })
+        if !item.starts_with("mod ") {
+            continue;
+        }
+        // A module's closer is a `}` at the module keyword's own
+        // indentation.  Every test module in this workspace is rustfmt'd,
+        // so that is exact; an unclosed one exempts the rest of the file,
+        // which is the pre-#1787 behaviour and the safe direction.
+        let indent = decl.len() - trimmed.len();
+        let end = lines[at + 1..]
+            .iter()
+            .position(|l| l.trim_end() == format!("{}}}", " ".repeat(indent)))
+            .map_or(lines.len(), |n| at + n + 2);
+        out.push(i..end);
+    }
+    out
 }
 
 /// The code part of a line: everything before a `//` that is not inside a
@@ -555,9 +645,37 @@ mod tests {
         assert!(scan(src).is_empty());
     }
 
+    /// The exemption follows the module's own extent, not "everything after
+    /// the first `#[cfg(test)]`".  `tcl-compiler`'s `lowering/mod.rs` opens a
+    /// test module 500 lines before the end of its production code; under the
+    /// old cutoff the private classifier rule 4 bans was invisible there.
+    #[test]
+    fn production_code_after_a_test_module_is_still_scanned() {
+        let src = "#[cfg(test)]\nmod tests {\n    fn g(c: u8) { \
+                   let _ = matches!(c, b'\\n' | b';'); }\n}\n\n\
+                   fn later(c: u8) { let _ = matches!(c, b'\\n' | b';'); }\n";
+        let hits = scan(src);
+        assert_eq!(hits.len(), 1, "{hits:?}");
+        assert_eq!(hits[0].0, 6, "the hit is the one outside the test module");
+    }
+
+    #[test]
+    fn a_list_of_parse_failures_is_a_hit_but_a_single_message_is_not() {
+        let list = "const M: &[&str] = &[\n    \"missing close-bracket\",\n\
+                    \"extra characters after close-quote\",\n];\n";
+        assert_eq!(scan(list).len(), 1, "{:?}", scan(list));
+        // One message, raised rather than classified.
+        assert!(scan("return Err(\"missing close-bracket\");\n").is_empty());
+        // Two messages that are not collected into a list.
+        let prose = "fn a() { raise(\"missing close-bracket\"); }\n\
+                     fn b() { raise(\"missing )\"); }\n";
+        assert!(scan(prose).is_empty(), "{:?}", scan(prose));
+    }
+
     #[test]
     fn owner_and_test_paths_are_exempt() {
         assert!(is_exempt_path("rust/tcl-lexer/src/script.rs"));
+        assert!(is_exempt_path("rust/tcl-lexer/src/parse_cut.rs"));
         assert!(is_exempt_path("rust/tcl-lexer/src/structural_index.rs"));
         assert!(is_exempt_path("rust/tcl-compiler/src/segmenter.rs"));
         assert!(is_exempt_path("rust/tcl-lexer/tests/lexer_depth.rs"));

--- a/rust/xtask/src/segmentation_drift.rs
+++ b/rust/xtask/src/segmentation_drift.rs
@@ -441,7 +441,14 @@ fn test_module_ranges(lines: &[&str]) -> Vec<Range<usize>> {
         let trimmed = decl.trim_start();
         let item = trimmed.strip_prefix("pub ").unwrap_or(trimmed);
         let item = item.strip_prefix("(crate) ").unwrap_or(item);
-        if !item.starts_with("mod ") {
+        // Only an *inline* module has an extent to skip. A `#[cfg(test)] mod
+        // tests;` declaration names an external file — eight of them in this
+        // workspace, `tcl-compiler/src/native_lowering/mod.rs` among them —
+        // and has no `}` of its own, so treating it as a range blanks out
+        // every line after it and silently drops the rest of the file from
+        // the lint. The external file is exempt by path anyway
+        // (`is_exempt_path` covers `**/tests.rs`).
+        if !item.starts_with("mod ") || !item.contains('{') {
             continue;
         }
         // A module's closer is a `}` at the module keyword's own
@@ -657,6 +664,24 @@ mod tests {
         let hits = scan(src);
         assert_eq!(hits.len(), 1, "{hits:?}");
         assert_eq!(hits[0].0, 6, "the hit is the one outside the test module");
+    }
+
+    /// A `#[cfg(test)] mod tests;` declaration names an *external* file and
+    /// has no `}` of its own. Treating it as a module range blanks out every
+    /// line after it — which is what happened in
+    /// `tcl-compiler/src/native_lowering/mod.rs`, where the declaration sits
+    /// 500 lines above the end of the production code.
+    #[test]
+    fn an_external_test_module_declaration_does_not_exempt_the_file() {
+        let src = "#[cfg(test)]\nmod tests;\n\n\
+                   fn later(c: u8) { let _ = matches!(c, b'\\n' | b';'); }\n";
+        let hits = scan(src);
+        assert_eq!(hits.len(), 1, "{hits:?}");
+        assert_eq!(hits[0].0, 4);
+        // The external file itself is exempt by path, so nothing is lost.
+        assert!(is_exempt_path(
+            "rust/tcl-compiler/src/native_lowering/tests.rs"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **`tcl_lexer::parse_cut::first_parse_cut`** is the one answer to *where a script stops parsing*: which command C rejects, at what offset, with which message. It walks `group_commands` and `word_parts` in C's own order — commands, then words, then components, descending into `[…]` bodies and `$arr(index)` as `ParseTokens` does. Nothing in it is a new scanner; each class of failure is delegated to the primitive that already owns its spelling. What is new is the **command index**, which a message alone cannot carry and which is what a bytecode front-end needs to compile the prefix that runs before the raise (#1603).
- **`tcl-compiler`'s `FATAL_PARSE_MESSAGES` is deleted.** `first_fatal_parse_error{,_with_config}` delegate to the owner, and `first_fatal_parse_cut` exposes the index. That private list of eight message strings, filtered out of the lexer's flat **warning stream** and taken lowest-offset-first, was wrong wherever the failure was nested — a warning stream is flat and C's parse is not. Measured on 8.4.20, 8.5.19, 8.6.16, 9.0.4 and 9.1b0, identical on all five:

  | script | C | was |
  |---|---|---|
  | `list [sfx one] [list "oops]` | `missing "` | `missing close-bracket` |
  | `puts $a([set q "x)` | `missing "` | `missing )` |
  | `set y {a}b` | `extra characters after close-brace` | accepted as three words |

  The whole `tcl-vm` suite passes unchanged, so no test had encoded the wrong answers.
- **A live `runtime/rust` bug, found by the new differential.** `puts "50% of $"` raised `missing close-brace`. So did `puts "$"`, `puts "a$ b"` and `puts a$%b` — all plain text on every shell. `brace_token_unterminated` asked whether a `Str` token reached its closer without first checking it opens a brace, and `Str` is the lexer's *literal-fragment* class, not its brace class. Committed separately (`e0d721d`).
- **This is the reshape agreed on #1787**: a shared parse-error *cut* owner applied twice, rather than the shared parse-then-evaluate *driver* the issue originally asked for. The rationale is in [the #1787 comment](https://github.com/bitwisecook/tcl-lsp/issues/1787#issuecomment-5535000401); the VM half (prefix compilation, closing #1603) stays open.

Two traps the corpus found, both documented at the site: `WordKind::Braced` means *one `Str` token*, not *brace-delimited* (a lone `$` is one too), and widening a word to its closing delimiter is the **last token's** job — `word_span_at` only widens a span that opens with a delimiter, so asking it about the whole word leaves `lappend x pre-[cmd arg]` a byte short and its `]` invisible.

### One divergence pinned, not fixed

The close-quote weld (`"a"b`): C rejects it, the owner reports it, `runtime/rust` concatenates to `ab`. That is the exact sibling of the welded close-brace #1818 taught the runtime to raise, and raising a new error from the evaluator wants its own oracle sheet — so it is a follow-up, and `KNOWN_DIVERGENCES` in `parse_cut_agreement.rs` is the record that it is known and measured rather than missed.

### Gate

Rule 4 of `xtask-segmentation-drift` bans a private list of two or more of C's parse failures — the exact shape deleted here. Proving it fires exposed a blind spot in the gate itself: it stopped scanning at the *first* `#[cfg(test)]` and treated the rest of the file as test code, which in `lowering/mod.rs` (test module at 3724, production code to 4300) hid the very constant rule 4 bans. The exemption now follows each module's own extent; widening it surfaced no pre-existing hits. Owner-resolution is at 33 rows.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

```
cargo test -p tcl-lexer -p tcl-compiler --lib     # 464 + 6055 pass
cargo test -p tcl-vm                              # whole suite, unchanged
cargo test -p xtask                               # 201 pass (incl. the 3 new gate tests)
make runtime-rust-test                            # all suites green
cargo test --manifest-path runtime/rust/Cargo.toml --test parse_cut_agreement
cargo run -p xtask -- segmentation-drift          # OK
cargo run -p xtask -- owner-resolution            # OK (33 rows)
make xtask-check                                  # all gates OK
cargo fmt --check && cargo clippy --all-targets    # clean, both workspaces
```

Gate plant/revert: the deleted `FATAL_PARSE_MESSAGES` shape re-added to `lowering/mod.rs` is flagged by rule 4 and by nothing else; removing it returns the gate to OK.

Corpus: `first_parse_cut` over 1361 files (`samples/`, `tmp/tcl9.0.4/library`, `tmp/tcllib-2.0/modules`) reports exactly one cut — `samples/tcl/05_warning_examples.tcl:19`, a deliberate demonstration file, confirmed a real `extra characters after close-quote` against `tclsh9.0` in isolation.

## Compiler / diagnostics checklist

- [x] Did this change alter a compiler fact contract? **Yes** — a new owner row, and the segmentation row's gate now also covers parse-failure classification.
- [x] If yes, I updated the owning design doc under `docs/design/contracts/` — `shared-utility-contracts-rust.md` gains the `parse-error cut` manifest row, an owner bullet for `first_parse_cut`, and the `parse_cut_agreement.rs` differential in the gate list.
- [x] If I added or changed a diagnostic or optimisation code, I updated its page under `docs/kcs/codes/` — n/a, no diagnostic or optimisation code changed; these are C Tcl runtime error messages, which the owner spells and does not invent.
- [x] If I added a design doc, I linked it from `docs/design/README.md` — n/a, no new design doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013wqsJY5pcg8Uyk1H4e7V8y

---
_Generated by [Claude Code](https://claude.ai/code/session_013wqsJY5pcg8Uyk1H4e7V8y)_