### PR TITLE
ci: reuse green PRs after identical squashes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,22 +177,23 @@ jobs:
                 --jq ".[] | select(.merged_at != null and .merge_commit_sha == \"$GITHUB_SHA\" and .base.ref == \"rust\") | .head.sha" \
                 2>/dev/null)" || pr_heads=""
             fi
-            current_tree="$(git rev-parse 'HEAD^{tree}')"
-            for pr_head in $pr_heads; do
+            # More than one association is ambiguous even if one candidate
+            # happens to share the tree. Ambiguity must run the complete suite.
+            if [ "$(printf '%s\n' "$pr_heads" | awk 'NF { n += NF } END { print n + 0 }')" -eq 1 ]; then
+              pr_head="$pr_heads"
+              current_tree="$(git rev-parse 'HEAD^{tree}')"
               pr_tree="$(git rev-parse "$pr_head^{tree}" 2>/dev/null || true)"
               if [ -z "$pr_tree" ]; then
                 pr_tree="$(gh api "repos/$GITHUB_REPOSITORY/git/commits/$pr_head" \
                   --jq '.tree.sha' 2>/dev/null)" || pr_tree=""
               fi
-              [ -n "$pr_tree" ] && [ "$current_tree" = "$pr_tree" ] || continue
-              n="$(gh api "$api?head_sha=$pr_head&event=pull_request&status=success&per_page=20" \
-                    --jq "[.workflow_runs[] | select(.updated_at > \"$cutoff\")] | length" \
-                    2>/dev/null || echo 0)"
-              if [ "${n:-0}" -gt 0 ]; then
-                already=true
-                break
+              if [ -n "$pr_tree" ] && [ "$current_tree" = "$pr_tree" ]; then
+                n="$(gh api "$api?head_sha=$pr_head&event=pull_request&status=success&per_page=20" \
+                      --jq "[.workflow_runs[] | select(.updated_at > \"$cutoff\")] | length" \
+                      2>/dev/null || echo 0)"
+                [ "${n:-0}" -gt 0 ] && already=true
               fi
-            done
+            fi
           fi
           echo "already_green=$already" >> "$GITHUB_OUTPUT"
           echo "already_green=$already (ref=$GITHUB_REF sha=$GITHUB_SHA)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,15 +64,15 @@ jobs:
   #                        pure repetition (measured: v2.1.18 re-ran the
   #                        identical 20-job surface on the same SHA 74 minutes
   #                        after it went green);
-  #                      * a push to rust of a merge commit whose tree is
-  #                        byte-identical to a PR head with a green PR run —
-  #                        what the merge button produces when the PR was up to
-  #                        date with the base.  Tree equality is the guarantee
-  #                        that matters: identical tree ⇒ identical inputs ⇒
-  #                        identical verdict, and a merge that DID pick up new
-  #                        base-branch commits gets a different tree and a full
-  #                        re-test — exactly the case where re-testing has
-  #                        value.
+  #                      * a push to rust of a merge or squash commit whose
+  #                        tree is byte-identical to the associated PR head
+  #                        with a green PR run — what the merge button produces
+  #                        when the PR was up to date with the base.  Tree
+  #                        equality is the guarantee that matters: identical
+  #                        tree ⇒ identical inputs ⇒ identical verdict, and a
+  #                        merge that DID pick up new base-branch commits gets
+  #                        a different tree and a full re-test — exactly the
+  #                        case where re-testing has value.
   #                    The 24 h bound stops the skip compounding into stale
   #                    territory: the floating `stable` toolchain and the
   #                    advisory database both move under an unchanged tree, so
@@ -122,6 +122,7 @@ jobs:
     permissions:
       contents: read
       actions: read # query prior workflow runs for already_green
+      pull-requests: read # resolve a squash commit back to its PR head
     outputs:
       prerelease: ${{ steps.detect.outputs.prerelease }}
       already_green: ${{ steps.green.outputs.already_green }}
@@ -136,8 +137,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # Depth 2 so a merge commit's parents resolve for the tree
-          # comparison in the already-green check.
+          # Depth 2 so a two-parent merge commit's PR parent resolves locally.
+          # Squash PR heads are resolved through the API below.
           fetch-depth: 2
       - name: Detect release channel from the ref
         id: detect
@@ -166,17 +167,32 @@ jobs:
                   2>/dev/null || echo 0)"
             [ "${n:-0}" -gt 0 ] && already=true
           elif [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
-            # Merge push: does a PR head with the identical tree have a green
-            # PR run?  HEAD^2 only exists on a 2-parent merge commit; squash
-            # and direct pushes fall through to a full run.
-            pr_head="$(git rev-parse -q --verify HEAD^2 || true)"
-            if [ -n "$pr_head" ] &&
-              [ "$(git rev-parse 'HEAD^{tree}')" = "$(git rev-parse "$pr_head^{tree}")" ]; then
+            # Merge push: find the PR head, then require exact tree equality
+            # before carrying its green result forward. A two-parent merge has
+            # the head locally as HEAD^2. For a squash merge, GitHub records
+            # the association even though the PR head is not an ancestor.
+            pr_heads="$(git rev-parse -q --verify HEAD^2 || true)"
+            if [ -z "$pr_heads" ]; then
+              pr_heads="$(gh api "repos/$GITHUB_REPOSITORY/commits/$GITHUB_SHA/pulls" \
+                --jq ".[] | select(.merged_at != null and .merge_commit_sha == \"$GITHUB_SHA\" and .base.ref == \"rust\") | .head.sha" \
+                2>/dev/null)" || pr_heads=""
+            fi
+            current_tree="$(git rev-parse 'HEAD^{tree}')"
+            for pr_head in $pr_heads; do
+              pr_tree="$(git rev-parse "$pr_head^{tree}" 2>/dev/null || true)"
+              if [ -z "$pr_tree" ]; then
+                pr_tree="$(gh api "repos/$GITHUB_REPOSITORY/git/commits/$pr_head" \
+                  --jq '.tree.sha' 2>/dev/null)" || pr_tree=""
+              fi
+              [ -n "$pr_tree" ] && [ "$current_tree" = "$pr_tree" ] || continue
               n="$(gh api "$api?head_sha=$pr_head&event=pull_request&status=success&per_page=20" \
                     --jq "[.workflow_runs[] | select(.updated_at > \"$cutoff\")] | length" \
                     2>/dev/null || echo 0)"
-              [ "${n:-0}" -gt 0 ] && already=true
-            fi
+              if [ "${n:-0}" -gt 0 ]; then
+                already=true
+                break
+              fi
+            done
           fi
           echo "already_green=$already" >> "$GITHUB_OUTPUT"
           echo "already_green=$already (ref=$GITHUB_REF sha=$GITHUB_SHA)"

--- a/Makefile
+++ b/Makefile
@@ -210,7 +210,7 @@ TS_SRCS  := $(shell find $(EXT_DIR)/src -name '*.ts' 2>/dev/null)
 # Tests
 .PHONY: test test-ext test-emacs test-rust rust-server rust-tcl rust-f5 rust-mcp rust-clis ensure-server-cross-deps server-cross-build server-cross-build-all mcp-cross-build-all cli-cross-build-all server-cross-test server-cross-test-build print-server-targets-all print-server-targets-jetbrains
 .PHONY: xtask-check xtask-editor-extensions xtask-kcs-index-links xtask-diag-tables xtask-diag-emission-check xtask-gen-editor-catalogs xtask-gen-bundled-environments xtask-gen-editor-dialects xtask-gen-irule-test-data xtask-gen-zed-queries xtask-gen-editor-settings xtask-gen-vscode-package xtask-gen-jetbrains-catalog xtask-gen-ai-diagnostics xtask-owner-resolution xtask-command-backing xtask-audit-option-dialects xtask-registry-oracle xtask-sslictcl-data xtask-runtime-stdlib tcltest-sweep tcltest-sweep-check xtask-f5query-builtins-doc xtask-bigip-data-schema xtask-c-api-ownership check-c-api-ownership
-.PHONY: xtask-workflow-sync xtask-resolution-drift xtask-retired-api-gate xtask-pack-goldens xtask-number-drift xtask-gen-tmlanguage-keywords xtask-option-registry-drift xtask-callback-inventory check-tcl-reference-toolchains check-spectcl-compat-paths check-runtime-rust-paths check-rust-tests-runner check-wasm-cc-env check-homebrew-ci check-sign-and-upload xtask-dialect-drift xtask-segmentation-drift
+.PHONY: xtask-workflow-sync xtask-resolution-drift xtask-retired-api-gate xtask-pack-goldens xtask-number-drift xtask-gen-tmlanguage-keywords xtask-option-registry-drift xtask-callback-inventory check-tcl-reference-toolchains check-spectcl-compat-paths check-runtime-rust-paths check-rust-tests-runner check-already-green check-wasm-cc-env check-homebrew-ci check-sign-and-upload xtask-dialect-drift xtask-segmentation-drift
 # Lint / format / typecheck
 .PHONY: lint format lint-ts format-ts typecheck-ts check-rust check-rust-pr _check-rust-pr rust-deny
 .PHONY: build-report-assets build-report-pyz lint-report-ts typecheck-report-ts check-report-assets lint-spec-studio-ts typecheck-spec-studio-ts
@@ -759,7 +759,7 @@ coverage-ext: compile $(NPM_STAMP) ensure-vscode-test-deps ## Run VS Code extens
 # --- Native (cargo xtask) check gates.  These need the Rust toolchain, so CI
 # runs them in the rust-tests job (rust-gate.yml / ci.yml).  `xtask-check` is
 # the CI aggregate.
-xtask-check: check-tcl-reference-toolchains check-spectcl-compat-paths check-runtime-rust-paths check-rust-tests-runner check-wasm-cc-env check-homebrew-ci check-sign-and-upload xtask-workflow-sync xtask-kcs-index-links xtask-diag-tables xtask-diag-emission-check xtask-gen-editor-catalogs xtask-gen-bundled-environments xtask-gen-editor-dialects xtask-gen-irule-test-data xtask-gen-zed-queries xtask-gen-tmlanguage-keywords xtask-gen-editor-settings xtask-gen-vscode-package xtask-gen-jetbrains-catalog xtask-gen-ai-diagnostics xtask-owner-resolution xtask-resolution-drift xtask-retired-api-gate xtask-pack-goldens xtask-number-drift xtask-segmentation-drift xtask-command-backing xtask-callback-inventory xtask-option-registry-drift xtask-sslictcl-data xtask-runtime-stdlib xtask-editor-extensions xtask-f5query-builtins-doc xtask-bigip-data-schema xtask-c-api-ownership ## Rust-side check gates (docs index coverage + generated-table/catalog drift) xtask-dialect-drift
+xtask-check: check-tcl-reference-toolchains check-spectcl-compat-paths check-runtime-rust-paths check-rust-tests-runner check-already-green check-wasm-cc-env check-homebrew-ci check-sign-and-upload xtask-workflow-sync xtask-kcs-index-links xtask-diag-tables xtask-diag-emission-check xtask-gen-editor-catalogs xtask-gen-bundled-environments xtask-gen-editor-dialects xtask-gen-irule-test-data xtask-gen-zed-queries xtask-gen-tmlanguage-keywords xtask-gen-editor-settings xtask-gen-vscode-package xtask-gen-jetbrains-catalog xtask-gen-ai-diagnostics xtask-owner-resolution xtask-resolution-drift xtask-retired-api-gate xtask-pack-goldens xtask-number-drift xtask-segmentation-drift xtask-command-backing xtask-callback-inventory xtask-option-registry-drift xtask-sslictcl-data xtask-runtime-stdlib xtask-editor-extensions xtask-f5query-builtins-doc xtask-bigip-data-schema xtask-c-api-ownership ## Rust-side check gates (docs index coverage + generated-table/catalog drift) xtask-dialect-drift
 
 check-tcl-reference-toolchains: ## Verify pinned C Tcl patchlevels across shell setup and Rust oracle discovery
 	@echo "==> Checking C Tcl reference toolchain ownership"
@@ -777,6 +777,10 @@ check-runtime-rust-paths: ## Verify CI's standalone-runtime dependency closure a
 check-rust-tests-runner: ## Verify trusted rust-tests jobs serialize on the shared tank host
 	@echo "==> Checking self-hosted Rust test scheduling"
 	@sh scripts/dev/test-rust-tests-runner.sh
+
+check-already-green: ## Verify exact-tree green-result reuse stays fail-closed for merges and squashes
+	@echo "==> Checking exact-tree green-result reuse"
+	@sh scripts/dev/test-already-green.sh
 
 check-wasm-cc-env: ## Verify wasm32 C-compiler selection and dependency diagnostics
 	@echo "==> Checking wasm32 C compiler bootstrap"

--- a/scripts/dev/test-already-green.sh
+++ b/scripts/dev/test-already-green.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+# tcl-lsp — a language server and toolchain for Tcl
+# Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+# Contract for carrying a green pull-request result onto its merge push. The
+# optimization is safe only while it resolves the real PR head, compares exact
+# Git tree identities, is bounded in time, and fails closed on every API error.
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+REPO_ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/../.." && pwd)
+WORKFLOW=$REPO_ROOT/.github/workflows/ci.yml
+
+green_step=$(awk '
+    /      - name: Check whether this exact code is already green/ { in_step = 1 }
+    in_step && /      - name: Classify changed paths/ { exit }
+    in_step { print }
+' "$WORKFLOW")
+
+test -n "$green_step" || {
+    echo "ci.yml must define the exact-code already-green step" >&2
+    exit 1
+}
+
+require_text() {
+    description=$1
+    wanted=$2
+    case "$green_step" in
+        *"$wanted"*) ;;
+        *)
+            echo "already-green contract lost $description" >&2
+            exit 1
+            ;;
+    esac
+}
+
+case "$(cat "$WORKFLOW")" in
+    *'pull-requests: read # resolve a squash commit back to its PR head'*) ;;
+    *)
+        echo "the channel job needs read-only PR permission for squash resolution" >&2
+        exit 1
+        ;;
+esac
+
+require_text "the 24-hour freshness bound" "date -u -d '24 hours ago'"
+require_text "two-parent merge-head resolution" 'git rev-parse -q --verify HEAD^2'
+require_text "squash-to-PR resolution" 'commits/$GITHUB_SHA/pulls'
+require_text "the exact merged-commit association" '.merge_commit_sha == \"$GITHUB_SHA\"'
+require_text "the protected base-branch restriction" '.base.ref == \"rust\"'
+require_text "the PR-head tree lookup" 'git/commits/$pr_head'
+require_text "local current-tree identity" "git rev-parse 'HEAD^{tree}'"
+require_text "exact tree equality" '[ "$current_tree" = "$pr_tree" ]'
+require_text "successful PR workflow lookup" 'head_sha=$pr_head&event=pull_request&status=success'
+require_text "fail-closed PR resolution" '|| pr_heads=""'
+require_text "fail-closed tree resolution" '|| pr_tree=""'
+
+echo "exact-tree green-result reuse contract passed"

--- a/scripts/dev/test-already-green.sh
+++ b/scripts/dev/test-already-green.sh
@@ -50,6 +50,7 @@ require_text "two-parent merge-head resolution" 'git rev-parse -q --verify HEAD^
 require_text "squash-to-PR resolution" 'commits/$GITHUB_SHA/pulls'
 require_text "the exact merged-commit association" '.merge_commit_sha == \"$GITHUB_SHA\"'
 require_text "the protected base-branch restriction" '.base.ref == \"rust\"'
+require_text "fail-closed ambiguous association handling" "awk 'NF { n += NF } END { print n + 0 }')\" -eq 1"
 require_text "the PR-head tree lookup" 'git/commits/$pr_head'
 require_text "local current-tree identity" "git rev-parse 'HEAD^{tree}'"
 require_text "exact tree equality" '[ "$current_tree" = "$pr_tree" ]'


### PR DESCRIPTION
## Summary

- extend the existing 24-hour exact-tree green-result reuse to squash merges
- resolve GitHub's commit-to-PR association and compare the single resulting PR-head tree to the pushed tree
- fail closed on absent or ambiguous associations, API errors, tree differences, stale runs, or non-green runs
- add a static workflow contract and regression fixture

## Root cause

The existing duplicate-work suppression handled tags and two-parent merge commits, but the repository normally squash-merges PRs. Those squash commits have one parent, so an already-green, byte-identical tree was fully retested after merge.

## Experimental proof

- merged PR #1812 is an exact-tree squash candidate and the detector returns true
- merged PR #1823 has a different head/merge tree and the detector returns false
- 4 of 20 recent merges (20%) were exact-tree candidates
- equality is on Git tree hashes, not commit identity; a squash that picks up any different base content runs the complete suite
- the prior 24-hour freshness and successful-PR-workflow requirements remain
- API failures, missing or multiple associations, and tree differences run the complete suite
- the static contract pins exact association, single-head resolution, freshness, and tree equality
- `make rust-check` and `make prep-pr` pass after the review fix; all 29 smoke tests pass