### PR TITLE
fix(compiler): one owner for the words a nested substitution runs

### DIFF
--- a/docs/design/contracts/shared-utility-contracts-rust.md
+++ b/docs/design/contracts/shared-utility-contracts-rust.md
@@ -50,6 +50,7 @@ entry point, or gate moves without this contract being updated.
 | command errors | `rust/tcl-cmd-core/src/error.rs` | `CmdError`; `wrong_args`; `bad_choice` | invariant | none |
 | expression grammar / evaluation | `rust/tcl-syntax/src/expr/parser.rs`; `rust/tcl-syntax/src/expr/eval.rs`; `rust/tcl-registry/src/expr_surface.rs` | `parse_expr`; `eval`; `RuntimeExprSurface` | `RuntimeExprSurface` per release | none |
 | command / word segmentation | `rust/tcl-lexer/src/script.rs`; `rust/tcl-compiler/src/segmenter.rs`; `rust/tcl-compiler/src/parsing/syntax/build.rs`; `rust/tcl-compiler/src/parsing/syntax/segment.rs` | `group_commands`; `CommandSpan`; `WordSpan`; `WordKind`; `SegmentedCommand`; `segment_commands` | `LexerConfig` per document dialect | `xtask-segmentation-drift` |
+| nested command-substitution words | `rust/tcl-compiler/src/word_subst.rs` | `nested_command_words`; `NestedWordsDecline`; `lifted_calls`; `lifted_exprs`; `LiftedCall` | `LexerConfig` per document dialect, inherited from the segmentation owner it runs | none |
 | parse-error cut | `rust/tcl-lexer/src/parse_cut.rs` | `first_parse_cut`; `first_parse_cut_in`; `ParseCut`; `EXTRA_AFTER_CLOSE_QUOTE` | `LexerConfig` per emulated release, inherited from the segmentation and word-component owners it walks | `xtask-segmentation-drift` |
 | script completeness / reparse windows | `rust/tcl-lexer/src/structural_index.rs` | `script_is_complete`; `command_boundaries`; `reparse_window`; `BracketIndex`; `BraceIndex`; `ExprParenIndex`; `ParenBalance` | dialect-blind by construction: one byte scan of stock 8.6/9.x brace, quote, `${…}`-nesting, comment and terminator structure, so an editor keystroke costs no tokenise. The two grammar axes that really do move a command boundary — the F5 `BraceLineContinuation::Continues` next-line-`{` rule and the 8.x `BracedVarStyle::FirstClose` name rule — are pinned as measured divergences by `differential_boundaries`, never silently absorbed | `xtask-segmentation-drift` |
 | iRules execution boundaries and placement | `rust/tcl-syntax/src/event_handler.rs`; `rust/tcl-registry/src/events.rs`; `rust/tcl-registry/src/registry.rs`; `rust/tcl-irules/src/when_block.rs`; `rust/tcl-irules/src/executable.rs` | `event_handlers`; `event_handlers_with_head_predicate`; `script_commands`; `top_level_when_handlers_with_registry_and_head_resolver`; `IrulesDeclarationArguments`; `IrulesExecutionContext`; `IrulesCommandPlacement`; `IrulesTopLevelDeclaration`; `IrulesTopLevelEffect`; `CommandRegistry::irules_command_placement`; `CommandRegistry::irules_event_declaration`; `CommandRegistry::irules_top_level_declaration`; `CommandRegistry::irules_top_level_declaration_shape`; `CommandRegistry::irules_top_level_effect`; `when_blocks`; `irules_executable_commands` | caller-supplied `LexerConfig`; offset-keyed resolved command identity; exact single-braced declaration body; declaration-only top level; known-event roots; call-reachable procedure bodies; stateful priority (`0..=1000`, default 500) | `xtask-gen-ai-diagnostics` |
@@ -548,6 +549,23 @@ entry point, or gate moves without this contract being updated.
   (`wrong_args`, `bad_choice`, …). The runtimes' arity helpers are
   thin adapters: `runtime/rust`'s single `Interp::wrong_args` method
   and the VM's `interp::err_wrong_args`.
+
+### `tcl-compiler` — nested command-substitution words
+
+- `word_subst::nested_command_words` is the one recovery of the words
+  inside a `[cmd …]`. The word snapshot keeps a substitution as a
+  single opaque spelling, so the words are recovered by running the
+  canonical segmenter over its recorded lexical extent — never a
+  bespoke bracket scan — and anything but exactly one complete command
+  declines. Consumers: the shimmer and SSA lifts
+  (`word_subst::lifted_calls` / `lifted_exprs`), the native lowering's
+  `nested_words`, and the WASM leaf-invoke planner's. Analysis and the
+  two AOT tiers therefore cannot disagree about what a substitution
+  runs, which they could while each kept its own copy.
+- `LiftedCall` carries that structure to consumers in `arg_words`, so a
+  braced literal is told from a word that substitutes by the
+  segmenter's `WordExpr`, not by a `{`/`[` test over argument text —
+  the distinction `Statement::Call::args` cannot make.
 
 ### `tcl-compiler` — text similarity
 

--- a/docs/design/contracts/shimmer-reference-behaviour.md
+++ b/docs/design/contracts/shimmer-reference-behaviour.md
@@ -192,8 +192,8 @@ variable* was judged against a stale representation: `set x [llength $l]` then
 `puts [lindex $x 0]` then `incr x` reported nothing at all, while the identical
 code with `lindex $x 0` on its own line reported both halves.
 
-`shimmer::nested` lifts those substitutions, and `commit`, `use_site` and
-`expr` each consume them. Three properties matter:
+`word_subst` lifts those substitutions, and `commit`, `use_site` and `expr`
+each consume them. Four properties matter:
 
 - **It reads `word_exprs`, never the argument text.** Tcl substitutes `[…]` in
   bare and `"…"`-quoted words but not in braced ones, and
@@ -202,6 +202,12 @@ code with `lindex $x 0` on its own line reported both halves.
   `WordExpr` already models the braced word as `BracedLiteral` and the
   substituted one as `CommandSubstitution`, so the distinction is free and
   exact.
+- **That holds at every depth.** A substitution's own words are recovered by
+  the same segmenter (`word_subst::nested_command_words`, the one owner the
+  native and WASM lowerings also plan from), so `[list "[lindex $x 0]"]` and
+  `[list a[lindex $x 0]b]` run their `lindex` and `[list {[lindex $x 0]}]` does
+  not. A `[`-prefix test over the argument text missed the first two and the
+  structure decides all three.
 - **Order is innermost-first**, Tcl's own evaluation order, so the commit state
   moves exactly as the runtime converts.
 - **`return [expr …]` needs no lifting at all**: the lowerer already parses it
@@ -253,8 +259,8 @@ dedicated `Statement::Incr` node.
 
 ## Coverage
 
-- Nested-substitution coverage: `shimmer::nested` (lifting and the braced-word
-  distinction), `shimmer::expr` (`expr_shimmer_fires_in_a_return_expression`,
+- Nested-substitution coverage: `word_subst` (lifting, the braced-word
+  distinction at every depth, and `arg_words` alignment), `shimmer::expr` (`expr_shimmer_fires_in_a_return_expression`,
   `expr_shimmer_fires_in_a_nested_call_argument` and their braced twins),
   `shimmer::use_site` (`use_site_shimmer_fires_in_a_nested_call_argument`,
   `a_nested_conversion_is_visible_to_later_reads`).

--- a/rust/tcl-compiler/src/codegen/wasm/leaf_invoke.rs
+++ b/rust/tcl-compiler/src/codegen/wasm/leaf_invoke.rs
@@ -58,7 +58,7 @@ use crate::backend_registry::{
     SelectorPriority, SelectorRequest,
 };
 use crate::codegen::values::whole_var_reference;
-use crate::ir::{CommandTokens, Provenance, SourceSite, WordExpr, WordPart};
+use crate::ir::{Provenance, SourceSite, WordExpr, WordPart};
 use crate::target_contract::{
     LegalisationRequirements, TargetCapabilities, TargetContract, TargetFamily,
 };
@@ -532,49 +532,32 @@ fn split_element(name: &str) -> Option<(&str, &str)> {
 
 /// The structured words of a `[…]` command substitution.
 ///
-/// The word snapshot keeps a command substitution as one opaque spelling, so
-/// its inner words are recovered by running the canonical segmenter over the
-/// recorded lexical extent — the same segmentation the outer command's words
-/// came from, not a bespoke parser. Anything other than exactly one complete
-/// command declines.
+/// [`crate::word_subst::nested_command_words`] owns the recovery: the word
+/// snapshot keeps a command substitution as one opaque spelling, and running
+/// the canonical segmenter over its recorded lexical extent is what turns it
+/// back into the words this tier plans — the same words the analysis tier
+/// lifts, so the two can never disagree about what a substitution runs.
 fn nested_words(
     spelling: &str,
     source: &SourceSite,
     config: tcl_lexer::LexerConfig,
 ) -> Result<Vec<WordExpr>, WasmLeafInvokeDecline> {
-    let inner = spelling
-        .strip_prefix('[')
-        .and_then(|text| text.strip_suffix(']'))
-        .ok_or(WasmLeafInvokeDecline::UnmodelledCommandSubstitution)?;
-    if inner.trim().is_empty() {
-        return Err(WasmLeafInvokeDecline::UnmodelledCommandSubstitution);
-    }
-    let base = if source.provenance == Provenance::Source {
-        source.span.start().saturating_add(1)
-    } else {
-        0
-    };
-    let segments = crate::segmenter::segment_commands_with_offset_and_config(inner, base, config);
-    let [segment] = segments.as_slice() else {
-        return Err(WasmLeafInvokeDecline::UnmodelledCommandSubstitution);
-    };
-    if segment.is_partial {
-        return Err(WasmLeafInvokeDecline::UnmodelledCommandSubstitution);
-    }
-    // The nested script is a sub-lex: its own text, segmented at the document
-    // offset it sits at, so the word model reads `inner` and still reports
-    // document spans (`SourceMap::with_base` is that sub-lexing contract).
-    let sm = tcl_lexer::SourceMap::new(inner).with_base(base, 0, 0);
-    let tokens = CommandTokens::from_segmented(&sm, config, segment);
-    if tokens.word_exprs.is_empty() {
-        return Err(WasmLeafInvokeDecline::MissingCommandHead);
-    }
-    Ok(tokens.word_exprs)
+    crate::word_subst::nested_command_words(spelling, source, config)
+        .map(|tokens| tokens.word_exprs)
+        .map_err(|decline| match decline {
+            crate::word_subst::NestedWordsDecline::Unmodelled => {
+                WasmLeafInvokeDecline::UnmodelledCommandSubstitution
+            }
+            crate::word_subst::NestedWordsDecline::NoWords => {
+                WasmLeafInvokeDecline::MissingCommandHead
+            }
+        })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ir::CommandTokens;
     use crate::segmenter::segment_commands;
 
     /// The structured words of the first command in `source`.

--- a/rust/tcl-compiler/src/native_lowering/lower.rs
+++ b/rust/tcl-compiler/src/native_lowering/lower.rs
@@ -1942,40 +1942,24 @@ fn extent(span: Span) -> usize {
 }
 
 /// The structured words of a `[…]` command substitution, recovered by the
-/// canonical segmenter over the recorded lexical extent.
+/// canonical segmenter over the recorded lexical extent
+/// ([`crate::word_subst::nested_command_words`] owns that recovery, so this
+/// tier plans the same words the analysis tier lifts).
 fn nested_words(
     spelling: &str,
     source: &SourceSite,
     config: tcl_lexer::LexerConfig,
 ) -> Result<Vec<WordExpr>, NativeLoweringDecline> {
-    let inner = spelling
-        .strip_prefix('[')
-        .and_then(|text| text.strip_suffix(']'))
-        .ok_or(NativeLoweringDecline::UnmodelledCommandSubstitution)?;
-    if inner.trim().is_empty() {
-        return Err(NativeLoweringDecline::UnmodelledCommandSubstitution);
-    }
-    let base = if source.provenance == Provenance::Source {
-        source.span.start().saturating_add(1)
-    } else {
-        0
-    };
-    let segments = crate::segmenter::segment_commands_with_offset_and_config(inner, base, config);
-    let [segment] = segments.as_slice() else {
-        return Err(NativeLoweringDecline::UnmodelledCommandSubstitution);
-    };
-    if segment.is_partial {
-        return Err(NativeLoweringDecline::UnmodelledCommandSubstitution);
-    }
-    // The nested script is a sub-lex: its own text, segmented at the document
-    // offset it sits at, so the word model reads `inner` and still reports
-    // document spans (`SourceMap::with_base` is that sub-lexing contract).
-    let sm = tcl_lexer::SourceMap::new(inner).with_base(base, 0, 0);
-    let tokens = CommandTokens::from_segmented(&sm, config, segment);
-    if tokens.word_exprs.is_empty() {
-        return Err(NativeLoweringDecline::MissingCommandTokens);
-    }
-    Ok(tokens.word_exprs)
+    crate::word_subst::nested_command_words(spelling, source, config)
+        .map(|tokens| tokens.word_exprs)
+        .map_err(|decline| match decline {
+            crate::word_subst::NestedWordsDecline::Unmodelled => {
+                NativeLoweringDecline::UnmodelledCommandSubstitution
+            }
+            crate::word_subst::NestedWordsDecline::NoWords => {
+                NativeLoweringDecline::MissingCommandTokens
+            }
+        })
 }
 
 /// Reverse post-order over the executable CFG, the loop headers (targets of

--- a/rust/tcl-compiler/src/ssa.rs
+++ b/rust/tcl-compiler/src/ssa.rs
@@ -2027,18 +2027,19 @@ fn scan_nested_substitution_words(
             .flat_map(|&role| registry.arg_indices_for_role(&lifted.command, &arg_strs, role))
             .collect();
         for idx in in_frame {
-            let Some(word) = lifted.args.get(idx) else {
-                continue;
-            };
             // Only a braced word needs recovering. An unbraced one already
             // substitutes at the command level, so the enclosing word's own
-            // scan has seen it.
-            let trimmed = word.trim();
-            if !(trimmed.starts_with('{') && trimmed.ends_with('}')) {
-                continue;
-            }
-            out.substituted
-                .extend(scanner.scan_word(trimmed.trim_matches(['{', '}']), registry));
+            // scan has seen it. Which word is braced is the segmenter's
+            // answer, not a `{`/`}` test over the argument text: `{a}{b}` and
+            // a word merely *containing* braces are not brace-quoted literals.
+            let braced = match lifted.arg_words.get(idx) {
+                Some(WordExpr::BracedLiteral { text, .. }) => text.as_str(),
+                // The structure is only absent when the word recovery
+                // declined the substitution's shape, and then there is
+                // nothing to recover from it either.
+                _ => continue,
+            };
+            out.substituted.extend(scanner.scan_word(braced, registry));
         }
     }
 }
@@ -4703,5 +4704,51 @@ mod tests {
         // the assertion is that this returns at all without overflowing the
         // stack, not what it returns.
         let _ = extra;
+    }
+
+    /// The classified uses of every `Call` in a one-statement proc, lowered
+    /// from source so the statement carries the real word snapshot.
+    fn classified_call_uses(body: &str) -> Vec<(String, UseClass)> {
+        let reg = CommandRegistry::build_default();
+        let src = format!("proc f {{tainted}} {{\n {body}\n}}");
+        let cu = crate::compilation_unit::CompilationUnit::build_for(&src, &reg, false);
+        let fu = cu.function("::f").expect("proc lowered");
+        let mut scanner = VarReferenceScanner::new(VarScanOptions::default());
+        let mut out = Vec::new();
+        for block in fu.cfg.blocks.values() {
+            for stmt in &block.statements {
+                if matches!(stmt, Statement::Call { .. }) {
+                    out.extend(uses_of_classified(stmt, &mut scanner, &reg));
+                }
+            }
+        }
+        out
+    }
+
+    /// A braced word of a *nested* command is read exactly as the same word of
+    /// a direct call is, when the registry says the callee evaluates it in
+    /// this frame. Only a pair of braces separated `[expr $tainted]` (whose
+    /// read the enclosing word's own scan already saw) from
+    /// `[expr {$tainted}]` (invisible to every consumer of the use map)
+    /// before the def-use hole was closed — issue #1814.
+    #[test]
+    fn braced_word_of_a_nested_substitution_is_read_in_an_evaluated_role() {
+        let uses = classified_call_uses("puts [expr {$tainted}]");
+        assert!(
+            uses.contains(&("tainted".to_owned(), UseClass::Substituted)),
+            "an `Expr` role's braced word substitutes in this frame: {uses:?}"
+        );
+    }
+
+    /// …and a braced word in a role the callee does *not* evaluate stays the
+    /// literal it is. `list` builds a value; `{$tainted}` is one of its
+    /// elements, not a script.
+    #[test]
+    fn braced_word_of_a_nested_substitution_stays_literal_in_a_data_role() {
+        let uses = classified_call_uses("puts [list {$tainted}]");
+        assert!(
+            !uses.contains(&("tainted".to_owned(), UseClass::Substituted)),
+            "`list` does not evaluate its arguments in the calling frame: {uses:?}"
+        );
     }
 }

--- a/rust/tcl-compiler/src/word_subst.rs
+++ b/rust/tcl-compiler/src/word_subst.rs
@@ -55,7 +55,7 @@
 
 use tcl_lexer::Span;
 
-use crate::ir::{CommandTokens, WordExpr, WordPart};
+use crate::ir::{CommandTokens, Provenance, SourceSite, WordExpr, WordPart};
 
 /// How deep a nest of `[cmd [cmd …]]` this walks before giving up. Tcl's own
 /// parser caps nesting far above anything hand-written; this only has to stop
@@ -74,6 +74,14 @@ pub struct LiftedCall {
     pub args: Vec<String>,
     /// Absolute source span of each argument word.
     pub arg_spans: Vec<Span>,
+    /// The structured syntax of each argument word, index-aligned with
+    /// [`Self::args`] — so a consumer can tell a braced literal from a word
+    /// that substitutes without re-deciding it from the text.
+    ///
+    /// Empty when [`nested_command_words`] declined the substitution, or when
+    /// its word count disagreed with the argument split; a consumer that reads
+    /// this must keep working without it.
+    pub arg_words: Vec<WordExpr>,
     /// Absolute source span of the whole `[…]`.
     pub span: Span,
 }
@@ -110,14 +118,14 @@ fn collect_word(
     match word {
         // The whole word is `[cmd …]`.
         WordExpr::CommandSubstitution { spelling, source } => {
-            push_substitution(spelling, source.span.start(), config, depth, out);
+            push_substitution(spelling, source, config, depth, out);
         }
         // A compound word — `"[cmd …]"`, `a[cmd …]b`, `$v[cmd …]` — whose
         // parts evaluate left to right.
         WordExpr::Template { parts, .. } => {
             for part in parts {
                 if let WordPart::CommandSubstitution { spelling, source } = part {
-                    push_substitution(spelling, source.span.start(), config, depth, out);
+                    push_substitution(spelling, source, config, depth, out);
                 }
             }
         }
@@ -137,7 +145,7 @@ fn collect_word(
 /// nested in its own arguments.
 fn push_substitution(
     spelling: &str,
-    base: u32,
+    source: &SourceSite,
     config: tcl_lexer::LexerConfig,
     depth: u32,
     out: &mut Vec<LiftedCall>,
@@ -150,33 +158,117 @@ fn push_substitution(
     else {
         return;
     };
+    let base = source.span.start();
     let leading = u32::try_from(spelling.len() - spelling.trim_start().len()).unwrap_or(0);
     let span = Span::new(
         base + leading,
         base + leading + u32::try_from(spelling.trim().len()).unwrap_or(0),
     );
 
+    // The substitution's own words, recovered by the canonical segmenter. Its
+    // structure is what decides which of them evaluate a further substitution
+    // — `[list "[a]"]` and `[list b[c]d]` run one, `[list {[a]}]` does not —
+    // and no test over the flat argument text can tell those apart.
+    let nested = nested_command_words(spelling, source, config).ok();
+    if let Some(tokens) = nested.as_ref() {
+        for word in &tokens.word_exprs {
+            collect_word(word, config, depth + 1, out);
+        }
+    }
+    // Index-aligned with `args` (which start at word 1) or empty: the two
+    // recoveries split words under the same `LexerConfig`, so a disagreement
+    // means one of them declined the shape and the structure is not safe to
+    // pair up positionally.
+    let arg_words = nested
+        .as_ref()
+        .and_then(|tokens| tokens.word_exprs.get(1..))
+        .filter(|words| words.len() == args_with_spans.len())
+        .map(<[WordExpr]>::to_vec)
+        .unwrap_or_default();
+
     let mut args = Vec::with_capacity(args_with_spans.len());
     let mut arg_spans = Vec::with_capacity(args_with_spans.len());
     for (text, rel) in &args_with_spans {
-        let abs = Span::new(base + rel.start(), base + rel.end());
-        // An argument that is itself a substitution is evaluated first, so it
-        // is pushed first. A braced word starts with `{`, so this `[` test
-        // keeps a literal `{[cmd …]}` argument out, exactly as the whole-word
-        // `BracedLiteral` arm does one level up.
-        let trimmed = text.trim();
-        if trimmed.starts_with('[') && trimmed.ends_with(']') {
-            push_substitution(text, abs.start(), config, depth + 1, out);
-        }
         args.push(text.clone());
-        arg_spans.push(abs);
+        arg_spans.push(Span::new(base + rel.start(), base + rel.end()));
     }
     out.push(LiftedCall {
         command,
         args,
         arg_spans,
+        arg_words,
         span,
     });
+}
+
+/// Why the words of a `[…]` command substitution could not be recovered.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NestedWordsDecline {
+    /// The spelling is not one complete, non-empty `[…]` command.
+    Unmodelled,
+    /// It segmented, but carried no words.
+    NoWords,
+}
+
+/// The structured words of a `[…]` command substitution.
+///
+/// The word snapshot keeps a command substitution as one opaque spelling, so
+/// its inner words are recovered by running the canonical segmenter over the
+/// recorded lexical extent — the same segmentation the outer command's words
+/// came from, not a bespoke parser. Anything other than exactly one complete
+/// command declines.
+///
+/// The one owner for this: the native and WASM lowerings plan a nested
+/// invocation from the same words this module lifts for analysis, and a second
+/// recovery that split a word differently would let the two tiers disagree
+/// about what a substitution runs.
+///
+/// # Errors
+///
+/// Returns [`NestedWordsDecline`] when the spelling is not a single complete
+/// `[…]` command, or when it carries no words at all.
+pub fn nested_command_words(
+    spelling: &str,
+    source: &SourceSite,
+    config: tcl_lexer::LexerConfig,
+) -> Result<CommandTokens, NestedWordsDecline> {
+    // Word spellings arrive exact, but a substitution recovered from argument
+    // text can carry the whitespace that separated it; the offset the trim
+    // drops is added back so spans stay anchored where the word really sits.
+    let leading = u32::try_from(spelling.len() - spelling.trim_start().len()).unwrap_or(0);
+    let inner = spelling
+        .trim()
+        .strip_prefix('[')
+        .and_then(|text| text.strip_suffix(']'))
+        .ok_or(NestedWordsDecline::Unmodelled)?;
+    if inner.trim().is_empty() {
+        return Err(NestedWordsDecline::Unmodelled);
+    }
+    let base = if source.provenance == Provenance::Source {
+        source
+            .span
+            .start()
+            .saturating_add(leading)
+            .saturating_add(1)
+    } else {
+        0
+    };
+    let segments = crate::segmenter::segment_commands_with_offset_and_config(inner, base, config);
+    let [segment] = segments.as_slice() else {
+        return Err(NestedWordsDecline::Unmodelled);
+    };
+    if segment.is_partial {
+        return Err(NestedWordsDecline::Unmodelled);
+    }
+    // The nested script is a sub-lex: its own text, segmented at the document
+    // offset it sits at, so the word model reads `inner` and still reports
+    // document spans (`SourceMap::with_base` is that sub-lexing contract).
+    let sm = tcl_lexer::SourceMap::new(inner).with_base(base, 0, 0);
+    let tokens = CommandTokens::from_segmented(&sm, config, segment);
+    if tokens.word_exprs.is_empty() {
+        return Err(NestedWordsDecline::NoWords);
+    }
+    Ok(tokens)
 }
 
 /// Every nested `[expr …]` in `tokens`' words, parsed, with the absolute span
@@ -224,8 +316,8 @@ mod tests {
         tcl_registry::CommandRegistry::build_default()
     }
 
-    /// Lift the substitutions of the single `Call` in a one-statement proc.
-    fn lift(body: &str) -> Vec<(String, Vec<String>)> {
+    /// Every substitution lifted from the single `Call` in a one-statement proc.
+    fn lift_calls(body: &str) -> Vec<LiftedCall> {
         let reg = registry();
         let src = format!("proc f {{x}} {{\n {body}\n}}");
         let cu = CompilationUnit::build_for(&src, &reg, false);
@@ -235,15 +327,19 @@ mod tests {
         for block in fu.cfg.blocks.values() {
             for stmt in &block.statements {
                 if let Statement::Call { tokens, .. } = stmt {
-                    out.extend(
-                        lifted_calls(tokens.as_ref(), config)
-                            .into_iter()
-                            .map(|c| (c.command, c.args)),
-                    );
+                    out.extend(lifted_calls(tokens.as_ref(), config));
                 }
             }
         }
         out
+    }
+
+    /// Lift the substitutions of the single `Call` in a one-statement proc.
+    fn lift(body: &str) -> Vec<(String, Vec<String>)> {
+        lift_calls(body)
+            .into_iter()
+            .map(|c| (c.command, c.args))
+            .collect()
     }
 
     /// The whole point of reading `word_exprs` rather than the argument text:
@@ -296,5 +392,81 @@ mod tests {
     fn words_without_substitutions_lift_nothing() {
         assert!(lift("puts $x").is_empty());
         assert!(lift("puts plain").is_empty());
+    }
+
+    /// A substitution nested in a *quoted* word of another substitution still
+    /// runs — Tcl substitutes inside `"…"`. Recovering the nested command's
+    /// own words is what sees it; the argument text `"[lindex $x 0]"` starts
+    /// with a quote, so no `[`-prefix test over that text ever could.
+    ///
+    /// Asserted on the commands and the inner call's own arguments: the outer
+    /// `list`'s argument *text* is the compatibility spelling, which this
+    /// change does not touch.
+    #[test]
+    fn substitution_inside_a_quoted_nested_word_is_lifted() {
+        let calls = lift_calls("puts [list \"[lindex $x 0]\"]");
+        assert_eq!(
+            calls.iter().map(|c| c.command.as_str()).collect::<Vec<_>>(),
+            vec!["lindex", "list"]
+        );
+        assert_eq!(calls[0].args, vec!["$x".to_owned(), "0".to_owned()]);
+    }
+
+    /// The same for a substitution welded into a larger nested word.
+    #[test]
+    fn substitution_welded_into_a_nested_word_is_lifted() {
+        assert_eq!(
+            lift("puts [list a[lindex $x 0]b]"),
+            vec![
+                ("lindex".to_owned(), vec!["$x".to_owned(), "0".to_owned()]),
+                ("list".to_owned(), vec!["a[lindex $x 0]b".to_owned()]),
+            ]
+        );
+    }
+
+    /// …and the brace rule holds one level down too: a braced argument of a
+    /// nested command is literal text, not a command to run.
+    #[test]
+    fn braced_word_of_a_nested_substitution_is_not_run() {
+        assert_eq!(
+            lift("puts [list {[lindex $x 0]}]"),
+            vec![("list".to_owned(), vec!["{[lindex $x 0]}".to_owned()])]
+        );
+    }
+
+    /// A substitution in the *command* position runs before the command it
+    /// spells is looked up.
+    #[test]
+    fn substitution_in_the_command_word_is_lifted() {
+        assert_eq!(
+            lift("puts [[lindex $x 0] 1]"),
+            vec![
+                ("lindex".to_owned(), vec!["$x".to_owned(), "0".to_owned()]),
+                ("[lindex $x 0]".to_owned(), vec!["1".to_owned()]),
+            ]
+        );
+    }
+
+    /// `arg_words` is the segmenter's structure for the same words `args`
+    /// spells, index-aligned, so a consumer can tell a braced literal from a
+    /// word that substitutes without re-deciding it from the text.
+    #[test]
+    fn arg_words_align_with_args() {
+        let calls = lift_calls("puts [list {a b} $x [set y] plain]");
+        // `[set y]` is evaluated first, so the outer `list` is lifted last.
+        let [_, lifted] = calls.as_slice() else {
+            panic!("expected the inner `set` then the outer `list`, got {calls:?}");
+        };
+        assert_eq!(lifted.command, "list");
+        assert_eq!(lifted.arg_words.len(), lifted.args.len());
+        assert!(matches!(
+            lifted.arg_words.as_slice(),
+            [
+                WordExpr::BracedLiteral { .. },
+                WordExpr::Variable { .. },
+                WordExpr::CommandSubstitution { .. },
+                WordExpr::Literal { .. },
+            ]
+        ));
     }
 }


### PR DESCRIPTION
## Summary

- `word_subst` decided which arguments of a `[cmd …]` were themselves commands with a `[`-prefix test over the flat argument text. That text cannot answer the question: `puts [list "[lindex $x 0]"]` and `puts [list a[lindex $x 0]b]` both run their `lindex`, neither argument starts with `[`, and both reported nothing — the same class of hole as #1814, one level further in.
- The segmenter already answers it. `word_subst::nested_command_words` runs it over the substitution's recorded lexical extent and returns the real words, so a `BracedLiteral` is told from a `CommandSubstitution` by structure and the walk recurses into whatever the nested command actually evaluates — including its command word (`[[lindex $x 0] 1]`).
- `LiftedCall::arg_words` carries that structure to consumers; `ssa::scan_nested_substitution_words` reads it instead of testing argument text for `{`/`}`.
- That recovery already existed **twice** — byte-identical in `native_lowering::lower` and `codegen::wasm::leaf_invoke` but for their decline enum. Both now call the one owner, so analysis lifts the same words the two AOT tiers plan. Registered in the owner-resolution manifest, so a third copy fails `make xtask-owner-resolution`.
- `args` / `arg_spans` keep their existing spellings — only the structure alongside them is new — so no consumer's text handling changes.

Before / after on the two shapes that were silent:

```tcl
proc f {l} {
    set x [llength $l]
    puts [list "[lindex $x 0]"]   ;# now S100, was nothing
    puts [list a[lindex $x 0]b]   ;# now S100, was nothing
    puts [list {[lindex $x 0]}]   ;# still nothing — braced, never run
}
```

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

```
make rust-check                                   # fmt + clippy + generated-file drift, clean
cargo test -p tcl-compiler --lib                  # 6094 passed
cargo test -p tcl-compiler --test checks --test taint --test analyser --test differential_word_expr
cargo test -p tcl-compiler --test wasm_codegen --test codegen --test wasm_tiers \
                           --test inlining_rename --test core_analyses
cargo test -p tcl-compiler --test fp_depth --test per_item_corpus --test dataflow
cargo run -p xtask -- owner-resolution            # 34 owner rows resolve
cargo run -p xtask -- fp-sweep --code S100 --code S101 --code T100 \
                               --corpus tmp/tcllib-2.0/modules
```

The false-positive sweep over all of tcllib 2.0's modules reports **no S100/S101 findings at
all** with this change in place, and 12 T100s that are tcllib's own (`$passwd`, `$len`, `$tag`
into `expr`). Since widening the lift can only ever *add* reports, an empty S100/S101 result
across a corpus that size is the useful measurement: the two shapes this fixes are real but
rare, and nothing else started firing.

Cost, measured rather than assumed — `tcl diag` over 60 tcllib modules, three runs each:
`58.39 / 58.43 / 60.26` s with the change against `59.01 / 58.44 / 58.53` s without. Inside
run-to-run noise: the extra segmenter pass only runs where a substitution actually exists, and
`lifted_calls` still returns on the `word_exprs` scan for the overwhelming majority of statements
that have none.

## Compiler / diagnostics checklist

- [x] Did this change alter a compiler fact contract? Yes — nested-substitution coverage now holds at every depth, and the word recovery has one owner.
- [x] Updated `docs/design/contracts/shimmer-reference-behaviour.md` (the nested-substitution section, and a stale `shimmer::nested` reference left by #1826's rename) and `docs/design/contracts/shared-utility-contracts-rust.md` (new owner row + section).
- [x] No new or changed diagnostic code — S100/S101/T100 simply reach sites they could not see before.
- [x] No new design doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PKQ5b7ZLU5XPDaugte4Feb