### PR TITLE
ci: reuse completed npm installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -514,7 +514,14 @@ jobs:
 
       - name: Install npm dependencies
         if: env.RUN_EXT == 'true'
-        run: cd editors/vscode && npm ci
+        run: |
+          cd editors/vscode
+          npm ci
+          # `make test-ext` calls the ordinary compile target later. Record
+          # that this exact package/lock pair is already installed so it does
+          # not immediately run a second `npm install` in the same job.
+          mkdir -p ../../build/stamps
+          touch ../../build/stamps/npm-install
 
       # `@vscode/test-electron` downloads a full VS Code build on every run and
       # nothing cached it, so the extension-test step paid that download each
@@ -1953,7 +1960,12 @@ jobs:
             ${{ runner.os }}-npm-
 
       - name: Install npm dependencies
-        run: cd editors/vscode && npm ci
+        run: |
+          cd editors/vscode
+          npm ci
+          # The packaging targets use the same Makefile dependency stamp.
+          mkdir -p ../../build/stamps
+          touch ../../build/stamps/npm-install
 
       # Bundle all seven native binaries into one untargeted "universal"
       # VSIX — the Marketplace's fallback for any client with no dedicated

--- a/Makefile
+++ b/Makefile
@@ -1484,19 +1484,19 @@ smoke-vsix: compile ## Build and verify the VSIX packages without error
 
 npm-env: $(NPM_STAMP) ## Install/update npm dependencies
 
-$(NPM_STAMP): $(EXT_DIR)/package.json
+$(NPM_STAMP): $(EXT_DIR)/package.json $(EXT_DIR)/package-lock.json
 	@echo "==> Installing npm dependencies"
 	cd $(EXT_DIR) && $(NPM) install
 	@mkdir -p $(STAMP_DIR)
 	@touch $@
 
-$(REPORT_NPM_STAMP): $(REPORT_SHARED_DIR)/package.json
+$(REPORT_NPM_STAMP): $(REPORT_SHARED_DIR)/package.json $(REPORT_SHARED_DIR)/package-lock.json
 	@echo "==> Installing shared report front-end npm dependencies"
 	cd $(REPORT_SHARED_DIR) && $(NPM) install
 	@mkdir -p $(STAMP_DIR)
 	@touch $@
 
-$(SPEC_STUDIO_NPM_STAMP): $(SPEC_STUDIO_WEB)/package.json
+$(SPEC_STUDIO_NPM_STAMP): $(SPEC_STUDIO_WEB)/package.json $(SPEC_STUDIO_WEB)/package-lock.json
 	@echo "==> Installing spec studio front-end npm dependencies"
 	cd $(SPEC_STUDIO_WEB) && $(NPM) install
 	@mkdir -p $(STAMP_DIR)


### PR DESCRIPTION
## Summary

- record the successful VS Code `npm ci` as the Makefile dependency stamp in `test-ext` and release packaging jobs
- make every frontend npm stamp depend on both `package.json` and `package-lock.json`
- retain the existing npm installation and audit behavior unchanged

## Root cause

The workflow ran `npm ci`, then `make test-ext` or the packaging target entered the ordinary compile dependency graph and immediately ran `npm install` against the same package/lock pair again. The second command added no dependency coverage; it repeated installation and registry audit work in the same job.

## Experimental proof

- a representative CI `test-ext` run spent 4m44s in its explicit `npm ci`
- its later `make test-ext` then spent another 3m13s auditing the same 631-package tree
- after emulating the new post-`npm ci` stamp, `make -n npm-env` reports `Nothing to be done`
- touching `package-lock.json` makes the install recipe reappear, proving lockfile changes invalidate the stamp
- `make rust-check` passes
- `make prep-pr` passes, including all 29 smoke tests

This does not suppress `npm audit`, alter audit thresholds, or share a stamp between jobs. It only records installation already completed successfully inside the current job.