### PR TITLE
test(lsp): make progressive coverage deterministic

### DIFF
--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -1484,6 +1484,63 @@ const SEMANTIC_TOKENS_FAST_PATH_BUDGET: std::time::Duration = std::time::Duratio
 /// half that keeps trivial files a single publish regardless of cold-start.
 const DIAGNOSTICS_FAST_TIER_BUDGET: std::time::Duration = std::time::Duration::from_millis(40);
 
+/// One-shot test seam that chooses the semantic-token coarse branch without a
+/// timing race. Integration tests use it to exercise the real continuation on
+/// a compact document, then make the refresh-driven re-request await the real
+/// enriched arm; separate latency tests still cover the 40 ms race.
+/// Unset or any value other than `1` is a no-op in every real session.
+const FORCE_SEMANTIC_TOKENS_COARSE_ENV: &str = "TCL_LSP_TEST_FORCE_SEMANTIC_TOKENS_COARSE";
+
+/// One-shot test seam that chooses the progressive diagnostics fast branch.
+/// See [`FORCE_SEMANTIC_TOKENS_COARSE_ENV`].
+const FORCE_DIAGNOSTICS_FAST_TIER_ENV: &str = "TCL_LSP_TEST_FORCE_DIAGNOSTICS_FAST_TIER";
+
+// Process-wide state for the one-shot semantic-token override. A convergence
+// re-request must observe the now-memoised enriched result normally rather
+// than being forced through the coarse path forever.
+static FORCE_SEMANTIC_TOKENS_COARSE_ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+static FORCE_SEMANTIC_TOKENS_COARSE_TAKEN: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+fn semantic_tokens_test_seam_enabled() -> bool {
+    *FORCE_SEMANTIC_TOKENS_COARSE_ENABLED
+        .get_or_init(|| std::env::var(FORCE_SEMANTIC_TOKENS_COARSE_ENV).as_deref() == Ok("1"))
+}
+
+/// Take the configured semantic-token branch override once per process.
+fn take_force_semantic_tokens_coarse() -> bool {
+    semantic_tokens_test_seam_enabled()
+        && !FORCE_SEMANTIC_TOKENS_COARSE_TAKEN.swap(true, std::sync::atomic::Ordering::Relaxed)
+}
+
+/// Let a test retry the forced branch when a normal salsa cancellation meant
+/// its first continuation never reached the comparison.
+fn rearm_semantic_tokens_test_seam() {
+    if semantic_tokens_test_seam_enabled() {
+        FORCE_SEMANTIC_TOKENS_COARSE_TAKEN.store(false, std::sync::atomic::Ordering::Relaxed);
+    }
+}
+
+// Process-wide state for the one-shot diagnostics override.
+static FORCE_DIAGNOSTICS_FAST_TIER_ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+static FORCE_DIAGNOSTICS_FAST_TIER_TAKEN: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+/// Whether the diagnostics override is still available. It is consumed only
+/// after the shared base analysis succeeds, so a normal salsa cancellation and
+/// retry cannot spend the one shot without publishing the fast tier.
+fn diagnostics_fast_tier_force_pending() -> bool {
+    *FORCE_DIAGNOSTICS_FAST_TIER_ENABLED
+        .get_or_init(|| std::env::var(FORCE_DIAGNOSTICS_FAST_TIER_ENV).as_deref() == Ok("1"))
+        && !FORCE_DIAGNOSTICS_FAST_TIER_TAKEN.load(std::sync::atomic::Ordering::Relaxed)
+}
+
+/// Consume the diagnostics override after the base analysis has succeeded.
+fn take_force_diagnostics_fast_tier() -> bool {
+    diagnostics_fast_tier_force_pending()
+        && !FORCE_DIAGNOSTICS_FAST_TIER_TAKEN.swap(true, std::sync::atomic::Ordering::Relaxed)
+}
+
 /// How long [`Backend::report_edit_barrier_stall`] waits between its two
 /// [`DocumentStore::contention`] samples.
 ///
@@ -2648,21 +2705,23 @@ impl DeliveryCtx<'_> {
     async fn deliver_fast_tier_if_current(
         &self,
         diags: Vec<tower_lsp_server::ls_types::Diagnostic>,
-    ) {
+    ) -> Option<tokio::sync::oneshot::Receiver<DiagnosticPublishOutcome>> {
         if self.client_supports_pull {
-            return;
+            return None;
         }
         let docs = self.documents.lock("deliver_fast_tier_if_current").await;
         if self.is_current(&docs).await {
             // Do not wait: the deep future is pinned in this same task and must
             // keep progressing so its authoritative set can replace this one.
-            drop(self.diagnostic_publisher.enqueue(
+            Some(self.diagnostic_publisher.enqueue(
                 self.uri.clone(),
                 diags,
                 self.version,
                 false,
                 false,
-            ));
+            ))
+        } else {
+            None
         }
     }
 
@@ -4511,15 +4570,18 @@ async fn run_diagnostics_analyser_path(
     );
     tokio::pin!(deep);
 
-    tokio::select! {
-        biased;
-        // The whole pipeline finished inside the budget: the deep publish is the
-        // one and only publish, so the fast tier is never sent (no redundant
-        // round-trip on small / warm files — the debounce-skip trap #844 calls
-        // out).  `biased` prefers this arm so a deep pass that lands right on the
-        // deadline still skips the fast tier.
-        settled = &mut deep => return settled,
-        () = crate::rt::sleep_until(fast_tier_deadline) => {}
+    let force_fast_tier = diagnostics_fast_tier_force_pending();
+    if !force_fast_tier {
+        tokio::select! {
+            biased;
+            // The whole pipeline finished inside the budget: the deep publish is the
+            // one and only publish, so the fast tier is never sent (no redundant
+            // round-trip on small / warm files — the debounce-skip trap #844 calls
+            // out).  `biased` prefers this arm so a deep pass that lands right on the
+            // deadline still skips the fast tier.
+            settled = &mut deep => return settled,
+            () = crate::rt::sleep_until(fast_tier_deadline) => {}
+        }
     }
 
     // Budget elapsed with the deep pass still running: publish the flicker-safe
@@ -4527,7 +4589,20 @@ async fn run_diagnostics_analyser_path(
     // — one in-flight read, never a second whole-file walk. A cancellation here is
     // harmless: the deep pass observes the same edit and settles it.
     if let ControlFlow::Continue(analysis) = base.await {
-        publish_fast_tier(delivery, &analysis, lift_inputs).await;
+        // Spend the one shot only once there is a real fast tier to publish. A
+        // cancelled base analysis returns below with it still available for
+        // the scheduler's retry.
+        if force_fast_tier && !take_force_diagnostics_fast_tier() {
+            return deep.await;
+        }
+        let fast_receipt = publish_fast_tier(delivery, &analysis, lift_inputs).await;
+        // The test seam waits until the actual push reaches the reference
+        // client before allowing the deep future to replace it. Production
+        // drops this receipt immediately and retains the fully concurrent
+        // progressive path above.
+        if force_fast_tier && let Some(receipt) = fast_receipt {
+            let _ = receipt.await;
+        }
     }
     deep.await
 }
@@ -4709,7 +4784,7 @@ async fn publish_fast_tier(
     delivery: &DeliveryCtx<'_>,
     analysis: &Arc<AnalysisResult>,
     lift_inputs: &LiftInputs<'_>,
-) {
+) -> Option<tokio::sync::oneshot::Receiver<DiagnosticPublishOutcome>> {
     let fast: Vec<tcl_compiler::analyser::Diagnostic> = analysis
         .diagnostics
         .iter()
@@ -4742,7 +4817,9 @@ async fn publish_fast_tier(
     })
     .await;
     if let Ok(diagnostics) = lifted {
-        delivery.deliver_fast_tier_if_current(diagnostics).await;
+        delivery.deliver_fast_tier_if_current(diagnostics).await
+    } else {
+        None
     }
 }
 
@@ -8907,46 +8984,52 @@ impl Backend {
             return Ok(data);
         };
 
-        tokio::select! {
-            biased;
-            result = &mut enriched => {
-                if let Ok(Some(tokens)) = result {
-                    // The enriched tier won the race and is being served as-is:
-                    // settled, nothing to converge to.
+        if semantic_tokens_test_seam_enabled() {
+            if let Some(tokens) = self.semantic_tokens_test_override(uri, enriched).await {
+                return Ok(tokens);
+            }
+        } else {
+            tokio::select! {
+                biased;
+                result = &mut enriched => {
+                    if let Ok(Some(tokens)) = result {
+                        // The enriched tier won the race and is being served as-is:
+                        // settled, nothing to converge to.
+                        log_full_convergence_settled(
+                            &self.client,
+                            uri,
+                            false,
+                            FullSettleOutcome::ServedEnriched,
+                        )
+                        .await;
+                        return Ok(tokens.data);
+                    }
+                    // A genuine salsa cancellation (a concurrent edit landed) or a
+                    // worker panic — either way, don't retry inline or surface an
+                    // error: fall through to the cheap coarse tier below so the
+                    // caller still gets a prompt result. The edit that cancelled
+                    // this read has already scheduled its own diagnostics run,
+                    // which will prime a fresh enriched result for the next
+                    // request.
+                    //
+                    // Settle explicitly: the coarse tier is about to be served and
+                    // *no* continuation is detached on this path, so without the
+                    // marker an observer waiting for the convergence decision would
+                    // wait for something that is never coming.
                     log_full_convergence_settled(
                         &self.client,
                         uri,
                         false,
-                        FullSettleOutcome::ServedEnriched,
+                        FullSettleOutcome::Cancelled,
                     )
                     .await;
-                    return Ok(tokens.data);
                 }
-                // A genuine salsa cancellation (a concurrent edit landed) or a
-                // worker panic — either way, don't retry inline or surface an
-                // error: fall through to the cheap coarse tier below so the
-                // caller still gets a prompt result. The edit that cancelled
-                // this read has already scheduled its own diagnostics run,
-                // which will prime a fresh enriched result for the next
-                // request.
-                //
-                // Settle explicitly: the coarse tier is about to be served and
-                // *no* continuation is detached on this path, so without the
-                // marker an observer waiting for the convergence decision would
-                // wait for something that is never coming.
-                log_full_convergence_settled(
-                    &self.client,
-                    uri,
-                    false,
-                    FullSettleOutcome::Cancelled,
-                )
-                .await;
-            }
-            () = crate::rt::sleep(SEMANTIC_TOKENS_FAST_PATH_BUDGET) => {
-                // Too slow for a synchronous first paint: hand the still-running
-                // enriched read to a detached continuation rather than blocking
-                // this response on it, and serve the coarse tier below.
-                self.spawn_full_convergence(uri, enriched).await;
+                () = crate::rt::sleep(SEMANTIC_TOKENS_FAST_PATH_BUDGET) => {
+                    // Too slow for a synchronous first paint: hand the still-running
+                    // enriched read to a detached continuation rather than blocking
+                    // this response on it, and serve the coarse tier below.
+                    self.spawn_full_convergence(uri, enriched).await;
+                }
             }
         }
 
@@ -8966,6 +9049,34 @@ impl Backend {
             message: format!("semantic_tokens worker panicked: {err}").into(),
             data: None,
         })
+    }
+
+    /// Deterministically select both sides of the semantic-token budget race
+    /// for an integration-test child process.
+    async fn semantic_tokens_test_override(
+        &self,
+        uri: &Uri,
+        enriched: crate::rt::JoinHandle<Option<tcl_lsp_core::semantic_tokens::SemanticTokens>>,
+    ) -> Option<Vec<u32>> {
+        if take_force_semantic_tokens_coarse() {
+            self.spawn_full_convergence(uri, enriched).await;
+            return None;
+        }
+
+        // After the first forced-coarse response, make the refresh-driven
+        // re-request await the genuine enriched arm without a timing race.
+        if let Ok(Some(tokens)) = enriched.await {
+            log_full_convergence_settled(
+                &self.client,
+                uri,
+                false,
+                FullSettleOutcome::ServedEnriched,
+            )
+            .await;
+            return Some(tokens.data);
+        }
+        log_full_convergence_settled(&self.client, uri, false, FullSettleOutcome::Cancelled).await;
+        None
     }
 
     /// Detach the `semanticTokens/full` convergence continuation for a request
@@ -9011,6 +9122,9 @@ impl Backend {
                 }
                 _ => FullSettleOutcome::Cancelled,
             };
+            if matches!(outcome, FullSettleOutcome::Cancelled) {
+                rearm_semantic_tokens_test_seam();
+            }
             // Release the per-URI claim only now the decision is made, so every
             // request that arrived while this ran rode along with it — and honour
             // what rode along: a request skipped as `coalesced` has no refresh of
@@ -18173,17 +18287,31 @@ impl Backend {
                 > = None;
                 let mut analysis_slot: Option<Option<Arc<tcl_compiler::analyser::AnalysisResult>>> =
                     None;
-                let both_ready = tokio::select! {
-                    biased;
-                    () = async {
-                        tokio::join!(
-                            async { cu_slot = Some((&mut cu_handle).await.ok().flatten()) },
-                            async {
-                                analysis_slot = Some((&mut analysis_handle).await.ok().flatten());
-                            },
-                        );
-                    } => true,
-                    () = crate::rt::sleep(SEMANTIC_TOKENS_FAST_PATH_BUDGET) => false,
+                let both_ready = if take_force_semantic_tokens_coarse() {
+                    false
+                } else if semantic_tokens_test_seam_enabled() {
+                    // The refresh-driven re-request takes the real enriched
+                    // arm deterministically; see the full-token twin above.
+                    tokio::join!(
+                        async { cu_slot = Some((&mut cu_handle).await.ok().flatten()) },
+                        async {
+                            analysis_slot = Some((&mut analysis_handle).await.ok().flatten());
+                        },
+                    );
+                    true
+                } else {
+                    tokio::select! {
+                        biased;
+                        () = async {
+                            tokio::join!(
+                                async { cu_slot = Some((&mut cu_handle).await.ok().flatten()) },
+                                async {
+                                    analysis_slot = Some((&mut analysis_handle).await.ok().flatten());
+                                },
+                            );
+                        } => true,
+                        () = crate::rt::sleep(SEMANTIC_TOKENS_FAST_PATH_BUDGET) => false,
+                    }
                 };
                 if both_ready {
                     // Both landed inside the budget — serve the enriched viewport.
@@ -18296,6 +18424,9 @@ impl Backend {
             } else {
                 RangeSettleOutcome::Compared
             };
+            if cancelled {
+                rearm_semantic_tokens_test_seam();
+            }
             // Release the per-URI claim only now the decision is made, so every
             // viewport request that arrived while this ran rode along with it —
             // and honour what rode along: a viewport skipped as `coalesced` has
@@ -41507,14 +41638,41 @@ proc p {} {
     #[tokio::test]
     async fn workspace_symbol_caps_its_answer() {
         let backend = test_backend();
-        let uri = Uri::from_str("file:///w/many.tcl").unwrap();
         let over_the_cap = core_workspace_symbols::MAX_WORKSPACE_SYMBOL_RESULTS + 25;
-        let src = (0..over_the_cap).fold(String::new(), |mut src, n| {
+        // The cap is a workspace-wide response contract, not a large-file
+        // analyser test. Reuse one small, real analysis across enough indexed
+        // documents to exceed the cap; a single 1,025-proc fixture made this
+        // otherwise constant-time assertion pay the analyser's large-document
+        // scaling cost on every CI run.
+        let symbols_per_document = 41;
+        let document_count = over_the_cap.div_ceil(symbols_per_document);
+        let src = (0..symbols_per_document).fold(String::new(), |mut src, n| {
             use std::fmt::Write;
             let _ = writeln!(src, "proc capped_{n} {{}} {{}}");
             src
         });
-        register(&backend, &uri, &src).await;
+        let analysis = {
+            let mut analyser = Analyser::new();
+            analyser.analyse(&src, "tcl8.6").clone()
+        };
+        let uris: Vec<Uri> = (0..document_count)
+            .map(|n| Uri::from_str(&format!("file:///w/many-{n}.tcl")).unwrap())
+            .collect();
+        {
+            let mut documents = backend.documents.lock("test").await;
+            for uri in &uris {
+                documents.insert(
+                    uri.clone(),
+                    DocumentState::new(src.clone(), "tcl8.6".to_owned()),
+                );
+            }
+        }
+        {
+            let mut index = backend.workspace_index.write().await;
+            for uri in &uris {
+                index.add_document(uri.as_str(), &analysis);
+            }
+        }
 
         let found = backend
             .symbol(WorkspaceSymbolParams {

--- a/rust/tcl-lsp-server/tests/e2e/common/mod.rs
+++ b/rust/tcl-lsp-server/tests/e2e/common/mod.rs
@@ -488,6 +488,11 @@ impl Lsp {
         Self::with_config(json!({ "features": { "linkedEditingRange": true } }))
     }
 
+    /// [`Lsp::tcl`] with test-only environment seams installed on the child.
+    pub fn tcl_with_env(env: &[(&str, &str)]) -> Self {
+        Self::with_config_env(json!({ "features": { "linkedEditingRange": true } }), env)
+    }
+
     /// A server dedicated to iRules-dialect documents (dialect switch is
     /// process-global, so those tests use their own server). Same config as
     /// [`Lsp::tcl`].
@@ -534,7 +539,13 @@ impl Lsp {
     /// `with_config` caller is now guaranteed that its config is in effect
     /// before it opens anything.
     pub fn with_config(config: Value) -> Self {
-        let mut lsp = Self::spawn(config);
+        Self::with_config_env(config, &[])
+    }
+
+    /// [`Lsp::with_config`] with test-only environment seams installed on the
+    /// child process.
+    pub fn with_config_env(config: Value, env: &[(&str, &str)]) -> Self {
+        let mut lsp = Self::spawn_with_env(config, env);
         lsp.initialize();
         // Settle on exactly what this client will reply to
         // `workspace/configuration` with, read back from the shared slot.

--- a/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
+++ b/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
@@ -3312,8 +3312,7 @@ fn autoload_library_command_references_and_rename_m8() {
 
 // -- #844 progressive (two-tier) diagnostics -----------------------------
 
-/// Build a large Tcl document (~`n` procs, ~10×`n` lines) whose deep
-/// diagnostics pass reliably overruns `DIAGNOSTICS_FAST_TIER_BUDGET`, plus one
+/// Build a large Tcl document (~`n` procs, ~10×`n` lines), plus one
 /// proc whose unbraced `expr` yields a fast-tier **W100** (an analyser code) and
 /// a deep-tier-only **O111** (the optimiser hint paired with W100) — so the two
 /// progressive publishes are distinguishable regardless of package-database
@@ -3350,14 +3349,21 @@ fn big_tcl_with_split_markers(n: usize) -> String {
 ///
 /// A small / warm file settles inside `DIAGNOSTICS_FAST_TIER_BUDGET` and skips
 /// the fast tier entirely (a single publish — the debounce-skip guarded by the
-/// existing `diagnostics_delivery_smoke` single-publish tests); this test
-/// deliberately uses a large file so the deep pass overruns the budget and the
-/// fast tier fires.
+/// existing `diagnostics_delivery_smoke` single-publish tests). This test uses
+/// a one-shot child-process seam to choose the same fast-tier branch without
+/// making its coverage depend on host speed; other tests retain the actual
+/// 40 ms budget race.
 #[test]
 fn large_file_publishes_fast_tier_before_deep_tier() {
-    let mut lsp = Lsp::tcl();
+    let mut lsp = Lsp::tcl_with_env(&[("TCL_LSP_TEST_FORCE_DIAGNOSTICS_FAST_TIER", "1")]);
     let uri = unique_uri("tcl");
-    let big = big_tcl_with_split_markers(600);
+    // 70 procs remain above the production 500-line progressive-tier floor,
+    // while avoiding the unrelated scaling cost of the former 600-proc input.
+    let big = big_tcl_with_split_markers(70);
+    assert!(
+        big.lines().count() >= 500,
+        "fixture must enter the fast tier"
+    );
 
     let since = lsp.notification_cursor();
     lsp.open_document_lang(&uri, &big, "tcl", 1);
@@ -3399,18 +3405,6 @@ fn large_file_publishes_fast_tier_before_deep_tier() {
             "no deep-tier publish (carrying the optimiser O111) arrived; publishes: {all_codes:?}"
         );
     };
-    if deep_idx == 0 {
-        // Coalesced into a single publish on an unexpectedly fast host (the deep
-        // pass landed inside the 40 ms budget). The two sibling
-        // progressive/convergence tests carry the same escape hatch; the fast→deep
-        // split is not observable this run, but completeness still is.
-        let only = codes(&pubs[0]);
-        assert!(
-            only.contains("W100") && only.contains("O111"),
-            "a coalesced single publish must still carry the complete set: {only:?}",
-        );
-        return;
-    }
     assert!(
         deep_idx >= 1,
         "the fast tier must be published before the deep tier on a large file, \

--- a/rust/tcl-lsp-server/tests/e2e/semantic_tokens_reference_client.rs
+++ b/rust/tcl-lsp-server/tests/e2e/semantic_tokens_reference_client.rs
@@ -300,6 +300,20 @@ fn first_divergence(server: &[SemToken], truth: &[SemToken]) -> String {
 /// [`LatencyBudget`], which is a separate, measured thing.
 const BIG_DOC_SETTLE: Duration = Duration::from_mins(3);
 
+/// Compact but still realistically large (~600-line) fixture used by tests
+/// that exercise convergence mechanics rather than large-file latency. Their
+/// one-shot server seam chooses the coarse branch deterministically; the
+/// 600-proc prompt-response fixtures above retain the real latency/race
+/// coverage.
+const CONVERGENCE_FIXTURE_PROCS: usize = 60;
+
+/// A child whose one-shot environment seam selects the real coarse
+/// continuation deterministically, even when diagnostics have already warmed
+/// the memoised enriched analysis.
+fn convergence_lsp() -> Lsp {
+    Lsp::tcl_with_env(&[("TCL_LSP_TEST_FORCE_SEMANTIC_TOKENS_COARSE", "1")])
+}
+
 /// How long one [`converge_via_refresh`] round may wait for its settled marker
 /// before the loop gives up on *that round* and re-requests.
 ///
@@ -321,7 +335,7 @@ const REFRESH_ARRIVAL: Duration = Duration::from_secs(20);
 fn cold_tokens(lsp: &mut Lsp, text: &str) -> Vec<SemToken> {
     let uri = unique_uri("tcl");
     lsp.open_ready_timeout(&uri, text, BIG_DOC_SETTLE);
-    let raw = lsp.semantic_tokens(&uri);
+    let raw = lsp.semantic_tokens_settled(&uri);
     lsp.close_document(&uri);
     decode_semantic_tokens(&raw)
 }
@@ -338,6 +352,11 @@ fn cold_range_tokens(
 ) -> Vec<SemToken> {
     let uri = unique_uri("tcl");
     lsp.open_ready_timeout(&uri, text, BIG_DOC_SETTLE);
+    // Settle the shared CU/analysis explicitly before sampling the range. A
+    // diagnostics publish can complete while the independent semantic-token
+    // query is still cold, so readiness alone does not make a bare range call
+    // an enriched oracle.
+    let _ = lsp.semantic_tokens_settled(&uri);
     let raw = lsp.semantic_tokens_range(&uri, start, end);
     lsp.close_document(&uri);
     decode_semantic_tokens(&raw)
@@ -938,25 +957,23 @@ fn large_file_range_semantic_tokens_response_is_prompt() {
 /// editor re-requests and converges on the fully enriched tokens — "do the
 /// bulk of the semantic tokens first, then update the ones resolved in
 /// deeper analysis."
-// Deliberately NOT #[ignore]d: the coarse-vs-enriched decision is a wall-clock
-// budget (SEMANTIC_TOKENS_FAST_PATH_BUDGET), so only a document big enough to
-// overrun it ever serves the coarse tier and converges via refresh — a
-// small-document test cannot reach this branch, making this the sole automated
-// cover for the stale-token convergence contract (PR #1476 review).
+// Deliberately NOT #[ignore]d: this is the automated stale-token convergence
+// contract (PR #1476 review). A one-shot child-process seam chooses the same
+// coarse branch the 40 ms budget selects, while the prompt-response tests above
+// retain large cold documents and cover the real wall-clock race.
 #[test]
 fn large_file_semantic_tokens_refresh_delivers_enriched_result() {
-    let mut lsp = Lsp::tcl();
     // `generate_big_tcl` alone uses no construct the enriched tier treats
     // differently from the coarse one (no `regexp`, no object dispatch), so
     // the coarse and enriched streams would be byte-identical regardless of
     // which one served the request — useless for detecting which tier
-    // actually won. Append one proc with a provably-constant regex source
+    // actually won. Append a provably-constant regex source
     // (the same shape `semantic_tokens_retags_constant_regex_source_true_positive`
     // in tcl-lsp-db proves the enriched tier retags) so `same_tokens` below
     // can actually tell the two tiers apart.
     let big = format!(
         "{}\nproc ::bench::regex_check {{}} {{\n    set my_re \".*abc\"\n    regexp $my_re $s\n}}\n",
-        generate_big_tcl(600)
+        generate_big_tcl(CONVERGENCE_FIXTURE_PROCS)
     );
 
     // Compute the enriched truth from a settled separate document *before* the
@@ -967,10 +984,19 @@ fn large_file_semantic_tokens_refresh_delivers_enriched_result() {
     // waited fifteen seconds for. That window widens with machine load, which
     // is exactly the shape of the flake in issue #1082. Done up front it cannot
     // interfere. (The range twin below has always done it this way.)
-    let truth = cold_tokens(&mut lsp, &big);
+    let truth = {
+        let mut oracle = Lsp::tcl();
+        cold_tokens(&mut oracle, &big)
+    };
+
+    // Choose the real coarse branch once, independent of host timing. The
+    // continuation still computes and compares the real enriched result; the
+    // separate prompt-response tests cover the production 40 ms race.
+    let mut lsp = convergence_lsp();
 
     let uri = unique_uri("tcl");
-    lsp.open_document_lang(&uri, &big, "tcl", 1);
+    // Settle didOpen/project indexing before exercising the continuation.
+    let _ = lsp.open_ready_timeout(&uri, &big, BIG_DOC_SETTLE);
 
     let converged = converge_via_refresh(
         &mut lsp,
@@ -992,18 +1018,13 @@ fn large_file_semantic_tokens_refresh_delivers_enriched_result() {
          fully enriched tokens — {}",
         first_divergence(&converged.tokens, &truth)
     );
-    if converged.refreshes == 0 {
-        // The race was won this run (fast machine / the debounced diagnostics
-        // worker happened to prime the analysis first): the first response was
-        // already fully enriched, so there was nothing to refresh. The tiering
-        // mechanism itself is covered deterministically by tcl-lsp-db's
-        // `semantic_tokens_retags_constant_regex_source_true_positive` and
-        // `semantic_tokens_shares_incremental_analysis_with_diagnostics`.
-        eprintln!(
-            "large_file_semantic_tokens_refresh_delivers_enriched_result: \
-             fast path won the race, refresh not exercised this run"
-        );
-    }
+    assert_eq!(
+        converged.rounds,
+        converged.no_refresh_decisions + 2,
+        "apart from cancelled retries: one coarse request, one enriched re-request"
+    );
+    assert_eq!(converged.refresh_decisions, 1);
+    assert_eq!(converged.refreshes, 1);
     eprintln!(
         "large_file_semantic_tokens_refresh_delivers_enriched_result: converged in {} rounds \
          ({} refreshes; {} rounds settled with a cancelled/equal enriched read)",
@@ -1018,23 +1039,21 @@ fn large_file_semantic_tokens_refresh_delivers_enriched_result() {
 /// differs, so a static cold viewport converges on the enriched tier instead of
 /// staying coarse until the next scroll or edit (the gap `semantic_tokens_range`
 /// had that `_full` did not).
-// Deliberately NOT #[ignore]d: same budget-gated branch as the `_full`
-// convergence test, for the range path specifically (#844 Gap 4 — a skipped
-// viewport staying coarse until the next scroll).  Small-document range tests
-// never overrun the budget, so they cannot cover this.
+// Deliberately NOT #[ignore]d: same deterministically-selected production
+// branch as the `_full` convergence test, for the range path specifically
+// (#844 Gap 4 — a skipped viewport staying coarse until the next scroll).
 #[test]
 fn large_file_range_semantic_tokens_converges_via_refresh() {
-    let mut lsp = Lsp::tcl();
     // The same provably-constant regex source the `_full` test uses, so the
     // enriched tier (which retags it) differs from the coarse tier — otherwise
     // the two are byte-identical and no refresh is warranted.
     let big = format!(
         "{}\nproc ::bench::regex_check {{}} {{\n    set my_re \".*abc\"\n    regexp $my_re $s\n}}\n",
-        generate_big_tcl(600)
+        generate_big_tcl(CONVERGENCE_FIXTURE_PROCS)
     );
     let line_count = u32::try_from(big.lines().count()).unwrap();
 
-    // A viewport over the appended regexp proc (the last few lines), where the
+    // A viewport over the appended regexp commands (the last few lines), where the
     // coarse and enriched tiers provably differ.
     let start = (line_count.saturating_sub(6), 0);
     let end = (line_count, 0);
@@ -1044,10 +1063,17 @@ fn large_file_range_semantic_tokens_converges_via_refresh() {
     // `Project` (`set_files`), which cancels an in-flight convergence
     // continuation — so doing it mid-test would suppress the very refresh under
     // test.  Done up front, it cannot interfere.
-    let truth = cold_range_tokens(&mut lsp, &big, start, end);
+    let truth = {
+        let mut oracle = Lsp::tcl();
+        cold_range_tokens(&mut oracle, &big, start, end)
+    };
+
+    // See the full-token twin: force the real coarse continuation once,
+    // independent of whether diagnostics happened to warm this document.
+    let mut lsp = convergence_lsp();
 
     let uri = unique_uri("tcl");
-    lsp.open_document_lang(&uri, &big, "tcl", 1);
+    let _ = lsp.open_ready_timeout(&uri, &big, BIG_DOC_SETTLE);
 
     let converged = converge_via_refresh(
         &mut lsp,
@@ -1071,15 +1097,13 @@ fn large_file_range_semantic_tokens_converges_via_refresh() {
          the enriched tier — {}",
         first_divergence(&converged.tokens, &truth)
     );
-    if converged.refreshes == 0 {
-        // The race was won this run — the cold viewport was already enriched, so
-        // there was nothing to converge. The tiering itself is covered
-        // deterministically in tcl-lsp-db.
-        eprintln!(
-            "large_file_range_semantic_tokens_converges_via_refresh: \
-             fast path won the race, refresh not exercised this run"
-        );
-    }
+    assert_eq!(
+        converged.rounds,
+        converged.no_refresh_decisions + 2,
+        "apart from cancelled retries: one coarse request, one enriched re-request"
+    );
+    assert_eq!(converged.refresh_decisions, 1);
+    assert_eq!(converged.refreshes, 1);
     eprintln!(
         "large_file_range_semantic_tokens_converges_via_refresh: converged in {} rounds \
          ({} refreshes; {} rounds settled with a cancelled/equal enriched read)",
@@ -1098,20 +1122,19 @@ fn large_file_range_semantic_tokens_converges_via_refresh() {
 /// document — a visible flicker of already-correct tokens.
 #[test]
 fn range_semantic_tokens_no_spurious_refresh_when_converged() {
-    let mut lsp = Lsp::tcl();
+    let mut lsp = convergence_lsp();
     // Plain `generate_big_tcl` (no regex / object-dispatch construct): the coarse
     // (segmenter + registry) and enriched (CU + analysis) tiers are identical —
     // that is exactly why the convergence tests above have to *append* a regex
-    // proc to force a difference. The file is still large/cold enough that the
-    // CU/analysis reads overrun `SEMANTIC_TOKENS_FAST_PATH_BUDGET`, so `pending`
-    // is `Some` and the continuation actually runs the coarse-vs-enriched compare.
-    let big = generate_big_tcl(600);
+    // construct to force a difference. The one-shot seam makes `pending` some
+    // and runs the real coarse-vs-enriched comparison without a timing race.
+    let big = generate_big_tcl(CONVERGENCE_FIXTURE_PROCS);
     let line_count = u32::try_from(big.lines().count()).unwrap();
     let start = (line_count.saturating_sub(6), 0);
     let end = (line_count, 0);
 
     let uri = unique_uri("tcl");
-    lsp.open_document_lang(&uri, &big, "tcl", 1);
+    let _ = lsp.open_ready_timeout(&uri, &big, BIG_DOC_SETTLE);
     let req_since = lsp.server_request_cursor();
     let log_since = lsp.notification_cursor();
     let first = decode_semantic_tokens(&lsp.semantic_tokens_range(&uri, start, end));
@@ -1128,26 +1151,21 @@ fn range_semantic_tokens_no_spurious_refresh_when_converged() {
     // not been made yet".  The timeout is only a backstop against a total hang,
     // never the synchronisation.
     //
-    // `outcome` says which shape the run took.  The one under test is
-    // `compared`: the cold 600-proc file overran the 40ms fast-path budget, the
-    // coarse tier was served, and the detached continuation (#844 Gap 4) diffed
-    // it against the recomputed enriched viewport.  A loaded machine can instead
-    // reach `no-analysis` (the document is not yet in the salsa db when the
-    // request lands) or `cancelled`, and a very quick one `served-enriched` —
-    // none of which run the compare.  `coalesced` (#1147) is a fourth: a
-    // continuation for this document was already in flight, so this request rode
-    // along with it.  The refresh assertion below is asserted in
-    // *every* case, because "no spurious refresh" must hold on all of them; the
-    // outcome is reported so a run that did not exercise the compare is visible
-    // rather than silently vacuous. This wait observes the detached deep-tier
-    // comparison; first-response latency is asserted separately, so it needs
-    // enough headroom for a debug server on a loaded CI runner.
+    // `outcome=compared` proves the one-shot seam served the coarse tier and the
+    // detached continuation (#844 Gap 4) compared it with the recomputed
+    // enriched viewport. This wait observes that real deep-tier comparison;
+    // first-response latency is asserted separately, so the timeout is only a
+    // hang guard for a loaded debug runner.
     let settled = lsp.await_log(
         &["semantic_tokens.range_convergence.settled", uri.as_str()],
         Duration::from_mins(1),
         log_since,
     );
     eprintln!("range_semantic_tokens_no_spurious_refresh_when_converged: {settled}");
+    assert!(
+        settled.contains("outcome=compared"),
+        "the forced coarse branch must execute its equality comparison: {settled:?}"
+    );
     // The decision is recorded in the marker itself: `refresh=false` means
     // `request_refresh_coalesced` was not called, so no debounced
     // `workspace/semanticTokens/refresh` can ever fire for this request.  This is


### PR DESCRIPTION
## Root cause

Four end-to-end tests used 600-procedure documents primarily to force a 40 ms production race, and the workspace-symbol cap test analysed one 1,025-procedure file solely to create 1,025 response candidates. In the baseline CI run, those five assertions consumed about 10.5 minutes of the 752.417-second lsp-e2e test phase. Their oversized inputs tested host speed and analyser scaling in addition to the intended protocol contracts.

## Fix

- Add opt-in, one-shot child-process seams that select the real semantic-token coarse continuation and diagnostics fast-tier branches without a wall-clock race. Unset behavior is unchanged.
- Keep the existing 600-procedure first-response tests as the real 40 ms latency checks.
- Reduce the convergence fixtures to 60 procedures and the progressive-diagnostics fixture to 70 procedures while preserving the 500-line production floor.
- Strengthen the semantic-token oracles so expected output is settled/enriched, require the real comparison marker, require exactly one refresh for differing output, and require no refresh for equal output.
- Exercise the workspace-symbol 1,000-result cap with 25 indexed documents sharing one real 41-procedure analysis, retaining 1,025 genuine candidates.

## Experimental proof

Baseline CI run 33874403776: lsp-e2e nextest took 752.417 s. The five targeted tests took 134.896 s, 118.295 s, 130.842 s, 212.770 s, and 20.978 s.

On this tree, the focused five-test run passes in 3.375 s: 0.203 s, 1.278 s, 3.373 s, 3.098 s, and 1.180 s respectively. The full package run passes 2,102/2,102 in 66.285 s of test time; total wall time was 141.77 s including a 75-second rebuild. CI on this PR is the cross-runner confirmation.

## Validation

- cargo nextest run --no-fail-fast -p tcl-lsp-server: 2,102 passed
- focused five-test run after final refactor: 5 passed in 3.375 s
- make rust-check
- make prep-pr: 29 smoke tests passed