### PR TITLE
ci: cache Rust compilation by source

### DIFF
--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -46,10 +46,12 @@ jobs:
           PR_REF: refs/pull/${{ github.event.pull_request.number }}/merge
         run: |
           echo "Pruning caches scoped to $PR_REF"
-          # Filter on ref in jq rather than `gh cache list --ref` so this
-          # works regardless of the runner's gh version.
-          ids=$(gh cache list --repo "$REPO" --limit 100 --json id,ref \
-            --jq ".[] | select(.ref == \"$PR_REF\") | .id")
+          # Fetch every page before deleting anything.  Compiler caches can
+          # create hundreds of records for one PR, and deleting while paging
+          # would shift the remaining API pages underneath the traversal.
+          ids=$(gh api --paginate \
+            "repos/$REPO/actions/caches?per_page=100" \
+            --jq ".actions_caches[] | select(.ref == \"$PR_REF\") | .id")
           if [ -z "$ids" ]; then
             echo "  no caches for this PR"
           else
@@ -64,16 +66,27 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
+          SCCACHE_MAX_IDLE_DAYS: 7
         run: |
-          # Protect the caches of the long-lived branches that have
-          # push-triggered blocking workflows. ci.yml runs on `push:
-          # branches: [rust]`, so its rust-cache entries live on that ref;
-          # purging refs/heads/rust every week forces cold rebuilds on the
-          # gate. Keep this in sync with ci.yml's push triggers.
-          echo "Sweeping caches not on the protected ref (rust)"
-          # Single pass (limit 100); a residual >100 is caught next week.
-          ids=$(gh cache list --repo "$REPO" --limit 100 --json id,ref \
-            --jq '.[] | select(.ref != "refs/heads/rust") | .id')
+          # Preserve the conventional caches of the long-lived branch that has
+          # push-triggered blocking workflows. ci.yml runs on `rust`, so
+          # purging those rust-cache entries every week would force cold gates.
+          # sccache is different: every compiler object has its own immutable,
+          # content-addressed record. Keep recently used objects on rust, but
+          # retire ones whose source/compiler key has not been read for a week.
+          # Keep the protected ref in sync with ci.yml's push triggers.
+          cutoff=$(date -u -d "$SCCACHE_MAX_IDLE_DAYS days ago" +%Y-%m-%dT%H:%M:%SZ)
+          echo "Sweeping non-rust caches and rust sccache objects idle since $cutoff"
+
+          # Collect every page before deletion so records cannot shift the
+          # remaining API pages underneath the traversal.
+          ids=$(gh api --paginate \
+            "repos/$REPO/actions/caches?per_page=100" \
+            --jq ".actions_caches[] | select(\
+              .ref != \"refs/heads/rust\" or \
+              (.ref == \"refs/heads/rust\" and \
+               (.key | startswith(\"sccache/\")) and \
+               .last_accessed_at < \"$cutoff\")) | .id")
           if [ -z "$ids" ]; then
             echo "  nothing to sweep"
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -835,6 +835,11 @@ jobs:
     # branches in this repo, which only collaborators can create) goes to `tank`.
     needs: [channel]
     runs-on: ${{ (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || needs.channel.outputs.runner_policy_changed == 'true')) && 'ubuntu-26.04' || 'tank' }}
+    # The action starts the sccache server during setup, so the backend must be
+    # configured at job scope rather than only on the later Cargo steps.
+    env:
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
     concurrency:
       group: rust-tests-${{ (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || needs.channel.outputs.runner_policy_changed == 'true')) && format('hosted-{0}', github.run_id) || 'tank' }}
       queue: max
@@ -898,8 +903,6 @@ jobs:
         if: needs.channel.outputs.docs_only != 'true' && !(startsWith(github.ref, 'refs/tags/') && needs.channel.outputs.already_green == 'true')
         env:
           ALREADY_GREEN: ${{ needs.channel.outputs.already_green }}
-          RUSTC_WRAPPER: sccache
-          SCCACHE_GHA_ENABLED: "true"
         run: |
           extra="--no-fail-fast"
           if [ "$ALREADY_GREEN" = "true" ]; then
@@ -913,9 +916,6 @@ jobs:
       # not duplicate them.  Deps are already built, so this is compile + run.
       - name: cargo test --doc
         if: needs.channel.outputs.docs_only != 'true' && needs.channel.outputs.already_green != 'true'
-        env:
-          RUSTC_WRAPPER: sccache
-          SCCACHE_GHA_ENABLED: "true"
         run: cargo test --workspace --all-features --doc --no-fail-fast
 
   # Fail-closed SpecTcl compatibility on every PR that changes its TclVM,
@@ -1329,6 +1329,9 @@ jobs:
     # Deliberately hosted -- see `rust-tests-heavy`.
     needs: [channel]
     runs-on: ubuntu-26.04
+    env:
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -1359,8 +1362,6 @@ jobs:
         if: needs.channel.outputs.docs_only != 'true' && !(startsWith(github.ref, 'refs/tags/') && needs.channel.outputs.already_green == 'true')
         env:
           ALREADY_GREEN: ${{ needs.channel.outputs.already_green }}
-          RUSTC_WRAPPER: sccache
-          SCCACHE_GHA_ENABLED: "true"
         run: |
           extra="--no-fail-fast"
           if [ "$ALREADY_GREEN" = "true" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -856,6 +856,15 @@ jobs:
           toolchain: stable
           cache-key: rust-tests
 
+      # rust-cache restores dependency artefacts, but intentionally removes
+      # workspace crates before saving.  This source-aware compiler cache keeps
+      # those expensive compilations reusable across runner registrations and
+      # source revisions without weakening Cargo's freshness checks.
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
+        with:
+          version: v0.16.0
+
       - name: Install cargo-nextest
         uses: taiki-e/install-action@37f7c5781271959fb65b6b35224e28652ff2b63d # v2.87.0
         with:
@@ -889,6 +898,8 @@ jobs:
         if: needs.channel.outputs.docs_only != 'true' && !(startsWith(github.ref, 'refs/tags/') && needs.channel.outputs.already_green == 'true')
         env:
           ALREADY_GREEN: ${{ needs.channel.outputs.already_green }}
+          RUSTC_WRAPPER: sccache
+          SCCACHE_GHA_ENABLED: "true"
         run: |
           extra="--no-fail-fast"
           if [ "$ALREADY_GREEN" = "true" ]; then
@@ -902,6 +913,9 @@ jobs:
       # not duplicate them.  Deps are already built, so this is compile + run.
       - name: cargo test --doc
         if: needs.channel.outputs.docs_only != 'true' && needs.channel.outputs.already_green != 'true'
+        env:
+          RUSTC_WRAPPER: sccache
+          SCCACHE_GHA_ENABLED: "true"
         run: cargo test --workspace --all-features --doc --no-fail-fast
 
   # Fail-closed SpecTcl compatibility on every PR that changes its TclVM,
@@ -1326,6 +1340,11 @@ jobs:
           toolchain: stable
           cache-key: lsp-e2e
 
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
+        with:
+          version: v0.16.0
+
       - name: Install cargo-nextest
         uses: taiki-e/install-action@37f7c5781271959fb65b6b35224e28652ff2b63d # v2.87.0
         with:
@@ -1340,6 +1359,8 @@ jobs:
         if: needs.channel.outputs.docs_only != 'true' && !(startsWith(github.ref, 'refs/tags/') && needs.channel.outputs.already_green == 'true')
         env:
           ALREADY_GREEN: ${{ needs.channel.outputs.already_green }}
+          RUSTC_WRAPPER: sccache
+          SCCACHE_GHA_ENABLED: "true"
         run: |
           extra="--no-fail-fast"
           if [ "$ALREADY_GREEN" = "true" ]; then

--- a/scripts/dev/test-monitoring-triggers.sh
+++ b/scripts/dev/test-monitoring-triggers.sh
@@ -4,10 +4,10 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-# Fail closed if a future cadence edit removes a release benchmark or narrows
-# the repository-wide Scorecard push scan. Binary-Artifacts examines file
-# content, including extensionless executables, so filename filters are not a
-# complete representation of its input surface.
+# Fail closed if a future cadence edit removes a release benchmark, narrows the
+# repository-wide Scorecard push scan, or makes cache retention unbounded.
+# Binary-Artifacts examines file content, including extensionless executables,
+# so filename filters are not a complete representation of its input surface.
 
 set -eu
 
@@ -15,6 +15,7 @@ SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 REPO_ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/../.." && pwd)
 PERF=$REPO_ROOT/.github/workflows/perf.yml
 SCORECARD=$REPO_ROOT/.github/workflows/scorecard.yml
+CACHE_CLEANUP=$REPO_ROOT/.github/workflows/cache-cleanup.yml
 
 perf_push=$(awk '
     /^  push:/ { in_push = 1 }
@@ -52,6 +53,23 @@ grep -Fq 'branch_protection_rule:' "$SCORECARD" || {
 }
 grep -Fq 'cron: "23 4 * * 2"' "$SCORECARD" || {
     echo "Scorecard must retain its weekly ecosystem-drift scan" >&2
+    exit 1
+}
+
+[ "$(grep -c -- '--paginate' "$CACHE_CLEANUP")" -eq 2 ] || {
+    echo "cache cleanup must paginate both PR-close and weekly inventories" >&2
+    exit 1
+}
+grep -Fq 'SCCACHE_MAX_IDLE_DAYS: 7' "$CACHE_CLEANUP" || {
+    echo "default-branch sccache retention must stay bounded" >&2
+    exit 1
+}
+grep -Fq '(.key | startswith(\"sccache/\"))' "$CACHE_CLEANUP" || {
+    echo "weekly cleanup must identify content-addressed sccache objects" >&2
+    exit 1
+}
+grep -Fq '.last_accessed_at < \"$cutoff\"' "$CACHE_CLEANUP" || {
+    echo "weekly sccache retention must use last-access time" >&2
     exit 1
 }
 


### PR DESCRIPTION
## Root cause

The existing Cargo cache restores dependency artefacts but intentionally removes workspace-crate outputs before saving. That leaves the broad Rust lane recompiling workspace code across runner registrations and source revisions even when most compiler inputs are identical.

## Fix

Add the pinned Mozilla sccache action to `rust-tests` and `lsp-e2e`, with the GitHub Actions backend configured before the cache server starts. Cargo remains the freshness authority and every test/doctest is unchanged.

Cache retention is bounded with the same change:

- PR-close and weekly cleanup paginate the complete Actions-cache inventory and collect IDs before deletion, so page shifts cannot skip records.
- ordinary `refs/heads/rust` caches remain protected;
- content-addressed `sccache/` objects on `rust` expire after seven idle days;
- the monitoring drift test pins pagination, the key restriction, the seven-day bound, and last-access filtering.

## Experimental proof

Comparable hosted controls without sccache:

| Lane | Test-target compile | Test execution | Doctest compile |
|---|---:|---:|---:|
| rust-tests, #1820 | 5m17s | 1606.861s | 1m13s |
| rust-tests, #1836 | 3m46s | 1555.010s | 1m19s |
| lsp-e2e, #1820/#1836 | 1m27s--1m32s | 682.218s--752.417s | n/a |

The cold/population run proved the backend was active across concurrent lanes: LSP reported 110 Rust hits out of 169 cacheable requests (65.1%), while all 2,102 LSP tests passed; the broad Rust lane passed all 18,739 tests.

The definitive exact-source reuse run on `2d886c5d7` was fully green:

- `rust-tests`: 29 compiler requests, 25 hits (86.2%); test-target compilation 2m19s; 18,739/18,739 tests in 981.360s; doctest compilation 16.30s.
- Compared with the two hosted controls, compilation fell by 2m24s--3m55s per broad Rust run.
- `lsp-e2e`: target preparation 45.05s; 2,102/2,102 tests in 592.797s; 11m05s total.
- All required checks passed, including pr-gate, extension, runtime, WASM, supply-chain, and Python lanes.

The storage cost is explicit and bounded. During the multi-run experiment this PR accumulated 936 sccache objects (about 797 MB); its complete PR cache scope was 941 records / 2.73 GB including the existing Cargo caches. Live API enumeration and synthetic filter tests proved the cleanup handles that scale and preserves current/default-branch conventional caches.

## Local validation

- `make rust-check`
- `make prep-pr` (29/29 smoke tests)
