### PR TITLE
fix(compiler): lift an assignment's nested substitutions like a call's

### DIFF
--- a/docs/design/contracts/shimmer-reference-behaviour.md
+++ b/docs/design/contracts/shimmer-reference-behaviour.md
@@ -214,14 +214,29 @@ each consume them. Five properties matter:
   onto `Terminator::Return::expr`, and leaves it `None` for the braced
   `return {[expr …]}`. The walker just reads it, as it already did for
   `Terminator::Branch`.
-- **Every statement that carries substitutable words is lifted the same way.**
-  Both `Statement::Call` and `Statement::AssignValue` hold `CommandTokens`, and
-  the outer command changes nothing about what Tcl evaluates inside a word — so
-  `set r [list [lindex $x 0]]` reports exactly what `puts [list [lindex $x 0]]`
-  does. `AssignValue` used to parse only its outermost `[cmd …]` and go silent
-  below depth one (issue #1844); the outermost substitution is now simply the
-  depth-zero case of the same walk, not a shape the arm re-derives — the lift
-  is the single owner of "which commands does this statement run".
+- **Every statement that carries substitutable words is lifted the same way,
+  in every consumer.** Both `Statement::Call` and `Statement::AssignValue` hold
+  `CommandTokens`, and the outer command changes nothing about what Tcl
+  evaluates inside a word — so `set r <word>` reports exactly what
+  `puts <word>` does. `AssignValue` used to parse only its outermost `[cmd …]`
+  and go silent below depth one (issue #1844); the outermost substitution is
+  now simply the depth-zero case of the same walk, not a shape the arm
+  re-derives. The symmetry has to hold in all four places that read the lift,
+  or it holds nowhere: `use_site` (what reports), `commit` (what moves the
+  state), `expr` (nested `[expr …]`, which carries its reads in an expression
+  rather than in registry roles), and `ssa::scan_nested_substitution_words`
+  (which puts a nested expression's operands into `SsaStatement::uses` at all —
+  without it the `expr` detector has nothing to resolve against).
+- **A nested command's `Body` is not lifted into the enclosing frame, though a
+  statement's is.** `ArgRole::braced_word_evaluated_in_frame` answers for
+  `Body` as well as `Expr`, and for a statement that is right: the lowerer
+  gives `foreach x $l {…}` its own CFG block, so the loop variable is *defined*
+  where the body's reads are seen. A nested substitution gets no block — that
+  is the representational gap below — so lifting `[lmap x $l {… $x …}]`'s body
+  recorded a read of `x` that nothing in the frame writes, and `W210 read
+  before it is set` fired on the loop variable itself. `Expr` is the role that
+  substitutes here *and* binds nothing of its own, so it is the only one the
+  nested scan takes.
 
 ### Known limitation — the underlying representational gap
 
@@ -276,7 +291,13 @@ dedicated `Statement::Incr` node.
   statement kinds against each other so they cannot drift apart again,
   alongside `assign_value_substitution_is_reported_once`,
   `assign_value_nested_substitution_span_is_tight` and
-  `a_nested_conversion_in_an_assignment_is_visible_to_later_reads`).
+  `a_nested_conversion_in_an_assignment_is_visible_to_later_reads`), and
+  `shimmer::expr` again for the expression half of that symmetry
+  (`assign_value_lifts_the_same_nested_expr_a_call_does`,
+  `a_bare_expr_assignment_is_reported_once`).
+- The use-map half, in `ssa`: `braced_word_of_a_nested_substitution_is_read_in_an_assignment_value`
+  for what must be recorded, and `body_word_of_a_nested_substitution_is_not_a_frame_read`
+  (plus its assignment and `catch`-local twins) for what must not.
 - Unit tests co-located with each shimmer module (`rust/tcl-compiler/src/shimmer/*.rs`) and in `rust/tcl-compiler/tests/checks.rs`.
 - TP/FP/TN/FN regression fixtures in `rust/tcl-compiler/src/analyser/diagnostics/fp/sh.rs` (the `FP-SH-NN` series).
 - Native `lsp_e2e` coverage in `rust/tcl-lsp-server/tests/e2e/diagnostics.rs` and `rust/tcl-lsp-server/tests/e2e/code_actions.rs` (the noqa suppress quick fix).

--- a/docs/design/contracts/shimmer-reference-behaviour.md
+++ b/docs/design/contracts/shimmer-reference-behaviour.md
@@ -193,7 +193,7 @@ variable* was judged against a stale representation: `set x [llength $l]` then
 code with `lindex $x 0` on its own line reported both halves.
 
 `word_subst` lifts those substitutions, and `commit`, `use_site` and `expr`
-each consume them. Four properties matter:
+each consume them. Five properties matter:
 
 - **It reads `word_exprs`, never the argument text.** Tcl substitutes `[…]` in
   bare and `"…"`-quoted words but not in braced ones, and
@@ -214,6 +214,14 @@ each consume them. Four properties matter:
   onto `Terminator::Return::expr`, and leaves it `None` for the braced
   `return {[expr …]}`. The walker just reads it, as it already did for
   `Terminator::Branch`.
+- **Every statement that carries substitutable words is lifted the same way.**
+  Both `Statement::Call` and `Statement::AssignValue` hold `CommandTokens`, and
+  the outer command changes nothing about what Tcl evaluates inside a word — so
+  `set r [list [lindex $x 0]]` reports exactly what `puts [list [lindex $x 0]]`
+  does. `AssignValue` used to parse only its outermost `[cmd …]` and go silent
+  below depth one (issue #1844); the outermost substitution is now simply the
+  depth-zero case of the same walk, not a shape the arm re-derives — the lift
+  is the single owner of "which commands does this statement run".
 
 ### Known limitation — the underlying representational gap
 
@@ -263,7 +271,12 @@ dedicated `Statement::Incr` node.
   distinction at every depth, and `arg_words` alignment), `shimmer::expr` (`expr_shimmer_fires_in_a_return_expression`,
   `expr_shimmer_fires_in_a_nested_call_argument` and their braced twins),
   `shimmer::use_site` (`use_site_shimmer_fires_in_a_nested_call_argument`,
-  `a_nested_conversion_is_visible_to_later_reads`).
+  `a_nested_conversion_is_visible_to_later_reads`, and their `AssignValue`
+  twins — `assign_value_lifts_the_same_substitutions_a_call_does` pins the two
+  statement kinds against each other so they cannot drift apart again,
+  alongside `assign_value_substitution_is_reported_once`,
+  `assign_value_nested_substitution_span_is_tight` and
+  `a_nested_conversion_in_an_assignment_is_visible_to_later_reads`).
 - Unit tests co-located with each shimmer module (`rust/tcl-compiler/src/shimmer/*.rs`) and in `rust/tcl-compiler/tests/checks.rs`.
 - TP/FP/TN/FN regression fixtures in `rust/tcl-compiler/src/analyser/diagnostics/fp/sh.rs` (the `FP-SH-NN` series).
 - Native `lsp_e2e` coverage in `rust/tcl-lsp-server/tests/e2e/diagnostics.rs` and `rust/tcl-lsp-server/tests/e2e/code_actions.rs` (the noqa suppress quick fix).

--- a/rust/tcl-compiler/src/shimmer/commit.rs
+++ b/rust/tcl-compiler/src/shimmer/commit.rs
@@ -572,20 +572,13 @@ fn typed_reads_of_statement(
                 }
             }
         }
-        Statement::AssignValue { value, .. } => {
-            if let Some((command, args)) =
-                crate::value_shapes::parse_command_substitution_with_config(
-                    value.trim(),
-                    tcl_lexer::LexerConfig::for_profile(ctx.registry.profile()),
-                )
-            {
-                let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
-                for (i, word) in args.iter().enumerate() {
-                    if let Some(expected) = arg_shimmer_type(ctx.registry, &command, &arg_refs, i) {
-                        push_var_read(ctx, &mut out, word, expected, stmt.span(), uses);
-                    }
-                }
-            }
+        Statement::AssignValue { tokens, .. } => {
+            // An assignment's value word substitutes exactly as a call's
+            // words do, so its reads land the same way and through the same
+            // lift — `set r [list [lindex $x 0]]` converts `x` to a list just
+            // as `set r [lindex $x 0]` does, and the outermost `[cmd …]` is
+            // only the depth-zero case of that walk (issue #1844).
+            push_lifted_reads(ctx, &mut out, tokens.as_ref(), stmt.span(), uses);
         }
         Statement::Incr { name, amount, .. } => {
             push_var_read(

--- a/rust/tcl-compiler/src/shimmer/expr.rs
+++ b/rust/tcl-compiler/src/shimmer/expr.rs
@@ -133,7 +133,18 @@ pub(crate) fn find_expr_shimmers(
                 // Its operands resolve through the statement's own `uses`,
                 // which `ssa::scan_nested_substitution_words` now populates
                 // for a nested command's in-frame braced words.
-                Statement::Call { tokens, .. } => {
+                //
+                // Both statement kinds that carry substitutable words are
+                // lifted, for the reason the arm exists at all: the outer
+                // command decides nothing about what Tcl evaluates inside a
+                // word, so `set r [list [expr {0 in $x}]]` runs the same
+                // expression as `puts [list [expr {0 in $x}]]`. Only the
+                // `Call` half was lifted, so the assignment spelling reported
+                // nothing (issue #1844 review). A `set x [expr {…}]` whose
+                // value word *is* the substitution never reaches here — the
+                // lowerer already made it the `AssignExpr` above — so the two
+                // arms cannot both report the same expression.
+                Statement::Call { tokens, .. } | Statement::AssignValue { tokens, .. } => {
                     for (expr, span) in
                         crate::word_subst::lifted_exprs(tokens.as_ref(), registry.profile())
                     {
@@ -910,6 +921,64 @@ mod tests {
         let cu = CompilationUnit::build_for(src, &registry(), false);
         let fu = cu.function("::f").unwrap();
         assert!(expr_shimmers(fu, &registry()).is_empty());
+    }
+
+    /// Issue #1844 review: a nested `[expr …]` must be lifted out of an
+    /// assignment value exactly as it is out of a call argument. The outer
+    /// command decides nothing about what Tcl evaluates inside the word, so
+    /// `set r <word>` and `puts <word>` run the same expression — but only the
+    /// `Call` arm was lifted here, so the assignment spelling reported nothing
+    /// even while `commit` recorded the conversion for later reads.
+    ///
+    /// Paired against the call spelling rather than asserted on its own: it is
+    /// the symmetry that is the contract, and only a comparison catches the
+    /// two arms drifting apart again. The braced row is the control — Tcl
+    /// never substitutes it, at either spelling.
+    #[test]
+    fn assign_value_lifts_the_same_nested_expr_a_call_does() {
+        for (word, runs) in [
+            ("[expr {0 in $x}]", true),
+            ("[list [expr {0 in $x}]]", true),
+            ("[list \"[expr {0 in $x}]\"]", true),
+            ("[list {[expr {0 in $x}]}]", false),
+        ] {
+            let mut verdicts = Vec::new();
+            for stmt in [format!("puts {word}"), format!("set r {word}")] {
+                let src = format!("proc f {{lst}} {{\n set x [llength $lst]\n {stmt}\n}}");
+                let cu = CompilationUnit::build_for(&src, &registry(), false);
+                let fu = cu.function("::f").unwrap();
+                let w = expr_shimmers(fu, &registry());
+                let hit = w.iter().find(|sw| sw.variable == "x").cloned();
+                if let Some(hit) = hit.as_ref() {
+                    assert_eq!(hit.to_type, TclType::List, "in {stmt:?}");
+                }
+                verdicts.push((stmt, hit.is_some()));
+            }
+            let [(call, call_fired), (assign, assign_fired)] = verdicts.as_slice() else {
+                unreachable!("one verdict per spelling")
+            };
+            assert_eq!(
+                call_fired, assign_fired,
+                "{call:?} and {assign:?} evaluate the same expression and must report alike"
+            );
+            assert_eq!(*call_fired, runs, "wrong verdict for {call:?}");
+        }
+    }
+
+    /// A `set x [expr {…}]` whose value word *is* the substitution is lowered
+    /// to `AssignExpr`, so widening the lift to `AssignValue` must not make
+    /// the two arms report the same expression twice.
+    #[test]
+    fn a_bare_expr_assignment_is_reported_once() {
+        let src = "proc f {lst} {\n set x [llength $lst]\n set r [expr {0 in $x}]\n}";
+        let cu = CompilationUnit::build_for(src, &registry(), false);
+        let fu = cu.function("::f").unwrap();
+        let w = expr_shimmers(fu, &registry());
+        assert_eq!(
+            w.iter().filter(|sw| sw.variable == "x").count(),
+            1,
+            "one expression, one report: {w:?}"
+        );
     }
 
     /// Review follow-up on #1814: `%`, the shifts and the bitwise operators

--- a/rust/tcl-compiler/src/shimmer/use_site.rs
+++ b/rust/tcl-compiler/src/shimmer/use_site.rs
@@ -666,69 +666,15 @@ fn check_statement(ctx: &mut UseSiteCtx<'_>, stmt: &Statement, uses: &HashMap<Sy
             );
         }
 
-        // A command substitution lifted into an assignment value
-        // (`set b [lindex $x 0]`) reads its arguments just like a direct
-        // call. The substitution's own command word is re-parsed from raw
-        // text (no lowering pass resolves it), so no `interp alias`
-        // resolution is available here — the lookup key is the source
-        // spelling itself.
-        Statement::AssignValue { value, tokens, .. } => {
-            // The value word's own absolute span (`argv`'s last entry —
-            // `set name value` is always two args) anchors the re-lexed
-            // substitution's relative spans; falls back to the
-            // whole-statement span when tokens aren't available (some test
-            // fixtures build `AssignValue` without them).
-            let value_base = tokens
-                .as_ref()
-                .and_then(|t| t.argv.last())
-                .map(|sp| sp.start());
-            if let (Some(base), Some((command, args_with_spans))) = (
-                value_base,
-                crate::value_shapes::parse_command_substitution_with_spans_and_config(
-                    value,
-                    tcl_lexer::LexerConfig::for_profile(ctx.registry.profile()),
-                ),
-            ) {
-                let args: Vec<String> = args_with_spans.iter().map(|(a, _)| a.clone()).collect();
-                let arg_spans: Vec<Span> = args_with_spans
-                    .iter()
-                    .map(|(_, rel)| Span::new(base + rel.start(), base + rel.end()))
-                    .collect();
-                check_invocation(
-                    ctx,
-                    &InvocationSite {
-                        command: &command,
-                        lookup_command: &command,
-                        args: &args,
-                        arg_spans: &arg_spans,
-                        is_foreach_header: false,
-                        fallback_span: stmt.span(),
-                    },
-                    uses,
-                );
-            } else if let Some((command, args)) =
-                crate::value_shapes::parse_command_substitution_with_config(
-                    value.trim(),
-                    tcl_lexer::LexerConfig::for_profile(ctx.registry.profile()),
-                )
-            {
-                // Fallback for shapes the span-aware lexer-based parser
-                // rejects (no `tokens`, or an embedded `;`/newline second
-                // command) but the older bracket-counting parser still
-                // accepts — whole-statement span, same as before this fix.
-                check_invocation(
-                    ctx,
-                    &InvocationSite {
-                        command: &command,
-                        lookup_command: &command,
-                        args: &args,
-                        arg_spans: &[],
-                        is_foreach_header: false,
-                        fallback_span: stmt.span(),
-                    },
-                    uses,
-                );
-            }
+        // The words of an assignment substitute exactly as a call's do —
+        // `set b [lindex $x 0]` runs `lindex` before it stores anything, and
+        // `set b [list [lindex $x 0]]` runs it just the same, one level down.
+        // So the value word goes through the same lift as a call's words
+        // (issue #1844): one owner decides which substitutions a statement
+        // runs, and the outermost `[cmd …]` is simply its depth-zero case
+        // rather than a shape this arm re-derives for itself.
+        Statement::AssignValue { tokens, .. } => {
+            check_lifted_calls(ctx, tokens.as_ref(), stmt.span(), uses);
         }
 
         Statement::Incr { name, amount, .. } => {
@@ -1017,6 +963,91 @@ mod tests {
         );
     }
 
+    /// Issue #1844: the two statement kinds that carry substitutable words
+    /// must agree about which commands a word runs. `puts <word>` and
+    /// `set r <word>` differ only in the outer command, and neither outer
+    /// command changes what Tcl evaluates inside the word — so any word that
+    /// shimmers in a call argument shimmers identically in an assignment
+    /// value, and any word that does not, does not.
+    ///
+    /// Written as a paired assertion rather than two independent expectations
+    /// on purpose: it is the *symmetry* that regressed (the `AssignValue` arm
+    /// parsed only its outermost `[cmd …]` and so went silent below depth
+    /// one), and only a test that compares the paths can catch them drifting
+    /// apart again.
+    #[test]
+    fn assign_value_lifts_the_same_substitutions_a_call_does() {
+        // (word, does its `lindex` run?) — a bare substitution, then the
+        // nesting depths the `AssignValue` arm used to lose, then the braced
+        // spelling Tcl never substitutes.
+        for (word, runs) in [
+            ("[lindex $x 0]", true),
+            ("[list [lindex $x 0]]", true),
+            ("[list \"[lindex $x 0]\"]", true),
+            ("[list a[lindex $x 0]b]", true),
+            ("[list {[lindex $x 0]}]", false),
+        ] {
+            let mut verdicts = Vec::new();
+            for stmt in [format!("puts {word}"), format!("set r {word}")] {
+                let src = format!("proc f {{lst}} {{\n set x [llength $lst]\n {stmt}\n}}");
+                let cu = CompilationUnit::build_for(&src, &registry(), false);
+                let fu = cu.function("::f").unwrap();
+                let w = use_site_shimmers(fu, &registry());
+                let hit = w.iter().find(|w| w.command == "lindex").cloned();
+                if let Some(hit) = hit.as_ref() {
+                    assert_eq!(hit.from_type, TclType::Int, "in {stmt:?}");
+                    assert_eq!(hit.to_type, TclType::List, "in {stmt:?}");
+                }
+                verdicts.push((stmt, hit.is_some()));
+            }
+            let [(call, call_fired), (assign, assign_fired)] = verdicts.as_slice() else {
+                unreachable!("one verdict per spelling")
+            };
+            assert_eq!(
+                call_fired, assign_fired,
+                "{call:?} and {assign:?} run the same commands and must report alike"
+            );
+            assert_eq!(*call_fired, runs, "wrong verdict for {call:?}");
+        }
+    }
+
+    /// The lift is the *only* path into the `AssignValue` arm, so the
+    /// depth-zero substitution it used to special-case must still be reported
+    /// exactly once — a second, arm-local parse of the outermost `[cmd …]`
+    /// would double every `set b [lindex $x 0]` diagnostic.
+    #[test]
+    fn assign_value_substitution_is_reported_once() {
+        let cu = CompilationUnit::build_for(
+            "proc f {lst} {\n set x [llength $lst]\n set b [lindex $x 0]\n}",
+            &registry(),
+            false,
+        );
+        let fu = cu.function("::f").unwrap();
+        let w = use_site_shimmers(fu, &registry());
+        assert_eq!(
+            w.iter().filter(|w| w.command == "lindex").count(),
+            1,
+            "one substitution, one report: {w:?}"
+        );
+    }
+
+    /// The span stays tight around the `$x` of the *nested* command, not the
+    /// outer `[list …]` and not the whole `set` — the developer's eye has to
+    /// land on the read that actually converts.
+    #[test]
+    fn assign_value_nested_substitution_span_is_tight() {
+        let src = "proc f {lst} {\n set x [llength $lst]\n set r [list [lindex $x 0]]\n}";
+        let cu = CompilationUnit::build_for(src, &registry(), false);
+        let fu = cu.function("::f").unwrap();
+        let warnings = use_site_shimmers(fu, &registry());
+        let w = warnings
+            .iter()
+            .find(|w| w.command == "lindex")
+            .unwrap_or_else(|| panic!("expected nested lindex shimmer, got: {warnings:?}"));
+        let text = &src[w.span.start() as usize..w.span.end() as usize];
+        assert_eq!(text, "$x", "got {text:?} from {w:?}");
+    }
+
     /// The conversion a nested substitution performs must also reach the
     /// commit state, or every later read of the same variable is judged
     /// against a stale representation. Before this, the `incr` here reported
@@ -1026,6 +1057,29 @@ mod tests {
     fn a_nested_conversion_is_visible_to_later_reads() {
         let cu = CompilationUnit::build_for(
             "proc f {lst} {\n set x [llength $lst]\n puts [lindex $x 0]\n incr x\n}",
+            &registry(),
+            false,
+        );
+        let fu = cu.function("::f").unwrap();
+        let w = use_site_shimmers(fu, &registry());
+        let incr = w.iter().find(|w| w.command == "incr");
+        assert!(incr.is_some(), "the incr after a nested list read: {w:?}");
+        assert_eq!(
+            incr.unwrap().from_type,
+            TclType::List,
+            "it converted back from the list the nested `lindex` installed"
+        );
+    }
+
+    /// Issue #1844, the commit half: the same must hold when the nested
+    /// substitution sits in an assignment value. The `AssignValue` transfer
+    /// function used to walk only the outermost `[cmd …]`, so `[list […]]`
+    /// moved no state and the following `incr` was judged against the stale
+    /// `Int` — reporting nothing.
+    #[test]
+    fn a_nested_conversion_in_an_assignment_is_visible_to_later_reads() {
+        let cu = CompilationUnit::build_for(
+            "proc f {lst} {\n set x [llength $lst]\n set r [list [lindex $x 0]]\n incr x\n}",
             &registry(),
             false,
         );

--- a/rust/tcl-compiler/src/ssa.rs
+++ b/rust/tcl-compiler/src/ssa.rs
@@ -1848,9 +1848,18 @@ fn uses_in_assignment(
             name,
             name_braced,
             value,
+            tokens,
             ..
         } => {
             vars_found.extend(scanner.scan_word(value, registry));
+            // `scan_word` declines to substitute inside braces, exactly as the
+            // *word* parser does — but a nested `[expr {$x + 1}]` substitutes
+            // its own braced body, and that read is real. The call path has
+            // recovered it since #1826; an assignment value substitutes by the
+            // same rules, so `set r [list [expr {0 in $x}]]` reads `x` just as
+            // `puts [list [expr {0 in $x}]]` does (issue #1844 review). Same
+            // owner, one more statement kind — not a second recovery.
+            scan_nested_substitution_words(tokens.as_ref(), scanner, registry, vars_found);
             if is_dynamic_write_target(name, *name_braced) {
                 vars_found.extend(scanner.scan_word(name, registry));
             } else {
@@ -1979,7 +1988,7 @@ fn scan_command_words(
             };
         }
     }
-    scan_nested_substitution_words(tokens, scanner, registry, out);
+    scan_nested_substitution_words(tokens, scanner, registry, &mut out.substituted);
 }
 
 /// Record the reads inside a nested `[cmd …]`'s brace-quoted words that the
@@ -2008,24 +2017,48 @@ fn scan_command_words(
 /// ```
 ///
 /// So this applies the same registry-driven rule at the nested positions,
-/// rather than teaching any consumer about substitutions. Only the words the
-/// nested command evaluates in this frame are scanned here; a braced word it
-/// merely carries as data is left to the conservative `Quoted` handling the
-/// enclosing word already got.
+/// rather than teaching any consumer about substitutions. A braced word the
+/// nested command merely carries as data is left to the conservative `Quoted`
+/// handling the enclosing word already got.
+///
+/// Writes only substituted names — a word the nested command evaluates in this
+/// frame is a genuine read — so it takes that half directly rather than the
+/// whole [`ClassifiedUses`], which lets the assignment path (whose collector
+/// *is* the substituted set) share the one owner.
+///
+/// # Why `Expr` only, and not every in-frame role
+///
+/// [`ArgRole::braced_word_evaluated_in_frame`](tcl_registry::ArgRole::braced_word_evaluated_in_frame)
+/// answers for `Body` as well as `Expr`, and for a **statement** that is right:
+/// `foreach x $l {…}` runs its body in this frame, and the lowerer gives that
+/// body its own CFG block, so the loop variable is *defined* where the body's
+/// reads are seen.
+///
+/// A nested substitution gets no such block — that is the representational gap
+/// this whole module works around — so a nested body's reads would arrive with
+/// none of its own definitions:
+///
+/// ```tcl
+/// set r [join [lmap x $lines {string toupper $x}] ","]
+/// ```
+///
+/// scanning the `lmap` body records a read of `x` that nothing in the frame
+/// ever writes, and `W210 read before it is set` fires on the loop variable.
+/// `Expr` is the role that both substitutes here *and* binds nothing of its
+/// own, which is exactly what the `[expr {$x + 1}]` case this exists for
+/// needs; `Body` is left to the conservative handling until a nested
+/// substitution is lowered as a command.
 fn scan_nested_substitution_words(
     tokens: Option<&CommandTokens>,
     scanner: &mut VarReferenceScanner,
     registry: &CommandRegistry,
-    out: &mut ClassifiedUses,
+    substituted: &mut BTreeSet<String>,
 ) {
     let config = tcl_lexer::LexerConfig::for_profile(registry.profile());
     for lifted in crate::word_subst::lifted_calls(tokens, config) {
         let arg_strs: Vec<&str> = lifted.args.iter().map(String::as_str).collect();
-        let in_frame: std::collections::HashSet<usize> = tcl_registry::ArgRole::ALL
-            .iter()
-            .filter(|role| role.braced_word_evaluated_in_frame())
-            .flat_map(|&role| registry.arg_indices_for_role(&lifted.command, &arg_strs, role))
-            .collect();
+        let in_frame =
+            registry.arg_indices_for_role(&lifted.command, &arg_strs, tcl_registry::ArgRole::Expr);
         for idx in in_frame {
             // Only a braced word needs recovering. An unbraced one already
             // substitutes at the command level, so the enclosing word's own
@@ -2039,7 +2072,7 @@ fn scan_nested_substitution_words(
                 // nothing to recover from it either.
                 _ => continue,
             };
-            out.substituted.extend(scanner.scan_word(braced, registry));
+            substituted.extend(scanner.scan_word(braced, registry));
         }
     }
 }
@@ -4749,6 +4782,77 @@ mod tests {
         assert!(
             !uses.contains(&("tainted".to_owned(), UseClass::Substituted)),
             "`list` does not evaluate its arguments in the calling frame: {uses:?}"
+        );
+    }
+
+    /// A nested command's **body** must not be read as a frame use, even
+    /// though a body written on a *statement* is. The difference is the
+    /// lowering: a statement's body becomes its own CFG block, so `lmap`'s
+    /// loop variable is defined where the body's reads are seen, while a
+    /// nested substitution gets no block at all — so its body's reads arrive
+    /// with none of its own definitions and `x` looks read-before-set
+    /// (issue #1844 review).
+    #[test]
+    fn body_word_of_a_nested_substitution_is_not_a_frame_read() {
+        let uses = classified_call_uses("puts [join [lmap x $tainted {string toupper $x}] ,]");
+        assert!(
+            !uses.iter().any(|(name, _)| name == "x"),
+            "`lmap` binds its own loop variable; the frame never reads it: {uses:?}"
+        );
+    }
+
+    /// The same for a body whose locals are set inside it — `catch`'s script
+    /// declares `inner`, so the enclosing frame neither reads nor defines it.
+    #[test]
+    fn body_locals_of_a_nested_substitution_are_not_frame_reads() {
+        let uses = classified_call_uses("puts [catch {set inner 1; expr {$inner + 1}}]");
+        assert!(
+            !uses.iter().any(|(name, _)| name == "inner"),
+            "a nested body's own local is not a read of this frame: {uses:?}"
+        );
+    }
+
+    /// The classified uses of every `AssignValue` in a one-statement proc —
+    /// the assignment twin of [`classified_call_uses`].
+    fn classified_assign_uses(body: &str) -> Vec<(String, UseClass)> {
+        let reg = CommandRegistry::build_default();
+        let src = format!("proc f {{tainted}} {{\n {body}\n}}");
+        let cu = crate::compilation_unit::CompilationUnit::build_for(&src, &reg, false);
+        let fu = cu.function("::f").expect("proc lowered");
+        let mut scanner = VarReferenceScanner::new(VarScanOptions::default());
+        let mut out = Vec::new();
+        for block in fu.cfg.blocks.values() {
+            for stmt in &block.statements {
+                if matches!(stmt, Statement::AssignValue { .. }) {
+                    out.extend(uses_of_classified(stmt, &mut scanner, &reg));
+                }
+            }
+        }
+        out
+    }
+
+    /// Issue #1844 review: an assignment's value word substitutes by exactly
+    /// the rules a call's word does, so the braced body of a nested `[expr …]`
+    /// is a read there too. Without it the expression's operands were absent
+    /// from `uses` and every consumer of that map — the expr shimmer detector
+    /// included — was blind to `set r [list [expr {$tainted + 1}]]`.
+    #[test]
+    fn braced_word_of_a_nested_substitution_is_read_in_an_assignment_value() {
+        let uses = classified_assign_uses("set r [list [expr {$tainted + 1}]]");
+        assert!(
+            uses.contains(&("tainted".to_owned(), UseClass::Substituted)),
+            "an `Expr` role's braced word substitutes in this frame: {uses:?}"
+        );
+    }
+
+    /// …and the body exclusion holds on the assignment path too — this is the
+    /// spelling the repository's own corpus actually contains.
+    #[test]
+    fn body_word_of_a_nested_substitution_in_an_assignment_is_not_a_frame_read() {
+        let uses = classified_assign_uses("set r [join [lmap x $tainted {string toupper $x}] ,]");
+        assert!(
+            !uses.iter().any(|(name, _)| name == "x"),
+            "`lmap` binds its own loop variable; the frame never reads it: {uses:?}"
         );
     }
 }


### PR DESCRIPTION
## Summary

A word substitutes by the same rules wherever it is written — the outer command decides nothing about what Tcl evaluates inside it. `Statement::Call` and `Statement::AssignValue` both carry `CommandTokens`, but only the call half was ever lifted, so the assignment spelling was silent below depth one. This makes the two agree, in every consumer of the lift.

```tcl
proc f {l} {
    set x [llength $l]
    puts [list [lindex $x 0]]     ;# S100
    set r [lindex $x 0]           ;# S100
    set r [list [lindex $x 0]]    ;# nothing, before this
    set r [list "[lindex $x 0]"]  ;# nothing
    set r [list a[lindex $x 0]b]  ;# nothing
    set r [list [expr {0 in $x}]] ;# nothing
}
```

`word_subst::lifted_calls` already owns *which commands does this statement run*, including the `word_exprs` reading that keeps `[list {[lindex $x 0]}]` a literal at every depth. So the fix is **not a second nesting walk** but the removal of the arms' bespoke ones. Four places read that lift, and the symmetry has to hold in all of them or it holds nowhere:

| consumer | what it does | change |
|---|---|---|
| `shimmer::use_site` | emits S100/S101 | `AssignValue` → `check_lifted_calls` |
| `shimmer::commit` | moves the committed-intrep state | `AssignValue` → `push_lifted_reads` |
| `shimmer::expr` | nested `[expr …]`, whose reads live in operands, not registry roles | `AssignValue` → `lifted_exprs` |
| `ssa::scan_nested_substitution_words` | puts a nested expression's operands into `SsaStatement::uses` at all | `AssignValue` → same recovery |

The issue named only `commit`. That arm is the state half — without it a later read is judged against a stale representation (`set r [list [lindex $x 0]]` then `incr x` reported nothing) — but `use_site` is what *reports*, and fixing `commit` alone would have moved state without ever emitting. The `expr` and `ssa` halves came out of review (#1848 review, Codex P2).

**The outermost-substitution special case is dropped, not kept alongside the lift** — the issue asked whether it could be, and it can:
- redundant: the outermost `[cmd …]` is depth zero of the same walk, and keeping it would report every `set b [lindex $x 0]` **twice** (`assign_value_substitution_is_reported_once` pins this);
- already weaker than it read: its `else` branch was commented as a fallback to "the older bracket-counting parser" for embedded-`;` shapes, but `parse_command_substitution_with_config` is now a thin wrapper delegating to the *same* lexer-based parser as the primary path, so it declined exactly the shapes it claimed to rescue. Measured: `set r [lindex $x 0; llength $x]` reported nothing before and nothing after;
- its only other reach was a `tokens`-less `AssignValue`, built solely by `inlining::substitute_irreturn`, and `inline_module` has no caller on the diagnostic pipeline.

### A pre-existing false positive fixed on the way

`scan_nested_substitution_words` selected every role whose braced word is evaluated in this frame, which is `Body` as well as `Expr`. For a *statement* `Body` is right — the lowerer gives `foreach x $l {…}` its own CFG block, so the loop variable is defined where the body's reads are seen. A *nested* substitution gets no block, so a nested body's reads arrived with none of its own definitions. This was already firing on the call path:

```tcl
puts [lmap n {1 2 3} {apply {{x} {expr {$x + 100}}} $n}]
```

reported `n` and `x` as `W210 read before it is set` — the loop variable and the lambda parameter, neither of which the frame reads. Extending the recovery to assignments would have spread it to the spelling the corpus mostly uses, so the rule is narrowed to `Expr`: the role that substitutes here *and* binds nothing of its own, which is precisely what the `[expr {$x + 1}]` case it exists for needs.

### Not fixed here, deliberately: #1851

`ShimmerFacts::record_use_targets` does not lift either, so a loop-invariant value alternating representations through nested substitutions reports S100 where S101 is right. Measured on **both** paths and they are identical (`puts [list [llength $x]]` and `set a [list [llength $x]]` both S100; the direct `llength $x` S101), so it predates this work, and fixing it moves severities on already-shipped call-site findings. Filed as #1851 with the three-row table.

### Before / after

`tcl diag`, tcl9.0 profile, one invocation per file — every fixture defines `proc f`, so a multi-file batch analyses conflicting definitions and the numbers stop meaning anything.

| form | before | after |
|---|---|---|
| `puts [list [lindex $x 0]]` | S100 @ 3:24 | S100 @ 3:24 |
| `set r [lindex $x 0]` | S100 @ 3:19 | S100 @ 3:19 (once) |
| `set r [list [lindex $x 0]]` | **nothing** | **S100 @ 3:25** |
| `set r [list "[lindex $x 0]"]` | **nothing** | **S100 @ 3:26** |
| `set r [list a[lindex $x 0]b]` | **nothing** | **S100 @ 3:26** |
| `puts [list [expr {0 in $x}]]` | S100 @ 3:16 | S100 @ 3:16 |
| `set r [list [expr {0 in $x}]]` | **nothing** | **S100 @ 3:17** |
| `set r [list {[lindex $x 0]}]` | nothing | nothing (braces are never substituted) |
| `set r [lindex $x 0; llength $x]` | nothing | nothing (unchanged — see above) |

Every column lands on the `$x` of the *nested* command, not the outer `[list …]` and not the whole `set`.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

All with `CARGO_TARGET_DIR=/home/user/tcl-lsp/target`:

| command | result |
|---|---|
| `cargo fmt --all` | clean |
| `make rust-check` | **exit 0** — fmt + clippy `-D warnings` on the workspace and `runtime/rust`, plus every generated-file drift gate |
| `cargo test -p tcl-compiler --lib` | **ok. 6104 passed; 0 failed; 2 ignored** |
| `cargo test -p tcl-compiler --test checks` | **ok. 256 passed; 0 failed** |
| `cargo test -p tcl-compiler --test taint` | **ok. 370 passed; 0 failed** |
| `cargo test -p tcl-compiler --test analyser` | **ok. 501 passed; 0 failed** |

`make prep-pr` / `make smoke` / a workspace-wide `nextest` were deliberately not run — linking every test binary exceeds the disk available in this environment. CI covers them.

**Corpus differential.** `tcl diag` over all 428 `.tcl` files in the repository, pre-PR baseline binary vs this branch:

```
+ expr_ops.tcl:348:49: warning S101  variable 'brace_pos' has string intrep used in arithmetic expression (operand of '+')
- 34_apply_lambda.tcl:4:1: warning W210  Variable 'n' is read before it is set
- 34_apply_lambda.tcl:4:1: warning W210  Variable 'x' is read before it is set
```

One true positive added, two false positives removed, nothing else changed across 1255 diagnostic lines.

The added one is the bug, in this repository's own code: in `rust/tcl-irule-test/tcl/expr_ops.tcl`, `brace_pos` was already reported at line 333 (`[expr {$brace_pos - 1}]` nested in an `append` call) and at line 338 (`set scan [expr {$brace_pos + 1}]`, a bare value the lowerer makes an `AssignExpr`) — but was silent at line 348, where the identical `[expr {$brace_pos + 1}]` sits inside an assignment value. Same variable, same operator, three spellings, one silent.

### Tests

Ten, all pinning the two statement kinds **against each other** rather than asserting on each separately — it is the symmetry that regressed, so only a comparison catches them drifting apart:

- `assign_value_lifts_the_same_substitutions_a_call_does` and `assign_value_lifts_the_same_nested_expr_a_call_does` — for each word, run both `puts <word>` and `set r <word>`, assert the verdicts are *equal*, then that the pair is right. Braced rows are the controls.
- `assign_value_substitution_is_reported_once`, `a_bare_expr_assignment_is_reported_once` — no double-reporting from re-adding an arm-local parse.
- `assign_value_nested_substitution_span_is_tight` — the span covers `$x`, not the enclosing word.
- `a_nested_conversion_in_an_assignment_is_visible_to_later_reads` — the `commit` half.
- `braced_word_of_a_nested_substitution_is_read_in_an_assignment_value` — what the use map must record.
- `body_word_of_a_nested_substitution_is_not_a_frame_read`, its assignment twin, and `body_locals_of_a_nested_substitution_are_not_frame_reads` — what it must not.

## Compiler / diagnostics checklist

- [x] **Did this change alter a compiler fact contract?** Yes. The reads a `Statement::AssignValue` contributes to `SsaStatement::uses` and to the commit dataflow, and the invocations and expressions checked for it, all widen from the outermost substitution to every substitution the value word evaluates. Separately, `scan_nested_substitution_words` narrows from `{Body, Expr}` to `Expr`, removing frame reads a nested body never performs. No diagnostic code, severity or message changed.
- [x] **If yes, I updated the owning design doc.** `docs/design/contracts/shimmer-reference-behaviour.md` — the nested-substitution section gains the "every statement kind, in every consumer" property naming all four consumers, and a property recording why `Body` is excluded at nested positions though it is included at statement ones; the Coverage list names the new tests.
- [x] **If I added or changed a diagnostic or optimisation code, I updated its page under `docs/kcs/codes/`.** No code was added or changed. `kcs-diagnostic-s100-shimmer-outside-loop.md` documents the rule, not its statement-kind reach.
- [x] **If I added a design doc, I linked it from `docs/design/README.md`.** No new design doc.

Taint (T100/T101) has its own walk and already reported on both paths; `--test taint` is green.

Closes #1844

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PKQ5b7ZLU5XPDaugte4Feb