### PR TITLE
feat(packages): declare what a binary extension loads (#1813)

### DIFF
--- a/docs/design/contracts/package-loading.md
+++ b/docs/design/contracts/package-loading.md
@@ -235,13 +235,29 @@ per-dialect spec packs, never as name-matching in a consumer (see
 
 19. The closure searches the file's own directives before the configured
     edges, and a package reached through either carries it onward, so the two
-    surfaces chain. It is breadth-first and visits each name once, so each
-    package is anchored at the earliest require reaching it and a cyclic
-    declaration terminates. A declared entry carries no version requirement,
-    so it contributes no version floor: a declaration says a package is
-    *there*, never which release.
+    surfaces chain. It is breadth-first over the **earliest anchor** each
+    package has so far, not a visited set: a package the source *also*
+    requires explicitly further down keeps the earlier, declared anchor,
+    because H301 takes the minimum start per package and a set would leave
+    only the later span — reporting the command between the two as
+    used-before-available purely because the file names the package twice.
+    Re-reaching a package at an anchor no earlier than the one it has stops,
+    so a cyclic declaration still terminates. A declared entry carries no
+    version requirement, so it contributes no version floor: a declaration
+    says a package is *there*, never which release.
 
-20. The tail is the one point both the whole-file walk and the per-item
+20. Every analyser that produces a **published or indexed** result carries
+    the edges — the interactive path, the recovery path taken while a buffer
+    has an unclosed delimiter, the disk scanner and the startup workspace
+    scan. `workspace_index` harvests `package_requires`, and a `source`
+    descendant inherits those names, so an analyser that omits the edges does
+    not merely under-report its own file: it writes an index entry that
+    under-reports for every file downstream of it. The edges are also
+    resolved **per folder** (`tclLsp.packages.provides` is `scope: resource`
+    and a `.tcl-lsp.ini` belongs to its own project), so a secondary root
+    declares its own and never inherits a sibling's.
+
+21. The tail is the one point both the whole-file walk and the per-item
     (incremental) walk reach with their `package_requires` merged, so the two
     strategies cannot disagree. The per-item path's mid-walk Tk hand-off runs
     *before* the tail, so `has_tk_require` consults the declarations directly
@@ -252,20 +268,20 @@ per-dialect spec packs, never as name-matching in a consumer (see
 
 ### Workspace index integration
 
-21. `WorkspaceIndex::add_document(uri, analysis)` records a document's procs,
+22. `WorkspaceIndex::add_document(uri, analysis)` records a document's procs,
     classes, invocation sites, `source` targets, and `package require`s;
     `remove_document(uri)` drops every entry from that document before a
     re-index or on close.
-22. The server seeds the index from both editor-opened documents (via the
+23. The server seeds the index from both editor-opened documents (via the
     diagnostics path) and an on-disk scan of the workspace folders
     (`scan_workspace_folders`), so unopened `.tcl` / `.tm` files are covered.
-23. Open buffers win over disk-scanned copies: `merge_workspace_scan_results`
+24. Open buffers win over disk-scanned copies: `merge_workspace_scan_results`
     re-checks the live open set at publication time and never overwrites an
     open document's entry with a stale on-disk analysis.
 
 ### Missing-`package require` refinement (W120)
 
-24. The analyser's single-file W120 knows only the requires in the current
+25. The analyser's single-file W120 knows only the requires in the current
     document. Two workspace-level refinements are layered on top, both in the
     server's `refine_w120_diagnostics`:
     - **#723 transitive resolution** — a required package is resolved through
@@ -277,9 +293,9 @@ per-dialect spec packs, never as name-matching in a consumer (see
 
 ### Cross-file `package require` inheritance (W120, #804)
 
-25. A file need not carry its own `package require` for a command whose package
+26. A file need not carry its own `package require` for a command whose package
     was required by an **entry** file that `source`s it.
-26. **Automatic (default).** The workspace index's `source` targets and
+27. **Automatic (default).** The workspace index's `source` targets and
     `package require`s feed a reverse-reachability walk
     (`tcl-lsp-core::source_graph::ancestor_requires`): a module inherits the
     requires of every file that transitively `source`s it. Only **literal**
@@ -287,30 +303,30 @@ per-dialect spec packs, never as name-matching in a consumer (see
     yields no static edge. Path resolution is
     `source_graph::resolve_source_target` (lexical, no filesystem access); the
     server supplies the URI ↔ path conversion.
-27. **Explicit.** `.tcl-lsp.ini [project] entryPoints` lists the entry files
+28. **Explicit.** `.tcl-lsp.ini [project] entryPoints` lists the entry files
     (relative to the folder root, or absolute). When set, the union of those
     files' requires is treated as available for W120 across the whole folder,
     and the automatic `source`-graph inheritance is **disabled** for that
     folder.
-28. The inherited requires are merged with the document's own before the #723
+29. The inherited requires are merged with the document's own before the #723
     transitive resolution runs, so an inherited `package require myWrapper`
     still (transitively) pulls in whatever `myWrapper` provides.
 
 ### iRules cross-file equivalent
 
-29. iRules do not support `package require` on BIG-IP, so W120 never applies
+30. iRules do not support `package require` on BIG-IP, so W120 never applies
     to the `f5-irules` dialect (the refinement early-returns when the registry
     has no `package` command).
-30. iRules procs are instead globally visible across files through the same
+31. iRules procs are instead globally visible across files through the same
     workspace index proc aggregation the LSP cross-document features use.
 
 ### Split packages
 
-31. A single `package ifneeded` script may `source` multiple files
+32. A single `package ifneeded` script may `source` multiple files
     (`source [file join $dir a.tcl]; source [file join $dir b.tcl]`); each is
     extracted independently by the lexer-driven parser, so no regex
     semicolon-capture limitation applies.
-32. A single `pkgIndex.tcl` may declare multiple unrelated packages — each
+33. A single `pkgIndex.tcl` may declare multiple unrelated packages — each
     `package ifneeded` line is parsed independently.
 
 ## File-path anchors

--- a/docs/design/contracts/package-loading.md
+++ b/docs/design/contracts/package-loading.md
@@ -172,22 +172,100 @@ per-dialect spec packs, never as name-matching in a consumer (see
     own `package require`s — which is how a wrapper package that internally
     `package require Tk` makes `Tk` available (#723).
 
+### Declared package provides (#1813)
+
+15. A **binary** extension can load another package with nothing in any Tcl
+    source to say so: its C `Init` calls `Tcl_PkgRequire`, or it links Tk
+    through `Tk_InitStubs`. Rule 14 has nothing to read there — a `load`-only
+    `ifneeded` script sources no Tcl file — so the dependency is not
+    discoverable by any scan, by us or by anything else. It is **declared**,
+    in either of two places, because the two answer different questions.
+
+16. **The directive** — `# tcl-lsp: package NAME provides PKG …` — states
+    the edge for one file:
+
+    ```tcl
+    # tcl-lsp: package myExtension provides Tk
+    package require myExtension
+    ```
+
+    `package` occupies the keyword slot, as in every other member of the
+    family (`supports`, `stub`, `disable`), so `matches_marker` handles it and
+    no future keyword can be confused with a package name; the wording
+    deliberately echoes the Tcl commands the line is about.
+    `parse_provides_directives` reads it from **anywhere** in the file (any
+    line whose first non-whitespace character is `#`, the same terms
+    `scan_source_for_stubs` reads a stub block on), because the line names
+    its loader rather than relying on where it sits. It travels with the file
+    and needs no configuration, so it is also the only form the CLI honours
+    (`tcl diag` / `lint` read no `.tcl-lsp.ini`).
+
+17. **The configured edge** — `[packages.provides]` in `.tcl-lsp.ini`, or
+    `tclLsp.packages.provides` — says "requiring *this* package loads
+    *those*", once for the whole project:
+
+    ```ini
+    [packages.provides]
+    myExtension = Tk
+    bigWrapper = Tk, Img
+    ```
+
+    equivalently `{ "myExtension": ["Tk"] }` (a bare string is accepted for
+    one name).
+
+18. Both reach the analyser as `Analyser::with_package_provides` /
+    `directive_provides` and are applied by
+    `expand_implied_package_requires` at the head of the shared diagnostic
+    tail. Each package the edges reach becomes an ordinary
+    `SignaturePackageRequire` on `AnalysisResult.package_requires`, carrying
+    **the span of the `package require` that loaded it** — the position from
+    which it is genuinely available, which is what keeps H301's ordering
+    claim honest — and a `PackageRequireOrigin` (`Directive(pkg)` or
+    `Provides(pkg)`, naming the loader) for the consumers that want what the
+    source literally says. Every consumer that asks "is this package
+    available here?" — W120, H301, the W123 widening, the Tk activation gate,
+    completion's `tk_loaded`, hover's package annotation — therefore answers
+    exactly as it would for a written `package require`, with no consumer
+    taught about the mechanism.
+
+    An edge is inert until the document requires its loader: a
+    `# tcl-lsp: package myExtension provides Tk` in a file that never says
+    `package require myExtension` declares nothing, which is what makes the
+    two surfaces the same fact rather than two mechanisms.
+
+19. The closure searches the file's own directives before the configured
+    edges, and a package reached through either carries it onward, so the two
+    surfaces chain. It is breadth-first and visits each name once, so each
+    package is anchored at the earliest require reaching it and a cyclic
+    declaration terminates. A declared entry carries no version requirement,
+    so it contributes no version floor: a declaration says a package is
+    *there*, never which release.
+
+20. The tail is the one point both the whole-file walk and the per-item
+    (incremental) walk reach with their `package_requires` merged, so the two
+    strategies cannot disagree. The per-item path's mid-walk Tk hand-off runs
+    *before* the tail, so `has_tk_require` consults the declarations directly
+    (`tk_is_declared_available`), and `fresh_full_analyse` carries the
+    configured edges into the full re-analysis it falls back to — the
+    directives need no carrying, being a pure function of the source it
+    re-scans.
+
 ### Workspace index integration
 
-15. `WorkspaceIndex::add_document(uri, analysis)` records a document's procs,
+21. `WorkspaceIndex::add_document(uri, analysis)` records a document's procs,
     classes, invocation sites, `source` targets, and `package require`s;
     `remove_document(uri)` drops every entry from that document before a
     re-index or on close.
-16. The server seeds the index from both editor-opened documents (via the
+22. The server seeds the index from both editor-opened documents (via the
     diagnostics path) and an on-disk scan of the workspace folders
     (`scan_workspace_folders`), so unopened `.tcl` / `.tm` files are covered.
-17. Open buffers win over disk-scanned copies: `merge_workspace_scan_results`
+23. Open buffers win over disk-scanned copies: `merge_workspace_scan_results`
     re-checks the live open set at publication time and never overwrites an
     open document's entry with a stale on-disk analysis.
 
 ### Missing-`package require` refinement (W120)
 
-18. The analyser's single-file W120 knows only the requires in the current
+24. The analyser's single-file W120 knows only the requires in the current
     document. Two workspace-level refinements are layered on top, both in the
     server's `refine_w120_diagnostics`:
     - **#723 transitive resolution** — a required package is resolved through
@@ -199,9 +277,9 @@ per-dialect spec packs, never as name-matching in a consumer (see
 
 ### Cross-file `package require` inheritance (W120, #804)
 
-19. A file need not carry its own `package require` for a command whose package
+25. A file need not carry its own `package require` for a command whose package
     was required by an **entry** file that `source`s it.
-20. **Automatic (default).** The workspace index's `source` targets and
+26. **Automatic (default).** The workspace index's `source` targets and
     `package require`s feed a reverse-reachability walk
     (`tcl-lsp-core::source_graph::ancestor_requires`): a module inherits the
     requires of every file that transitively `source`s it. Only **literal**
@@ -209,30 +287,30 @@ per-dialect spec packs, never as name-matching in a consumer (see
     yields no static edge. Path resolution is
     `source_graph::resolve_source_target` (lexical, no filesystem access); the
     server supplies the URI ↔ path conversion.
-21. **Explicit.** `.tcl-lsp.ini [project] entryPoints` lists the entry files
+27. **Explicit.** `.tcl-lsp.ini [project] entryPoints` lists the entry files
     (relative to the folder root, or absolute). When set, the union of those
     files' requires is treated as available for W120 across the whole folder,
     and the automatic `source`-graph inheritance is **disabled** for that
     folder.
-22. The inherited requires are merged with the document's own before the #723
+28. The inherited requires are merged with the document's own before the #723
     transitive resolution runs, so an inherited `package require myWrapper`
     still (transitively) pulls in whatever `myWrapper` provides.
 
 ### iRules cross-file equivalent
 
-23. iRules do not support `package require` on BIG-IP, so W120 never applies
+29. iRules do not support `package require` on BIG-IP, so W120 never applies
     to the `f5-irules` dialect (the refinement early-returns when the registry
     has no `package` command).
-24. iRules procs are instead globally visible across files through the same
+30. iRules procs are instead globally visible across files through the same
     workspace index proc aggregation the LSP cross-document features use.
 
 ### Split packages
 
-25. A single `package ifneeded` script may `source` multiple files
+31. A single `package ifneeded` script may `source` multiple files
     (`source [file join $dir a.tcl]; source [file join $dir b.tcl]`); each is
     extracted independently by the lexer-driven parser, so no regex
     semicolon-capture limitation applies.
-26. A single `pkgIndex.tcl` may declare multiple unrelated packages — each
+32. A single `pkgIndex.tcl` may declare multiple unrelated packages — each
     `package ifneeded` line is parsed independently.
 
 ## File-path anchors
@@ -259,12 +337,18 @@ per-dialect spec packs, never as name-matching in a consumer (see
   `w120_inheritance_config`, `scan_workspace_folders`,
   `build_package_resolver`.
 - `tcl-lsp-server/src/config_ini.rs` — `settings_from_ini` (`entryPoints`,
-  `libraryPaths`).
+  `libraryPaths`, `[packages.provides]`).
+- `tcl-compiler/src/analyser/state.rs` — `Analyser::with_package_provides`,
+  `expand_implied_package_requires`, `implied_package_requires`.
+- `tcl-compiler/src/analyser/utils.rs` — `parse_provides_directives`.
+- `tcl-compiler/src/signature_scan/types.rs` — `PackageRequireOrigin`.
 
 ## Failure modes
 
 - **Missing completions**: a `package require` not detected → the package's
-  gated commands stay hidden.
+  gated commands stay hidden. A **binary** extension that loads a package from
+  its C `Init` is never detected by design; declare it with a
+  `# tcl-lsp: provides` comment or under `[packages.provides]`.
 - **False W120 diagnostics**: a require not recorded, or the workspace not yet
   scanned, → W120 fires for a command that is actually imported (directly, via
   a wrapper package, or via an entry file that sources the module).
@@ -285,7 +369,19 @@ per-dialect spec packs, never as name-matching in a consumer (see
   `source`-graph walk, and `package require` recording.
 - `tcl-lsp-core/src/source_graph.rs` (tests) — path resolution and ancestor
   reachability.
+- `tcl-compiler/src/analyser/tk_checks.rs` (tests) —
+  `declared_package_provides_activates_tk`,
+  `declared_package_provides_is_transitive_and_cycle_safe`,
+  `declared_package_provides_agrees_across_walk_strategies`,
+  `provides_directive_activates_tk`,
+  `provides_directive_without_the_require_is_inert`,
+  `provides_directive_and_configured_edge_compose`,
+  `provides_directive_agrees_across_walk_strategies`.
+- `tcl-compiler/src/analyser/utils.rs` (tests) —
+  `parse_provides_directives_read_edges_from_the_whole_file`,
+  `parse_provides_directives_ignore_other_shapes`.
 - `tcl-lsp-server/src/lib.rs` (tests) — `refine_w120_*`,
+  `declared_package_provides_makes_tk_available_to_diagnostics`,
   `compute_inherited_requires`, and the push/pull integration
   (`source_graph_inheritance_suppresses_w120_in_sourced_module`,
   `explicit_entry_point_config_suppresses_w120_project_wide`,

--- a/docs/kcs/README.md
+++ b/docs/kcs/README.md
@@ -237,6 +237,10 @@ symptom with several possible causes worth telling apart. See rule 13 in
   — say a library is ambient under one of a pack's environments and not
   another, with an `environment { ambient … }` row and a shared version
   variable.
+- [kcs-howto-declare-a-package-a-binary-extension-loads.md](kcs-howto-declare-a-package-a-binary-extension-loads.md)
+  — tell the server that a compiled `.dll` / `.so` extension brings Tk (or
+  any other package) up from its C `Init`, so the Tk completions, hover and
+  checks switch on without a `package require Tk` in the source.
 - [kcs-howto-derive-version-ranges-from-releases.md](kcs-howto-derive-version-ranges-from-releases.md)
   — derive `introduced_version` / `retired_version` facts from several
   package releases with `tcl spec import`, read the evidence header it

--- a/docs/kcs/kcs-howto-declare-a-package-a-binary-extension-loads.md
+++ b/docs/kcs/kcs-howto-declare-a-package-a-binary-extension-loads.md
@@ -1,0 +1,100 @@
+# KCS: How do I tell tcl-lsp that a binary extension also loads Tk?
+
+> **Audience:** User
+> **Type:** How-To
+
+## Applies to
+
+VS Code, all-editors
+
+## Question
+
+My script says `package require myExtension` and then calls `ttk::frame`
+and `pack`. `myExtension` is a compiled extension — a `.dll` / `.so` —
+whose C `Init` brings Tk up for me, so I never write `package require Tk`.
+The editor still treats the file as plain Tcl: no Tk completions, no Tk
+checks, and a warning that `ttk::frame` "requires `package require Tk`".
+How do I tell it Tk is there?
+
+## Before you start
+
+- You know which package your extension loads behind the scenes. Tk is the
+  usual one, but the same steps work for any package name.
+- You can either edit the file, or add a setting to your workspace or a
+  `.tcl-lsp.ini` file beside your project.
+
+## Answer
+
+Declare the dependency. tcl-lsp reads a `pkgIndex.tcl` and follows the
+`package require`s inside the Tcl files it loads, so a *Tcl* wrapper
+package is found on its own. A compiled extension loads Tk from C, where
+there is no Tcl text to read, so the link has to be stated.
+
+There are two ways to state it. Use the comment when the fact belongs to
+the file you are looking at, and the config file when it belongs to the
+project.
+
+### A comment in the file
+
+Add a `# tcl-lsp: package … provides …` line naming the extension and what
+it brings up:
+
+```tcl
+# tcl-lsp: package myExtension provides Tk
+package require myExtension
+
+ttk::frame .f
+pack .f
+```
+
+Name several packages on one line — `# tcl-lsp: package myExtension
+provides Tk Img` — and put the comment wherever you like; because it names
+the extension, it does not have to sit next to the `package require`. It
+only takes effect in a file that actually requires that extension. This
+form travels with the file, needs no configuration at all, and is the only
+one the `tcl` CLI reads.
+
+### `.tcl-lsp.ini` (shared with the project)
+
+Add a `[packages.provides]` section, one line per package:
+
+```ini
+[packages.provides]
+myExtension = Tk
+```
+
+List several with commas — `myExtension = Tk, Img` — and add a line per
+extension. State it once here and every file in the project is covered.
+The declarations chain: if `myExtension` provides `myWidgets` and
+`myWidgets` provides `Tk`, requiring `myExtension` gets you Tk.
+
+### VS Code settings (just for you)
+
+Set `tclLsp.packages.provides` in your workspace or user settings:
+
+```json
+"tclLsp.packages.provides": {
+    "myExtension": ["Tk"]
+}
+```
+
+## How to tell it worked
+
+Open a file that requires your extension and type `tt` at the start of a
+line: `ttk::frame`, `ttk::button` and the rest of the Tk widgets are now
+offered, and hovering one shows its documentation. The "requires
+`package require Tk`" warning is gone, and the Tk-specific checks are
+running — a widget path whose parent was never created is reported, and so
+is a `pack` / `grid` conflict on the same container.
+
+Nothing else changes: the declaration says the package is *there*, never
+which release it is, so no version-gated check starts firing against a
+version you did not claim.
+
+## Related
+
+- [KCS index](README.md)
+- [Glossary](../GLOSSARY.md)
+- [W120 — missing package require](codes/kcs-diagnostic-w120-missing-package-require.md)
+- [What sections and keys are valid in tcl-lsp config files?](kcs-qa-what-config-sections-are-valid.md)
+- [How do I say a package is ambient under one of my pack's dialects and not another?](kcs-howto-scope-an-ambient-package-to-one-dialect.md)

--- a/docs/kcs/kcs-qa-tcl-lsp-annotations.md
+++ b/docs/kcs/kcs-qa-tcl-lsp-annotations.md
@@ -14,7 +14,7 @@ does each one do?
 
 ## Answer
 
-tcl-lsp reads four kinds of structured comment from your Tcl source.
+tcl-lsp reads five kinds of structured comment from your Tcl source.
 They all live in plain Tcl comments — no separate config file is required,
 and they have no effect on the running interpreter.
 
@@ -120,6 +120,33 @@ declared inside the same stub block:
 The trailing number is the arity (1 for unary functions, 2 for binary
 operators, and so on).
 
+### 5. Packages another package loads
+
+`# tcl-lsp: package NAME provides PKG …` says that loading `NAME` also
+loads the packages listed. It exists for a compiled extension — a `.dll` /
+`.so` whose C `Init` calls `Tcl_PkgRequire` or `Tk_InitStubs` — which
+loads a package with nothing in any Tcl source to say so, so nothing the
+analyser can read would ever reveal it.
+
+```tcl
+# tcl-lsp: package myExtension provides Tk
+package require myExtension
+
+ttk::frame .f
+pack .f
+```
+
+Tk's completions, hover and checks now switch on, and the "requires
+`package require Tk`" warning (W120) goes quiet — exactly as if the file
+had said `package require Tk` alongside the extension. Name several
+packages on one line, and put the comment anywhere in the file: it names
+the extension, so it does not depend on where it sits, and it does nothing
+in a file that never requires that extension.
+
+The same fact can be declared once for a whole project instead, under
+`[packages.provides]` in `.tcl-lsp.ini` — see
+[how do I tell tcl-lsp that a binary extension also loads Tk?](kcs-howto-declare-a-package-a-binary-extension-loads.md).
+
 ### What annotations do *not* do
 
 - They do not change runtime Tcl behaviour — they are plain `#` comments.
@@ -131,6 +158,7 @@ operators, and so on).
 ## Related
 
 - [How to annotate an external Tcl command with a stub](kcs-howto-annotate-commands-with-stubs.md)
+- [How do I tell tcl-lsp that a binary extension also loads Tk?](kcs-howto-declare-a-package-a-binary-extension-loads.md)
 - [How to suppress diagnostics inline](kcs-howto-suppress-diagnostics.md)
 - [KCS index](README.md)
 - [Glossary](../GLOSSARY.md)

--- a/docs/kcs/kcs-qa-what-config-sections-are-valid.md
+++ b/docs/kcs/kcs-qa-what-config-sections-are-valid.md
@@ -15,7 +15,7 @@ does each section accept, and what values are valid?
 ## Answer
 
 Both the global `config.ini` and the project `.tcl-lsp.ini` use the
-same INI schema. Eleven sections are recognised in total — nine of
+same INI schema. Twelve sections are recognised in total — ten of
 them work in either file, plus one location-specific section for each
 file (`[global]` and `[project]`). Any section or key the parser does
 not know is silently ignored, so a typo turns into a no-op rather
@@ -160,6 +160,35 @@ The complete list, with defaults and ranges, is in the
 Style settings that affect linting but not formatting.
 
 - `line_length` — integer.
+
+### `[packages]` and `[packages.provides]`
+
+How the modelled interpreter loads packages.
+
+- `preferLatest` — boolean. Start the interpreter with `package prefer
+  latest` already in force, as `TCL_PKG_PREFER_LATEST` in the environment
+  (or, on Tcl 9.0+, an unstable build of Tcl) does. Decides which release
+  a `package require` navigates into when a prerelease and a stable
+  version both satisfy it.
+
+`[packages.provides]` says what loading one package also loads. Every
+key is a **package name**, so there is no fixed key list:
+
+```ini
+[packages.provides]
+myExtension = Tk
+bigWrapper = Tk, Img
+```
+
+Use it for a **compiled** extension — a `.dll` / `.so` whose C `Init`
+calls `Tcl_PkgRequire` or `Tk_InitStubs`. A Tcl wrapper package is found
+on its own, because the server reads the `package require`s in the files
+its `pkgIndex.tcl` loads; a binary one has no Tcl text to read, so the
+link has to be declared. Declarations chain, so `a = b` plus `b = Tk`
+means requiring `a` gets you Tk. The per-file equivalent is a
+`# tcl-lsp: package myExtension provides Tk` comment, which is also the
+only form the `tcl` CLI reads. See
+[how do I tell tcl-lsp that a binary extension also loads Tk?](kcs-howto-declare-a-package-a-binary-extension-loads.md).
 
 ### `[iruleslx.plugins]` and `[iruleslx.rules]`
 

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -3461,6 +3461,19 @@
             "default": false,
             "description": "Start the modelled interpreter with ``package prefer latest`` already in force, as TCL_PKG_PREFER_LATEST in the environment (or, on Tcl 9.0+, an unstable build of Tcl itself) does. Neither is visible in the source tree, so it is a setting rather than an inference. Affects which release a ``package require`` navigates into when a prerelease and a stable version both satisfy it.",
             "order": 7
+          },
+          "tclLsp.packages.provides": {
+            "scope": "resource",
+            "type": "object",
+            "default": {},
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "markdownDescription": "Packages that loading another package also makes available — `{ \"myExtension\": [\"Tk\"] }` says a file with `package require myExtension` may use Tk commands. A binary extension whose C `Init` calls `Tcl_PkgRequire` or `Tk_InitStubs` loads Tk with nothing in any Tcl source to say so, so the workspace `pkgIndex.tcl` scan (which reads a Tcl wrapper's own `package require`s) cannot find it. Declared edges are followed transitively, and each implied package counts as required from the `package require` that loads it — activating the Tk checks, completions and hover, and silencing the \"requires `package require Tk`\" warning. To declare the same edge in one file rather than project-wide, put a `# tcl-lsp: package myExtension provides Tk` comment in it.",
+            "order": 8
           }
         }
       },

--- a/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
@@ -10315,6 +10315,7 @@ fn analyse_w123_package_require_gate_suppresses_when_recorded() {
         range: Span::new(0, 24),
         conditional: false,
         control_flow: false,
+        origin: crate::signature_scan::types::PackageRequireOrigin::Source,
     });
     // Seed an invocation that would otherwise trip W123.
     a.result

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -5946,6 +5946,7 @@ impl Analyser {
                 range: cmd_tok.span,
                 conditional: self.conditional_depth > 0,
                 control_flow: self.control_flow_body_depth > 0,
+                origin: crate::signature_scan::types::PackageRequireOrigin::Source,
             });
     }
 

--- a/rust/tcl-compiler/src/analyser/per_item.rs
+++ b/rust/tcl-compiler/src/analyser/per_item.rs
@@ -486,6 +486,13 @@ impl Analyser {
         // flush.  Pinned explicitly rather than left to the constructor for
         // exactly that reason.
         self.tk_accumulation_enabled = false;
+        // The `# tcl-lsp: package NAME provides …` edges, scanned here for the
+        // same reason the whole-file ingresses scan them (issue #1813): the
+        // Tk hand-off below reads them *during* the walk, through
+        // `has_tk_require`, to decide whether this document needs a full
+        // analysis at all. Without this the two strategies disagree — the
+        // whole-file walk sees a declared Tk and the per-item one does not.
+        self.directive_provides = super::utils::parse_provides_directives(source);
         let file_codes = super::utils::parse_file_suppression(source);
         for code in &file_codes {
             self.disabled_diagnostics.insert(code.clone());

--- a/rust/tcl-compiler/src/analyser/state.rs
+++ b/rust/tcl-compiler/src/analyser/state.rs
@@ -2888,12 +2888,22 @@ impl Analyser {
         {
             return Vec::new();
         }
-        let mut seen: HashSet<String> = self
-            .result
-            .package_requires
-            .iter()
-            .map(|pr| pr.name.clone())
-            .collect();
+        // The earliest offset each package is already available from — not a
+        // visited *set*. Seeding with the source requires keeps a redundant
+        // entry out, but comparing offsets keeps the earlier anchor when a
+        // declared edge makes a package available *above* the explicit
+        // require for it. A set would discard the edge's entry outright and
+        // leave only the later span, and H301 takes the **minimum** start per
+        // package (`unresolved.rs`), so the command between the two would be
+        // reported as used-before-available — a hint that appears only
+        // because the file *also* requires the package explicitly.
+        let mut earliest: HashMap<String, u32> = HashMap::new();
+        for pr in &self.result.package_requires {
+            earliest
+                .entry(pr.name.clone())
+                .and_modify(|at| *at = (*at).min(pr.range.start()))
+                .or_insert_with(|| pr.range.start());
+        }
         // `(package name, span, conditional, control_flow)` — the anchor an
         // edge's target inherits from whatever made its source available.
         let mut queue: Vec<(String, tcl_lexer::Span, bool, bool)> = self
@@ -2914,9 +2924,16 @@ impl Analyser {
                 .chain(self.package_provides.iter().map(|edge| (edge, false)));
             for ((from, to), from_directive) in edges.filter(|((from, _), _)| *from == name) {
                 for loaded in to {
-                    if !seen.insert(loaded.clone()) {
+                    // `<=` rather than `<` is what keeps a cyclic declaration
+                    // terminating: re-reaching a package with the identical
+                    // anchor stops. Every anchor is one of the finitely many
+                    // require starts, and a name is only re-enqueued when its
+                    // anchor strictly decreases.
+                    let start = range.start();
+                    if earliest.get(loaded).is_some_and(|&at| at <= start) {
                         continue;
                     }
+                    earliest.insert(loaded.clone(), start);
                     let origin = if from_directive {
                         PackageRequireOrigin::Directive(from.clone())
                     } else {

--- a/rust/tcl-compiler/src/analyser/state.rs
+++ b/rust/tcl-compiler/src/analyser/state.rs
@@ -547,6 +547,23 @@ pub struct Analyser {
     /// [`Self::resolve_declared_targets`]. Empty — the default — leaves
     /// range mode off and every answer byte-identical to today.
     pub declared_targets: Vec<(String, String)>,
+    /// Configured "requiring this package also loads these" edges
+    /// (`tclLsp.packages.provides` / `.tcl-lsp.ini` `[packages.provides]`),
+    /// in configuration order. Each pair is a package name and the packages
+    /// its loader brings in behind the analyser's back — the binary
+    /// extension whose `Init` calls `Tcl_PkgRequire` / `Tk_InitStubs`, where
+    /// no Tcl source anywhere states the dependency, so it can only be
+    /// declared (issue #1813). Applied to the walk's own
+    /// `package require`s by [`Self::expand_implied_package_requires`].
+    /// Empty — the default — leaves every answer as before.
+    pub package_provides: Vec<(String, Vec<String>)>,
+    /// The `# tcl-lsp: package NAME provides …` edges declared in this walk's
+    /// source —
+    /// the same `(package, packages it also loads)` edges
+    /// [`Self::package_provides`] carries for the whole workspace, declared
+    /// for one file (issue #1813). Re-scanned at every walk ingress, so it is
+    /// a pure function of the source and cannot go stale.
+    pub(super) directive_provides: Vec<(String, Vec<String>)>,
     /// The resolved range-mode context: the walk generation's
     /// [`tcl_registry::model::ResolvedContext`] with the merged target
     /// declarations recorded on it (§5.4). `None` whenever nothing is
@@ -1516,6 +1533,8 @@ impl Analyser {
             pending_gated_bare_ensemble: Vec::new(),
             library_versions: tcl_dialect::LibraryVersionOverrides::default(),
             declared_targets: Vec::new(),
+            package_provides: Vec::new(),
+            directive_provides: Vec::new(),
             range_context: None,
             range_numeral_grammars: Vec::new(),
             range_gate_sites: Vec::new(),
@@ -1690,6 +1709,15 @@ impl Analyser {
     #[must_use]
     pub fn with_declared_targets(mut self, targets: Vec<(String, String)>) -> Self {
         self.declared_targets = targets;
+        self
+    }
+
+    /// Declare what a `package require` additionally loads
+    /// ([`Self::package_provides`]) — `("myExtension", ["Tk"])` says a
+    /// document that requires `myExtension` has `Tk` available too.
+    #[must_use]
+    pub fn with_package_provides(mut self, provides: Vec<(String, Vec<String>)>) -> Self {
+        self.package_provides = provides;
         self
     }
 
@@ -1956,7 +1984,9 @@ impl Analyser {
         let _dialect_scope = tcl_registry::pack_hooks::DialectScope::enter(Some(self.profile.name));
         self.result.dialect = dialect.to_string();
         self.result.library_versions = self.library_versions.clone();
-        self.tk_accumulation_enabled = super::tk_checks::tk_checks_could_apply(source, tk_ambient);
+        self.tk_accumulation_enabled =
+            super::tk_checks::tk_checks_could_apply(source, tk_ambient, &self.package_provides);
+        self.directive_provides = super::utils::parse_provides_directives(source);
         self.tk_ambient = tk_ambient;
         // §5.4 range targeting: resolve configured + directive-declared
         // version targets for this walk (a no-op for the undeclared
@@ -2363,7 +2393,9 @@ impl Analyser {
         let tk_ambient = self.resolve_walk_environment(dialect);
         self.result.dialect = dialect.to_string();
         self.result.library_versions = self.library_versions.clone();
-        self.tk_accumulation_enabled = super::tk_checks::tk_checks_could_apply(source, tk_ambient);
+        self.tk_accumulation_enabled =
+            super::tk_checks::tk_checks_could_apply(source, tk_ambient, &self.package_provides);
+        self.directive_provides = super::utils::parse_provides_directives(source);
         self.tk_ambient = tk_ambient;
         // §5.4 range targeting — same resolution as `analyse`.
         self.resolve_declared_targets(source);
@@ -2457,7 +2489,9 @@ impl Analyser {
         let tk_ambient = self.resolve_walk_environment(dialect);
         self.result.dialect = dialect.to_string();
         self.result.library_versions = self.library_versions.clone();
-        self.tk_accumulation_enabled = super::tk_checks::tk_checks_could_apply(source, tk_ambient);
+        self.tk_accumulation_enabled =
+            super::tk_checks::tk_checks_could_apply(source, tk_ambient, &self.package_provides);
+        self.directive_provides = super::utils::parse_provides_directives(source);
         self.tk_ambient = tk_ambient;
         // §5.4 range targeting — same resolution as `analyse`.
         self.resolve_declared_targets(source);
@@ -2624,7 +2658,8 @@ impl Analyser {
     pub(super) fn fresh_full_analyse(&self, new_text: &str, dialect: &str) -> AnalysisResult {
         let mut fresh = Analyser::with_disabled_diagnostics(self.disabled_diagnostics.clone())
             .with_non_ascii_mode(self.non_ascii_mode)
-            .with_shared_extra_commands(Arc::clone(&self.extra_commands));
+            .with_shared_extra_commands(Arc::clone(&self.extra_commands))
+            .with_package_provides(self.package_provides.clone());
         fresh.analyse(new_text, dialect)
     }
 
@@ -2798,7 +2833,118 @@ impl Analyser {
             .collect();
     }
 
+    /// Record the packages a declared edge says the document's own `package
+    /// require`s also load (issue #1813).
+    ///
+    /// A binary extension whose `Init` calls `Tcl_PkgRequire` — or links Tk
+    /// through `Tk_InitStubs` — makes a package available with nothing in any
+    /// Tcl source to say so, so no amount of workspace scanning can find it
+    /// (the `pkgIndex.tcl` route [`transitive_available_packages`] follows
+    /// reads the *Tcl* files an `ifneeded` script sources, and a `load`-only
+    /// extension has none). It can only be declared, and both places it can
+    /// be declared state the same edge:
+    ///
+    /// - `# tcl-lsp: package myExtension provides Tk` in the file
+    ///   ([`Self::directive_provides`]), which travels with it; or
+    /// - a `[packages.provides]` / `tclLsp.packages.provides` entry
+    ///   ([`Self::package_provides`]), which states it once for the project.
+    ///
+    /// Each package the edges reach becomes an ordinary
+    /// [`SignaturePackageRequire`](crate::signature_scan::types::SignaturePackageRequire)
+    /// carrying the span of the `package require` that loaded it — the point
+    /// at which it really does become available, so the order-sensitive H301
+    /// stays right — plus a
+    /// [`PackageRequireOrigin`](crate::signature_scan::types::PackageRequireOrigin)
+    /// naming the loader, for the consumers that want what the source
+    /// literally says.
+    ///
+    /// Called from the head of [`Self::run_diagnostic_emitters`], the one
+    /// tail both the whole-file and the per-item walk reach with their
+    /// `package_requires` already merged — so the two strategies cannot
+    /// disagree about what a declaration made available.
+    fn expand_implied_package_requires(&mut self) {
+        let implied = self.implied_package_requires();
+        self.result.package_requires.extend(implied);
+    }
+
+    /// Every package the declared edges reach from this document's own
+    /// `package require`s, minus everything it already requires, as
+    /// ready-to-record synthetic requires.
+    ///
+    /// Breadth-first, so each package is anchored at the earliest require
+    /// that reaches it and the result is independent of hash iteration order;
+    /// each name is visited once, so a cyclic declaration terminates. The
+    /// file's own directives are searched before the configured edges, and a
+    /// package reached through either can carry the closure onward. Empty —
+    /// the fast path for every document — whenever nothing is declared or
+    /// nothing is required.
+    pub(super) fn implied_package_requires(
+        &self,
+    ) -> Vec<crate::signature_scan::types::SignaturePackageRequire> {
+        use crate::signature_scan::types::{PackageRequireOrigin, SignaturePackageRequire};
+
+        if (self.directive_provides.is_empty() && self.package_provides.is_empty())
+            || self.result.package_requires.is_empty()
+        {
+            return Vec::new();
+        }
+        let mut seen: HashSet<String> = self
+            .result
+            .package_requires
+            .iter()
+            .map(|pr| pr.name.clone())
+            .collect();
+        // `(package name, span, conditional, control_flow)` — the anchor an
+        // edge's target inherits from whatever made its source available.
+        let mut queue: Vec<(String, tcl_lexer::Span, bool, bool)> = self
+            .result
+            .package_requires
+            .iter()
+            .map(|pr| (pr.name.clone(), pr.range, pr.conditional, pr.control_flow))
+            .collect();
+        let mut out: Vec<SignaturePackageRequire> = Vec::new();
+        let mut head = 0;
+        while head < queue.len() {
+            let (name, range, conditional, control_flow) = queue[head].clone();
+            head += 1;
+            let edges = self
+                .directive_provides
+                .iter()
+                .map(|edge| (edge, true))
+                .chain(self.package_provides.iter().map(|edge| (edge, false)));
+            for ((from, to), from_directive) in edges.filter(|((from, _), _)| *from == name) {
+                for loaded in to {
+                    if !seen.insert(loaded.clone()) {
+                        continue;
+                    }
+                    let origin = if from_directive {
+                        PackageRequireOrigin::Directive(from.clone())
+                    } else {
+                        PackageRequireOrigin::Provides(from.clone())
+                    };
+                    out.push(SignaturePackageRequire {
+                        name: loaded.clone(),
+                        version: None,
+                        requirements: Vec::new(),
+                        exact: false,
+                        range,
+                        conditional,
+                        control_flow,
+                        origin,
+                    });
+                    queue.push((loaded.clone(), range, conditional, control_flow));
+                }
+            }
+        }
+        out
+    }
+
     pub(super) fn run_diagnostic_emitters(&mut self, source: &str) {
+        // Declared package availability first: every emitter below that asks
+        // "is this package available here?" — W120, H301, the W123 widening,
+        // the Tk activation gate — reads `package_requires`, so the declared
+        // entries have to be in it before any of them run.
+        self.expand_implied_package_requires();
         // Whole-source security checks belong in the analyser result so direct
         // consumers receive the same verdict as the LSP and CLI adapters. The
         // pure producer is also reused by non-Tcl F5 document adapters.

--- a/rust/tcl-compiler/src/analyser/tk_checks.rs
+++ b/rust/tcl-compiler/src/analyser/tk_checks.rs
@@ -1106,6 +1106,45 @@ frame .outer.inner
         assert!(codes(&whole).iter().any(|c| c == "TK1002"));
     }
 
+    /// Review follow-up: a declared edge makes a package available at the
+    /// require that loads it, and an *explicit* require for the same package
+    /// further down must not erase that earlier anchor. H301 takes the
+    /// minimum start per package, so losing it reports the command between
+    /// the two as used-before-available — a hint that appears only because
+    /// the file also requires the package explicitly.
+    #[test]
+    fn a_later_explicit_require_keeps_the_earlier_declared_anchor() {
+        let src = "package require myExtension\n\
+                   frame .outer.inner\n\
+                   package require Tk\n";
+        let res = Analyser::new()
+            .with_package_provides(vec![("myExtension".to_owned(), vec!["Tk".to_owned()])])
+            .analyse(src, "tcl8.6");
+        assert!(
+            !res.diagnostics.iter().any(|d| d.code.as_str() == "H301"),
+            "Tk is available from the `package require myExtension` above the \
+             widget, so nothing is used before its package: {:?}",
+            res.diagnostics
+        );
+        // The implied entry survives alongside the explicit one, anchored
+        // earlier than it.
+        let implied_start = res
+            .package_requires
+            .iter()
+            .filter(|pr| pr.name == "Tk")
+            .map(|pr| pr.range.start())
+            .min()
+            .expect("Tk recorded");
+        let ext_start = res
+            .package_requires
+            .iter()
+            .find(|pr| pr.name == "myExtension")
+            .expect("the loader")
+            .range
+            .start();
+        assert_eq!(implied_start, ext_start);
+    }
+
     /// The closure is transitive and terminates on a cycle.
     #[test]
     fn declared_package_provides_is_transitive_and_cycle_safe() {

--- a/rust/tcl-compiler/src/analyser/tk_checks.rs
+++ b/rust/tcl-compiler/src/analyser/tk_checks.rs
@@ -178,17 +178,28 @@ pub(super) const TK_PACKAGE: &str = "Tk";
 /// Cheap **necessary** condition for the per-command Tk accumulation to be
 /// worth running at all — *not* the activation decision (see the module docs).
 ///
-/// Activation requires either an ambient `Tk` placement or a
-/// statically-resolvable `package require Tk`, and the latter cannot exist in
-/// a source that never contains the literal package name.  So this is sound:
+/// Activation requires an ambient `Tk` placement, a statically-resolvable
+/// `package require Tk`, a `# tcl-lsp: provides Tk` directive, or a configured
+/// `[packages.provides]` edge that puts `Tk` behind another package (issue
+/// #1813).  The first three cannot exist in a source that never contains the
+/// literal package name; the last is visible in the declaration itself rather
+/// than in the text.  So this is sound:
 /// it never returns `false` for a document that goes on to activate.  It over-approximates
 /// freely — a `Tk` inside a comment, a string, or generated data trips it —
 /// which costs only a registry lookup per command, because
 /// [`Analyser::flush_tk_geometry_diagnostics`] discards everything the walk
 /// buffered unless the exact activation fact holds.
 #[must_use]
-pub(super) fn tk_checks_could_apply(source: &str, tk_ambient: bool) -> bool {
-    tk_ambient || source.contains(TK_PACKAGE)
+pub(super) fn tk_checks_could_apply(
+    source: &str,
+    tk_ambient: bool,
+    package_provides: &[(String, Vec<String>)],
+) -> bool {
+    tk_ambient
+        || source.contains(TK_PACKAGE)
+        || package_provides
+            .iter()
+            .any(|(_, provided)| provided.iter().any(|p| p == TK_PACKAGE))
 }
 
 /// Compiler-facing wrapper around the registry-owned Tk widget-path grammar.
@@ -891,11 +902,29 @@ impl Analyser {
     /// `pub(super)`: [`Analyser::analyse_per_item_with`](super::state::Analyser)
     /// consults the same fact post-walk to decide whether the incremental path
     /// must hand off to a full analysis (issue #1188).
+    /// Whether a declaration makes `Tk` available — a `# tcl-lsp: provides
+    /// Tk` comment, or a configured `[packages.provides]` edge behind a
+    /// package the document requires (issue #1813).
+    ///
+    /// The activation gate has to see this **during** the walk, not only
+    /// after `expand_implied_package_requires` has recorded the declared
+    /// entries in the tail: `analyse_per_item`'s
+    /// [`tk_activation_fallback`](super::state::Analyser) decides mid-walk
+    /// whether to hand off to a full analysis, and Tk's whole-file
+    /// accumulators are exactly what an isolated body cannot see. Costs two
+    /// `is_empty`s for every document that declares nothing.
+    fn tk_is_declared_available(&self) -> bool {
+        self.implied_package_requires()
+            .iter()
+            .any(|pr| pr.name == TK_PACKAGE)
+    }
+
     pub(super) fn has_tk_require(&self) -> bool {
         self.result
             .package_requires
             .iter()
             .any(|pr| pr.name == TK_PACKAGE)
+            || self.tk_is_declared_available()
     }
 
     /// Post-walk flush of all TK diagnostics.  Emits the buffered TK1002 /
@@ -933,6 +962,197 @@ mod tests {
 
     fn has(source: &str, dialect: &str, code: &str) -> bool {
         codes(source, dialect).iter().any(|(c, _)| c == code)
+    }
+
+    /// Issue #1813: a binary extension that loads Tk itself leaves no
+    /// `package require Tk` to find, so a declared `[packages.provides]` edge
+    /// is the only way the analyser can know. With one, the document is Tk —
+    /// the TK checks activate and the W120 "requires `package require Tk`"
+    /// nag goes away.
+    #[test]
+    fn declared_package_provides_activates_tk() {
+        let src = "package require myExtension
+frame .outer.inner
+";
+        let provides = vec![("myExtension".to_owned(), vec!["Tk".to_owned()])];
+
+        let mut bare = Analyser::new();
+        let without = bare.analyse(src, "tcl8.6");
+        assert!(
+            !without
+                .diagnostics
+                .iter()
+                .any(|d| d.code.as_str() == "TK1002"),
+            "no declaration ⇒ not a Tk document: {:?}",
+            without.diagnostics
+        );
+        assert!(
+            without
+                .diagnostics
+                .iter()
+                .any(|d| d.code.as_str() == "W120"),
+            "no declaration ⇒ the Tk widget still wants a require: {:?}",
+            without.diagnostics
+        );
+
+        let mut declared = Analyser::new().with_package_provides(provides);
+        let with = declared.analyse(src, "tcl8.6");
+        assert!(
+            with.diagnostics.iter().any(|d| d.code.as_str() == "TK1002"),
+            "declared ⇒ the TK checks run: {:?}",
+            with.diagnostics
+        );
+        assert!(
+            !with.diagnostics.iter().any(|d| d.code.as_str() == "W120"),
+            "declared ⇒ Tk is available, no missing-require warning: {:?}",
+            with.diagnostics
+        );
+        let tk = with
+            .package_requires
+            .iter()
+            .find(|pr| pr.name == "Tk")
+            .expect("Tk recorded as available");
+        assert_eq!(
+            tk.origin,
+            crate::signature_scan::types::PackageRequireOrigin::Provides("myExtension".to_owned())
+        );
+    }
+
+    /// Issue #1813: the same edge declared as a source comment, which travels
+    /// with the file and needs no workspace configuration.
+    #[test]
+    fn provides_directive_activates_tk() {
+        let src = "# tcl-lsp: package myExtension provides Tk\n\
+                   package require myExtension\n\
+                   frame .outer.inner\n";
+        let res = Analyser::new().analyse(src, "tcl8.6");
+        assert!(
+            res.diagnostics.iter().any(|d| d.code.as_str() == "TK1002"),
+            "declared ⇒ the TK checks run: {:?}",
+            res.diagnostics
+        );
+        assert!(
+            !res.diagnostics.iter().any(|d| d.code.as_str() == "W120"),
+            "declared ⇒ no missing-require warning: {:?}",
+            res.diagnostics
+        );
+        let tk = res
+            .package_requires
+            .iter()
+            .find(|pr| pr.name == "Tk")
+            .expect("Tk recorded as available");
+        assert_eq!(
+            tk.origin,
+            crate::signature_scan::types::PackageRequireOrigin::Directive("myExtension".to_owned())
+        );
+        // The edge names its loader, so Tk is anchored at the `package
+        // require` that loads it — not at the comment, wherever that sits.
+        let require = res
+            .package_requires
+            .iter()
+            .find(|pr| pr.name == "myExtension")
+            .expect("the require itself");
+        assert_eq!(tk.range, require.range);
+    }
+
+    /// An edge whose loader the document never requires declares nothing —
+    /// which is what makes the directive the same fact as the configured
+    /// entry rather than a second mechanism.
+    #[test]
+    fn provides_directive_without_the_require_is_inert() {
+        let src = "# tcl-lsp: package myExtension provides Tk\nframe .outer.inner\n";
+        let res = Analyser::new().analyse(src, "tcl8.6");
+        assert!(!res.package_requires.iter().any(|pr| pr.name == "Tk"));
+        assert!(!res.diagnostics.iter().any(|d| d.code.as_str() == "TK1002"));
+    }
+
+    /// A directive edge and a configured edge chain into one another.
+    #[test]
+    fn provides_directive_and_configured_edge_compose() {
+        let src = "# tcl-lsp: package myExtension provides myWidgets\n\
+                   package require myExtension\n\
+                   frame .outer.inner\n";
+        let res = Analyser::new()
+            .with_package_provides(vec![("myWidgets".to_owned(), vec!["Tk".to_owned()])])
+            .analyse(src, "tcl8.6");
+        assert!(res.diagnostics.iter().any(|d| d.code.as_str() == "TK1002"));
+        let tk = res
+            .package_requires
+            .iter()
+            .find(|pr| pr.name == "Tk")
+            .expect("Tk reached through the two edges");
+        assert_eq!(
+            tk.origin,
+            crate::signature_scan::types::PackageRequireOrigin::Provides("myWidgets".to_owned())
+        );
+    }
+
+    /// The directive reaches the per-item walk's mid-walk Tk hand-off too.
+    #[test]
+    fn provides_directive_agrees_across_walk_strategies() {
+        let src = "# tcl-lsp: package myExtension provides Tk\n\
+                   package require myExtension\n\
+                   proc build {} {\n\
+                   \x20   frame .outer.inner\n\
+                   }\n";
+        let codes = |r: &crate::analyser::types::AnalysisResult| {
+            let mut c: Vec<String> = r.diagnostics.iter().map(|d| d.code.to_string()).collect();
+            c.sort();
+            c
+        };
+        let whole = Analyser::new().analyse(src, "tcl8.6");
+        let per_item = Analyser::new().analyse_per_item(src, "tcl8.6");
+        assert_eq!(codes(&whole), codes(&per_item));
+        assert!(codes(&whole).iter().any(|c| c == "TK1002"));
+    }
+
+    /// The closure is transitive and terminates on a cycle.
+    #[test]
+    fn declared_package_provides_is_transitive_and_cycle_safe() {
+        let provides = vec![
+            ("a".to_owned(), vec!["b".to_owned()]),
+            ("b".to_owned(), vec!["Tk".to_owned(), "a".to_owned()]),
+        ];
+        let mut a = Analyser::new().with_package_provides(provides);
+        let res = a.analyse(
+            "package require a
+frame .outer.inner
+",
+            "tcl8.6",
+        );
+        let mut names: Vec<&str> = res
+            .package_requires
+            .iter()
+            .map(|pr| pr.name.as_str())
+            .collect();
+        names.sort_unstable();
+        assert_eq!(names, ["Tk", "a", "b"]);
+        assert!(res.diagnostics.iter().any(|d| d.code.as_str() == "TK1002"));
+    }
+
+    /// The per-item walk must reach the same verdict as the whole-file one —
+    /// its mid-walk Tk hand-off reads the declaration too.
+    #[test]
+    fn declared_package_provides_agrees_across_walk_strategies() {
+        let src = "package require myExtension
+proc build {} {
+    frame .outer.inner
+}
+";
+        let provides = vec![("myExtension".to_owned(), vec!["Tk".to_owned()])];
+        let whole = Analyser::new()
+            .with_package_provides(provides.clone())
+            .analyse(src, "tcl8.6");
+        let per_item = Analyser::new()
+            .with_package_provides(provides)
+            .analyse_per_item(src, "tcl8.6");
+        let codes = |r: &crate::analyser::types::AnalysisResult| {
+            let mut c: Vec<String> = r.diagnostics.iter().map(|d| d.code.to_string()).collect();
+            c.sort();
+            c
+        };
+        assert_eq!(codes(&whole), codes(&per_item));
+        assert!(codes(&whole).iter().any(|c| c == "TK1002"));
     }
 
     #[test]

--- a/rust/tcl-compiler/src/analyser/utils.rs
+++ b/rust/tcl-compiler/src/analyser/utils.rs
@@ -819,6 +819,89 @@ fn matches_marker(body: &str, marker: &str) -> bool {
     head.eq_ignore_ascii_case(marker)
 }
 
+/// Scan `source` for ``# tcl-lsp: package NAME provides PKG …`` directives,
+/// returning each declared edge as `(loading package, packages it also
+/// loads)` in source order.
+///
+/// The directive states what a package's loader pulls in behind the
+/// analyser's back — a binary extension whose C `Init` calls
+/// `Tcl_PkgRequire` or `Tk_InitStubs` (issue #1813). It declares the same
+/// edge `[packages.provides]` configures, for one file, and it names the
+/// loading package rather than relying on where it sits: a document gains
+/// the packages only once it actually requires the one named, and the
+/// directive may live anywhere, including the top-of-file comment block.
+///
+/// `package` is the keyword, as in every other member of the family
+/// (`supports`, `stub`, `disable`), and it deliberately echoes the Tcl
+/// commands the line is about.
+///
+/// The scan covers the whole file on the same terms as
+/// [`scan_source_for_stubs`] — any line whose first non-whitespace character
+/// is `#`. One directive may name several loaded packages, and several
+/// directives may name the same loader; the edges merge, keeping
+/// first-declaration order.
+#[must_use]
+pub fn parse_provides_directives(source: &str) -> Vec<(String, Vec<String>)> {
+    let mut out: Vec<(String, Vec<String>)> = Vec::new();
+    for line in source.lines() {
+        let stripped = line.trim();
+        if !stripped.starts_with('#') {
+            continue;
+        }
+        let body = stripped.trim_start_matches('#').trim_start();
+        if !matches_marker(body, "package") {
+            continue;
+        }
+        let Some((from, loaded)) = parse_provides_directive(body) else {
+            continue;
+        };
+        let position = out.iter().position(|(existing, _)| existing == from);
+        let index = position.unwrap_or_else(|| {
+            out.push((from.to_owned(), Vec::new()));
+            out.len() - 1
+        });
+        for name in loaded.split_whitespace() {
+            if !out[index].1.iter().any(|existing| existing == name) {
+                out[index].1.push(name.to_owned());
+            }
+        }
+    }
+    out.retain(|(_, loaded)| !loaded.is_empty());
+    out
+}
+
+/// Match ``# tcl-lsp: package NAME provides PKG …`` on a comment body whose
+/// `package` marker [`matches_marker`] already confirmed, returning the
+/// loading package and the raw list of packages it loads.
+///
+/// `None` when the line is not that shape — a `package` with no name, no
+/// `provides`, or nothing after it declares no edge.
+fn parse_provides_directive(body: &str) -> Option<(&str, &str)> {
+    let s = body.trim_start();
+    let rest = s
+        .get("tcl-lsp".len()..)?
+        .trim_start()
+        .strip_prefix(':')?
+        .trim_start();
+    let after_kw = rest.get("package".len()..)?;
+    // The keyword must end at a word boundary (`packages` is not it).
+    if !after_kw.starts_with([' ', '\t']) {
+        return None;
+    }
+    let (from, rest) = after_kw.trim_start().split_once([' ', '\t'])?;
+    let rest = rest.trim_start();
+    let verb = "provides";
+    if !rest.get(..verb.len())?.eq_ignore_ascii_case(verb) {
+        return None;
+    }
+    let loaded = rest.get(verb.len()..)?;
+    if !loaded.starts_with([' ', '\t']) {
+        return None;
+    }
+    let loaded = loaded.trim();
+    (!from.is_empty() && !loaded.is_empty()).then_some((from, loaded))
+}
+
 /// Extract the command name from a ``# tcl-lsp: stub NAME …``
 /// line.  Returns the raw name as a borrowed slice or `None`
 /// when the line doesn't match the stub shape.
@@ -1747,6 +1830,54 @@ mod tests {
         let src = "# Just a comment\nproc foo {} {}\n";
         let codes = parse_file_suppression(src);
         assert!(codes.is_empty());
+    }
+
+    /// Issue #1813: the `package … provides …` directive is read anywhere in
+    /// the file and names the loading package, so it does not depend on where
+    /// it sits.
+    #[test]
+    fn parse_provides_directives_read_edges_from_the_whole_file() {
+        let src = "# tcl-lsp: package myExtension provides Tk\n\
+                   package require myExtension\n\
+                   proc build {} {\n\
+                   \x20   # TCL-LSP: Package bigWrapper Provides Img snit\n\
+                   }\n\
+                   # tcl-lsp: package myExtension provides Tk Img\n";
+        assert_eq!(
+            parse_provides_directives(src),
+            vec![
+                (
+                    "myExtension".to_owned(),
+                    vec!["Tk".to_owned(), "Img".to_owned()],
+                ),
+                (
+                    "bigWrapper".to_owned(),
+                    vec!["Img".to_owned(), "snit".to_owned()],
+                ),
+            ],
+            "edges merge per loader, in first-declaration order",
+        );
+    }
+
+    /// A directive that declares no edge, and the neighbouring members of the
+    /// `# tcl-lsp:` family, are not this one.
+    #[test]
+    fn parse_provides_directives_ignore_other_shapes() {
+        for src in [
+            "# tcl-lsp: package myExtension provides\n",
+            "# tcl-lsp: package myExtension\n",
+            "# tcl-lsp: package provides Tk\n",
+            "# tcl-lsp: packages myExtension provides Tk\n",
+            "# tcl-lsp: supports Tk 8.5-8.6\n",
+            "# tcl-lsp: disable=W120\n",
+            "# tcl-lsp: stub myproc {a b}\n",
+            "set x {package require Tk}\n",
+        ] {
+            assert!(
+                parse_provides_directives(src).is_empty(),
+                "must declare no edge: {src:?}"
+            );
+        }
     }
 
     #[test]

--- a/rust/tcl-compiler/src/signature_scan/handlers.rs
+++ b/rust/tcl-compiler/src/signature_scan/handlers.rs
@@ -443,6 +443,7 @@ pub(super) fn handle_package_require(
         range: argv[idx].span,
         conditional,
         control_flow: conditional,
+        origin: crate::signature_scan::types::PackageRequireOrigin::Source,
     });
 }
 

--- a/rust/tcl-compiler/src/signature_scan/types.rs
+++ b/rust/tcl-compiler/src/signature_scan/types.rs
@@ -143,6 +143,31 @@ pub struct SignaturePackageRequire {
     /// `true` when the call is nested in a registry-declared control-flow
     /// body which may run zero or multiple times.
     pub control_flow: bool,
+    /// Where this requirement came from — a `package require` in the source,
+    /// or one of the two ways a package that loads another is declared.
+    pub origin: PackageRequireOrigin,
+}
+
+/// How a [`SignaturePackageRequire`] came to be recorded.
+///
+/// A binary extension makes a package available with nothing in any Tcl
+/// source to say so: its C `Init` calls `Tcl_PkgRequire`, or it links Tk
+/// through `Tk_InitStubs`. Neither leaves anything for the `pkgIndex.tcl`
+/// scan to read, so the dependency is **declared** rather than discovered
+/// (issue #1813), and a declared entry is recorded here exactly like a
+/// written one — carrying the span of whatever made the package available,
+/// because that is the position from which it is available.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum PackageRequireOrigin {
+    /// A `package require` written in the source.
+    #[default]
+    Source,
+    /// A configured `[packages.provides]` / `tclLsp.packages.provides` edge.
+    /// Carries the package whose loader brings this one in.
+    Provides(String),
+    /// A `# tcl-lsp: package NAME provides …` comment in the source,
+    /// declaring the same edge for one file. Carries the loading package.
+    Directive(String),
 }
 
 /// A `package prefer latest` invocation — the one form of `package

--- a/rust/tcl-lsp-db/examples/cc_diff.rs
+++ b/rust/tcl-lsp-db/examples/cc_diff.rs
@@ -48,6 +48,7 @@ fn main() {
         None,
         0,
         Vec::new(),
+        Vec::new(),
     );
     let memo = compiler_check_diagnostics(&db, file, cfg);
     let reg = db.registry(&dialect);

--- a/rust/tcl-lsp-db/examples/edit_memory.rs
+++ b/rust/tcl-lsp-db/examples/edit_memory.rs
@@ -106,6 +106,7 @@ fn main() {
         None,
         0,
         Vec::new(),
+        Vec::new(),
     );
 
     println!(

--- a/rust/tcl-lsp-db/examples/fa_diff.rs
+++ b/rust/tcl-lsp-db/examples/fa_diff.rs
@@ -43,6 +43,7 @@ fn main() {
         None,
         0,
         Vec::new(),
+        Vec::new(),
     );
     let file = SourceFile::new(&db, src.clone(), dialect.clone(), None);
     let inc = file_analysis_incremental(&db, file, cfg);

--- a/rust/tcl-lsp-db/examples/stress_concurrent_analysis.rs
+++ b/rust/tcl-lsp-db/examples/stress_concurrent_analysis.rs
@@ -186,7 +186,7 @@ fn dump_repro_bundle(tag: &str, text: &str, params: &RunParams, failure: &str) {
          \n\
          ```rust\n\
          let db = TclDatabase::default();\n\
-         let cfg = AnalyserConfig::new(&db, Vec::new(), NonAsciiMode::Default, Vec::new(), None, None, 0, Vec::new());\n\
+         let cfg = AnalyserConfig::new(&db, Vec::new(), NonAsciiMode::Default, Vec::new(), None, None, 0, Vec::new(), Vec::new());\n\
          let text = std::fs::read_to_string(\"fixture.tcl\").unwrap();\n\
          let file = SourceFile::new(&db, text, \"{dialect}\".to_owned());\n\
          let tokens = semantic_tokens(&db, file, cfg);\n\
@@ -448,6 +448,7 @@ fn main() {
         None,
         None,
         0,
+        Vec::new(),
         Vec::new(),
     );
     let file = SourceFile::new(&db, base_text.clone(), params.dialect.clone(), None);

--- a/rust/tcl-lsp-db/examples/tail_profile.rs
+++ b/rust/tcl-lsp-db/examples/tail_profile.rs
@@ -105,6 +105,7 @@ fn main() {
         None,
         0,
         Vec::new(),
+        Vec::new(),
     );
     let file = SourceFile::new(&db, src.clone(), dialect.to_owned(), None);
     let _ = file_analysis_incremental(&db, file, cfg);
@@ -241,6 +242,7 @@ fn breadth_for_edit(src: &str, dialect: &str, edited: &str) -> (Vec<String>, Vec
         None,
         None,
         0,
+        Vec::new(),
         Vec::new(),
     );
     let file = SourceFile::new(&db, src.to_owned(), dialect.to_owned(), None);

--- a/rust/tcl-lsp-db/src/lib.rs
+++ b/rust/tcl-lsp-db/src/lib.rs
@@ -482,6 +482,14 @@ pub struct AnalyserConfig {
     /// overrides the configured pair for the same provider.
     #[returns(ref)]
     pub targets: Vec<(String, String)>,
+    /// Declared "requiring this package also loads these" edges
+    /// (`tclLsp.packages.provides` / `.tcl-lsp.ini` `[packages.provides]`),
+    /// feeding `Analyser::with_package_provides`. A binary extension whose
+    /// `Init` calls `Tcl_PkgRequire` / `Tk_InitStubs` leaves nothing in any
+    /// Tcl source to scan for, so the dependency can only be declared
+    /// (issue #1813). Empty — the default — changes nothing.
+    #[returns(ref)]
+    pub package_provides: Vec<(String, Vec<String>)>,
 }
 
 /// Whole-file analysis, behind an `Arc` so reads bump a refcount rather than
@@ -517,6 +525,7 @@ pub fn file_analysis(
         .with_extra_commands(extra)
         .with_bigip_version(config.bigip_version(db).clone())
         .with_declared_targets(config.targets(db).clone())
+        .with_package_provides(config.package_provides(db).clone())
         .with_file_path(file.path(db).clone())
         .with_workspace_class_factories(file.workspace_class_factories(db).clone())
         .with_workspace_subclass_methods(file.workspace_subclass_methods(db).clone());
@@ -3156,6 +3165,7 @@ pub fn file_analysis_incremental(
         .with_extra_commands(extra_commands)
         .with_bigip_version(config.bigip_version(db).clone())
         .with_declared_targets(config.targets(db).clone())
+        .with_package_provides(config.package_provides(db).clone())
         .with_file_path(file.path(db).clone())
         .with_workspace_class_factories(workspace_class_factories.clone())
         .with_workspace_subclass_methods(file.workspace_subclass_methods(db).clone());
@@ -3633,6 +3643,7 @@ mod tests {
             None,
             0,
             Vec::new(),
+            Vec::new(),
         )
     }
 
@@ -3909,6 +3920,7 @@ mod tests {
             None,
             None,
             0,
+            Vec::new(),
             Vec::new(),
         );
         let file = SourceFile::new(&db, SRC.to_owned(), "tcl8.6".to_owned(), None);
@@ -4701,6 +4713,7 @@ mod tests {
             Some("21.1.0".to_owned()),
             0,
             Vec::new(),
+            Vec::new(),
         );
         let file = SourceFile::new(
             &db,
@@ -4735,6 +4748,7 @@ mod tests {
             None,
             0,
             vec![("tcl".to_owned(), "8.5-9.0".to_owned())],
+            Vec::new(),
         );
         let bare = AnalyserConfig::new(
             &db,
@@ -4744,6 +4758,7 @@ mod tests {
             None,
             None,
             0,
+            Vec::new(),
             Vec::new(),
         );
         let file = SourceFile::new(
@@ -4799,6 +4814,7 @@ mod tests {
             None,
             None,
             0,
+            Vec::new(),
             Vec::new(),
         );
         let file = SourceFile::new(
@@ -4860,6 +4876,7 @@ mod tests {
             None,
             None,
             0,
+            Vec::new(),
             Vec::new(),
         );
         let file = SourceFile::new(
@@ -4923,6 +4940,7 @@ mod tests {
                     None,
                     None,
                     0,
+                    Vec::new(),
                     Vec::new(),
                 ),
             );
@@ -5183,6 +5201,7 @@ mod tests {
                     None,
                     0,
                     Vec::new(),
+                    Vec::new(),
                 ),
             );
             let want = compiler_check_diagnostics_uncached(src, registry, dialect, None, None);
@@ -5339,6 +5358,7 @@ mod tests {
                 None,
                 0,
                 Vec::new(),
+                Vec::new(),
             ),
         );
         assert_eq!(
@@ -5364,6 +5384,7 @@ mod tests {
                 None,
                 None,
                 0,
+                Vec::new(),
                 Vec::new(),
             ),
         );
@@ -5552,6 +5573,7 @@ mod tests {
                 None,
                 0,
                 Vec::new(),
+                Vec::new(),
             ),
         );
         assert_eq!(
@@ -5577,6 +5599,7 @@ mod tests {
                 None,
                 None,
                 0,
+                Vec::new(),
                 Vec::new(),
             ),
         );
@@ -5779,6 +5802,7 @@ mod tests {
             None,
             0,
             Vec::new(),
+            Vec::new(),
         );
         // `a` defines `foo` (1 param) and an unrelated `bar`.
         let a = SourceFile::new(
@@ -5864,6 +5888,7 @@ mod tests {
             None,
             0,
             Vec::new(),
+            Vec::new(),
         );
         let a = SourceFile::new(
             &db,
@@ -5934,6 +5959,7 @@ mod tests {
                 None,
                 0,
                 Vec::new(),
+                Vec::new(),
             );
             let a = SourceFile::new(&db, a_text.to_owned(), "tcl8.6".to_owned(), None);
             let b = SourceFile::new(&db, b_text.to_owned(), "tcl8.6".to_owned(), None);
@@ -5950,6 +5976,7 @@ mod tests {
             None,
             None,
             0,
+            Vec::new(),
             Vec::new(),
         );
         let a = SourceFile::new(&db, a_text.to_owned(), "tcl8.6".to_owned(), None);
@@ -6010,6 +6037,7 @@ mod tests {
                 None,
                 0,
                 Vec::new(),
+                Vec::new(),
             );
             let a = SourceFile::new(&db, a_text.to_owned(), "tcl8.6".to_owned(), None);
             let b = SourceFile::new(&db, b_text.to_owned(), "tcl8.6".to_owned(), None);
@@ -6026,6 +6054,7 @@ mod tests {
             None,
             None,
             0,
+            Vec::new(),
             Vec::new(),
         );
         let a = SourceFile::new(&db, a_variants[0].to_owned(), "tcl8.6".to_owned(), None);
@@ -6074,6 +6103,7 @@ mod tests {
             None,
             None,
             0,
+            Vec::new(),
             Vec::new(),
         );
         // B defines `proc helper {x y}` — arity exactly 2.
@@ -6132,6 +6162,7 @@ mod tests {
             None,
             None,
             0,
+            Vec::new(),
             Vec::new(),
         );
         // B: a class `Widget` AND a proc whose tail is also `Widget` (arity 1).
@@ -6193,6 +6224,7 @@ mod tests {
             None,
             None,
             0,
+            Vec::new(),
             Vec::new(),
         );
         // B defines onNode with 2 params; `graph walk -command` appends 3.
@@ -6275,6 +6307,7 @@ mod tests {
             None,
             0,
             Vec::new(),
+            Vec::new(),
         );
         let d_on = project_diagnostics(&db, a, cfg_on, proj);
         assert!(has(&d_on, "E003"), "baseline: E003 present when enabled");
@@ -6290,6 +6323,7 @@ mod tests {
             None,
             None,
             0,
+            Vec::new(),
             Vec::new(),
         );
         let d_off = project_diagnostics(&db, a, cfg_off, proj);
@@ -6330,6 +6364,7 @@ mod tests {
             None,
             None,
             0,
+            Vec::new(),
             Vec::new(),
         );
 
@@ -6384,6 +6419,7 @@ mod tests {
             None,
             0,
             Vec::new(),
+            Vec::new(),
         );
         assert!(has_w123(base), "baseline W123 expected");
         // With the command declared extra → suppressed.
@@ -6395,6 +6431,7 @@ mod tests {
             None,
             None,
             0,
+            Vec::new(),
             Vec::new(),
         );
         assert!(!has_w123(cfg), "extraCommands should suppress W123");
@@ -6414,6 +6451,7 @@ mod tests {
             None,
             None,
             0,
+            Vec::new(),
             Vec::new(),
         );
         // B defines a TclOO class `Widget`.
@@ -6455,6 +6493,7 @@ mod tests {
             None,
             None,
             0,
+            Vec::new(),
             Vec::new(),
         );
         let b = SourceFile::new(
@@ -6534,6 +6573,7 @@ mod tests {
             None,
             0,
             Vec::new(),
+            Vec::new(),
         );
         let b = SourceFile::new(
             &db,
@@ -6597,6 +6637,7 @@ mod tests {
             None,
             0,
             Vec::new(),
+            Vec::new(),
         );
         let b = SourceFile::new(
             &db,
@@ -6646,6 +6687,7 @@ mod tests {
             None,
             0,
             Vec::new(),
+            Vec::new(),
         );
         let b = SourceFile::new(
             &db,
@@ -6690,6 +6732,7 @@ mod tests {
             None,
             0,
             Vec::new(),
+            Vec::new(),
         );
         let b = SourceFile::new(
             &db,
@@ -6730,6 +6773,7 @@ mod tests {
             None,
             None,
             0,
+            Vec::new(),
             Vec::new(),
         );
         let f = SourceFile::new(&db, src.to_owned(), "tcl9.0".to_owned(), None);
@@ -7104,6 +7148,7 @@ mod tests {
             None,
             0,
             Vec::new(),
+            Vec::new(),
         );
         let file = SourceFile::new(&db, src.to_owned(), "tcl8.6".to_owned(), None);
         let _ = file_analysis_incremental(&db, file, cfg);
@@ -7149,6 +7194,7 @@ mod tests {
             None,
             None,
             0,
+            Vec::new(),
             Vec::new(),
         );
         let file = SourceFile::new(
@@ -7212,6 +7258,7 @@ mod tests {
             None,
             None,
             0,
+            Vec::new(),
             Vec::new(),
         );
         // Four independent procedures; we edit `b`'s body and leave a, c, d alone.
@@ -7300,6 +7347,7 @@ mod tests {
             None,
             0,
             Vec::new(),
+            Vec::new(),
         );
         // `other` first so editing it shifts the two below; `target` takes a
         // param `caller` always passes the literal `42` for -> param_constants.
@@ -7377,6 +7425,7 @@ mod tests {
             None,
             None,
             0,
+            Vec::new(),
             Vec::new(),
         );
         let src = "proc a {x} { return $x }\nproc b {} { a 1 }\n";

--- a/rust/tcl-lsp-db/tests/compiler_check_corpus.rs
+++ b/rust/tcl-lsp-db/tests/compiler_check_corpus.rs
@@ -60,6 +60,7 @@ fn default_config(db: &TclDatabase) -> AnalyserConfig {
         None,
         0,
         Vec::new(),
+        Vec::new(),
     )
 }
 

--- a/rust/tcl-lsp-db/tests/dialect_seam.rs
+++ b/rust/tcl-lsp-db/tests/dialect_seam.rs
@@ -82,6 +82,7 @@ fn config(db: &TclDatabase) -> AnalyserConfig {
         None,
         0,
         Vec::new(),
+        Vec::new(),
     )
 }
 

--- a/rust/tcl-lsp-db/tests/file_analysis_corpus.rs
+++ b/rust/tcl-lsp-db/tests/file_analysis_corpus.rs
@@ -89,6 +89,7 @@ fn alias_declared_outside_body_matches_full() {
         None,
         0,
         Vec::new(),
+        Vec::new(),
     );
     let file = SourceFile::new(&db, src.to_owned(), "tcl8.6".to_owned(), None);
     let inc = file_analysis_incremental(&db, file, cfg);
@@ -120,6 +121,7 @@ fn rename_declared_outside_body_matches_full() {
         None,
         None,
         0,
+        Vec::new(),
         Vec::new(),
     );
     let file = SourceFile::new(&db, src.to_owned(), "tcl8.6".to_owned(), None);
@@ -176,6 +178,7 @@ fn file_analysis_incremental_matches_full_over_corpus() {
                     None,
                     None,
                     0,
+                    Vec::new(),
                     Vec::new(),
                 );
                 let file = SourceFile::new(&db, src.clone(), dialect.to_owned(), None);

--- a/rust/tcl-lsp-db/tests/interned_gc.rs
+++ b/rust/tcl-lsp-db/tests/interned_gc.rs
@@ -281,6 +281,7 @@ fn make_inputs(db: &TclDatabase, durability: InputDurability) -> (SourceFile, An
                 None,
                 0,
                 Vec::new(),
+                Vec::new(),
             ),
         ),
         InputDurability::RaisedToHigh => (
@@ -294,6 +295,7 @@ fn make_inputs(db: &TclDatabase, durability: InputDurability) -> (SourceFile, An
                 None,
                 None,
                 0,
+                Vec::new(),
                 Vec::new(),
             )
             .durability(salsa::Durability::HIGH)

--- a/rust/tcl-lsp-db/tests/memory_growth.rs
+++ b/rust/tcl-lsp-db/tests/memory_growth.rs
@@ -148,6 +148,7 @@ fn build_config(db: &TclDatabase) -> AnalyserConfig {
         None,
         0,
         Vec::new(),
+        Vec::new(),
     )
 }
 

--- a/rust/tcl-lsp-db/tests/project_diagnostics_corpus.rs
+++ b/rust/tcl-lsp-db/tests/project_diagnostics_corpus.rs
@@ -129,6 +129,7 @@ fn build_project(
         None,
         0,
         Vec::new(),
+        Vec::new(),
     );
     let mut files = vec![
         SourceFile::new(&db, lib.to_owned(), dialect.to_owned(), None),

--- a/rust/tcl-lsp-server/src/config_ini.rs
+++ b/rust/tcl-lsp-server/src/config_ini.rs
@@ -221,16 +221,7 @@ pub fn settings_from_ini(content: &str, layer: Layer) -> Value {
         }
     }
 
-    // [packages]: `preferLatest` → the interpreter's starting `package prefer`
-    // mode (issue #1253).  A config-file key rather than an inference: the
-    // real inputs — `TCL_PKG_PREFER_LATEST` in the environment, or an unstable
-    // 9.0+ build of Tcl — belong to the interpreter the user runs, not to the
-    // server's own process or to the source tree.
-    if let Some(b) = section_value(&sections, "packages", "preferLatest").and_then(parse_bool) {
-        let mut packages = Map::new();
-        packages.insert("preferLatest".to_owned(), Value::Bool(b));
-        out.insert("packages".to_owned(), Value::Object(packages));
-    }
+    insert_packages(&sections, &mut out);
 
     // [features]: every key → bool.
     if let Some(section) = sections.iter().find(|s| s.name == "features") {
@@ -283,6 +274,53 @@ pub fn settings_from_ini(content: &str, layer: Layer) -> Value {
     insert_iruleslx(&sections, &mut out);
 
     Value::Object(out)
+}
+
+/// `[packages]` / `[packages.provides]` — how the modelled interpreter loads
+/// packages.
+///
+/// `preferLatest` is the interpreter's starting `package prefer` mode: a
+/// config-file key rather than an inference, because the real inputs —
+/// `TCL_PKG_PREFER_LATEST` in the environment, or an unstable 9.0+ build of
+/// Tcl — belong to the interpreter the user runs, not to the server's own
+/// process or to the source tree (issue #1253).
+///
+/// `[packages.provides]` declares what loading one package also loads:
+///
+/// ```ini
+/// [packages.provides]
+/// myExtension = Tk
+/// bigWrapper = Tk, Img
+/// ```
+///
+/// Every key is a package name, so the section is read key-by-key like
+/// `[features]` rather than through a fixed key list. It exists for a
+/// **binary** extension whose C `Init` calls `Tcl_PkgRequire` or
+/// `Tk_InitStubs`: that leaves no `package require Tk` anywhere for the
+/// `pkgIndex.tcl` scan to read, so the edge can only be declared (#1813).
+fn insert_packages(sections: &[Section], out: &mut Map<String, Value>) {
+    let mut packages = Map::new();
+    if let Some(b) = section_value(sections, "packages", "preferLatest").and_then(parse_bool) {
+        packages.insert("preferLatest".to_owned(), Value::Bool(b));
+    }
+    if let Some(section) = sections.iter().find(|s| s.name == "packages.provides") {
+        let mut provides = Map::new();
+        for (package, raw) in &section.entries {
+            let loaded = parse_comma_list(raw);
+            if !package.is_empty() && !loaded.is_empty() {
+                provides.insert(
+                    package.clone(),
+                    Value::Array(loaded.into_iter().map(Value::String).collect()),
+                );
+            }
+        }
+        if !provides.is_empty() {
+            packages.insert("provides".to_owned(), Value::Object(provides));
+        }
+    }
+    if !packages.is_empty() {
+        out.insert("packages".to_owned(), Value::Object(packages));
+    }
 }
 
 /// `[iruleslx.plugins]` / `[iruleslx.rules]` — the iRulesLX plugin ↔ workspace

--- a/rust/tcl-lsp-server/src/config_ini/tests.rs
+++ b/rust/tcl-lsp-server/src/config_ini/tests.rs
@@ -55,6 +55,30 @@ fn project_entry_points_list() {
     assert!(none.get("entryPoints").is_none());
 }
 
+/// Issue #1813: `[packages.provides]` declares what loading a package also
+/// loads, key by key, with a comma list for several.
+#[test]
+fn packages_provides_section() {
+    let ini = "[project]\n\
+               [packages]\n\
+               preferLatest = true\n\
+               [packages.provides]\n\
+               myExtension = Tk\n\
+               bigWrapper = Tk, Img\n";
+    let s = settings_from_ini(ini, Layer::Project);
+    assert_eq!(s["packages"]["preferLatest"], json!(true));
+    assert_eq!(s["packages"]["provides"]["myExtension"], json!(["Tk"]));
+    assert_eq!(
+        s["packages"]["provides"]["bigWrapper"],
+        json!(["Tk", "Img"])
+    );
+    // Absent section ⇒ nothing emitted, and `preferLatest` still stands alone.
+    let only_prefer = settings_from_ini("[packages]\npreferLatest = true\n", Layer::Project);
+    assert!(only_prefer["packages"].get("provides").is_none());
+    let neither = settings_from_ini("[project]\ndialect = tcl9.0\n", Layer::Project);
+    assert!(neither.get("packages").is_none());
+}
+
 #[test]
 fn project_layer_reads_project_section_only() {
     let ini = "[global]\ndialect = tcl8.6\n[project]\ndialect = tcl9.0\n";

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -2904,10 +2904,16 @@ async fn compute_base_analysis(
         let widened = widen_recovery_extra_commands(recovery, extra_commands, text, dialect).await;
         let (a_text, a_dialect, a_disabled) =
             (text.to_owned(), dialect.to_owned(), disabled.clone());
-        let a_packs = config.spec_pack_key(&*db.lock().await);
+        let (a_packs, a_provides) = {
+            let db = db.lock().await;
+            (
+                config.spec_pack_key(&*db),
+                config.package_provides(&*db).clone(),
+            )
+        };
         return match crate::rt::spawn_blocking(move || {
             with_pack_hooks(|| {
-                Backend::recovery_analyser(a_disabled, non_ascii_mode, widened, a_packs)
+                Backend::recovery_analyser(a_disabled, non_ascii_mode, widened, a_packs, a_provides)
                     .analyse(&a_text, a_dialect.name)
                     .clone()
             })
@@ -6765,6 +6771,11 @@ struct FolderConfig {
     shimmer_enabled: Option<bool>,
     /// `tclLsp.extraCommands` override; `None` inherits the global set.
     extra_commands: Option<Vec<String>>,
+    /// `tclLsp.packages.provides` / `[packages.provides]` override; `None`
+    /// inherits the global map. The setting is `"scope": "resource"` and a
+    /// `.tcl-lsp.ini` belongs to its own project, so a secondary root's
+    /// declarations must not be answered with the primary root's.
+    package_provides: Option<Vec<(String, Vec<String>)>>,
     /// `tclLsp.signatureHelp.disabledCommands` override; `None` inherits the
     /// global list. `Some([])` explicitly enables every built-in signature.
     signature_help_disabled_commands: Option<Vec<String>>,
@@ -9110,6 +9121,7 @@ impl Backend {
         uri: Uri,
         folder_dialects: Arc<Vec<(Uri, String)>>,
         default_dialect: Arc<String>,
+        package_provides: Arc<Vec<(String, Vec<String>)>>,
     ) -> Option<(Uri, String, String, AnalysisResult)> {
         let store = Arc::clone(store);
         crate::rt::spawn_blocking(move || {
@@ -9127,7 +9139,18 @@ impl Backend {
             let text = tcl_lexer::normalise_lone_cr(&raw).into_owned();
             let dialect =
                 Self::dialect_for_closed_sync(&uri, &text, &folder_dialects, &default_dialect);
-            let analysis = Analyser::new().analyse(&text, &dialect);
+            // The declared edges belong here as much as on the interactive
+            // path: this analysis becomes the file's *index* entry, and
+            // `workspace_index` harvests `package_requires` from it. Without
+            // them a closed file's entry omits the implied requires, so a
+            // sibling that inherits through `source` under-reports — and the
+            // same file yields different requires depending on whether it was
+            // reached through this path or the closed-file branch of
+            // `compute_base_analysis`, which does carry them (issue #1813
+            // review).
+            let analysis = Analyser::new()
+                .with_package_provides(package_provides.as_ref().clone())
+                .analyse(&text, &dialect);
             Some((uri, text, dialect, analysis))
         })
         .await
@@ -9157,6 +9180,7 @@ impl Backend {
         }
         let folder_dialects = Arc::new(self.folder_dialect_overrides().await);
         let default_dialect = Arc::new(self.session_dialect().await);
+        let package_provides = Arc::new(self.package_provides.lock().await.clone());
         let concurrency =
             crate::rt::available_parallelism().min(WORKSPACE_ANALYSIS_MAX_CONCURRENCY);
         let futures: Vec<_> = uris
@@ -9166,10 +9190,16 @@ impl Backend {
                 let folder_dialects = Arc::clone(&folder_dialects);
                 let default_dialect = Arc::clone(&default_dialect);
                 let store = Arc::clone(&self.store);
+                let package_provides = Arc::clone(&package_provides);
                 async move {
-                    let scanned =
-                        Self::scan_disk_file(&store, uri.clone(), folder_dialects, default_dialect)
-                            .await;
+                    let scanned = Self::scan_disk_file(
+                        &store,
+                        uri.clone(),
+                        folder_dialects,
+                        default_dialect,
+                        package_provides,
+                    )
+                    .await;
                     Some((uri, scanned))
                 }
             })
@@ -9204,8 +9234,15 @@ impl Backend {
         // error in its siblings.
         let folder_dialects = Arc::new(self.folder_dialect_overrides().await);
         let default_dialect = Arc::new(self.session_dialect().await);
-        let scanned =
-            Self::scan_disk_file(&self.store, uri.clone(), folder_dialects, default_dialect).await;
+        let package_provides = Arc::new(self.package_provides.lock().await.clone());
+        let scanned = Self::scan_disk_file(
+            &self.store,
+            uri.clone(),
+            folder_dialects,
+            default_dialect,
+            package_provides,
+        )
+        .await;
         match scanned {
             Some(scanned) => {
                 self.publish_disk_results(
@@ -13794,7 +13831,7 @@ impl Backend {
         let (disabled, na_mode) = self.analyser_config().await;
         let extra: HashSet<String> = self.extra_commands.lock().await.iter().cloned().collect();
         let pack_key = self.spec_packs().await.key;
-        let provides = self.package_provides.lock().await.clone();
+        let provides = self.resolved_package_provides(&uri).await;
         let dialect = doc.dialect.clone();
         // The one place that legitimately owns a copy: fix-all *rewrites* the
         // source in a loop, so it needs a mutable buffer of its own rather than
@@ -14589,15 +14626,22 @@ impl Backend {
             .and_then(|p| p.get("provides"))
             .and_then(serde_json::Value::as_object)
         {
-            let mut provides: Vec<(String, Vec<String>)> = map
-                .iter()
-                .map(|(package, loaded)| (package.clone(), provided_package_names(loaded)))
-                .filter(|(_, loaded)| !loaded.is_empty())
-                .collect();
-            // Stable order: this feeds a salsa input, and a map iteration
-            // order change must not look like an edit.
-            provides.sort();
-            *self.package_provides.lock().await = provides;
+            let provides = parse_package_provides(map);
+            let changed = {
+                let mut guard = self.package_provides.lock().await;
+                if *guard == provides {
+                    false
+                } else {
+                    *guard = provides;
+                    true
+                }
+            };
+            // The workspace scan bakes these edges into every closed file's
+            // index entry, so a change to them has to re-scan — the same
+            // treatment `libraryPaths` gets above (issue #1813 review).
+            if changed {
+                self.scan_workspace_folders().await;
+            }
         }
     }
 
@@ -14854,6 +14898,7 @@ impl Backend {
             // process-global value when set; otherwise the folder inherits it.
             let global_extra = self.extra_commands.lock().await.clone();
             let global_generic = self.generic_variable_patterns.lock().await.clone();
+            let global_provides = self.package_provides.lock().await.clone();
             // Packs are a workspace fact, never a per-folder one, so every
             // folder handle carries the same key the global config does.
             let pack_key = self.spec_packs().await.key;
@@ -14872,6 +14917,7 @@ impl Backend {
                 if fc.disabled_diagnostics.is_none()
                     && fc.non_ascii_mode.is_none()
                     && fc.extra_commands.is_none()
+                    && fc.package_provides.is_none()
                     && matches!(fc.generic_variable_patterns, FolderGenericPatterns::Inherit)
                 {
                     continue;
@@ -14891,6 +14937,10 @@ impl Backend {
                     FolderGenericPatterns::BuiltinDefaults => None,
                     FolderGenericPatterns::Replace(list) => Some(list.clone()),
                 };
+                let provides = fc
+                    .package_provides
+                    .clone()
+                    .unwrap_or_else(|| global_provides.clone());
                 // The folder's own live handle first, then its retired one, and
                 // only then a fresh input.
                 if let Some(handle) = reclaimable
@@ -14902,6 +14952,7 @@ impl Backend {
                     handle.set_extra_commands(&mut *db).to(extra);
                     handle.set_generic_variable_patterns(&mut *db).to(generic);
                     handle.set_spec_pack_key(&mut *db).to(pack_key);
+                    handle.set_package_provides(&mut *db).to(provides);
                     next.push((folder.clone(), handle));
                 } else {
                     let handle = tcl_lsp_db::AnalyserConfig::new(
@@ -14913,7 +14964,7 @@ impl Backend {
                         None,
                         pack_key,
                         Vec::new(),
-                        Vec::new(),
+                        provides,
                     );
                     next.push((folder.clone(), handle));
                 }
@@ -14925,6 +14976,7 @@ impl Backend {
                 handle.set_disabled_diagnostics(&mut *db).to(Vec::new());
                 handle.set_extra_commands(&mut *db).to(Vec::new());
                 handle.set_generic_variable_patterns(&mut *db).to(None);
+                handle.set_package_provides(&mut *db).to(Vec::new());
                 handle.set_bigip_version(&mut *db).to(None);
                 handle.set_targets(&mut *db).to(Vec::new());
                 tombstones.insert(folder, handle);
@@ -15320,6 +15372,19 @@ impl Backend {
         }
     }
 
+    /// The resolved declared package edges for `uri`: a folder override wins,
+    /// else the process-global map.
+    async fn resolved_package_provides(&self, uri: &Uri) -> Vec<(String, Vec<String>)> {
+        let folder = {
+            let configs = self.folder_configs.lock().await;
+            longest_folder_match(&configs, uri).and_then(|f| f.package_provides.clone())
+        };
+        match folder {
+            Some(v) => v,
+            None => self.package_provides.lock().await.clone(),
+        }
+    }
+
     /// The resolved built-in signature-help exclusion list for `uri`: a
     /// folder override wins, else the process-global list.
     async fn resolved_signature_help_disabled_commands(&self, uri: &Uri) -> Vec<String> {
@@ -15449,11 +15514,20 @@ impl Backend {
         mode: NonAsciiMode,
         extra_commands: Arc<HashSet<String>>,
         pack_key: u64,
+        package_provides: Vec<(String, Vec<String>)>,
     ) -> Analyser {
         Analyser::with_disabled_diagnostics(disabled)
             .with_non_ascii_mode(mode)
             .with_shared_extra_commands(extra_commands)
             .with_pack_overlay(pack_key)
+            // Declared package edges must survive an incomplete buffer. They
+            // decide Tk activation and what `package_requires` contains, and
+            // this analysis is *published* — and indexed — so dropping them
+            // for the keystrokes between an opening brace and its match makes
+            // the TK checks and W120/H301 flicker, and republishes an index
+            // entry without the implied requires, which reschedules every
+            // peer document (issue #1813 review).
+            .with_package_provides(package_provides)
     }
 
     /// Return the command registry with `dialect` loaded on top of the
@@ -17394,6 +17468,7 @@ impl Backend {
                     .collect::<HashMap<String, std::collections::BTreeSet<String>>>()
             };
             let recorded = self.rehomed_source_seeds.lock().await.clone();
+            let package_provides = self.package_provides.lock().await.clone();
             let mut work: Vec<(String, Vec<String>)> = Vec::new();
             for (uri, seeds) in &desired {
                 let seeds: Vec<String> = seeds.iter().cloned().collect();
@@ -17424,11 +17499,16 @@ impl Backend {
                 let text = doc.text.clone();
                 let dialect = doc.dialect.clone();
                 let seeds_for_worker = seeds.clone();
+                let provides_for_worker = package_provides.clone();
                 let Ok(analyses) = crate::rt::spawn_blocking(move || {
                     seeds_for_worker
                         .iter()
                         .map(|seed| {
-                            let mut analyser = Analyser::new();
+                            // Re-homing overwrites the document's index entry,
+                            // so it must not re-drop the implied requires the
+                            // scan put there (issue #1813 review).
+                            let mut analyser =
+                                Analyser::new().with_package_provides(provides_for_worker.clone());
                             if seed == Self::STANDALONE_SEED {
                                 analyser.analyse(&text, &dialect)
                             } else {
@@ -17803,6 +17883,7 @@ impl Backend {
     ) -> (PackageResolver, usize) {
         let open = Arc::new(open);
         let folder_dialects = Arc::new(folder_dialects);
+        let package_provides = Arc::new(self.package_provides.lock().await.clone());
         let concurrency =
             crate::rt::available_parallelism().min(WORKSPACE_ANALYSIS_MAX_CONCURRENCY);
         let permits = Arc::new(Semaphore::new(concurrency));
@@ -17814,6 +17895,7 @@ impl Backend {
             let open = Arc::clone(&open);
             let folder_dialects = Arc::clone(&folder_dialects);
             let default_dialect = default_dialect.clone();
+            let package_provides = Arc::clone(&package_provides);
             let store = Arc::clone(&self.store);
             tasks.spawn(async move {
                 let _permit = permit;
@@ -17830,7 +17912,12 @@ impl Backend {
                     let text = tcl_lexer::normalise_lone_cr(&raw).into_owned();
                     let dialect = folder_dialect_for(&uri, &folder_dialects)
                         .unwrap_or_else(|| default_dialect.clone());
-                    let mut analyser = Analyser::new();
+                    // Same reason as `scan_disk_file`: this analysis becomes
+                    // the file's index entry, and `package_requires` is
+                    // harvested from it, so a `source` descendant inherits
+                    // whatever the edges imply here (issue #1813 review).
+                    let mut analyser =
+                        Analyser::new().with_package_provides(package_provides.as_ref().clone());
                     let analysis = analyser.analyse(&text, &dialect);
                     Some((uri, text, dialect, analysis))
                 })
@@ -22948,6 +23035,17 @@ fn parse_folder_config(cfg: &serde_json::Value) -> Option<FolderConfig> {
                 .collect(),
         );
     }
+    // `tclLsp.packages.provides` per-folder override. The setting is
+    // resource-scoped and a `.tcl-lsp.ini` belongs to its own project, so a
+    // secondary root declares its own edges (issue #1813 review). Parsed
+    // through the same normaliser the global path uses.
+    if let Some(map) = obj
+        .get("packages")
+        .and_then(|p| p.get("provides"))
+        .and_then(serde_json::Value::as_object)
+    {
+        fc.package_provides = Some(parse_package_provides(map));
+    }
     fc.signature_help_disabled_commands = signature_help_disabled_commands(cfg);
     parse_folder_diagnostics(obj, &mut fc);
     // `tclLsp.libraryPaths` per-folder override.
@@ -23618,6 +23716,23 @@ fn refine_w120_diagnostics(
 /// either a JSON array (`"myExtension": ["Tk", "Img"]`) or a single string
 /// (`"myExtension": "Tk"`) — the same one-or-many latitude the `.tcl-lsp.ini`
 /// `[packages.provides]` comma list has. Blank names are dropped.
+/// `tclLsp.packages.provides` / `[packages.provides]` as edges.
+///
+/// Shared by the global and per-folder parses so the two cannot disagree
+/// about normalisation or ordering. Sorted because it feeds a salsa input,
+/// where a map-iteration-order change must not look like an edit.
+fn parse_package_provides(
+    map: &serde_json::Map<String, serde_json::Value>,
+) -> Vec<(String, Vec<String>)> {
+    let mut provides: Vec<(String, Vec<String>)> = map
+        .iter()
+        .map(|(package, loaded)| (package.clone(), provided_package_names(loaded)))
+        .filter(|(_, loaded)| !loaded.is_empty())
+        .collect();
+    provides.sort();
+    provides
+}
+
 fn provided_package_names(value: &serde_json::Value) -> Vec<String> {
     match value {
         serde_json::Value::String(one) => one
@@ -32895,6 +33010,107 @@ mod tests {
         assert!(
             has_tk1002(&after),
             "declared ⇒ the Tk checks run: {after:?}",
+        );
+    }
+
+    /// Review follow-up on #1813: the declared edges must survive an
+    /// incomplete buffer. `compute_base_analysis` switches to
+    /// `recovery_analyser` on an unclosed delimiter, and that analysis is
+    /// published *and* indexed — so dropping the edges there made the Tk
+    /// checks and W120/H301 flicker for every keystroke between an opening
+    /// brace and its match, and republished an index entry without the
+    /// implied requires.
+    #[tokio::test]
+    async fn declared_package_provides_survive_an_incomplete_buffer() {
+        let backend = test_backend();
+        let uri = Uri::from_str("file:///ext_recovery.tcl").unwrap();
+        // Unclosed brace: `script_is_complete` is false, so this takes the
+        // recovery branch.
+        let src = "package require myExtension
+frame .outer.inner
+proc p {} {
+";
+        assert!(
+            !tcl_lexer::script_is_complete(src),
+            "the fixture must actually take the recovery branch"
+        );
+        let has_tk1002 = |diags: &[tower_lsp_server::ls_types::Diagnostic]| {
+            diags.iter().any(|d| {
+                matches!(
+                    &d.code,
+                    Some(tower_lsp_server::ls_types::NumberOrString::String(c)) if c == "TK1002"
+                )
+            })
+        };
+        register(&backend, &uri, src).await;
+        backend
+            .apply_global_config(&serde_json::json!({
+                "packages": { "provides": { "myExtension": ["Tk"] } },
+            }))
+            .await;
+        let diags = backend
+            .full_diagnostics_for(&uri, Arc::from(src), "tcl8.6".to_owned(), "tcl")
+            .await;
+        assert!(
+            has_tk1002(&diags),
+            "an unclosed brace must not switch Tk off: {diags:?}",
+        );
+    }
+
+    /// Review follow-up on #1813: `tclLsp.packages.provides` is
+    /// `"scope": "resource"`, so a folder override must win for documents
+    /// under it — and, just as importantly, a folder that overrides some
+    /// *other* analyser input must not silently lose the global edges (the
+    /// folder handle used to be constructed with an empty provides list).
+    #[tokio::test]
+    async fn declared_package_provides_resolve_per_folder() {
+        let backend = test_backend();
+        backend
+            .apply_global_config(&serde_json::json!({
+                "packages": { "provides": { "globalExt": ["Tk"] } },
+            }))
+            .await;
+
+        let root = Uri::from_str("file:///w/").unwrap();
+        let other = Uri::from_str("file:///other/").unwrap();
+        backend
+            .apply_folder_configs(vec![
+                (
+                    root.clone(),
+                    parse_folder_config(&serde_json::json!({
+                        "packages": { "provides": { "rootExt": ["Tk"] } },
+                    }))
+                    .expect("folder config parses"),
+                ),
+                (
+                    other.clone(),
+                    // Overrides an unrelated knob only: must still inherit the
+                    // global edges rather than get an empty map.
+                    parse_folder_config(&serde_json::json!({ "extraCommands": ["zzz"] }))
+                        .expect("folder config parses"),
+                ),
+            ])
+            .await;
+
+        let in_root = Uri::from_str("file:///w/a.tcl").unwrap();
+        assert_eq!(
+            backend.resolved_package_provides(&in_root).await,
+            vec![("rootExt".to_owned(), vec!["Tk".to_owned()])],
+            "a folder override wins for documents under it"
+        );
+
+        let in_other = Uri::from_str("file:///other/a.tcl").unwrap();
+        assert_eq!(
+            backend.resolved_package_provides(&in_other).await,
+            vec![("globalExt".to_owned(), vec!["Tk".to_owned()])],
+            "a folder overriding something else still inherits the global edges"
+        );
+
+        let elsewhere = Uri::from_str("file:///nowhere/a.tcl").unwrap();
+        assert_eq!(
+            backend.resolved_package_provides(&elsewhere).await,
+            vec![("globalExt".to_owned(), vec!["Tk".to_owned()])],
+            "no folder match falls back to the global map"
         );
     }
 

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -2963,21 +2963,28 @@ async fn compute_base_analysis(
         // the **closed-file** tier since #1144, not just a rare fallback, so a
         // closed file's badge must not lose them.
         let a_path = uri.to_file_path().map(|p| p.display().to_string());
-        let (a_bigip, a_packs) = {
+        let (a_bigip, a_packs, a_provides) = {
             let db = db.lock().await;
             (
                 config.bigip_version(&*db).clone(),
                 config.spec_pack_key(&*db),
+                config.package_provides(&*db).clone(),
             )
         };
         let analysis = crate::rt::spawn_blocking(move || {
             with_pack_hooks(|| {
                 Arc::new(
-                    Backend::configured_analyser(a_disabled, non_ascii_mode, a_extra, a_packs)
-                        .with_file_path(a_path)
-                        .with_bigip_version(a_bigip)
-                        .analyse(&a_text, a_dialect.name)
-                        .clone(),
+                    Backend::configured_analyser(
+                        a_disabled,
+                        non_ascii_mode,
+                        a_extra,
+                        a_packs,
+                        a_provides,
+                    )
+                    .with_file_path(a_path)
+                    .with_bigip_version(a_bigip)
+                    .analyse(&a_text, a_dialect.name)
+                    .clone(),
                 )
             })
         })
@@ -5807,6 +5814,16 @@ pub struct Backend {
     /// rather than inferred from the server's own environment — which is not
     /// the environment the user's interpreter runs in (issue #1253).
     package_prefer_latest_default: Mutex<bool>,
+    /// `tclLsp.packages.provides` — declared "requiring this package also
+    /// loads these" edges, as `(package, packages it also loads)` pairs in
+    /// declaration order; mirrored onto the salsa `AnalyserConfig`.
+    ///
+    /// A binary extension whose `Init` calls `Tcl_PkgRequire` — or links Tk
+    /// through `Tk_InitStubs` — makes a package available with nothing in any
+    /// Tcl source saying so, so the workspace `pkgIndex.tcl` scan that finds a
+    /// Tcl wrapper's own requires (#723) has nothing to read. Declaring the
+    /// edge is the only way to state it (issue #1813).
+    package_provides: Mutex<Vec<(String, Vec<String>)>>,
     /// User-declared extra command names (`tclLsp.extraCommands`) treated as
     /// known by the unknown-command (W123) check; mirrored onto the salsa
     /// `AnalyserConfig`.
@@ -7157,6 +7174,7 @@ impl Backend {
             None,
             0,
             Vec::new(),
+            Vec::new(),
         );
         let diagnostic_publisher = Arc::new(DiagnosticPublisher::new(client.clone()));
         Self {
@@ -7188,6 +7206,7 @@ impl Backend {
             discovered_tcl: Arc::new(std::sync::OnceLock::new()),
             editor_library_paths: Mutex::new(Vec::new()),
             package_prefer_latest_default: Mutex::new(false),
+            package_provides: Mutex::new(Vec::new()),
             extra_commands: Mutex::new(Vec::new()),
             signature_help_disabled_commands: Mutex::new(Vec::new()),
             spec_pack_paths: Mutex::new(Vec::new()),
@@ -7792,6 +7811,8 @@ impl Backend {
         config.set_bigip_version(&mut *db).to(bigip);
         let targets = self.declared_targets.lock().await.clone();
         config.set_targets(&mut *db).to(targets);
+        let provides = self.package_provides.lock().await.clone();
+        config.set_package_provides(&mut *db).to(provides);
     }
 
     /// Run the salsa `document_symbols` query for `uri` on a worker thread,
@@ -8015,17 +8036,19 @@ impl Backend {
         // fresh with the same per-folder config the cached path would have used,
         // so the on-demand result still honours folder-scoped suppression.
         let config = self.resolved_db_config(uri).await;
-        let (disabled, na_mode, extra, pack_key) = {
+        let (disabled, na_mode, extra, pack_key, provides) = {
             let db = self.db.lock().await;
             (
                 config.disabled_diagnostics(&*db).iter().cloned().collect(),
                 config.non_ascii_mode(&*db),
                 config.extra_commands(&*db).iter().cloned().collect(),
                 config.spec_pack_key(&*db),
+                config.package_provides(&*db).clone(),
             )
         };
         crate::rt::spawn_blocking(move || {
-            let mut analyser = Self::configured_analyser(disabled, na_mode, extra, pack_key);
+            let mut analyser =
+                Self::configured_analyser(disabled, na_mode, extra, pack_key, provides);
             Arc::new(analyser.analyse(&text, &dialect))
         })
         .await
@@ -9448,6 +9471,7 @@ impl Backend {
             discovered_tcl: _,
             editor_library_paths: _,
             package_prefer_latest_default: _,
+            package_provides: _,
             extra_commands: _,
             signature_help_disabled_commands: _,
             spec_pack_paths: _,
@@ -13770,6 +13794,7 @@ impl Backend {
         let (disabled, na_mode) = self.analyser_config().await;
         let extra: HashSet<String> = self.extra_commands.lock().await.iter().cloned().collect();
         let pack_key = self.spec_packs().await.key;
+        let provides = self.package_provides.lock().await.clone();
         let dialect = doc.dialect.clone();
         // The one place that legitimately owns a copy: fix-all *rewrites* the
         // source in a loop, so it needs a mutable buffer of its own rather than
@@ -13783,8 +13808,13 @@ impl Backend {
         let value = crate::rt::spawn_blocking(move || {
             let mut applied: Vec<serde_json::Value> = Vec::new();
             for _ in 0..FIX_ALL_MAX_PASSES {
-                let mut analyser =
-                    Self::configured_analyser(disabled.clone(), na_mode, extra.clone(), pack_key);
+                let mut analyser = Self::configured_analyser(
+                    disabled.clone(),
+                    na_mode,
+                    extra.clone(),
+                    pack_key,
+                    provides.clone(),
+                );
                 let analysis = analyser.analyse(&tcl_lexer::normalise_lone_cr(&source), &dialect);
                 let chosen = Self::bulk_applicable_fixes(&analysis);
                 if chosen.is_empty() {
@@ -14550,6 +14580,25 @@ impl Backend {
         {
             *self.package_prefer_latest_default.lock().await = flag;
         }
+        // `tclLsp.packages.provides` — what a `package require` additionally
+        // loads. See the field doc: a binary extension's own
+        // `Tcl_PkgRequire` / `Tk_InitStubs` is invisible to every scan, so it
+        // is declared (issue #1813).
+        if let Some(map) = cfg
+            .get("packages")
+            .and_then(|p| p.get("provides"))
+            .and_then(serde_json::Value::as_object)
+        {
+            let mut provides: Vec<(String, Vec<String>)> = map
+                .iter()
+                .map(|(package, loaded)| (package.clone(), provided_package_names(loaded)))
+                .filter(|(_, loaded)| !loaded.is_empty())
+                .collect();
+            // Stable order: this feeds a salsa input, and a map iteration
+            // order change must not look like an edit.
+            provides.sort();
+            *self.package_provides.lock().await = provides;
+        }
     }
 
     /// The interpreter's **starting** `package prefer` mode — the base
@@ -14863,6 +14912,7 @@ impl Backend {
                         generic,
                         None,
                         pack_key,
+                        Vec::new(),
                         Vec::new(),
                     );
                     next.push((folder.clone(), handle));
@@ -15381,11 +15431,13 @@ impl Backend {
         mode: NonAsciiMode,
         extra_commands: HashSet<String>,
         pack_key: u64,
+        package_provides: Vec<(String, Vec<String>)>,
     ) -> Analyser {
         Analyser::with_disabled_diagnostics(disabled)
             .with_non_ascii_mode(mode)
             .with_extra_commands(extra_commands)
             .with_pack_overlay(pack_key)
+            .with_package_provides(package_provides)
     }
 
     /// [`Self::configured_analyser`] taking the recovery path's **shared**
@@ -23562,6 +23614,28 @@ fn refine_w120_diagnostics(
         .collect()
 }
 
+/// The package names one `tclLsp.packages.provides` entry declares, accepting
+/// either a JSON array (`"myExtension": ["Tk", "Img"]`) or a single string
+/// (`"myExtension": "Tk"`) — the same one-or-many latitude the `.tcl-lsp.ini`
+/// `[packages.provides]` comma list has. Blank names are dropped.
+fn provided_package_names(value: &serde_json::Value) -> Vec<String> {
+    match value {
+        serde_json::Value::String(one) => one
+            .split([',', ' '])
+            .filter(|s| !s.is_empty())
+            .map(str::to_owned)
+            .collect(),
+        serde_json::Value::Array(many) => many
+            .iter()
+            .filter_map(serde_json::Value::as_str)
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_owned)
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
 /// What one set of `package require`s makes available, as the W120 check reads
 /// it — the two rules of [`refine_w120_diagnostics`] in a reusable form.
 ///
@@ -28644,14 +28718,25 @@ mod tests {
     #[test]
     fn configured_analyser_threads_mode_and_disabled() {
         // `Off` mode suppresses W108 entirely.
-        let mut a =
-            Backend::configured_analyser(HashSet::new(), NonAsciiMode::Off, HashSet::new(), 0);
+        let mut a = Backend::configured_analyser(
+            HashSet::new(),
+            NonAsciiMode::Off,
+            HashSet::new(),
+            0,
+            Vec::new(),
+        );
         let r = a.analyse("set x \u{201c}hi\u{201d}\n", "tcl8.6");
         assert!(!r.diagnostics.iter().any(|d| d.code == DiagCode::W108));
         // A disabled code is filtered from the analyser's output.
         let mut disabled = HashSet::new();
         disabled.insert("W108".to_string());
-        let mut b = Backend::configured_analyser(disabled, NonAsciiMode::Strict, HashSet::new(), 0);
+        let mut b = Backend::configured_analyser(
+            disabled,
+            NonAsciiMode::Strict,
+            HashSet::new(),
+            0,
+            Vec::new(),
+        );
         let r = b.analyse("set x \u{201c}hi\u{201d}\n", "tcl8.6");
         assert!(!r.diagnostics.iter().any(|d| d.code == DiagCode::W108));
     }
@@ -30921,6 +31006,7 @@ mod tests {
             None,
             0,
             Vec::new(),
+            Vec::new(),
         );
         Backend {
             client,
@@ -30951,6 +31037,7 @@ mod tests {
             discovered_tcl: Arc::new(std::sync::OnceLock::new()),
             editor_library_paths: Mutex::new(Vec::new()),
             package_prefer_latest_default: Mutex::new(false),
+            package_provides: Mutex::new(Vec::new()),
             extra_commands: Mutex::new(Vec::new()),
             signature_help_disabled_commands: Mutex::new(Vec::new()),
             spec_pack_paths: Mutex::new(Vec::new()),
@@ -32715,7 +32802,10 @@ mod tests {
             "dialect": "tcl9.0",
             "style": { "nonAscii": "strict" },
             "diagnostics": { "W211": false },
-            "packages": { "preferLatest": true },
+            "packages": {
+                "preferLatest": true,
+                "provides": { "myExtension": ["Tk"], "single": "Img" },
+            },
         });
         backend.apply_global_config(&cfg).await;
         assert!(!backend.feature_toggles.lock().await.is_enabled("hover"));
@@ -32748,6 +32838,63 @@ mod tests {
         assert_eq!(
             test_backend().default_package_prefer().await,
             tcl_lsp_core::package_resolver::PackagePrefer::Stable,
+        );
+        // Issue #1813 — declared "this package also loads that one" edges,
+        // in a stable order and accepting a bare string for a single name.
+        assert_eq!(
+            *backend.package_provides.lock().await,
+            vec![
+                ("myExtension".to_owned(), vec!["Tk".to_owned()]),
+                ("single".to_owned(), vec!["Img".to_owned()]),
+            ],
+        );
+    }
+
+    /// Issue #1813: the declared edge has to reach the *analyser*, not just
+    /// the backend field. A binary extension loads Tk with nothing in any Tcl
+    /// source to say so, and the Tk checks are gated on the document being Tk
+    /// — so TK1002 (a widget path whose parent was never created) is the
+    /// visible proof that the declaration activated Tk.
+    ///
+    /// W120 is the wrong probe here: `myExtension` is unresolvable in an
+    /// empty workspace, and the server already drops every W120 for a
+    /// document requiring a package it cannot resolve (#723's conservative
+    /// rule). The gap this closes is everything W120's abstention does not
+    /// cover — the Tk checks, completions, and hover.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn declared_package_provides_makes_tk_available_to_diagnostics() {
+        let backend = test_backend();
+        let uri = Uri::from_str("file:///ext.tcl").unwrap();
+        let src = "package require myExtension\nframe .outer.inner\n";
+        let has_tk1002 = |diags: &[tower_lsp_server::ls_types::Diagnostic]| {
+            diags.iter().any(|d| {
+                matches!(
+                    &d.code,
+                    Some(tower_lsp_server::ls_types::NumberOrString::String(c)) if c == "TK1002"
+                )
+            })
+        };
+        register(&backend, &uri, src).await;
+
+        let before = backend
+            .full_diagnostics_for(&uri, Arc::from(src), "tcl8.6".to_owned(), "tcl")
+            .await;
+        assert!(
+            !has_tk1002(&before),
+            "undeclared ⇒ not a Tk document: {before:?}",
+        );
+
+        backend
+            .apply_global_config(&serde_json::json!({
+                "packages": { "provides": { "myExtension": ["Tk"] } },
+            }))
+            .await;
+        let after = backend
+            .full_diagnostics_for(&uri, Arc::from(src), "tcl8.6".to_owned(), "tcl")
+            .await;
+        assert!(
+            has_tk1002(&after),
+            "declared ⇒ the Tk checks run: {after:?}",
         );
     }
 


### PR DESCRIPTION
## Summary

- A compiled extension can bring a package up from C — its `Init` calls `Tcl_PkgRequire`, or it links Tk through `Tk_InitStubs` — with nothing in any Tcl source to say so. The reporter's case:

  ```tcl
  package require myExtension
  ttk::frame .f
  pack .f
  ```

- **There is no heuristic available for this, by construction.** The #723 workspace scan reads the `package require`s inside the *Tcl* files a `pkgIndex.tcl` sources, and a `load`-only extension has none; the only other signal would be guessing from the extension's name. So the dependency is *declared*, as an edge — "loading this package also loads those" — in either of two places:

  ```tcl
  # tcl-lsp: package myExtension provides Tk
  ```
  ```ini
  [packages.provides]        # .tcl-lsp.ini / config.ini
  myExtension = Tk, Img
  ```
  ```jsonc
  "tclLsp.packages.provides": { "myExtension": ["Tk"] }
  ```

- The directive **names its loader** rather than relying on where it sits, so it may live anywhere in the file (including the top-of-file comment block) and is **inert until the document actually requires that package**. That is what makes the two surfaces the same fact rather than two mechanisms. `package` occupies the keyword slot, as in every other member of the family (`supports`, `stub`, `disable`), so `matches_marker` handles it and no future keyword can be confused with a package name; the wording deliberately echoes the Tcl commands the line is about. Being source-level, it is also the only form the CLI honours (`tcl diag` / `lint` read no `.tcl-lsp.ini`).

- Both are applied by `expand_implied_package_requires` at the head of the shared diagnostic tail. Each package the edges reach becomes an ordinary `SignaturePackageRequire` carrying **the span of the `package require` that loaded it** — the position from which it is genuinely available, which keeps H301's ordering claim honest — plus a `PackageRequireOrigin` (`Directive(pkg)` / `Provides(pkg)`) naming the loader, for consumers that want what the source literally says. So W120, H301, the W123 widening, the Tk activation gate, completion's `tk_loaded` and hover's package annotation all answer as they would for a written `package require`, **with no consumer taught about the mechanism**. A declared entry carries no version requirement and so contributes no version floor: it says a package is *there*, never which release.

- The tail is the one point both the whole-file and the per-item walk reach with their `package_requires` merged, so the strategies cannot disagree about the closure. The per-item path's Tk hand-off runs earlier, mid-walk, so `has_tk_require` consults the declarations directly and `per_item_setup` scans the directives — **without that the two walks genuinely diverged** (whole-file saw `TK1002`, per-item saw `W120`), which `provides_directive_agrees_across_walk_strategies` now pins.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

```
make rust-check                                          # exit 0, from a clean target
cargo run -p xtask -- kcs-index-links                     # KCS docs checks passed
cargo test -p tcl-compiler --lib -- provides_directive parse_provides_directives declared_package_provides
                                                          # 9 passed, 0 failed
cargo test -p tcl-lsp-server --lib -- declared_package_provides \
       apply_global_config_applies_every_knob packages_provides_section
                                                          # 3 passed, 0 failed
```

End-to-end through the real binaries, each with a control run:

| Check | With the declaration | Without |
|---|---|---|
| `tcl diag` (directive) | `TK1002` fires, no W120 | three W120s, no TK checks |
| directive at the *bottom* of the file | still active | — |
| directive whose loader is never required | inert, W120 stands | — |
| `tcl-lsp-server` + `.tcl-lsp.ini`, `diagnostics` | `TK1002` | no diagnostics |
| `tcl-lsp-server` + `.tcl-lsp.ini`, `completion` at `ttk::b` | `ttk::button — Tk` | 0 items |

`make prep-pr` could **not** be completed on this machine — the session's disk allowance was exhausted partway through the smoke tier (`No space left on device`, plus a linker `Bus error` from the same cause). Every failure in that run was disk, not code; `rust-check` and the suites above were re-run from a cleaned target afterwards and are green. Relying on CI for the deep tiers.

## Compiler / diagnostics checklist

- [x] Did this change alter a compiler fact contract? — yes: what counts as an available package for a document.
- [x] If yes, I updated the owning design doc — `docs/design/contracts/package-loading.md` gains § *Declared package provides (#1813)* (rules 15–20, later rules renumbered) plus file-path, failure-mode and test anchors.
- [x] No diagnostic or optimisation code was added or changed, so no `docs/kcs/codes/` page changes — W120/H301/TK100x keep their meanings and simply see a larger set of available packages.
- [x] No new *design* doc, so nothing to link from `docs/design/README.md`. The new KCS note **is** indexed from `docs/kcs/README.md` and `cargo xtask kcs-index-links` passes.

User-facing docs: new `docs/kcs/kcs-howto-declare-a-package-a-binary-extension-loads.md`; `kcs-qa-tcl-lsp-annotations.md` gains the directive as its fifth structured comment; `kcs-qa-what-config-sections-are-valid.md` gains `[packages]` / `[packages.provides]` (`[packages]` was previously undocumented); `tclLsp.packages.provides` added to the VS Code manifest.

Closes #1813

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PKQ5b7ZLU5XPDaugte4Feb

---
_Generated by [Claude Code](https://claude.ai/code/session_01PKQ5b7ZLU5XPDaugte4Feb)_