### PR TITLE
ci: stop duplicating performance monitoring on every merge

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -19,11 +19,11 @@ name: Performance
 
 on:
   push:
-    # `rust` gives the running trend — every merge is a data point,
-    # which is what makes a release number interpretable rather than a lone
-    # figure. `v*` gives the release record: those runs publish the graphs
-    # that go into the release notes and READMEs.
-    branches: [rust]
+    # `v*` gives the release record: those runs publish the graphs that go into
+    # the release notes and READMEs.  The nightly schedule below supplies the
+    # running trend.  Do not benchmark every merge as well: the suite is
+    # informational, so a merge-time result gates nothing and duplicates the
+    # next nightly sample on the same branch.
     tags: ["v*"]
   pull_request:
     branches: [rust]
@@ -39,8 +39,9 @@ on:
   # file sitting in the diff under review. Catching that after merge, or at
   # tag time, is catching it too late.
   schedule:
-    # Nightly on the default line, so the trend keeps accumulating even
-    # through weeks where nothing touches `rust/`.
+    # Nightly on the default line is the one regular trend sample.  This keeps
+    # accumulating even through weeks where nothing touches `rust/`, while
+    # avoiding one additional non-gating benchmark for every merge.
     - cron: "17 4 * * *"
   workflow_dispatch:
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,16 +1,40 @@
 name: OpenSSF Scorecard
 
-# Weekly and branch-protection-change OpenSSF Scorecard scan. Produces SARIF findings against
+# Weekly, score-input-change, and branch-protection-change OpenSSF Scorecard
+# scan. Produces SARIF findings against
 # supply-chain best practices (token permissions, pinned actions,
 # branch protection, signed releases, dependency-update tools, etc.) and
 # uploads them to the Security tab. This is monitoring, not gating: the
 # scheduled run catches dependency and ecosystem drift, while a protection
-# change triggers an immediate rescan. Ordinary source pushes cannot change
-# either input and therefore do not need a duplicate scan.
+# change or a change to repository inputs the score consumes triggers an
+# immediate rescan. Unrelated product-source pushes do not need a duplicate
+# scan.
 on:
   branch_protection_rule:
   schedule:
     - cron: "23 4 * * 2"
+  push:
+    branches: [rust]
+    paths:
+      # Scorecard reads workflow/action pins, token permissions, dependency
+      # update configuration, SAST/fuzzing setup, dependency manifests, the
+      # toolchain policy, and the repository licence/security policy.
+      - ".github/**"
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+      - "**/package.json"
+      - "**/package-lock.json"
+      - "**/pyproject.toml"
+      - "**/build.gradle*"
+      - "**/settings.gradle*"
+      - "editors/jetbrains/gradle/**"
+      - "editors/jetbrains/gradle.properties"
+      - "editors/jetbrains/gradlew*"
+      - "rust-toolchain.toml"
+      - "deny.toml"
+      - "LICENSE"
+      - "SECURITY.md"
+      - "rust/tcl-fuzz/**"
 
 permissions:
   contents: read

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,16 +1,16 @@
 name: OpenSSF Scorecard
 
-# Weekly OpenSSF Scorecard scan.  Produces SARIF findings against
+# Weekly and branch-protection-change OpenSSF Scorecard scan. Produces SARIF findings against
 # supply-chain best practices (token permissions, pinned actions,
 # branch protection, signed releases, dependency-update tools, etc.) and
-# uploads them to the Security tab.  This is monitoring, not gating —
-# we'll see score drift over time but it doesn't block PRs.
+# uploads them to the Security tab. This is monitoring, not gating: the
+# scheduled run catches dependency and ecosystem drift, while a protection
+# change triggers an immediate rescan. Ordinary source pushes cannot change
+# either input and therefore do not need a duplicate scan.
 on:
   branch_protection_rule:
   schedule:
     - cron: "23 4 * * 2"
-  push:
-    branches: [rust]
 
 permissions:
   contents: read

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,40 +1,16 @@
 name: OpenSSF Scorecard
 
-# Weekly, score-input-change, and branch-protection-change OpenSSF Scorecard
-# scan. Produces SARIF findings against
+# Weekly OpenSSF Scorecard scan.  Produces SARIF findings against
 # supply-chain best practices (token permissions, pinned actions,
 # branch protection, signed releases, dependency-update tools, etc.) and
-# uploads them to the Security tab. This is monitoring, not gating: the
-# scheduled run catches dependency and ecosystem drift, while a protection
-# change or a change to repository inputs the score consumes triggers an
-# immediate rescan. Unrelated product-source pushes do not need a duplicate
-# scan.
+# uploads them to the Security tab.  This is monitoring, not gating —
+# we'll see score drift over time but it doesn't block PRs.
 on:
   branch_protection_rule:
   schedule:
     - cron: "23 4 * * 2"
   push:
     branches: [rust]
-    paths:
-      # Scorecard reads workflow/action pins, token permissions, dependency
-      # update configuration, SAST/fuzzing setup, dependency manifests, the
-      # toolchain policy, and the repository licence/security policy.
-      - ".github/**"
-      - "**/Cargo.toml"
-      - "**/Cargo.lock"
-      - "**/package.json"
-      - "**/package-lock.json"
-      - "**/pyproject.toml"
-      - "**/build.gradle*"
-      - "**/settings.gradle*"
-      - "editors/jetbrains/gradle/**"
-      - "editors/jetbrains/gradle.properties"
-      - "editors/jetbrains/gradlew*"
-      - "rust-toolchain.toml"
-      - "deny.toml"
-      - "LICENSE"
-      - "SECURITY.md"
-      - "rust/tcl-fuzz/**"
 
 permissions:
   contents: read

--- a/Makefile
+++ b/Makefile
@@ -210,7 +210,7 @@ TS_SRCS  := $(shell find $(EXT_DIR)/src -name '*.ts' 2>/dev/null)
 # Tests
 .PHONY: test test-ext test-emacs test-rust rust-server rust-tcl rust-f5 rust-mcp rust-clis ensure-server-cross-deps server-cross-build server-cross-build-all mcp-cross-build-all cli-cross-build-all server-cross-test server-cross-test-build print-server-targets-all print-server-targets-jetbrains
 .PHONY: xtask-check xtask-editor-extensions xtask-kcs-index-links xtask-diag-tables xtask-diag-emission-check xtask-gen-editor-catalogs xtask-gen-bundled-environments xtask-gen-editor-dialects xtask-gen-irule-test-data xtask-gen-zed-queries xtask-gen-editor-settings xtask-gen-vscode-package xtask-gen-jetbrains-catalog xtask-gen-ai-diagnostics xtask-owner-resolution xtask-command-backing xtask-audit-option-dialects xtask-registry-oracle xtask-sslictcl-data xtask-runtime-stdlib tcltest-sweep tcltest-sweep-check xtask-f5query-builtins-doc xtask-bigip-data-schema xtask-c-api-ownership check-c-api-ownership
-.PHONY: xtask-workflow-sync xtask-resolution-drift xtask-retired-api-gate xtask-pack-goldens xtask-number-drift xtask-gen-tmlanguage-keywords xtask-option-registry-drift xtask-callback-inventory check-tcl-reference-toolchains check-spectcl-compat-paths check-runtime-rust-paths check-rust-tests-runner check-already-green check-wasm-cc-env check-homebrew-ci check-sign-and-upload xtask-dialect-drift xtask-segmentation-drift
+.PHONY: xtask-workflow-sync xtask-resolution-drift xtask-retired-api-gate xtask-pack-goldens xtask-number-drift xtask-gen-tmlanguage-keywords xtask-option-registry-drift xtask-callback-inventory check-tcl-reference-toolchains check-spectcl-compat-paths check-runtime-rust-paths check-rust-tests-runner check-already-green check-monitoring-triggers check-wasm-cc-env check-homebrew-ci check-sign-and-upload xtask-dialect-drift xtask-segmentation-drift
 # Lint / format / typecheck
 .PHONY: lint format lint-ts format-ts typecheck-ts check-rust check-rust-pr _check-rust-pr rust-deny
 .PHONY: build-report-assets build-report-pyz lint-report-ts typecheck-report-ts check-report-assets lint-spec-studio-ts typecheck-spec-studio-ts
@@ -759,7 +759,7 @@ coverage-ext: compile $(NPM_STAMP) ensure-vscode-test-deps ## Run VS Code extens
 # --- Native (cargo xtask) check gates.  These need the Rust toolchain, so CI
 # runs them in the rust-tests job (rust-gate.yml / ci.yml).  `xtask-check` is
 # the CI aggregate.
-xtask-check: check-tcl-reference-toolchains check-spectcl-compat-paths check-runtime-rust-paths check-rust-tests-runner check-already-green check-wasm-cc-env check-homebrew-ci check-sign-and-upload xtask-workflow-sync xtask-kcs-index-links xtask-diag-tables xtask-diag-emission-check xtask-gen-editor-catalogs xtask-gen-bundled-environments xtask-gen-editor-dialects xtask-gen-irule-test-data xtask-gen-zed-queries xtask-gen-tmlanguage-keywords xtask-gen-editor-settings xtask-gen-vscode-package xtask-gen-jetbrains-catalog xtask-gen-ai-diagnostics xtask-owner-resolution xtask-resolution-drift xtask-retired-api-gate xtask-pack-goldens xtask-number-drift xtask-segmentation-drift xtask-command-backing xtask-callback-inventory xtask-option-registry-drift xtask-sslictcl-data xtask-runtime-stdlib xtask-editor-extensions xtask-f5query-builtins-doc xtask-bigip-data-schema xtask-c-api-ownership ## Rust-side check gates (docs index coverage + generated-table/catalog drift) xtask-dialect-drift
+xtask-check: check-tcl-reference-toolchains check-spectcl-compat-paths check-runtime-rust-paths check-rust-tests-runner check-already-green check-monitoring-triggers check-wasm-cc-env check-homebrew-ci check-sign-and-upload xtask-workflow-sync xtask-kcs-index-links xtask-diag-tables xtask-diag-emission-check xtask-gen-editor-catalogs xtask-gen-bundled-environments xtask-gen-editor-dialects xtask-gen-irule-test-data xtask-gen-zed-queries xtask-gen-tmlanguage-keywords xtask-gen-editor-settings xtask-gen-vscode-package xtask-gen-jetbrains-catalog xtask-gen-ai-diagnostics xtask-owner-resolution xtask-resolution-drift xtask-retired-api-gate xtask-pack-goldens xtask-number-drift xtask-segmentation-drift xtask-command-backing xtask-callback-inventory xtask-option-registry-drift xtask-sslictcl-data xtask-runtime-stdlib xtask-editor-extensions xtask-f5query-builtins-doc xtask-bigip-data-schema xtask-c-api-ownership ## Rust-side check gates (docs index coverage + generated-table/catalog drift) xtask-dialect-drift
 
 check-tcl-reference-toolchains: ## Verify pinned C Tcl patchlevels across shell setup and Rust oracle discovery
 	@echo "==> Checking C Tcl reference toolchain ownership"
@@ -781,6 +781,10 @@ check-rust-tests-runner: ## Verify trusted rust-tests jobs serialize on the shar
 check-already-green: ## Verify exact-tree green-result reuse stays fail-closed for merges and squashes
 	@echo "==> Checking exact-tree green-result reuse"
 	@sh scripts/dev/test-already-green.sh
+
+check-monitoring-triggers: ## Verify monitoring cadence retains every score- and release-relevant trigger
+	@echo "==> Checking monitoring workflow triggers"
+	@sh scripts/dev/test-monitoring-triggers.sh
 
 check-wasm-cc-env: ## Verify wasm32 C-compiler selection and dependency diagnostics
 	@echo "==> Checking wasm32 C compiler bootstrap"

--- a/docs/design/contracts/release-and-publish.md
+++ b/docs/design/contracts/release-and-publish.md
@@ -353,8 +353,9 @@ stored, is a design conversation: it requires updating this contract and
   and [`scripts/release/perf_notes.py`](../../../scripts/release/perf_notes.py) —
   the release-notes performance graphs and the section that embeds them.
 - [`.github/workflows/perf.yml`](../../../.github/workflows/perf.yml) —
-  benchmarks every push and tag; attaches `perf-*.svg` / `perf-summary.md`
-  to the GitHub Release, which is what the notes link to.
+  benchmarks nightly, on release tags, and on manual dispatch; verifies graph
+  drift on pull requests; attaches `perf-*.svg` / `perf-summary.md` to the
+  GitHub Release, which is what the notes link to.
 - [`.github/workflows/ci.yml`](../../../.github/workflows/ci.yml) —
   builds artefacts, attests them, attaches them to the Release, and runs
   the three marketplace publish jobs.  Every `secrets.*` reference sits in a

--- a/scripts/dev/test-monitoring-triggers.sh
+++ b/scripts/dev/test-monitoring-triggers.sh
@@ -1,0 +1,73 @@
+#!/bin/sh
+# tcl-lsp — a language server and toolchain for Tcl
+# Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+# Fail closed if a future cadence edit removes a release benchmark or an
+# immediate Scorecard scan for a repository input that affects the score.
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+REPO_ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/../.." && pwd)
+PERF=$REPO_ROOT/.github/workflows/perf.yml
+SCORECARD=$REPO_ROOT/.github/workflows/scorecard.yml
+
+perf_push=$(awk '
+    /^  push:/ { in_push = 1 }
+    in_push && /^  pull_request:/ { exit }
+    in_push { print }
+' "$PERF")
+
+printf '%s\n' "$perf_push" | grep -Fq 'tags: ["v*"]' || {
+    echo "performance workflow must benchmark release tags" >&2
+    exit 1
+}
+if printf '%s\n' "$perf_push" | grep -Fq 'branches: [rust]'; then
+    echo "performance workflow must not duplicate nightly benchmarks on every merge" >&2
+    exit 1
+fi
+
+scorecard_push=$(awk '
+    /^  push:/ { in_push = 1 }
+    in_push && /^permissions:/ { exit }
+    in_push { print }
+' "$SCORECARD")
+
+for required in \
+    'branches: [rust]' \
+    'paths:' \
+    '".github/**"' \
+    '"**/Cargo.toml"' \
+    '"**/Cargo.lock"' \
+    '"**/package.json"' \
+    '"**/package-lock.json"' \
+    '"**/pyproject.toml"' \
+    '"**/build.gradle*"' \
+    '"**/settings.gradle*"' \
+    '"editors/jetbrains/gradle/**"' \
+    '"editors/jetbrains/gradle.properties"' \
+    '"editors/jetbrains/gradlew*"' \
+    '"rust-toolchain.toml"' \
+    '"deny.toml"' \
+    '"LICENSE"' \
+    '"SECURITY.md"' \
+    '"rust/tcl-fuzz/**"'
+do
+    printf '%s\n' "$scorecard_push" | grep -Fq -- "$required" || {
+        echo "Scorecard push filter lost required input: $required" >&2
+        exit 1
+    }
+done
+
+grep -Fq 'branch_protection_rule:' "$SCORECARD" || {
+    echo "Scorecard must rescan branch-protection changes" >&2
+    exit 1
+}
+grep -Fq 'cron: "23 4 * * 2"' "$SCORECARD" || {
+    echo "Scorecard must retain its weekly ecosystem-drift scan" >&2
+    exit 1
+}
+
+echo "monitoring workflow trigger contract passed"

--- a/scripts/dev/test-monitoring-triggers.sh
+++ b/scripts/dev/test-monitoring-triggers.sh
@@ -4,8 +4,10 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-# Fail closed if a future cadence edit removes a release benchmark or an
-# immediate Scorecard scan for a repository input that affects the score.
+# Fail closed if a future cadence edit removes a release benchmark or narrows
+# the repository-wide Scorecard push scan. Binary-Artifacts examines file
+# content, including extensionless executables, so filename filters are not a
+# complete representation of its input surface.
 
 set -eu
 
@@ -35,31 +37,14 @@ scorecard_push=$(awk '
     in_push { print }
 ' "$SCORECARD")
 
-for required in \
-    'branches: [rust]' \
-    'paths:' \
-    '".github/**"' \
-    '"**/Cargo.toml"' \
-    '"**/Cargo.lock"' \
-    '"**/package.json"' \
-    '"**/package-lock.json"' \
-    '"**/pyproject.toml"' \
-    '"**/build.gradle*"' \
-    '"**/settings.gradle*"' \
-    '"editors/jetbrains/gradle/**"' \
-    '"editors/jetbrains/gradle.properties"' \
-    '"editors/jetbrains/gradlew*"' \
-    '"rust-toolchain.toml"' \
-    '"deny.toml"' \
-    '"LICENSE"' \
-    '"SECURITY.md"' \
-    '"rust/tcl-fuzz/**"'
-do
-    printf '%s\n' "$scorecard_push" | grep -Fq -- "$required" || {
-        echo "Scorecard push filter lost required input: $required" >&2
-        exit 1
-    }
-done
+printf '%s\n' "$scorecard_push" | grep -Fq 'branches: [rust]' || {
+    echo "Scorecard must scan every rust push" >&2
+    exit 1
+}
+if printf '%s\n' "$scorecard_push" | grep -Eq '^[[:space:]]+paths(-ignore)?:'; then
+    echo "Scorecard push scan must not use an incomplete filename filter" >&2
+    exit 1
+fi
 
 grep -Fq 'branch_protection_rule:' "$SCORECARD" || {
     echo "Scorecard must rescan branch-protection changes" >&2


### PR DESCRIPTION
## Summary

- stop running the informational performance workflow after every ordinary push to `rust`
- retain nightly trend samples, release-tag benchmarks, pull-request graph drift checks, and manual runs
- keep OpenSSF Scorecard on every `rust` push after auditing its repository-wide input surface
- add a fail-closed trigger contract and update the release/publish contract

## Root cause

The performance workflow ran a non-gating benchmark after every merge even though the nightly run supplies the same trend sample and release tags retain exact release measurements.

Scorecard was investigated separately and deliberately not trimmed: checks such as Binary-Artifacts inspect repository file content, including extensionless binaries, so a filename filter cannot completely represent its inputs.

## Evidence since 2.2.0

- Performance: 212 pull-request runs / 52.87 workflow-minutes retained
- Performance: 62 ordinary `rust` push runs / 398.32 workflow-minutes removed
- release-tag, scheduled, and manual benchmark triggers remain
- all 57 ordinary Scorecard push runs remain, along with weekly and branch-protection-triggered scans
- the static contract pins release benchmarks, prevents merge-time performance duplication, and prevents incomplete Scorecard filename filtering
- `make rust-check` and `make prep-pr` pass after all review fixes; all 29 smoke tests pass

No check is removed: the change reduces redundant performance-monitoring cadence only.