### PR TITLE
Expose the wasm codegen optimisation passes as CLI flags and Explorer toggles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1255,6 +1255,12 @@ to "why didn't it?".  It is the first place to look when a constant fold — or
 its absence — is a surprise; the same data is the `unitScope` view in the
 `tcl explore` CLI and TUI.
 
+The WASM tab additionally carries a **Codegen passes** control: a checkbox
+per semantic/AOT optimisation pass, plus the `native-tier` and `all` presets.
+Every pass is off by default, so an untouched explorer shows the generic
+lowering; ticking one recompiles and repaints the disassembly.  The same
+selection is available to the CLI as `tcl explore --codegen-passes`.
+
 The IR, CFG, SSA, bytecode, and WASM tabs each carry an **optimiser lens**
 (`off` / `on` / `diff`).  The `diff` mode compares the relevant node — IR
 statement, CFG block, or bytecode instruction — rather than raw text, so
@@ -1413,7 +1419,18 @@ tcl compwasm script.tcl -o out.wasm --wat-output out.wat
 
 # Compile inline source
 tcl compwasm --source 'set x [expr {1+2}]' -o out.wasm
+
+# Enable codegen optimisation passes (default: none, the generic lowering)
+tcl compwasm script.tcl --codegen-passes native-tier -o out.wasm
+tcl compwasm script.tcl --codegen-passes native-lowering,cell-demotion -o out.wasm
 ```
+
+`--codegen-passes` selects the semantic/AOT passes the emitter may use —
+individual pass ids, or the `native-tier` / `all` groups.  Omitted, no pass
+runs and the emitter produces the generic lowering, which hands each command
+back to the interpreter rather than compiling it.  `tcl explore --json` lists
+every pass under `semanticOptimisations`.  It is a different axis from
+`tcl dis --optimise`, which runs the source-rewrite optimiser.
 
 #### Tcl VM
 

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -1341,6 +1341,32 @@ See also: [Codegen internals](design/compiler/codegen-internals.md)
 and [Codegen module map](design/compiler/codegen-module-map.md).
 KCS tag: `codegen`.
 
+### Codegen optimisation pass
+
+One of the twelve individually selectable semantic/AOT transformations the
+WASM emitter may use — `native-lowering`, `representation-inference`,
+`trace-barrier-elision`, `cell-demotion`, `direct-proc`, `frame-elision`,
+`native-integer` and the rest, enumerated by
+`tcl_compiler::semantic_optimisation::SemanticOptimisationPassId`. A pass
+authorises a *semantic* specialisation, not a target instruction sequence; a
+backend consumes an enabled pass only once its own requirements are met.
+
+Distinct from an optimisation *code* (`O1xx`), which is a **source-rewrite**
+the analyser suggests and `tcl opt` applies — see
+[Optimisation passes](design/compiler/optimisation-passes.md). A codegen pass
+changes what the compiler emits, never the source.
+
+**Every pass is off by default**, so an unflagged `tcl compwasm` and an
+untouched compiler explorer show the *generic lowering* — a module that hands
+each command back to the interpreter through `tcl_eval_code` rather than
+compiling it. Select them with `--codegen-passes` on `tcl compwasm` /
+`tcl explore`, or the explorer's *Codegen passes* toggles; `native-tier` is
+the group name for the four the native tier enables.
+
+See also: [WASM explorer view](design/contracts/wasm-explorer-view.md)
+§ *Optimisation passes*.
+KCS tag: `codegen-passes`.
+
 ### LVT
 
 Local Variable Table — maps variable names to integer slot indices for

--- a/docs/design/contracts/wasm-explorer-view.md
+++ b/docs/design/contracts/wasm-explorer-view.md
@@ -22,13 +22,15 @@ read the same shape.
   structural open/close), a source range, an indent level, and an explorer
   label.
 - [`rust/tcl-explorer/src/serialise.rs`](../../../rust/tcl-explorer/src/serialise.rs)
-  — `serialise_wasm` calls the canonical compiler, attaches the typed
-  `codegenPlan` evidence and full WAT `text` on the module header, and returns
-  the list as
-  `data.wasm` / `data.wasmOptimised`.
+  — `serialise_result_with_optimisations` calls the canonical compiler under a
+  chosen `SemanticOptimisationConfig`, attaches the typed `codegenPlan`
+  evidence and full WAT `text` on the module header, and returns the list as
+  `data.wasm` / `data.wasmOptimised`.  `serialise_result` is the same call
+  with every pass off.
 - [`rust/tcl-explorer-wasm`](../../../rust/tcl-explorer-wasm) — the
-  `wasm-bindgen` facade the browser worker calls (`compile`, plus `meta` for
-  the dialect list, which needs no compile).
+  `wasm-bindgen` facade the browser worker calls (`compile`,
+  `compile_with_optimisations` for a pass selection, plus `meta` for the
+  dialect list and the pass catalogue, which need no compile).
 
 ## Module header entry
 
@@ -106,10 +108,11 @@ plan's `semanticDecline` carries stable `kind` and `detailKind` fields
 explaining why narrower executable semantic selection declined. It never
 contains Rust `Debug` output.
 
-The current Explorer UI compiles with its default hosted, default-off options,
-so it does not select `native-i64-add`. The `nativeI64Add` record is retained
-for API/options-aware callers and for the future Explorer configuration that
-can explicitly request sealed-program semantic/AOT passes.
+The Explorer compiles with its default hosted, default-off options unless
+passes are selected, so an untouched Explorer does not select
+`native-i64-add`. The passes are selectable — see *Optimisation passes*
+below — and the `nativeI64Add` record is what an options-aware caller reads
+back once the sealed-program passes are explicitly requested.
 
 `regions` is the retained target-neutral `MixedRegionPlan`, not a plan rebuilt
 by Explorer. Entries are ordered by structural `NodeId`. An invocation's
@@ -132,6 +135,51 @@ only when all five required semantic passes are explicitly enabled and exact
 four-statement coverage succeeds; a missing pass, hosted environment, extra
 statement, mutation, trace, unsupported formal list, or non-i64 range returns
 the ordinary generic/general evidence instead.
+
+## Optimisation passes
+
+`data.semanticOptimisations` is the toggle surface for the two WASM views:
+
+```json
+{
+  "passes": [
+    { "id": "legacy-analysis-specialisation", "enabled": false },
+    { "id": "native-lowering",                "enabled": true  }
+  ],
+  "groups": [
+    { "id": "native-tier", "passes": ["native-lowering", "representation-inference",
+                                      "trace-barrier-elision", "cell-demotion"] },
+    { "id": "all",         "passes": ["..."] }
+  ]
+}
+```
+
+One row per `SemanticOptimisationPassId`, in `all()` order, with the state
+the shown module was built with; `groups` names the presets
+`SemanticOptimisationConfig::from_names` also accepts. A front end renders
+its checkboxes from these rows rather than from its own copy of the pass
+list — that duplication is what the view exists to prevent, and
+`native_tier_group_matches_the_wasm_option` pins the `native-tier` group to
+`WasmCompileOptions::native_tier` so the two cannot drift.
+
+The same catalogue, with nothing enabled, is in `meta.semanticOptimisations`,
+so a panel can be drawn before the first compile lands — the rule
+`meta.dialects` already follows (issue #1183).
+
+**Every pass is off by default.** `nativeLowering.enabled: false` on an
+untouched Explorer means the passes were never asked for, not that they found
+nothing. Selecting them:
+
+- browser — the toolbar's *Codegen passes* popover, which posts the selection
+  to `compile_with_optimisations`;
+- CLI — `tcl explore --codegen-passes PASS[,PASS...]` (and the same flag on
+  `tcl compwasm`), taking pass ids or a group name. It is rejected with
+  `--serve`: the served GUI carries its own toggles and the serve path never
+  reaches the compile the flag would configure.
+
+`--codegen-passes` is not `tcl dis --optimise`: that flag runs the
+*source-rewrite* optimiser (`tcl_compiler::optimiser`, the `O1xx` codes),
+which is a different axis from these target-neutral semantic/AOT passes.
 
 ## Function entry
 

--- a/docs/kcs/features/kcs-feature-compiler-explorer.md
+++ b/docs/kcs/features/kcs-feature-compiler-explorer.md
@@ -55,6 +55,18 @@ The **WASM** and **WASM (Opt)** tabs show a structured per-instruction disassemb
 - A label on `block` / `loop` / `if` opens identifying the Tcl construct that produced them (`foreach`, `while`, `for`, `if`, `catch body`, `switch arm`).
 - Orthogonal control-flow arrows in the left gutter showing every branch target, with forward edges drawn solid-blue and back-edges drawn dashed-yellow.
 
+### Codegen passes
+
+Every semantic/AOT codegen optimisation pass is **off by default**, so an untouched explorer shows the *generic lowering* — a module that hands each command back to the interpreter through `tcl_eval_code` rather than compiling it. `nativeLowering.enabled: false` in the plan means the passes were never asked for, not that they found nothing.
+
+The toolbar's **Codegen passes** control opens a checkbox per pass, plus the `native-tier` and `all` presets. Ticking one recompiles and repaints the WASM disassembly. On a hot integer loop the difference is visible immediately: the generic lowering emits `tcl_eval_code` calls and no arithmetic, while `native-tier` emits `i64.add` and `i64.lt_s` and no source-eval call at all.
+
+The rows come from `meta.semanticOptimisations`, so the panel is populated before the first compile.
+
+The CLI takes the same selection as `tcl explore --codegen-passes PASS[,PASS...]` (and `tcl compwasm --codegen-passes`), naming pass ids or a group. It is rejected together with `--serve`, because the served GUI has its own toggles and the serve path never reaches the compile the flag would configure.
+
+This is a different axis from the optimiser lens below: the lens shows what the **source-rewrite** optimiser (the `O1xx` codes) would change, while a codegen pass changes what the compiler emits for unchanged source.
+
 ### Optimiser lens (off / on / diff)
 
 The IR, CFG, SSA, bytecode, and WASM tabs each carry an optimiser lens with three modes:

--- a/docs/kcs/features/kcs-feature-tcl-verb-cli.md
+++ b/docs/kcs/features/kcs-feature-tcl-verb-cli.md
@@ -31,10 +31,12 @@ tcl command-info HTTP::uri --dialect f5-irules --json
 tcl find-legacy rule.irule --json
 tcl dis script.tcl
 tcl compwasm script.tcl -o out.wasm --wat-output out.wat
+tcl compwasm script.tcl --codegen-passes native-tier -o out.wasm
 tcl highlight script.tcl --force-colour
 tcl highlight script.tcl --format html -o out.html
 tcl diff old.irule new.irule --show ast,ir,cfg
 tcl explore script.tcl --show ir,cfg,opt
+tcl explore script.tcl --json --codegen-passes native-lowering,cell-demotion
 tcl help taint analysis --dialect f5-irules
 tcl help taint --json
 
@@ -96,10 +98,10 @@ tcl venv delete .venv
 - `command-info`: emits command registry metadata for a named command and dialect (`--json` supported).
 - `find-legacy`: emits diagnostics that map to known modernisation rewrites (`--json` supported, detection only — use `opt` to apply rewrites).
 - `dis`: compiles resolved source and emits bytecode disassembly.
-- `compwasm`: compiles resolved source to a WASM binary (`--wat-output` optional).
+- `compwasm`: compiles resolved source to a WASM binary (`--wat-output` optional). `--codegen-passes` selects the semantic/AOT codegen optimisation passes the emitter may use — individual pass ids, or the `native-tier` / `all` groups; omitted, no pass runs and the emitter produces the generic lowering. It is distinct from `dis --optimise`, which runs the *source-rewrite* optimiser.
 - `highlight`: emits syntax-highlighted output in ANSI or HTML (`--format`, `--no-colour`, `--force-colour`).
 - `diff`: compares two inputs at parser AST, lowered IR, and CFG layers (`--show` and `--json` supported).
-- `explore`: forwards combined source into compiler-explorer views.
+- `explore`: forwards combined source into compiler-explorer views. `--codegen-passes` applies to the `wasm` views, and the `semanticOptimisations` view lists every pass with the state the shown module was built with.
 - `help`: searches the KCS help database embedded in the binary at build time and reports KCS feature matches (`--dialect` optionally narrows matches).
 
 ## Exit-code contract

--- a/rust/tcl-cli/gui/index.html
+++ b/rust/tcl-cli/gui/index.html
@@ -86,6 +86,66 @@ body {
   outline: none;
 }
 .toolbar select:focus { border-color: var(--accent); }
+/* Codegen-pass toggles: a <details> popover so the toolbar stays one row.
+   Rows are built from meta.semanticOptimisations, never from a copy of the
+   pass list in this file. */
+.opt-panel { position: relative; }
+.opt-panel > summary {
+  list-style: none;
+  cursor: pointer;
+  background: var(--bg);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 3px 8px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  white-space: nowrap;
+}
+.opt-panel > summary::-webkit-details-marker { display: none; }
+.opt-panel[open] > summary { border-color: var(--accent); }
+.opt-panel .opt-body {
+  position: absolute;
+  z-index: 40;
+  top: calc(100% + 4px);
+  left: 0;
+  min-width: 260px;
+  max-height: 60vh;
+  overflow-y: auto;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 8px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+}
+.opt-panel .opt-body label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 0;
+  font-size: 11px;
+  font-family: var(--font-mono);
+  cursor: pointer;
+}
+.opt-panel .opt-groups {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  padding-bottom: 6px;
+  margin-bottom: 6px;
+  border-bottom: 1px solid var(--border);
+}
+.opt-panel .opt-groups button {
+  background: var(--bg);
+  color: var(--text-dim);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  padding: 2px 6px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  cursor: pointer;
+}
+.opt-panel .opt-groups button:hover { color: var(--text); border-color: var(--accent); }
 .compile-btn {
   background: var(--bg);
   color: var(--text);
@@ -993,6 +1053,17 @@ textarea#source::selection { background: rgba(137, 180, 250, 0.3); }
       <option value="tcl8.6" selected>Tcl 8.6</option>
     </select>
     <button id="compileBtn" class="compile-btn" type="button" title="Recompile the current source">Compile</button>
+    <!-- Codegen optimisation passes. Empty by default: the WASM views show
+         the generic lowering until a pass is ticked. Rows come from
+         meta.semanticOptimisations (filled on worker ready, like the dialect
+         dropdown), so this markup never lists passes itself. -->
+    <details class="opt-panel" id="optPanel">
+      <summary id="optSummary" title="Semantic/AOT codegen optimisation passes used by the WASM views">Codegen passes: none</summary>
+      <div class="opt-body">
+        <div class="opt-groups" id="optGroups"></div>
+        <div id="optPasses"></div>
+      </div>
+    </details>
     <div class="spinner" id="spinner"></div>
     <span class="status-msg" id="statusMsg">Loading compiler...</span>
     <div class="stats" id="stats"></div>
@@ -1194,6 +1265,7 @@ worker.onmessage = function(e) {
       // the module loads rather than leaving the hard-coded tcl8.6 fallback
       // up until a first result lands.
       populateDialectOptions(msg.meta && msg.meta.dialects);
+      populateOptimisationPanel(msg.meta && msg.meta.semanticOptimisations);
       setExplorerReferenceMeta(msg.meta);
       // Auto-compile if there's content.
       if (pendingCompile || textarea.value.trim()) {
@@ -1207,6 +1279,7 @@ worker.onmessage = function(e) {
         compiledSource = lastSource;
         compiledDialect = lastDialect;
         populateDialectOptions(data && data.meta && data.meta.dialects);
+        populateOptimisationPanel(data && data.semanticOptimisations);
         const failures = renderAll();
         if (failures && failures.length) {
           $('#statusMsg').style.display = '';
@@ -1355,11 +1428,71 @@ function populateDialectOptions(dialects) {
   }
 }
 
+// The ticked codegen-pass ids, in meta order. Empty means the generic
+// lowering, which is what an untouched Explorer shows.
+let enabledPasses = [];
+let lastPasses = null;
+
+// Build the toggle rows from the backend's own pass catalogue. Called on
+// worker `ready` (meta) and again on each result, so the panel is usable
+// before the first compile and stays in step with what the shown module was
+// actually built with.
+function populateOptimisationPanel(catalogue) {
+  if (!catalogue || !Array.isArray(catalogue.passes)) return;
+  const passBox = $('#optPasses');
+  const groupBox = $('#optGroups');
+  if (passBox.dataset.built !== 'yes') {
+    passBox.innerHTML = '';
+    catalogue.passes.forEach(pass => {
+      const label = document.createElement('label');
+      const box = document.createElement('input');
+      box.type = 'checkbox';
+      box.value = pass.id;
+      box.addEventListener('change', () => {
+        enabledPasses = Array.from(passBox.querySelectorAll('input:checked')).map(i => i.value);
+        updateOptimisationSummary();
+        forceCompile();
+      });
+      label.appendChild(box);
+      label.appendChild(document.createTextNode(pass.id));
+      passBox.appendChild(label);
+    });
+    groupBox.innerHTML = '';
+    (catalogue.groups || []).concat([{ id: 'none', passes: [] }]).forEach(group => {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.textContent = group.id;
+      button.addEventListener('click', () => {
+        setEnabledPasses(group.passes || []);
+        forceCompile();
+      });
+      groupBox.appendChild(button);
+    });
+    passBox.dataset.built = 'yes';
+  }
+  updateOptimisationSummary();
+}
+
+function setEnabledPasses(ids) {
+  enabledPasses = ids.slice();
+  $('#optPasses').querySelectorAll('input').forEach(box => {
+    box.checked = enabledPasses.indexOf(box.value) !== -1;
+  });
+  updateOptimisationSummary();
+}
+
+function updateOptimisationSummary() {
+  const n = enabledPasses.length;
+  $('#optSummary').textContent =
+    'Codegen passes: ' + (n === 0 ? 'none' : n === 1 ? enabledPasses[0] : n + ' on');
+}
+
 function compile() {
   const source = textarea.value;
   const dialect = $('#dialect').value;
+  const passes = enabledPasses.join(',');
   if (!source.trim()) return;
-  if (source === lastSource && dialect === lastDialect) return;
+  if (source === lastSource && dialect === lastDialect && passes === lastPasses) return;
 
   if (!workerReady) {
     // Remember that work is owed, but do NOT record this as the compiled
@@ -1372,15 +1505,18 @@ function compile() {
 
   lastSource = source;
   lastDialect = dialect;
+  lastPasses = passes;
   $('#spinner').style.display = 'block';
   setStatus('compiling');
-  worker.postMessage({ type: 'compile', source, dialect });
+  worker.postMessage({ type: 'compile', source, dialect, optimisations: passes });
 }
 
-// Force a compile even when the source and dialect are unchanged.
+// Force a compile even when the source, dialect and pass selection are
+// unchanged.
 function forceCompile() {
   lastSource = '';
   lastDialect = '';
+  lastPasses = null;
   clearTimeout(compileTimer);
   compile();
 }

--- a/rust/tcl-cli/gui/worker.js
+++ b/rust/tcl-cli/gui/worker.js
@@ -29,7 +29,8 @@
  * unchanged.
  *
  * Protocol (unchanged from the Pyodide worker, plus `ready.meta`):
- *   main → worker:  { type: "compile", source: string, dialect: string }
+ *   main → worker:  { type: "compile", source: string, dialect: string,
+ *                     optimisations?: string }
  *   worker → main:  { type: "result", data: <serialised JSON> }
  *   worker → main:  { type: "error", error: string, traceback?: string }
  *   worker → main:  { type: "ready", meta?: <serialised meta JSON> }
@@ -71,14 +72,21 @@ function readMeta() {
   }
 }
 
-function compile(source, dialect) {
+// `optimisations` is the comma-separated codegen-pass selection from the
+// toggle panel — "" for the generic lowering. `compile_with_optimisations`
+// arrived after `compile`, so a module built before it falls back to the
+// unoptimised entry point rather than failing to compile at all.
+function compile(source, dialect, optimisations) {
   if (!ready) {
     postMessage({ type: "error", error: "Compiler not ready yet" });
     return;
   }
 
   try {
-    const resultJson = wasm_bindgen.compile(source, dialect);
+    const resultJson =
+      optimisations && typeof wasm_bindgen.compile_with_optimisations === "function"
+        ? wasm_bindgen.compile_with_optimisations(source, dialect, optimisations)
+        : wasm_bindgen.compile(source, dialect);
     const data = JSON.parse(resultJson);
     // `compile` returns a JSON {error: ...} object on a pipeline failure
     // rather than throwing.
@@ -99,7 +107,7 @@ function compile(source, dialect) {
 onmessage = function (e) {
   const msg = e.data;
   if (msg.type === "compile") {
-    compile(msg.source, msg.dialect);
+    compile(msg.source, msg.dialect, msg.optimisations || "");
   }
 };
 

--- a/rust/tcl-cli/src/cli.rs
+++ b/rust/tcl-cli/src/cli.rs
@@ -149,6 +149,43 @@ pub struct ColourArgs {
     pub no_colour: bool,
 }
 
+/// Which semantic/AOT codegen optimisation passes the WASM emitter may use.
+///
+/// Deliberately **not** spelled `--optimise`: that flag already exists on
+/// `tcl dis` and means the *source-rewrite* optimiser
+/// (`tcl_compiler::optimiser`), which is a different thing from the
+/// target-neutral semantic passes
+/// (`tcl_compiler::semantic_optimisation`) this selects.
+#[derive(Debug, Args)]
+pub struct CodegenPassArgs {
+    /// Codegen optimisation passes to enable, comma-separated.
+    ///
+    /// Individual passes (`native-lowering`, `representation-inference`,
+    /// `trace-barrier-elision`, `cell-demotion`, `direct-proc`,
+    /// `frame-elision`, `native-integer`, …) or a group: `native-tier` for
+    /// the four the native tier enables, `all` for every pass. Omitted, no
+    /// pass runs and the emitter produces the generic lowering.
+    /// `tcl explore --json` lists them all under `semanticOptimisations`.
+    #[arg(long = "codegen-passes", value_name = "PASS[,PASS...]")]
+    pub codegen_passes: Option<String>,
+}
+
+impl CodegenPassArgs {
+    /// Resolve the selection, or an error naming the unrecognised pass.
+    ///
+    /// # Errors
+    ///
+    /// Propagates the parse failure from
+    /// [`SemanticOptimisationConfig::from_names`](tcl_explorer::SemanticOptimisationConfig::from_names).
+    pub fn config(&self) -> anyhow::Result<tcl_explorer::SemanticOptimisationConfig> {
+        match self.codegen_passes.as_deref() {
+            None => Ok(tcl_explorer::SemanticOptimisationConfig::new()),
+            Some(spec) => tcl_explorer::SemanticOptimisationConfig::from_names(spec)
+                .map_err(|message| anyhow::anyhow!("--codegen-passes: {message}")),
+        }
+    }
+}
+
 #[derive(Debug, Subcommand)]
 pub enum Command {
     /// Compile source and emit human-readable bytecode disassembly.
@@ -171,6 +208,8 @@ pub enum Command {
         /// Also write the textual WAT form to this path.
         #[arg(long = "wat-output", value_name = "FILE")]
         wat_output: Option<PathBuf>,
+        #[command(flatten)]
+        codegen: CodegenPassArgs,
     },
 
     /// Run diagnostics across all resolved inputs.
@@ -366,6 +405,8 @@ pub enum Command {
         /// Open the GUI in the default browser after `--serve` starts.
         #[arg(long)]
         open: bool,
+        #[command(flatten)]
+        codegen: CodegenPassArgs,
         #[command(flatten)]
         colour: ColourArgs,
     },

--- a/rust/tcl-cli/src/cli.rs
+++ b/rust/tcl-cli/src/cli.rs
@@ -166,6 +166,11 @@ pub struct CodegenPassArgs {
     /// the four the native tier enables, `all` for every pass. Omitted, no
     /// pass runs and the emitter produces the generic lowering.
     /// `tcl explore --json` lists them all under `semanticOptimisations`.
+    ///
+    /// Not accepted with `explore --serve`: the served GUI carries its own
+    /// per-pass toggles, and the serve path never reaches the compile this
+    /// would configure — so silently ignoring it (including an unrecognised
+    /// pass name) would report an optimised build that never happened.
     #[arg(long = "codegen-passes", value_name = "PASS[,PASS...]")]
     pub codegen_passes: Option<String>,
 }
@@ -183,6 +188,28 @@ impl CodegenPassArgs {
             Some(spec) => tcl_explorer::SemanticOptimisationConfig::from_names(spec)
                 .map_err(|message| anyhow::anyhow!("--codegen-passes: {message}")),
         }
+    }
+
+    /// Reject the flag on a path that never compiles, naming what to use
+    /// instead.
+    ///
+    /// Checked here rather than with clap's `conflicts_with`, because this
+    /// struct is flattened into `compwasm` too and that verb has no `--serve`
+    /// to conflict with — clap's builder asserts on a conflict target the
+    /// command does not define.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when a selection was given.
+    pub fn reject_for_serve(&self) -> anyhow::Result<()> {
+        if self.codegen_passes.is_some() {
+            anyhow::bail!(
+                "--codegen-passes cannot be used with --serve: the served compiler explorer \
+                 carries its own per-pass toggles, and the serve path never reaches the compile \
+                 this would configure"
+            );
+        }
+        Ok(())
     }
 }
 

--- a/rust/tcl-cli/src/commands/compile.rs
+++ b/rust/tcl-cli/src/commands/compile.rs
@@ -98,14 +98,23 @@ pub fn run_dis(input: &InputArgs, optimise_on: bool) -> anyhow::Result<u8> {
 /// `tcl compwasm` — compile source through the canonical analysis-aware WASM
 /// pipeline. Unsupported specialisations retain exact source-span runtime
 /// fallback inside the generated module.
-pub fn run_compwasm(input: &InputArgs, wat_output: Option<&std::path::Path>) -> anyhow::Result<u8> {
+///
+/// `optimisations` is the `--codegen-passes` selection. It defaults to empty:
+/// an unflagged `tcl compwasm` emits the generic lowering, with every
+/// semantic/AOT pass off.
+pub fn run_compwasm(
+    input: &InputArgs,
+    wat_output: Option<&std::path::Path>,
+    optimisations: tcl_explorer::SemanticOptimisationConfig,
+) -> anyhow::Result<u8> {
     let documents = read_input_documents(&input.inputs, &input.source, !input.no_recursive)?;
     let dialect = combined_effective_dialect(&documents, input.dialect_profile()?);
     let registry = registry_for_dialect(dialect.name);
     let source = combine_sources(&documents);
 
     let unit = CompilationUnit::build_for_dialect(&source, &registry, false, dialect.name);
-    let mut wasm = compile_wasm(&unit, &registry, WasmCompileOptions::hosted());
+    let options = WasmCompileOptions::hosted().with_semantic_optimisations(optimisations);
+    let mut wasm = compile_wasm(&unit, &registry, options);
     let bytes = wasm.to_bytes();
 
     // Unlike the other verbs, `compwasm` defaults to a file, not stdout: a bare

--- a/rust/tcl-cli/src/commands/explore.rs
+++ b/rust/tcl-cli/src/commands/explore.rs
@@ -39,6 +39,7 @@ pub fn run_explore(
     json: bool,
     text: bool,
     tui: bool,
+    optimisations: tcl_explorer::SemanticOptimisationConfig,
     colour: &ColourArgs,
 ) -> anyhow::Result<u8> {
     let documents = read_input_documents(&input.inputs, &input.source, !input.no_recursive)?;
@@ -51,11 +52,11 @@ pub fn run_explore(
     let _registry = tcl_cli_support::registry_for_dialect(dialect.name);
 
     if tui {
-        return run_tui(&source, dialect);
+        return run_tui(&source, dialect, optimisations);
     }
 
     let result = tcl_explorer::run_pipeline(&source, dialect.name);
-    let value = tcl_explorer::serialise_result(&result);
+    let value = tcl_explorer::serialise_result_with_optimisations(&result, optimisations);
 
     let target = OutputTarget::from_arg(input.output.as_deref());
     let output = if json {
@@ -72,13 +73,21 @@ pub fn run_explore(
 
 /// Launch the interactive TUI (feature `tui`), or explain how to enable it.
 #[cfg(feature = "tui")]
-fn run_tui(source: &str, dialect: &'static tcl_dialect::DialectProfile) -> anyhow::Result<u8> {
-    crate::tui::run(source, dialect)?;
+fn run_tui(
+    source: &str,
+    dialect: &'static tcl_dialect::DialectProfile,
+    optimisations: tcl_explorer::SemanticOptimisationConfig,
+) -> anyhow::Result<u8> {
+    crate::tui::run(source, dialect, optimisations)?;
     Ok(0)
 }
 
 #[cfg(not(feature = "tui"))]
-fn run_tui(_source: &str, _dialect: &'static tcl_dialect::DialectProfile) -> anyhow::Result<u8> {
+fn run_tui(
+    _source: &str,
+    _dialect: &'static tcl_dialect::DialectProfile,
+    _optimisations: tcl_explorer::SemanticOptimisationConfig,
+) -> anyhow::Result<u8> {
     anyhow::bail!("the TUI is not compiled in — rebuild with `--features tui`");
 }
 

--- a/rust/tcl-cli/src/lib.rs
+++ b/rust/tcl-cli/src/lib.rs
@@ -105,9 +105,11 @@ fn dispatch(command: &Command) -> anyhow::Result<u8> {
         }
         Command::Validate { input, diag } => commands::diag::run_validate(input, diag),
         Command::Dis { input, optimise } => commands::compile::run_dis(input, *optimise),
-        Command::Compwasm { input, wat_output } => {
-            commands::compile::run_compwasm(input, wat_output.as_deref())
-        }
+        Command::Compwasm {
+            input,
+            wat_output,
+            codegen,
+        } => commands::compile::run_compwasm(input, wat_output.as_deref(), codegen.config()?),
         Command::Diagram { input, json } => commands::diagram::run_diagram(input, *json),
         Command::Symbols { input, json } => commands::graphs::run_symbols(input, *json),
         Command::Symbolgraph { input, json } => commands::graphs::run_symbolgraph(input, *json),
@@ -229,12 +231,21 @@ fn dispatch(command: &Command) -> anyhow::Result<u8> {
             bind,
             port,
             open,
+            codegen,
             colour,
         } => {
             if *serve {
                 commands::gui::run_serve(bind, *port, *open)
             } else {
-                commands::explore::run_explore(input, show, *json, *text, *tui, colour)
+                commands::explore::run_explore(
+                    input,
+                    show,
+                    *json,
+                    *text,
+                    *tui,
+                    codegen.config()?,
+                    colour,
+                )
             }
         }
         Command::Help {

--- a/rust/tcl-cli/src/lib.rs
+++ b/rust/tcl-cli/src/lib.rs
@@ -235,6 +235,7 @@ fn dispatch(command: &Command) -> anyhow::Result<u8> {
             colour,
         } => {
             if *serve {
+                codegen.reject_for_serve()?;
                 commands::gui::run_serve(bind, *port, *open)
             } else {
                 commands::explore::run_explore(

--- a/rust/tcl-cli/src/tui.rs
+++ b/rust/tcl-cli/src/tui.rs
@@ -190,12 +190,19 @@ impl App {
 }
 
 /// Run the interactive explorer over `source`/`dialect`.
-pub fn run(source: &str, dialect: &'static tcl_dialect::DialectProfile) -> anyhow::Result<()> {
+pub fn run(
+    source: &str,
+    dialect: &'static tcl_dialect::DialectProfile,
+    optimisations: tcl_explorer::SemanticOptimisationConfig,
+) -> anyhow::Result<()> {
     // `dialect.name`: `tcl_explorer::run_pipeline` is a documented by-name
     // boundary (it keys the registry cache off the spelling), so the resolved
     // profile is projected back to its canonical name here rather than the
     // explorer API being widened. Matches `commands::explore`.
-    let data = tcl_explorer::serialise_result(&tcl_explorer::run_pipeline(source, dialect.name));
+    let data = tcl_explorer::serialise_result_with_optimisations(
+        &tcl_explorer::run_pipeline(source, dialect.name),
+        optimisations,
+    );
     let mut app = App::new(data);
 
     let (mut terminal, events) = init_terminal()?;

--- a/rust/tcl-cli/tests/compile_verbs.rs
+++ b/rust/tcl-cli/tests/compile_verbs.rs
@@ -271,6 +271,68 @@ fn eval_code_index(wat: &str) -> Option<usize> {
         .position(|line| line.contains("\"tcl_eval_code\""))
 }
 
+/// `--codegen-passes` is rejected with `explore --serve`.
+///
+/// The serve path never reaches the compile the flag would configure, so
+/// accepting it would start the server having silently ignored the
+/// selection — including an unrecognised pass name, which would otherwise
+/// have been an error. The served GUI carries its own per-pass toggles.
+#[test]
+fn explore_rejects_codegen_passes_with_serve() {
+    for passes in ["native-tier", "no-such-pass"] {
+        let out = Command::new(env!("CARGO_BIN_EXE_tcl"))
+            .args([
+                "explore",
+                "--serve",
+                "--codegen-passes",
+                passes,
+                "--source",
+                "set x 1",
+            ])
+            .output()
+            .expect("spawn tcl");
+        assert!(!out.status.success(), "{passes}: --serve accepted the flag");
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(stderr.contains("--codegen-passes"), "{passes}: {stderr}");
+        assert!(stderr.contains("--serve"), "{passes}: {stderr}");
+    }
+    // Without `--serve` the flag still works.
+    let out = Command::new(env!("CARGO_BIN_EXE_tcl"))
+        .args([
+            "explore",
+            "--json",
+            "--codegen-passes",
+            "native-tier",
+            "--source",
+            "set a 1\nincr a\n",
+        ])
+        .output()
+        .expect("spawn tcl");
+    assert!(
+        out.status.success(),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let value: serde_json::Value =
+        serde_json::from_slice(&out.stdout).expect("explorer contract JSON");
+    let enabled: Vec<&str> = value["semanticOptimisations"]["passes"]
+        .as_array()
+        .expect("pass rows")
+        .iter()
+        .filter(|row| row["enabled"] == true)
+        .map(|row| row["id"].as_str().expect("a pass id"))
+        .collect();
+    assert_eq!(
+        enabled,
+        vec![
+            "native-lowering",
+            "representation-inference",
+            "trace-barrier-elision",
+            "cell-demotion"
+        ]
+    );
+}
+
 #[test]
 fn compwasm_rejects_removed_backend_selection() {
     let output = Command::new(env!("CARGO_BIN_EXE_tcl"))

--- a/rust/tcl-cli/tests/compile_verbs.rs
+++ b/rust/tcl-cli/tests/compile_verbs.rs
@@ -150,6 +150,71 @@ fn compwasm_emits_valid_module_header() {
     let _ = std::fs::remove_dir_all(&dir);
 }
 
+/// `--codegen-passes` is what turns the semantic/AOT passes on; without it
+/// `compwasm` emits the generic lowering. The two modules must differ, or the
+/// flag is decorative.
+#[test]
+fn compwasm_codegen_passes_change_the_emitted_module() {
+    let dir = std::env::temp_dir().join("tcl_compwasm_passes_test");
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    let source = "set a 1\nincr a\nputs $a\n";
+
+    let emit = |name: &str, passes: Option<&str>| {
+        let wasm_path = dir.join(format!("{name}.wasm"));
+        let mut args = vec![
+            "compwasm".to_owned(),
+            "--source".to_owned(),
+            source.to_owned(),
+            "-o".to_owned(),
+            wasm_path.to_str().unwrap().to_owned(),
+        ];
+        if let Some(passes) = passes {
+            args.push("--codegen-passes".to_owned());
+            args.push(passes.to_owned());
+        }
+        let out = Command::new(env!("CARGO_BIN_EXE_tcl"))
+            .args(&args)
+            .output()
+            .expect("spawn tcl");
+        assert!(
+            out.status.success(),
+            "compwasm {passes:?} failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        std::fs::read(&wasm_path).expect("read wasm")
+    };
+
+    let generic = emit("generic", None);
+    let native = emit("native", Some("native-tier"));
+    assert_eq!(&generic[0..4], b"\0asm");
+    assert_eq!(&native[0..4], b"\0asm");
+    assert_ne!(
+        generic, native,
+        "--codegen-passes native-tier emitted the generic lowering"
+    );
+
+    // A misspelled pass fails loudly and names the offender, rather than
+    // quietly producing an unoptimised module.
+    let bad = Command::new(env!("CARGO_BIN_EXE_tcl"))
+        .args([
+            "compwasm",
+            "--source",
+            source,
+            "--codegen-passes",
+            "no-such-pass",
+            "-o",
+            dir.join("bad.wasm").to_str().unwrap(),
+        ])
+        .output()
+        .expect("spawn tcl");
+    assert!(!bad.status.success());
+    let stderr = String::from_utf8_lossy(&bad.stderr);
+    assert!(stderr.contains("no-such-pass"), "{stderr}");
+    assert!(stderr.contains("native-tier"), "{stderr}");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
 #[test]
 fn compwasm_rejects_removed_backend_selection() {
     let output = Command::new(env!("CARGO_BIN_EXE_tcl"))

--- a/rust/tcl-cli/tests/compile_verbs.rs
+++ b/rust/tcl-cli/tests/compile_verbs.rs
@@ -151,22 +151,47 @@ fn compwasm_emits_valid_module_header() {
 }
 
 /// `--codegen-passes` is what turns the semantic/AOT passes on; without it
-/// `compwasm` emits the generic lowering. The two modules must differ, or the
-/// flag is decorative.
+/// `compwasm` emits the generic lowering.
+///
+/// Asserting only that the two modules *differ* would pass on a flag that
+/// merely perturbed the output, so this checks what actually changes. The
+/// generic lowering for a hot integer loop is a source-eval fallback — it
+/// pushes the command text and calls `tcl_eval_code`, with no arithmetic of
+/// its own. The native tier replaces that with real instructions: the `<`
+/// and the `+` become `i64` operations and not one `tcl_eval_code` call
+/// survives.
+///
+/// The pass set itself is execution-verified elsewhere:
+/// `tcl-compiler`'s `wasm_tiers::native_plan_samples_reproduce_the_tclsh_oracles`
+/// links the same `native_tier()` options against the real runtime, runs
+/// every `samples/wasm` script under wasmtime, and diffs stdout against the
+/// committed `tclsh9.0` oracles.
 #[test]
-fn compwasm_codegen_passes_change_the_emitted_module() {
+fn compwasm_codegen_passes_natively_lower_a_hot_loop() {
     let dir = std::env::temp_dir().join("tcl_compwasm_passes_test");
     std::fs::create_dir_all(&dir).expect("mkdir");
-    let source = "set a 1\nincr a\nputs $a\n";
+    // An integer loop: a `<` guard and a `+` the representation lattice can
+    // keep native. Nothing here needs a string.
+    let source = "proc sum {n} {\n\
+                  set total 0\n\
+                  for {set i 0} {$i < $n} {incr i} {\n\
+                  set total [expr {$total + $i}]\n\
+                  }\n\
+                  return $total\n\
+                  }\n\
+                  puts [sum 10]\n";
 
     let emit = |name: &str, passes: Option<&str>| {
         let wasm_path = dir.join(format!("{name}.wasm"));
+        let wat_path = dir.join(format!("{name}.wat"));
         let mut args = vec![
             "compwasm".to_owned(),
             "--source".to_owned(),
             source.to_owned(),
             "-o".to_owned(),
             wasm_path.to_str().unwrap().to_owned(),
+            "--wat-output".to_owned(),
+            wat_path.to_str().unwrap().to_owned(),
         ];
         if let Some(passes) = passes {
             args.push("--codegen-passes".to_owned());
@@ -181,16 +206,39 @@ fn compwasm_codegen_passes_change_the_emitted_module() {
             "compwasm {passes:?} failed: {}",
             String::from_utf8_lossy(&out.stderr)
         );
-        std::fs::read(&wasm_path).expect("read wasm")
+        let bytes = std::fs::read(&wasm_path).expect("read wasm");
+        assert_eq!(&bytes[0..4], b"\0asm", "{name}: missing wasm magic");
+        std::fs::read_to_string(&wat_path).expect("read wat")
     };
 
     let generic = emit("generic", None);
     let native = emit("native", Some("native-tier"));
-    assert_eq!(&generic[0..4], b"\0asm");
-    assert_eq!(&native[0..4], b"\0asm");
-    assert_ne!(
-        generic, native,
-        "--codegen-passes native-tier emitted the generic lowering"
+
+    // The generic lowering hands the source back to the interpreter.
+    assert!(
+        generic.contains("tcl_eval_code"),
+        "the unflagged lowering was expected to import the source-eval \
+         fallback:\n{generic}"
+    );
+    assert!(
+        !generic.contains("i64.add"),
+        "the unflagged lowering must not emit native arithmetic:\n{generic}"
+    );
+
+    // The native tier compiles it instead.
+    let native_ops = ["i64.add", "i64.lt_s"];
+    for op in native_ops {
+        assert!(
+            native.contains(op),
+            "--codegen-passes native-tier emitted no `{op}`:\n{native}"
+        );
+    }
+    assert!(
+        !native
+            .lines()
+            .any(|line| line.trim_start().starts_with("call ")
+                && eval_code_index(&native).is_some_and(|i| line.trim() == format!("call {i}"))),
+        "a source-eval call survived the native tier:\n{native}"
     );
 
     // A misspelled pass fails loudly and names the offender, rather than
@@ -213,6 +261,14 @@ fn compwasm_codegen_passes_change_the_emitted_module() {
     assert!(stderr.contains("native-tier"), "{stderr}");
 
     let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// The import index `tcl_eval_code` was given, so a `call N` can be read as a
+/// source-eval fallback. Imports are numbered in declaration order.
+fn eval_code_index(wat: &str) -> Option<usize> {
+    wat.lines()
+        .filter(|line| line.trim_start().starts_with("(import "))
+        .position(|line| line.contains("\"tcl_eval_code\""))
 }
 
 #[test]

--- a/rust/tcl-cli/tests/explorer_gui.rs
+++ b/rust/tcl-cli/tests/explorer_gui.rs
@@ -229,6 +229,28 @@ fn assert_codegen_pass_toggles(report: &Value) {
         Some(4),
         "the `native-tier` preset did not tick its four passes"
     );
+
+    // And the answer to "does it live-update": the WASM pane must repaint
+    // from the new result. A recompile the page never renders would satisfy
+    // every assertion above and leave the user looking at the old module.
+    let before = &report["wasmBeforeToggle"];
+    let after = &report["wasmAfterToggle"];
+    assert_ne!(
+        before["wasmText"], after["wasmText"],
+        "the WASM pane did not repaint after a pass was ticked"
+    );
+    assert!(
+        after["wasmInstructions"].as_u64().unwrap_or(0) > 0,
+        "the repainted WASM pane rendered no instructions: {after}"
+    );
+    assert_eq!(
+        after["spinnerDisplay"], "none",
+        "the spinner never settled after the toggle recompile"
+    );
+    assert!(
+        after["errorBoxes"].as_array().is_some_and(Vec::is_empty),
+        "the toggle recompile surfaced an error box: {after}"
+    );
 }
 
 #[test]
@@ -248,10 +270,27 @@ fn gui_renders_the_wasm_tab_and_settles_the_spinner() {
     let payload = serde_json::to_string(&tcl_explorer::serialise_result(&result))
         .expect("explorer payload serialises");
 
+    // The payload the same source produces with the codegen passes on. The
+    // stub returns this one whenever a pass selection is sent, so the driver
+    // can tell a re-*render* from a mere re-compile: without it the WASM pane
+    // would look identical however the toggles were set and the test would
+    // pass on a page that never repainted.
+    let optimised = serde_json::to_string(&tcl_explorer::serialise_result_with_optimisations(
+        &result,
+        tcl_explorer::SemanticOptimisationConfig::from_names("all").expect("a valid group"),
+    ))
+    .expect("optimised explorer payload serialises");
+    assert_ne!(
+        payload, optimised,
+        "the two payloads must differ or the render assertion proves nothing"
+    );
+
     let out_dir = PathBuf::from(env!("CARGO_TARGET_TMPDIR"));
     std::fs::create_dir_all(&out_dir).expect("create target tmp dir");
     let payload_path = out_dir.join("explorer-gui-payload.json");
     std::fs::write(&payload_path, &payload).expect("write payload");
+    let optimised_path = out_dir.join("explorer-gui-payload-optimised.json");
+    std::fs::write(&optimised_path, &optimised).expect("write optimised payload");
 
     let driver = manifest_dir().join("tests/gui/explorer-gui-smoke.mjs");
     let gui = manifest_dir().join("gui");
@@ -259,6 +298,7 @@ fn gui_renders_the_wasm_tab_and_settles_the_spinner() {
     cmd.arg(&driver)
         .arg(&gui)
         .arg(&payload_path)
+        .arg(&optimised_path)
         .env("TCL_EXPLORER_PLAYWRIGHT", playwright);
     if let Ok(chromium) = std::env::var("TCL_EXPLORER_CHROMIUM") {
         cmd.env("TCL_EXPLORER_CHROMIUM", chromium);

--- a/rust/tcl-cli/tests/explorer_gui.rs
+++ b/rust/tcl-cli/tests/explorer_gui.rs
@@ -253,28 +253,17 @@ fn assert_codegen_pass_toggles(report: &Value) {
     );
 }
 
-#[test]
-fn gui_renders_the_wasm_tab_and_settles_the_spinner() {
-    if Command::new("node").arg("--version").output().is_err() {
-        skip("`node` is not on PATH");
-        return;
-    }
-    let Some(playwright) = playwright_specifier() else {
-        skip("playwright is not installed (npm i -g playwright)");
-        return;
-    };
-
-    // The payload the WASM facade would return for this source.
-    let source = "proc add {a b} {\n    return [expr {$a + $b}]\n}\nputs [add 1 2]\n";
+/// Write the two contract payloads the driver stubs the WASM facade with.
+///
+/// The first is what `compile` returns; the second is the same source with
+/// every codegen pass on, which the stub returns whenever a pass selection is
+/// sent. Without a *second* payload the WASM pane would look identical however
+/// the toggles were set, and the repaint assertion would pass on a page that
+/// never rendered.
+fn write_driver_payloads(source: &str) -> (PathBuf, PathBuf) {
     let result = tcl_explorer::run_pipeline(source, "tcl8.6");
     let payload = serde_json::to_string(&tcl_explorer::serialise_result(&result))
         .expect("explorer payload serialises");
-
-    // The payload the same source produces with the codegen passes on. The
-    // stub returns this one whenever a pass selection is sent, so the driver
-    // can tell a re-*render* from a mere re-compile: without it the WASM pane
-    // would look identical however the toggles were set and the test would
-    // pass on a page that never repainted.
     let optimised = serde_json::to_string(&tcl_explorer::serialise_result_with_optimisations(
         &result,
         tcl_explorer::SemanticOptimisationConfig::from_names("all").expect("a valid group"),
@@ -291,6 +280,22 @@ fn gui_renders_the_wasm_tab_and_settles_the_spinner() {
     std::fs::write(&payload_path, &payload).expect("write payload");
     let optimised_path = out_dir.join("explorer-gui-payload-optimised.json");
     std::fs::write(&optimised_path, &optimised).expect("write optimised payload");
+    (payload_path, optimised_path)
+}
+
+#[test]
+fn gui_renders_the_wasm_tab_and_settles_the_spinner() {
+    if Command::new("node").arg("--version").output().is_err() {
+        skip("`node` is not on PATH");
+        return;
+    }
+    let Some(playwright) = playwright_specifier() else {
+        skip("playwright is not installed (npm i -g playwright)");
+        return;
+    };
+
+    let source = "proc add {a b} {\n    return [expr {$a + $b}]\n}\nputs [add 1 2]\n";
+    let (payload_path, optimised_path) = write_driver_payloads(source);
 
     let driver = manifest_dir().join("tests/gui/explorer-gui-smoke.mjs");
     let gui = manifest_dir().join("gui");

--- a/rust/tcl-cli/tests/explorer_gui.rs
+++ b/rust/tcl-cli/tests/explorer_gui.rs
@@ -186,6 +186,51 @@ fn assert_compile_triggers(report: &Value) {
     );
 }
 
+/// The codegen-pass toggles: rows built from `meta.semanticOptimisations`
+/// before any compile lands, a tick that forces a recompile, and — the part a
+/// label alone would fake — the selection actually reaching the compiler.
+fn assert_codegen_pass_toggles(report: &Value) {
+    let rows = report["passRowCount"].as_u64().expect("pass row count");
+    assert_eq!(
+        rows,
+        tcl_explorer::SemanticOptimisationPassId::all().len() as u64,
+        "the toggle panel did not render one row per pass"
+    );
+    assert_eq!(
+        report["summaryBefore"].as_str().map(str::trim),
+        Some("Codegen passes: none"),
+        "an untouched Explorer must show the generic lowering"
+    );
+
+    let before = report["compilesBeforeToggle"]
+        .as_u64()
+        .expect("compile count");
+    let after = report["compilesAfterToggle"]
+        .as_u64()
+        .expect("compile count");
+    assert_eq!(
+        after,
+        before + 1,
+        "ticking a pass did not force a recompile ({before} -> {after})"
+    );
+    assert_eq!(
+        report["passesSent"].as_str(),
+        Some(tcl_explorer::SemanticOptimisationPassId::all()[0].as_str()),
+        "the ticked pass never reached the compiler"
+    );
+    assert_ne!(
+        report["summaryAfter"].as_str().map(str::trim),
+        Some("Codegen passes: none")
+    );
+
+    // The group buttons are presets over the same checkboxes.
+    assert_eq!(
+        report["nativeTierTicked"].as_u64(),
+        Some(4),
+        "the `native-tier` preset did not tick its four passes"
+    );
+}
+
 #[test]
 fn gui_renders_the_wasm_tab_and_settles_the_spinner() {
     if Command::new("node").arg("--version").output().is_err() {
@@ -301,4 +346,5 @@ fn gui_renders_the_wasm_tab_and_settles_the_spinner() {
     );
 
     assert_compile_triggers(&report);
+    assert_codegen_pass_toggles(&report);
 }

--- a/rust/tcl-cli/tests/gui/explorer-gui-smoke.mjs
+++ b/rust/tcl-cli/tests/gui/explorer-gui-smoke.mjs
@@ -65,7 +65,14 @@ await writeFile(
     'self.__initGate = new Promise(function (resolve) { self.__finishInit = resolve; });\n' +
     'self.wasm_bindgen = function () { return self.__initGate; };\n' +
     'self.wasm_bindgen.meta = function () { return self.__META; };\n' +
-    'self.wasm_bindgen.compile = function () { self.__COMPILES += 1; return self.__PAYLOAD; };\n',
+    'self.wasm_bindgen.compile = function () { self.__COMPILES += 1; return self.__PAYLOAD; };\n' +
+    // The toggle panel's entry point. Record the selection so the driver can
+    // assert the ticked passes actually reach the compiler rather than just
+    // changing a label.
+    'self.__LAST_PASSES = null;\n' +
+    'self.wasm_bindgen.compile_with_optimisations = function (source, dialect, passes) {\n' +
+    '  self.__COMPILES += 1; self.__LAST_PASSES = passes; return self.__PAYLOAD;\n' +
+    '};\n',
 );
 await writeFile(join(root, 'tcl_explorer_wasm_bg.wasm'), '');
 // Mermaid is vendored by `make explorer-wasm` and not checked in; the GUI
@@ -220,9 +227,40 @@ try {
     afterEdit = await compileCount(page);
   }
 
+  // The codegen-pass toggles: rows come from `meta.semanticOptimisations`, so
+  // the panel must be populated before any compile lands, ticking one must
+  // force a recompile, and the selection must reach the compiler.
+  // The panel is a closed <details> until the user opens it, so click the
+  // summary the way they would — the rows exist but are not clickable before.
+  await page.click('#optSummary');
+  const passRowCount = await page.locator('#optPasses input[type=checkbox]').count();
+  const summaryBefore = await page.locator('#optSummary').innerText();
+  const beforeToggle = await compileCount(page);
+  await page.locator('#optPasses input[type=checkbox]').first().check();
+  let afterToggle = beforeToggle;
+  for (let i = 0; i < 100 && afterToggle === beforeToggle; i += 1) {
+    await page.waitForTimeout(100);
+    afterToggle = await compileCount(page);
+  }
+  const passesSent = await lastPasses(page);
+  const summaryAfter = await page.locator('#optSummary').innerText();
+  // The group buttons are presets over the same checkboxes.
+  await page.locator('#optGroups button', { hasText: 'native-tier' }).first().click();
+  await page.waitForTimeout(300);
+  const nativeTierTicked = await page
+    .locator('#optPasses input[type=checkbox]:checked')
+    .count();
+
   report = {
     ok: true,
     first: afterFirst,
+    passRowCount,
+    summaryBefore,
+    summaryAfter,
+    compilesBeforeToggle: beforeToggle,
+    compilesAfterToggle: afterToggle,
+    nativeTierTicked,
+    passesSent,
     traitRowsBeforeCompile,
     queuedDuringLoad,
     compilesDuringLoad,
@@ -278,6 +316,15 @@ async function compileCount(page) {
   const workers = page.workers();
   if (!workers.length) return null;
   return workers[0].evaluate(() => self.__COMPILES);
+}
+
+// The pass selection the last compile actually carried into the compiler,
+// read from the worker the same way as the compile count. A label that
+// updates while the worker still gets "" is exactly the failure this catches.
+async function lastPasses(page) {
+  const workers = page.workers();
+  if (!workers.length) return null;
+  return workers[0].evaluate(() => self.__LAST_PASSES);
 }
 
 // Put source into the page the only way the shipped UI offers: through the

--- a/rust/tcl-cli/tests/gui/explorer-gui-smoke.mjs
+++ b/rust/tcl-cli/tests/gui/explorer-gui-smoke.mjs
@@ -35,9 +35,11 @@ import { readFile, mkdtemp, cp, writeFile, rm, mkdir } from 'node:fs/promises';
 import { join, extname } from 'node:path';
 import { tmpdir } from 'node:os';
 
-const [guiDir, payloadPath] = process.argv.slice(2);
-if (!guiDir || !payloadPath) {
-  console.error('usage: explorer-gui-smoke.mjs <gui-dir> <payload.json>');
+const [guiDir, payloadPath, optimisedPayloadPath] = process.argv.slice(2);
+if (!guiDir || !payloadPath || !optimisedPayloadPath) {
+  console.error(
+    'usage: explorer-gui-smoke.mjs <gui-dir> <payload.json> <payload-optimised.json>',
+  );
   process.exit(2);
 }
 
@@ -48,6 +50,10 @@ const launchOptions = process.env.TCL_EXPLORER_CHROMIUM
   : {};
 
 const payload = await readFile(payloadPath, 'utf8');
+// The same source compiled with every codegen pass on. The stub hands this
+// back whenever the page sends a pass selection, so a toggle changing the
+// rendered WASM can be told apart from a toggle that only recompiles.
+const optimisedPayload = await readFile(optimisedPayloadPath, 'utf8');
 const root = await mkdtemp(join(tmpdir(), 'explorer-gui-smoke-'));
 await cp(guiDir, root, { recursive: true });
 
@@ -70,8 +76,10 @@ await writeFile(
     // assert the ticked passes actually reach the compiler rather than just
     // changing a label.
     'self.__LAST_PASSES = null;\n' +
+    `self.__OPTIMISED_PAYLOAD = ${JSON.stringify(optimisedPayload)};\n` +
     'self.wasm_bindgen.compile_with_optimisations = function (source, dialect, passes) {\n' +
-    '  self.__COMPILES += 1; self.__LAST_PASSES = passes; return self.__PAYLOAD;\n' +
+    '  self.__COMPILES += 1; self.__LAST_PASSES = passes;\n' +
+    '  return passes ? self.__OPTIMISED_PAYLOAD : self.__PAYLOAD;\n' +
     '};\n',
 );
 await writeFile(join(root, 'tcl_explorer_wasm_bg.wasm'), '');
@@ -234,6 +242,8 @@ try {
   // summary the way they would — the rows exist but are not clickable before.
   await page.click('#optSummary');
   const passRowCount = await page.locator('#optPasses input[type=checkbox]').count();
+  const beforeToggleSnapshot = await snapshot(page);
+  const wasmTextBeforeToggle = beforeToggleSnapshot.wasmText;
   const summaryBefore = await page.locator('#optSummary').innerText();
   const beforeToggle = await compileCount(page);
   await page.locator('#optPasses input[type=checkbox]').first().check();
@@ -244,6 +254,18 @@ try {
   }
   const passesSent = await lastPasses(page);
   const summaryAfter = await page.locator('#optSummary').innerText();
+  // The point of the toggle: the WASM view must repaint from the new result,
+  // not merely have been recompiled behind it. Wait for the render rather
+  // than sampling immediately — `renderAll` runs on the result message.
+  await page.waitForFunction(
+    (before) => {
+      const pane = document.querySelector('#pane-wasm');
+      return pane && pane.textContent.replace(/\s+/g, ' ').trim().slice(0, 400) !== before;
+    },
+    wasmTextBeforeToggle,
+    { timeout: 30_000 },
+  );
+  const afterToggleSnapshot = await snapshot(page);
   // The group buttons are presets over the same checkboxes.
   await page.locator('#optGroups button', { hasText: 'native-tier' }).first().click();
   await page.waitForTimeout(300);
@@ -259,6 +281,8 @@ try {
     summaryAfter,
     compilesBeforeToggle: beforeToggle,
     compilesAfterToggle: afterToggle,
+    wasmBeforeToggle: beforeToggleSnapshot,
+    wasmAfterToggle: afterToggleSnapshot,
     nativeTierTicked,
     passesSent,
     traitRowsBeforeCompile,

--- a/rust/tcl-compiler/src/codegen/wasm/pipeline.rs
+++ b/rust/tcl-compiler/src/codegen/wasm/pipeline.rs
@@ -152,9 +152,18 @@ impl WasmCompileOptions {
 
     /// The native tier: lower every function through NLIR
     /// (`crate::native_lowering`) with representation inference,
-    /// trace-barrier elision, and cell demotion, and emit it natively. This is
-    /// what `tcl compwasm`, the Explorer, and the tier harness's native plan
-    /// use; it is shorthand for the four explicit passes it enables.
+    /// trace-barrier elision, and cell demotion, and emit it natively.
+    ///
+    /// Shorthand for the four passes it enables, and the same set the
+    /// `native-tier` group in
+    /// [`PASS_GROUPS`](crate::semantic_optimisation::PASS_GROUPS) names —
+    /// `native_tier_group_matches_the_wasm_option` keeps the two in step.
+    ///
+    /// The tier harness's native plan uses it unconditionally. `tcl compwasm`
+    /// and the Explorer reach it through `--optimise` / their pass toggles;
+    /// **both default to no optimisation at all**, so an unflagged
+    /// `tcl compwasm` and the Explorer's `wasm` view show the generic
+    /// lowering.
     #[must_use]
     pub const fn native_tier(self) -> Self {
         self.with_semantic_optimisation(SemanticOptimisationPassId::NativeLowering)

--- a/rust/tcl-compiler/src/semantic_optimisation.rs
+++ b/rust/tcl-compiler/src/semantic_optimisation.rs
@@ -91,6 +91,17 @@ impl SemanticOptimisationPassId {
         }
     }
 
+    /// Resolve a pass from its [`Self::as_str`] spelling.
+    ///
+    /// The inverse of `as_str`, so a CLI flag, an Explorer toggle and a JSON
+    /// contract all name a pass identically. Unknown names return `None`
+    /// rather than being ignored: an optimisation the caller asked for and
+    /// did not get is a wrong answer, not a lenient one.
+    #[must_use]
+    pub fn from_name(name: &str) -> Option<Self> {
+        Self::all().into_iter().find(|id| id.as_str() == name)
+    }
+
     const fn bit(self) -> u16 {
         match self {
             Self::LegacyAnalysisSpecialisation => 1 << 0,
@@ -153,7 +164,94 @@ impl SemanticOptimisationConfig {
     pub const fn disable(&mut self, pass: SemanticOptimisationPassId) {
         self.enabled &= !pass.bit();
     }
+
+    /// The enabled passes, in [`SemanticOptimisationPassId::all`] order.
+    pub fn enabled_passes(self) -> impl Iterator<Item = SemanticOptimisationPassId> {
+        SemanticOptimisationPassId::all()
+            .into_iter()
+            .filter(move |pass| self.is_enabled(*pass))
+    }
+
+    /// Parse a comma-separated pass selection.
+    ///
+    /// Each element is a [`SemanticOptimisationPassId::as_str`] spelling or
+    /// one of the two group names in [`PASS_GROUPS`]; empty elements and
+    /// surrounding whitespace are ignored, so `"native-tier,"` and
+    /// `" direct-proc , frame-elision "` both parse. An unrecognised name is
+    /// an error naming the offender — silently dropping it would report an
+    /// optimised build that was never optimised.
+    ///
+    /// ```
+    /// use tcl_compiler::semantic_optimisation::{
+    ///     SemanticOptimisationConfig as Config, SemanticOptimisationPassId as Pass,
+    /// };
+    /// let config = Config::from_names("direct-proc, frame-elision").unwrap();
+    /// assert!(config.is_enabled(Pass::DirectProc));
+    /// assert!(!config.is_enabled(Pass::NativeLowering));
+    /// assert!(Config::from_names("no-such-pass").is_err());
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns the unrecognised name, with the accepted spellings.
+    pub fn from_names(spec: &str) -> Result<Self, String> {
+        let mut config = Self::new();
+        for name in spec.split(',').map(str::trim).filter(|n| !n.is_empty()) {
+            if let Some(group) = PASS_GROUPS.iter().find(|(id, _)| *id == name) {
+                for pass in group.1 {
+                    config.enable(*pass);
+                }
+            } else if let Some(pass) = SemanticOptimisationPassId::from_name(name) {
+                config.enable(pass);
+            } else {
+                return Err(format!(
+                    "unknown optimisation pass `{name}`; expected one of: {}",
+                    Self::accepted_names().join(", ")
+                ));
+            }
+        }
+        Ok(config)
+    }
+
+    /// Every name [`Self::from_names`] accepts: the group names first, then
+    /// the individual passes in declaration order.
+    #[must_use]
+    pub fn accepted_names() -> Vec<&'static str> {
+        PASS_GROUPS
+            .iter()
+            .map(|(id, _)| *id)
+            .chain(
+                SemanticOptimisationPassId::all()
+                    .into_iter()
+                    .map(Pass::as_str),
+            )
+            .collect()
+    }
 }
+
+use SemanticOptimisationPassId as Pass;
+
+/// Named sets a caller can select instead of listing passes one by one.
+///
+/// `native-tier` is the four passes
+/// [`WasmCompileOptions::native_tier`](crate::codegen::wasm::WasmCompileOptions::native_tier)
+/// enables, kept in step with it by
+/// `native_tier_group_matches_the_wasm_option`; `all` is every pass, which is
+/// what a "turn everything on and see what changes" run wants.
+pub const PASS_GROUPS: &[(&str, &[SemanticOptimisationPassId])] = &[
+    (
+        "native-tier",
+        &[
+            Pass::NativeLowering,
+            Pass::RepresentationInference,
+            Pass::TraceBarrierElision,
+            Pass::CellDemotion,
+        ],
+    ),
+    ("all", &ALL_PASSES),
+];
+
+const ALL_PASSES: [SemanticOptimisationPassId; 12] = SemanticOptimisationPassId::all();
 
 #[cfg(test)]
 mod tests {
@@ -171,5 +269,55 @@ mod tests {
             assert!(!config.is_enabled(pass));
         }
         assert!(config.is_empty());
+    }
+
+    #[test]
+    fn every_pass_name_round_trips() {
+        for pass in Pass::all() {
+            assert_eq!(Pass::from_name(pass.as_str()), Some(pass), "{pass:?}");
+        }
+        assert_eq!(
+            Pass::from_name("native-tier"),
+            None,
+            "a group is not a pass"
+        );
+        assert_eq!(Pass::from_name(""), None);
+    }
+
+    #[test]
+    fn from_names_parses_passes_groups_and_whitespace() {
+        let config = SemanticOptimisationConfig::from_names(" direct-proc , frame-elision ,")
+            .expect("a valid selection");
+        assert_eq!(
+            config.enabled_passes().collect::<Vec<_>>(),
+            vec![Pass::DirectProc, Pass::FrameElision]
+        );
+        assert!(
+            SemanticOptimisationConfig::from_names("")
+                .unwrap()
+                .is_empty()
+        );
+        assert_eq!(
+            SemanticOptimisationConfig::from_names("all")
+                .unwrap()
+                .enabled_passes()
+                .count(),
+            Pass::all().len()
+        );
+        let error = SemanticOptimisationConfig::from_names("direct-proc,nope").unwrap_err();
+        assert!(error.contains("`nope`"), "{error}");
+        assert!(error.contains("native-tier"), "{error}");
+    }
+
+    /// The `native-tier` group and `WasmCompileOptions::native_tier` are two
+    /// spellings of one set; a pass added to the option and not the group
+    /// would make the CLI and the Explorer quietly weaker than the harness.
+    #[test]
+    fn native_tier_group_matches_the_wasm_option() {
+        let group = SemanticOptimisationConfig::from_names("native-tier").unwrap();
+        let option = crate::codegen::wasm::WasmCompileOptions::hosted()
+            .native_tier()
+            .semantic_optimisations();
+        assert_eq!(group, option);
     }
 }

--- a/rust/tcl-explorer-wasm/src/lib.rs
+++ b/rust/tcl-explorer-wasm/src/lib.rs
@@ -57,14 +57,69 @@ pub fn meta() -> String {
 #[wasm_bindgen]
 #[must_use]
 pub fn compile(source: &str, dialect: &str) -> String {
+    compile_with_optimisations(source, dialect, "")
+}
+
+/// [`compile`] with a comma-separated semantic/AOT optimisation selection —
+/// the GUI's per-pass toggles.
+///
+/// `optimisations` takes the pass ids the `semanticOptimisations` view lists
+/// (`native-lowering`, `representation-inference`, …) or one of its group
+/// names (`native-tier`, `all`); empty means the generic lowering, which is
+/// what [`compile`] asks for. An unknown name comes back as a JSON `error`
+/// object rather than being dropped: a toggle the user set and did not get is
+/// a wrong answer, and the GUI would otherwise show an unoptimised module as
+/// though it were optimised.
+#[wasm_bindgen]
+#[must_use]
+pub fn compile_with_optimisations(source: &str, dialect: &str, optimisations: &str) -> String {
+    let config = match tcl_explorer::SemanticOptimisationConfig::from_names(optimisations) {
+        Ok(config) => config,
+        Err(message) => {
+            return serde_json::json!({ "error": message }).to_string();
+        }
+    };
     let result = tcl_explorer::run_pipeline(source, dialect);
-    serde_json::to_string(&tcl_explorer::serialise_result(&result))
-        .unwrap_or_else(|e| format!(r#"{{"error":"serialise failed: {e}"}}"#))
+    serde_json::to_string(&tcl_explorer::serialise_result_with_optimisations(
+        &result, config,
+    ))
+    .unwrap_or_else(|e| format!(r#"{{"error":"serialise failed: {e}"}}"#))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The GUI's toggle path: a pass selection reaches the emitter, and an
+    /// unrecognised name comes back as an `error` object rather than being
+    /// silently dropped — a toggle that does nothing would show an
+    /// unoptimised module as though it were optimised.
+    #[test]
+    fn compile_with_optimisations_applies_the_selection_and_rejects_a_bad_name() {
+        let source = "set a 1\nincr a\n";
+        let off: serde_json::Value =
+            serde_json::from_str(&compile(source, "tcl9.0")).expect("result JSON");
+        assert_eq!(
+            off["wasm"][0]["codegenPlan"]["nativeLowering"]["enabled"],
+            false
+        );
+
+        let on: serde_json::Value =
+            serde_json::from_str(&compile_with_optimisations(source, "tcl9.0", "native-tier"))
+                .expect("result JSON");
+        assert_eq!(
+            on["wasm"][0]["codegenPlan"]["nativeLowering"]["enabled"],
+            true
+        );
+
+        let bad: serde_json::Value =
+            serde_json::from_str(&compile_with_optimisations(source, "tcl9.0", "nope"))
+                .expect("error JSON");
+        assert!(
+            bad["error"].as_str().is_some_and(|e| e.contains("`nope`")),
+            "{bad}"
+        );
+    }
 
     #[test]
     fn wasm_contract_exposes_the_descriptor_and_world_ssa_payload() {

--- a/rust/tcl-explorer/src/lib.rs
+++ b/rust/tcl-explorer/src/lib.rs
@@ -43,7 +43,16 @@ pub mod view_tree;
 pub mod views;
 pub mod wasm_explorer;
 
-pub use serialise::{serialise_meta, serialise_result};
+pub use serialise::{
+    serialise_meta, serialise_result, serialise_result_with_optimisations,
+    serialise_semantic_optimisations,
+};
+/// The semantic/AOT optimisation configuration the `wasm` views are built
+/// with, re-exported so a front end names passes through the explorer
+/// contract rather than reaching past it into `tcl-compiler`.
+pub use tcl_compiler::semantic_optimisation::{
+    PASS_GROUPS, SemanticOptimisationConfig, SemanticOptimisationPassId,
+};
 pub use view_tree::{ViewNode, build_view};
 
 use tcl_compiler::compilation_unit::{CompilationUnit, FunctionUnit};

--- a/rust/tcl-explorer/src/serialise.rs
+++ b/rust/tcl-explorer/src/serialise.rs
@@ -56,6 +56,7 @@ use tcl_compiler::segmenter::segment_commands_with_offset_and_config;
 use tcl_compiler::semantic_analysis::{
     ExecutableAnalysisAvailability, MixedRegionPlanAvailability,
 };
+use tcl_compiler::semantic_optimisation::{SemanticOptimisationConfig, SemanticOptimisationPassId};
 use tcl_compiler::shimmer::{
     find_byte_array_warnings_for_cu, find_sharing_warnings_for_cu, find_shimmer_warnings_for_cu,
     find_thunking_warnings_for_cu, type_name,
@@ -133,6 +134,13 @@ pub fn serialise_meta() -> Value {
         "views": views,
         "severities": severities,
         "traits": traits,
+        // The codegen-pass catalogue, so a front end can render its toggles
+        // before the first compile — the same reason `dialects` is here
+        // (issue #1183). The per-result `semanticOptimisations` view carries
+        // the same rows plus the state the shown module was built with.
+        "semanticOptimisations": serialise_semantic_optimisations(
+            SemanticOptimisationConfig::new(),
+        ),
     })
 }
 
@@ -251,21 +259,49 @@ fn serialise_children(stmt: &Statement, li: &LineIndex, source: &str) -> Option<
     }
 }
 
+/// Serialise the `semanticOptimisations` view: one row per pass, in
+/// [`SemanticOptimisationPassId::all`] order, with the state the shown
+/// `wasm` module was built with.
+///
+/// This is the toggle surface. A front-end renders a checkbox per row from
+/// `id` and `enabled` and sends the ids it wants back — it never needs its
+/// own copy of the pass list, which is the drift this view exists to
+/// prevent. `groups` names the presets `from_names` also accepts.
+#[must_use]
+pub fn serialise_semantic_optimisations(config: SemanticOptimisationConfig) -> Value {
+    let passes: Vec<Value> = SemanticOptimisationPassId::all()
+        .into_iter()
+        .map(|pass| {
+            serde_json::json!({
+                "id": pass.as_str(),
+                "enabled": config.is_enabled(pass),
+            })
+        })
+        .collect();
+    let groups: Vec<Value> = tcl_compiler::semantic_optimisation::PASS_GROUPS
+        .iter()
+        .map(|(id, members)| {
+            serde_json::json!({
+                "id": *id,
+                "passes": members.iter().map(|p| p.as_str()).collect::<Vec<_>>(),
+            })
+        })
+        .collect();
+    serde_json::json!({ "passes": passes, "groups": groups })
+}
+
 /// Serialise the `wasm` view: drive the analysis-aware WASM emitter used by
-/// `tcl compwasm` and emit the rich per-instruction
-/// explorer shape (`wasm_explorer::wasm_to_explorer_json` — resolved `call`
-/// targets, paired `br`/`br_if` targets, block-pairing indices, per-instruction
+/// `tcl compwasm` under `options` and emit the rich per-instruction explorer
+/// shape (`wasm_explorer::wasm_to_explorer_json` — resolved `call` targets,
+/// paired `br`/`br_if` targets, block-pairing indices, per-instruction
 /// ranges). The synthetic `(module)` entry additionally carries the full WAT
 /// `text`, so both the text renderer and the web GUI read one shape; the
 /// module-wide counts (`functionCount` / `totalInstrCount`) and the type
 /// section come from `wasm_to_explorer_json` itself.
-fn serialise_wasm(result: &ExplorerResult) -> Value {
-    serialise_wasm_with_options(
-        result,
-        tcl_compiler::codegen::wasm::WasmCompileOptions::hosted(),
-    )
-}
-
+///
+/// `options` carries the semantic/AOT optimisation configuration, so the same
+/// source can be shown as the generic lowering or as any pass selection —
+/// which is what the Explorer's per-pass toggles change.
 fn serialise_wasm_with_options(
     result: &ExplorerResult,
     options: tcl_compiler::codegen::wasm::WasmCompileOptions,
@@ -3081,12 +3117,33 @@ fn serialise_annotations(result: &ExplorerResult, li: &LineIndex, source: &str) 
     (Value::Array(dicts), Value::Object(by_line))
 }
 
-/// Serialise a full pipeline result to the explorer contract JSON.
+/// Serialise a full pipeline result to the explorer contract JSON, with
+/// every semantic/AOT optimisation pass **off** — the generic lowering.
+///
+/// Use [`serialise_result_with_optimisations`] to see what a pass changes.
+#[must_use]
+pub fn serialise_result(result: &ExplorerResult) -> Value {
+    serialise_result_with_optimisations(result, SemanticOptimisationConfig::new())
+}
+
+/// [`serialise_result`] with a chosen semantic/AOT optimisation
+/// configuration.
+///
+/// The configuration reaches the `wasm` and `wasmOptimised` views (the
+/// emitter's `WasmCompileOptions`) and is echoed in the
+/// `semanticOptimisations` view, so a front-end can render a toggle per pass
+/// and read back which ones the shown module was built with. Every other
+/// view is target-neutral and unaffected.
 // Assembles the whole explorer JSON contract field-by-field in one place;
 // each stage adds one top-level key, so the length is inherent to the schema.
 #[must_use]
 #[allow(clippy::too_many_lines)]
-pub fn serialise_result(result: &ExplorerResult) -> Value {
+pub fn serialise_result_with_optimisations(
+    result: &ExplorerResult,
+    optimisations: SemanticOptimisationConfig,
+) -> Value {
+    let options = tcl_compiler::codegen::wasm::WasmCompileOptions::hosted()
+        .with_semantic_optimisations(optimisations);
     let li = LineIndex::new(&result.source);
     let mut out = Map::new();
     out.insert("meta".to_owned(), serialise_meta());
@@ -3231,10 +3288,19 @@ pub fn serialise_result(result: &ExplorerResult) -> Value {
     // and surface its WAT plus the rich per-instruction
     // explorer shape (resolved `call`/branch targets, per-instruction ranges)
     // alongside per-function headers, which the text/`wasm` view renders.
-    out.insert("wasm".to_owned(), serialise_wasm(result));
+    out.insert(
+        "wasm".to_owned(),
+        serialise_wasm_with_options(result, options),
+    );
     out.insert(
         "wasmOptimised".to_owned(),
-        opt.as_ref().map_or(Value::Null, |(r, _)| serialise_wasm(r)),
+        opt.as_ref().map_or(Value::Null, |(r, _)| {
+            serialise_wasm_with_options(r, options)
+        }),
+    );
+    out.insert(
+        "semanticOptimisations".to_owned(),
+        serialise_semantic_optimisations(optimisations),
     );
 
     let (annotations, by_line) = serialise_annotations(result, &li, &result.source);
@@ -3269,9 +3335,9 @@ mod tests {
             assert!(entry["displayName"].as_str().is_some_and(|s| !s.is_empty()));
             assert!(entry["shortName"].as_str().is_some_and(|s| !s.is_empty()));
         }
-        // The original 27 views, plus World SSA and six durable compiler
-        // artefact views.
-        assert_eq!(meta["views"].as_array().unwrap().len(), 34);
+        // The original 27 views, plus World SSA, six durable compiler
+        // artefact views, and the optimisation-pass toggle surface.
+        assert_eq!(meta["views"].as_array().unwrap().len(), 35);
         assert_eq!(meta["severities"], json!(["error", "warning", "info"]));
         let traits = meta["traits"]
             .as_array()
@@ -3380,6 +3446,81 @@ mod tests {
         );
         assert_eq!(plan["nativeI64Add"]["frameElided"], true);
         assert_eq!(plan["nativeI64Add"]["closedProgramStatements"], 4);
+    }
+
+    /// The toggle surface a front end renders from: every pass, in a stable
+    /// order, with the state the shown module was built with — and the same
+    /// catalogue in `meta`, so the panel can be drawn before the first
+    /// compile.
+    #[test]
+    fn semantic_optimisations_view_carries_every_pass_and_its_state() {
+        let result = run_pipeline("set a 1\nincr a\n", "tcl9.0");
+        let off = serialise_result(&result);
+        let ids: Vec<&str> = off["semanticOptimisations"]["passes"]
+            .as_array()
+            .expect("pass rows")
+            .iter()
+            .map(|row| row["id"].as_str().expect("a pass id"))
+            .collect();
+        assert_eq!(
+            ids,
+            SemanticOptimisationPassId::all()
+                .iter()
+                .map(|p| p.as_str())
+                .collect::<Vec<_>>()
+        );
+        assert!(
+            off["semanticOptimisations"]["passes"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .all(|row| row["enabled"] == false),
+            "the default is the generic lowering"
+        );
+
+        let on = serialise_result_with_optimisations(
+            &result,
+            SemanticOptimisationConfig::from_names("native-tier").expect("a valid group"),
+        );
+        let enabled: Vec<&str> = on["semanticOptimisations"]["passes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter(|row| row["enabled"] == true)
+            .map(|row| row["id"].as_str().unwrap())
+            .collect();
+        assert_eq!(
+            enabled,
+            vec![
+                "native-lowering",
+                "representation-inference",
+                "trace-barrier-elision",
+                "cell-demotion"
+            ]
+        );
+        // The selection reaches the emitter, not just the echo.
+        assert_eq!(
+            on["wasm"].as_array().expect("WASM entries")[0]["codegenPlan"]["nativeLowering"]["enabled"],
+            true
+        );
+
+        // `meta` carries the catalogue with nothing enabled, so the panel can
+        // be built before a compile lands (issue #1183's rule for dialects).
+        let meta = serialise_meta();
+        assert_eq!(
+            meta["semanticOptimisations"]["passes"]
+                .as_array()
+                .unwrap()
+                .len(),
+            SemanticOptimisationPassId::all().len()
+        );
+        let groups: Vec<&str> = meta["semanticOptimisations"]["groups"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|g| g["id"].as_str().unwrap())
+            .collect();
+        assert_eq!(groups, vec!["native-tier", "all"]);
     }
 
     #[test]

--- a/rust/tcl-explorer/src/views.rs
+++ b/rust/tcl-explorer/src/views.rs
@@ -307,6 +307,17 @@ pub const VIEW_META: &[ViewDescriptor] = &[
         group: "codegen",
         render_kind: ViewRenderKind::Frontend,
     },
+    // The toggle surface for the two views above: one row per semantic/AOT
+    // optimisation pass with the state the shown module was built with. A
+    // front end renders its checkboxes from this payload rather than from a
+    // copy of the pass list — which is the point of shipping it as a view.
+    ViewDescriptor {
+        id: "semanticOptimisations",
+        label: "Optimisation Passes",
+        payload: "semanticOptimisations",
+        group: "codegen",
+        render_kind: ViewRenderKind::Frontend,
+    },
 ];
 
 /// IDs handled by the shared Explorer tree model, in tab-table order.


### PR DESCRIPTION
## Summary

- **The passes existed and nothing could reach them.** `SemanticOptimisationConfig` has had twelve individually selectable passes and a stable string spelling each since the P3 lane. `tcl compwasm` hardcoded `WasmCompileOptions::hosted()` and the Explorer's `wasm` view did the same, so both always emitted the generic lowering — while still *reporting* `nativeLowering.enabled: false`, which reads as "the optimiser found nothing" rather than "the optimiser was never asked". Only the tier harness enabled anything, and `native_tier()`'s own doc claimed all three used it (fixed here).
- **Core.** `SemanticOptimisationPassId::from_name` inverts `as_str`, which was write-only. `SemanticOptimisationConfig::from_names` parses a comma-separated selection over those spellings plus two group names — `native-tier` (the four `WasmCompileOptions::native_tier` enables) and `all`. An unknown name is an error naming the offender: an optimisation the caller asked for and did not get is a wrong answer, not a lenient one.
- **CLI.** `--codegen-passes PASS[,PASS...]` on `compwasm` and `explore`. Deliberately **not** `--optimise`: `tcl dis --optimise` already exists and means the *source-rewrite* optimiser (`tcl_compiler::optimiser`), which is a different thing from these target-neutral semantic passes.
- **Explorer.** `serialise_result_with_optimisations` threads the config into the `wasm` and `wasmOptimised` views, and a new `semanticOptimisations` view echoes every pass with the state the shown module was built with. The same catalogue is in `meta`, for the same reason `dialects` is (#1183): the panel has to be usable before the first compile lands.
- **GUI.** A toolbar popover with a checkbox per pass and the group presets as buttons. Its rows are built from `meta.semanticOptimisations`, never from a list in `index.html` — that is the drift the view exists to prevent. `compile_with_optimisations` is the new facade entry point; the worker falls back to `compile` when the loaded module predates it.

### Two guards against the tests being vacuous

Both of these were weaker first drafts, caught in review of my own work:

- **`compwasm` emits *optimised* code, not merely different code.** Asserting inequality passes on a flag that perturbs the output without optimising anything. The test now checks what actually changes on a hot integer loop: the generic lowering is a source-eval fallback that pushes the command text and calls `tcl_eval_code` (636 bytes, seven such calls, zero `i64` ops); the native tier compiles it, so the `<` becomes `i64.lt_s`, the `+` becomes `i64.add`, and no source-eval call survives (3231 bytes). Mutation-checked — making the flag a no-op in `run_compwasm` fails it on the missing `i64.add`.
- **The Explorer toggles *live-update the disassembly*, not just recompile.** The smoke stub returned one payload whatever selection it got, so the WASM pane looked identical either way and a page that never repainted would have passed. The driver now gets a second payload (the same source with every pass on), waits for `#pane-wasm` to change, and asserts the text differs, the repaint rendered instructions, the spinner settled and no error box appeared. Mutation-checked both ways: dropping `forceCompile()` from the checkbox handler, and skipping `renderAll()` on results after the first, each make it fail.

Correctness of the pass set is not this PR's to prove and is already covered: `wasm_tiers::native_plan_samples_reproduce_the_tclsh_oracles` links the same `native_tier()` options against the real runtime, runs every `samples/wasm` script under wasmtime, and diffs stdout against the committed `tclsh9.0` oracles. `native_tier_group_matches_the_wasm_option` pins the `native-tier` group to that option, so a pass added to one and not the other cannot make the CLI and the Explorer quietly weaker than the harness.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

```
cargo test -p tcl-compiler --lib semantic_optimisation   # 4 pass (incl. the group/option pin)
cargo test -p tcl-explorer                               # 90 pass
cargo test --manifest-path rust/tcl-explorer-wasm/Cargo.toml
cargo test -p tcl-cli --test compile_verbs               # 10 pass
cargo test -p tcl-cli --test explorer_gui                # 2 pass (headless Chromium)
cargo test -p tcl-compiler --test wasm_tiers native_plan # green on this branch
cargo test -p tcl-cli -p tcl-explorer                    # full suites
cargo fmt --check && cargo clippy --all-targets --all-features   # clean
cargo check --manifest-path rust/tcl-explorer-wasm/Cargo.toml --target wasm32-unknown-unknown
node --check on index.html's inline scripts, worker.js, explorer-core.js, the smoke driver
```

Manual: `tcl compwasm /tmp/hot.tcl` → 636 bytes with 7 `tcl_eval_code` calls and no native arithmetic; `--codegen-passes native-tier` → 3231 bytes with `i64.add` / `i64.lt_s` and none. `tcl explore --json --codegen-passes nope` errors naming the pass and listing the accepted spellings.

## Compiler / diagnostics checklist

- [x] Did this change alter a compiler fact contract? **No.** It exposes an existing one — `SemanticOptimisationConfig` and `WasmCompileOptions::with_semantic_optimisations` are unchanged in meaning; only their reachability and a stale doc comment change. The explorer JSON contract gains one view and one `meta` key, both additive.
- [x] If yes, I updated the owning design doc — n/a per the above; `docs/kcs/features/kcs-feature-tcl-verb-cli.md` documents the new flag on both verbs.
- [x] If I added or changed a diagnostic or optimisation code, I updated its page under `docs/kcs/codes/` — n/a. These are `SemanticOptimisationPassId` codegen passes, not `optimiser::PassId` rewrite codes; no `O1xx` code was added or changed.
- [x] If I added a design doc, I linked it from `docs/design/README.md` — n/a, no new design doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013wqsJY5pcg8Uyk1H4e7V8y

---
_Generated by [Claude Code](https://claude.ai/code/session_013wqsJY5pcg8Uyk1H4e7V8y)_