### PR TITLE
fix(compiler): a braced argument word reads and commits nothing

### DIFF
--- a/docs/design/compiler/def-use-chains.md
+++ b/docs/design/compiler/def-use-chains.md
@@ -81,7 +81,7 @@ class, and the answer is registry data rather than a command list
 
 | Kind | Test | Example | Class |
 |---|---|---|---|
-| script, this frame | the position's `ArgRole` answers `braced_word_evaluated_in_frame` (`Body` / `Expr`) | `expr {$a + $b}`, `if {$c} …` | `Substituted` |
+| script, this frame | the position's `ArgRole` answers `braced_word_evaluated_in_frame` (`Body` / `Expr`), resolved per call site by `CommandRegistry::arg_indices_evaluated_in_frame` | `expr {$a + $b}`, `if {$c} …` | `Substituted` |
 | data | the registry **describes** the command, and the role is not one of those | `puts {$y}`, `string match {$pat*} …`, `lsort -command {cmp $x}` | `Quoted` |
 | unclassified | the registry does **not** describe the command | `mywrapper {puts $myf}` | `Substituted`, unless the word `set`s the name itself → `Quoted` |
 

--- a/docs/design/contracts/shimmer-reference-behaviour.md
+++ b/docs/design/contracts/shimmer-reference-behaviour.md
@@ -215,6 +215,35 @@ each consume them. Four properties matter:
   `return {[expr …]}`. The walker just reads it, as it already did for
   `Terminator::Branch`.
 
+### A braced argument word substitutes nothing
+
+The same distinction applies to a statement's **own** words, and for the same
+reason: `Statement::Call::args` holds the *de-braced* text, so `lindex {$x} 0`
+and `lindex $x 0` both arrive as the argument `$x`. Only the second is a read
+— tclsh 9.0.4 answers `$x` (two characters) for the braced form and `5` for
+the bare and `"…"`-quoted ones — so `commit` and `use_site` gate the argument
+loop of their `Statement::Call` arm on `hints::inert_braced_args`, which pairs
+the segmenter's `CommandTokens::arg_is_braced_literal` with the registry's
+`CommandRegistry::arg_indices_evaluated_in_frame` (issue #1845).
+
+That second half makes the rule role-aware rather than "skip every braced
+argument": `expr` and `if` re-evaluate their braced word where the caller's
+variables are in scope, so `expr {$x} + 1` really is `6` for `x` = 5 and its
+operand stays a read, while `apply {{} {puts $x}}` runs in a fresh frame and
+does not. The authority is `ArgRole::braced_word_evaluated_in_frame`, the same
+one `ssa::braced_word_class` consults for the identical question — the
+detectors ask it, they do not restate it.
+
+Both passes need the gate because they have separate jobs: `commit` only moves
+the committed-intrep state and emits nothing, so gating solely the emitting
+pass still recorded a conversion at the braced word and made the *next*,
+genuine read report a shimmer against an intrep the runtime never installed.
+
+The substitution paths need no gate: a `[cmd …]` lifted out of a word and the
+command substitution inside a `Statement::AssignValue` both carry their
+argument words as raw source text with the braces still on, which
+`is_pure_var_ref` already declines.
+
 ### Known limitation — the underlying representational gap
 
 The lift above is a *shimmer-side* repair of a defect that is not
@@ -264,6 +293,11 @@ dedicated `Statement::Incr` node.
   `expr_shimmer_fires_in_a_nested_call_argument` and their braced twins),
   `shimmer::use_site` (`use_site_shimmer_fires_in_a_nested_call_argument`,
   `a_nested_conversion_is_visible_to_later_reads`).
+- Braced-argument coverage: `shimmer::use_site`
+  (`a_braced_argument_reads_only_where_the_callee_evaluates_it_in_frame` pins
+  the braced / quoted / bare triple for both a non-evaluating and an
+  evaluating command, `a_braced_argument_commits_no_intrep_for_later_reads`
+  the commit half) and the `FP-SH-24` fixtures.
 - Unit tests co-located with each shimmer module (`rust/tcl-compiler/src/shimmer/*.rs`) and in `rust/tcl-compiler/tests/checks.rs`.
 - TP/FP/TN/FN regression fixtures in `rust/tcl-compiler/src/analyser/diagnostics/fp/sh.rs` (the `FP-SH-NN` series).
 - Native `lsp_e2e` coverage in `rust/tcl-lsp-server/tests/e2e/diagnostics.rs` and `rust/tcl-lsp-server/tests/e2e/code_actions.rs` (the noqa suppress quick fix).

--- a/docs/kcs/codes/kcs-diagnostic-s100-shimmer-outside-loop.md
+++ b/docs/kcs/codes/kcs-diagnostic-s100-shimmer-outside-loop.md
@@ -84,6 +84,31 @@ lassign $point x y z
 set offset [expr {$x + $y + $z}]   ;# no S100 — x/y/z are elements, not lists
 ```
 
+### A variable named inside a brace-quoted word
+
+Tcl substitutes nothing inside `{…}`, so a `$name` written there is just the
+characters `$name` and the variable is never read:
+
+```tcl
+set x [llength $l]
+lindex {$x} 0        ;# no S100 — the word is the two characters "$x"
+lindex "$x" 0        ;# S100 — the quoted word does substitute
+lindex $x 0          ;# S100 — so does the bare one
+```
+
+The exceptions are the commands that evaluate their braced word as code where
+your own variables are in scope — `expr`, `if`, `while`, and the other
+expression and body positions. There the names really are read, so the warning
+still fires:
+
+```tcl
+set x [lrange $l 0 1]
+expr {$x + 1}        ;# S100 — expr evaluates the word here and now
+```
+
+`apply` is not one of them: its lambda runs in a fresh frame, so it never reads
+the caller's variables.
+
 ## Fix
 
 Use separate variables for numeric and string use:

--- a/rust/tcl-compiler/src/analyser/diagnostics/fp/sh.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/fp/sh.rs
@@ -1613,3 +1613,49 @@ fn fp_sh_23_bignum_folds_are_exact() {
         "the chained bignum fold must land the exact decimal"
     );
 }
+
+// FP-SH-24 — a braced argument word substitutes nothing (issue #1845)
+
+/// FP-SH-24: `lindex {$x} 0` reads nothing. Tcl performs no substitution
+/// inside `{…}` — tclsh 9.0.4: `set x 5; lindex {$x} 0` yields the two
+/// characters `$x` — but a statement's IR `args` hold the *de-braced* word,
+/// so the detectors saw a live `$x` and reported a conversion that never
+/// happens.
+#[test]
+fn fp_sh_24_braced_list_argument_silent() {
+    let src = "proc f {l} {\n set x [llength $l]\n lindex {$x} 0\n}\n";
+    assert!(
+        !fires(src, D, "S100") && !fires(src, D, "S101"),
+        "FP-SH-24: a braced word is two literal characters, not a read; got {:?}",
+        codes(src, D),
+    );
+}
+
+/// FP-SH-24 TP control: the substituting spellings of the same word are
+/// genuine reads and must still fire — the braced gate is not a blanket
+/// silencing of the argument position.
+#[test]
+fn fp_sh_24_substituting_list_argument_spellings_still_fire() {
+    for word in ["\"$x\"", "$x"] {
+        let src = format!("proc f {{l}} {{\n set x [llength $l]\n lindex {word} 0\n}}\n");
+        assert!(
+            fires(&src, D, "S100"),
+            "FP-SH-24 TP: {word} is a real list read; got {:?}",
+            codes(&src, D),
+        );
+    }
+}
+
+/// FP-SH-24 TP control: `expr` re-evaluates its braced word where the
+/// caller's variables are in scope (tclsh 9.0.4: `set x 5; expr {$x} + 1`
+/// yields `6`), so that spelling stays a read — the gate is role-aware, not
+/// a "skip every braced argument" rule.
+#[test]
+fn fp_sh_24_braced_expr_operand_still_fires() {
+    let src = "proc f {l} {\n set x [lrange $l 0 1]\n expr {$x} + 1\n}\n";
+    assert!(
+        fires(src, D, "S100"),
+        "FP-SH-24 TP: an expr operand is evaluated in this frame; got {:?}",
+        codes(src, D),
+    );
+}

--- a/rust/tcl-compiler/src/shimmer/commit.rs
+++ b/rust/tcl-compiler/src/shimmer/commit.rs
@@ -59,7 +59,7 @@ use crate::ssa::{SsaFunction, Symbol, ValueKey};
 use crate::types::{TypeKind, TypeLattice};
 use crate::value_shapes::is_pure_var_ref;
 
-use super::hints::{arg_shimmer_type, is_numeric_compatible, is_pure_intrep};
+use super::hints::{arg_shimmer_type, inert_braced_args, is_numeric_compatible, is_pure_intrep};
 use super::use_site::foreach_header_expected_type;
 
 /// Upper bound on the tracked may-set — a value committed to more than this
@@ -561,7 +561,18 @@ fn typed_reads_of_statement(
 
             let lookup = stmt.canonical_command_or_source();
             let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+            // `args` holds the *de-braced* word text, so a brace-quoted
+            // literal arrives spelled exactly like a live substitution.  Tcl
+            // converts nothing at such a position — `lindex {$x} 0` reads the
+            // two characters `$x` — so no commitment happens there either,
+            // and moving the state would make every later read of the same
+            // variable judge itself against an intrep the runtime never
+            // installed (issue #1845).
+            let inert = inert_braced_args(ctx.registry, lookup, &arg_refs, tokens.as_ref());
             for (i, word) in args.iter().enumerate() {
+                if inert.contains(&i) {
+                    continue;
+                }
                 let expected = if foreach_groups.is_some() {
                     foreach_header_expected_type(ctx.registry, lookup)
                 } else {

--- a/rust/tcl-compiler/src/shimmer/hints.rs
+++ b/rust/tcl-compiler/src/shimmer/hints.rs
@@ -25,6 +25,8 @@
 //! - [`is_uncommitted_first_conversion`] — true when reading a value as a
 //!   different type is the *first* conversion of an uncommitted (pure) value,
 //!   which Tcl performs for free rather than a genuine shimmer.
+//! - [`inert_braced_args`] — the argument positions whose brace-quoted word
+//!   Tcl never substitutes, so nothing in them is read here.
 
 use std::borrow::Cow;
 
@@ -33,6 +35,7 @@ use tcl_syntax::boolean::parse_boolean_word;
 use tcl_syntax::number::{self, NumberSyntax, ParseFlags};
 
 use crate::analyses::{ConstValue, LatticeValue};
+use crate::ir::CommandTokens;
 
 /// Return the expected `TclType` for argument `arg_index` of `command`
 /// when that argument position is tagged `shimmers = true` in the registry.
@@ -126,6 +129,53 @@ pub fn arg_shimmer_expectation(
         .iter()
         .find(|(i, _)| *i == needle)
         .and_then(|(_, h)| expectation(h))
+}
+
+/// The argument indices of one call whose word is a **brace-quoted literal
+/// the callee never substitutes in this frame** — the positions whose text
+/// must not be read as a variable reference at all.
+///
+/// Tcl performs no substitution inside `{…}`: `lindex {$x} 0` yields the two
+/// characters `$x` and reads nothing (tclsh 9.0.4). The IR's `args` hold the
+/// *de-braced* word, which is indistinguishable there from a real `$x`, so
+/// the answer comes from the segmenter's per-word token kinds
+/// ([`CommandTokens::arg_is_braced_literal`]) rather than from the text
+/// (issue #1845).
+///
+/// The exemption is
+/// [`CommandRegistry::arg_indices_evaluated_in_frame`]: `expr {$x} + 1` and
+/// `if {$c} …` re-evaluate their braced word where the caller's variables
+/// are in scope, so those names *are* read here and now — `expr {$x} + 1`
+/// really is 6 for `x` = 5. `apply {{} {puts $x}}` runs in a fresh frame and
+/// is not exempt.
+///
+/// Only [`crate::ir::Statement::Call`] needs this. A `[cmd …]` lifted out of
+/// a word and the command substitution inside a `Statement::AssignValue`
+/// both carry their argument words as raw source text with the braces still
+/// on, so `is_pure_var_ref("{$x}")` already declines for them.
+#[must_use]
+pub fn inert_braced_args(
+    registry: &CommandRegistry,
+    command: &str,
+    args: &[&str],
+    tokens: Option<&CommandTokens>,
+) -> Vec<usize> {
+    let Some(tokens) = tokens else {
+        return Vec::new();
+    };
+    let braced: Vec<usize> = (0..args.len())
+        .filter(|&idx| tokens.arg_is_braced_literal(idx))
+        .collect();
+    // The overwhelming majority of calls brace nothing; skip the role query
+    // entirely for those rather than run it per statement.
+    if braced.is_empty() {
+        return braced;
+    }
+    let evaluated = registry.arg_indices_evaluated_in_frame(command, args);
+    braced
+        .into_iter()
+        .filter(|idx| !evaluated.contains(idx))
+        .collect()
 }
 
 /// Return `true` when the two types are numerically compatible — i.e. a

--- a/rust/tcl-compiler/src/shimmer/use_site.rs
+++ b/rust/tcl-compiler/src/shimmer/use_site.rs
@@ -49,8 +49,8 @@ use crate::types::{TypeKind, TypeLattice};
 use crate::value_shapes::is_pure_var_ref;
 
 use super::hints::{
-    ShimmerExpectation, arg_shimmer_expectation, arg_shimmer_type, is_numeric_compatible,
-    is_uncommitted_first_conversion,
+    ShimmerExpectation, arg_shimmer_expectation, arg_shimmer_type, inert_braced_args,
+    is_numeric_compatible, is_uncommitted_first_conversion,
 };
 use super::span::def_range_map;
 use super::{ShimmerWarning, type_name};
@@ -299,6 +299,12 @@ struct InvocationSite<'a> {
     /// Per-argument absolute spans, index-aligned with `args`, when
     /// available (see `fallback_span`).
     arg_spans: &'a [Span],
+    /// The statement's word snapshot, when this site is a whole statement.
+    /// `args` is de-braced, so only these token kinds can tell a
+    /// brace-quoted literal from a live substitution — see
+    /// [`inert_braced_args`]. `None` for the two substitution sites, whose
+    /// argument words are raw source text with the braces still on.
+    tokens: Option<&'a crate::ir::CommandTokens>,
     /// True for the synthetic loop-header shape [`foreach_header_expected_type`]
     /// covers (`foreach` / `lmap` / `dict for` / `dict map`) — every
     /// argument shares one expected type instead of a per-index one.
@@ -333,7 +339,13 @@ fn check_invocation(
     uses: &HashMap<Symbol, u32>,
 ) {
     let arg_refs: Vec<&str> = site.args.iter().map(String::as_str).collect();
+    // Positions whose brace-quoted word Tcl never substitutes: their
+    // de-braced `args` text spells a live `$x` that is not one (issue #1845).
+    let inert = inert_braced_args(ctx.registry, site.lookup_command, &arg_refs, site.tokens);
     for (i, word) in site.args.iter().enumerate() {
+        if inert.contains(&i) {
+            continue;
+        }
         check_argument(ctx, site, i, word, &arg_refs, uses);
     }
 }
@@ -620,6 +632,7 @@ fn check_lifted_calls(
                 lookup_command: &lifted.command,
                 args: &lifted.args,
                 arg_spans: &lifted.arg_spans,
+                tokens: None,
                 is_foreach_header: false,
                 fallback_span,
             },
@@ -659,6 +672,7 @@ fn check_statement(ctx: &mut UseSiteCtx<'_>, stmt: &Statement, uses: &HashMap<Sy
                     lookup_command: lookup,
                     args,
                     arg_spans: &arg_spans,
+                    tokens: tokens.as_ref(),
                     is_foreach_header: foreach_groups.is_some(),
                     fallback_span: stmt.span(),
                 },
@@ -701,6 +715,7 @@ fn check_statement(ctx: &mut UseSiteCtx<'_>, stmt: &Statement, uses: &HashMap<Sy
                         lookup_command: &command,
                         args: &args,
                         arg_spans: &arg_spans,
+                        tokens: None,
                         is_foreach_header: false,
                         fallback_span: stmt.span(),
                     },
@@ -723,6 +738,7 @@ fn check_statement(ctx: &mut UseSiteCtx<'_>, stmt: &Statement, uses: &HashMap<Sy
                         lookup_command: &command,
                         args: &args,
                         arg_spans: &[],
+                        tokens: None,
                         is_foreach_header: false,
                         fallback_span: stmt.span(),
                     },
@@ -1014,6 +1030,57 @@ mod tests {
         assert!(
             !w.iter().any(|w| w.command == "lindex"),
             "a braced word is data, not a call: {w:?}"
+        );
+    }
+
+    /// Issue #1845: the braced / quoted / bare spellings of one argument
+    /// word, pinned against each other for a command that consumes its word
+    /// as **data** (`lindex`) and one that re-evaluates it **in the caller's
+    /// frame** (`expr`) — the two halves of the rule, so neither can drift.
+    ///
+    /// tclsh 9.0.4, `set x 5`: `lindex {$x} 0` yields the two characters
+    /// `$x` (no read at all) while `lindex "$x" 0` and `lindex $x 0` both
+    /// yield `5`; `expr {$x} + 1` yields `6`, so every `expr` spelling reads
+    /// `x`. A statement's IR `args` hold the *de-braced* word, so all six
+    /// spellings look alike there — the answer comes from the segmenter's
+    /// token kinds plus the registry's argument role.
+    #[test]
+    fn a_braced_argument_reads_only_where_the_callee_evaluates_it_in_frame() {
+        for (body, reads) in [
+            ("set x [llength $lst]\n lindex {$x} 0", false),
+            ("set x [llength $lst]\n lindex \"$x\" 0", true),
+            ("set x [llength $lst]\n lindex $x 0", true),
+            ("set x [lrange $lst 0 1]\n expr {$x} + 1", true),
+            ("set x [lrange $lst 0 1]\n expr \"$x\" + 1", true),
+            ("set x [lrange $lst 0 1]\n expr $x + 1", true),
+        ] {
+            let src = format!("proc f {{lst}} {{\n {body}\n}}");
+            let cu = CompilationUnit::build_for(&src, &registry(), false);
+            let w = super::super::find_shimmer_warnings_for_cu(&cu, &registry());
+            assert_eq!(
+                !w.is_empty(),
+                reads,
+                "expected reads={reads} for {src:?}, got: {w:?}"
+            );
+        }
+    }
+
+    /// The same braced word must not move the **committed-intrep state**
+    /// either. `commit.rs` emits nothing itself, so a gate only in the
+    /// emitting pass left `lindex {$x} 0` recording a list commitment that
+    /// made the genuine read on the next line report a conversion the
+    /// runtime never performs.
+    #[test]
+    fn a_braced_argument_commits_no_intrep_for_later_reads() {
+        let cu = CompilationUnit::build_for(
+            "proc f {lst} {\n set x [llength $lst]\n lindex {$x} 0\n expr {$x + 1}\n}",
+            &registry(),
+            false,
+        );
+        let w = super::super::find_shimmer_warnings_for_cu(&cu, &registry());
+        assert!(
+            w.is_empty(),
+            "the int `x` is only ever read as a number here: {w:?}"
         );
     }
 

--- a/rust/tcl-compiler/src/ssa.rs
+++ b/rust/tcl-compiler/src/ssa.rs
@@ -1944,15 +1944,13 @@ fn scan_command_words(
                 .collect()
         });
     // Positions whose brace-quoted word the callee still evaluates in *this*
-    // frame — `expr {$a + $b}`, `if {$c} …`. Registry-driven: the set is
-    // every `ArgRole` that answers `braced_word_evaluated_in_frame`, never a
-    // command name.
+    // frame — `expr {$a + $b}`, `if {$c} …`. Registry-driven, and asked of
+    // the registry's own owner for the question, never of a command name.
     let in_frame_braced: std::collections::HashSet<usize> = {
         let arg_strs: Vec<&str> = args.iter().map(String::as_str).collect();
-        tcl_registry::ArgRole::ALL
-            .iter()
-            .filter(|role| role.braced_word_evaluated_in_frame())
-            .flat_map(|&role| registry.arg_indices_for_role(lookup, &arg_strs, role))
+        registry
+            .arg_indices_evaluated_in_frame(lookup, &arg_strs)
+            .into_iter()
             .collect()
     };
     // Whether the registry describes this command at all — the difference

--- a/rust/tcl-registry/src/registry.rs
+++ b/rust/tcl-registry/src/registry.rs
@@ -3723,6 +3723,29 @@ impl CommandRegistry {
         out
     }
 
+    /// Resolve the argument indices whose **brace-quoted** word this command
+    /// nonetheless evaluates in the *calling* frame — `expr {$a} + 1`,
+    /// `if {$c} …` — so a `$name` written inside one is a genuine read at
+    /// the call site.
+    ///
+    /// Tcl substitutes nothing inside `{…}`; whether the callee then
+    /// evaluates that text, and in whose frame, is the per-role fact
+    /// [`ArgRole::braced_word_evaluated_in_frame`] owns. This is the one
+    /// place that asks it over a call's argument words, so the SSA use
+    /// classifier and the shimmer detectors share a single answer instead of
+    /// each rebuilding the set (issue #1845).
+    #[must_use]
+    pub fn arg_indices_evaluated_in_frame(&self, name: &str, args: &[&str]) -> Vec<usize> {
+        let mut out: Vec<usize> = ArgRole::ALL
+            .iter()
+            .filter(|role| role.braced_word_evaluated_in_frame())
+            .flat_map(|&role| self.arg_indices_for_role(name, args, role))
+            .collect();
+        out.sort_unstable();
+        out.dedup();
+        out
+    }
+
     /// Whether source words prove the option-dependent descriptor layout of
     /// `spec` (or its selected subcommand).  This is deliberately shared by
     /// pattern and format queries: both families otherwise risk interpreting
@@ -8095,6 +8118,29 @@ mod tests {
         let reg = CommandRegistry::build_default();
         let vars = reg.arg_indices_for_role("unset", &["x", "y", "z"], ArgRole::VarWrite);
         assert_eq!(vars, vec![0, 1, 2]);
+    }
+
+    /// `arg_indices_evaluated_in_frame` is the call-site half of
+    /// `ArgRole::braced_word_evaluated_in_frame`: it names the positions whose
+    /// brace-quoted word the callee still substitutes against the *caller's*
+    /// variables. tclsh 9.0.4: `set x 5; expr {$x} + 1` → `6`, while
+    /// `lindex {$x} 0` → the two characters `$x` and
+    /// `apply {{} {puts $x}}` errors with `can't read "x"` (a fresh frame).
+    #[test]
+    fn arg_indices_evaluated_in_frame_names_only_caller_frame_code_words() {
+        let reg = CommandRegistry::build_default();
+        assert_eq!(
+            reg.arg_indices_evaluated_in_frame("expr", &["$x", "+", "1"]),
+            vec![0],
+        );
+        assert!(
+            reg.arg_indices_evaluated_in_frame("lindex", &["$x", "0"])
+                .is_empty()
+        );
+        assert!(
+            reg.arg_indices_evaluated_in_frame("apply", &["{{} {puts $x}}"])
+                .is_empty()
+        );
     }
 
     /// `unset -nocomplain -- a b` skips the leading options and names only the


### PR DESCRIPTION
## Summary

- `lindex {$x} 0` reported `S100 variable 'x' has int intrep but 'lindex' expects list`. Tcl substitutes nothing inside `{…}`, so that word is the two characters `$x` and `x` is never read there. Oracle, `tmp/tcl9.0.4/unix/tclsh`:

  ```
  % set x 5; puts [lindex {$x} 0]; puts [lindex "$x" 0]
  $x
  5
  ```

- `Statement::Call::args` holds the **de-braced** word text, so the braced, quoted and bare spellings all arrive as the argument `$x`. Both shimmer passes walked that text and `is_pure_var_ref` found a live variable reference in all three.
- Both passes needed the gate. `use_site` emits the diagnostic; `commit` emits nothing but moves the committed-intrep state, so a gate only in the emitting pass still recorded a list commitment at the braced word and made the *next* line's genuine read report a conversion that never happens (`lindex {$x} 0` followed by `expr {$x + 1}` produced two S100s, not one).
- The gate is **role-aware**, not "skip every braced argument". `expr` and `if` re-evaluate their braced word where the caller's variables are in scope — tclsh 9.0.4 answers `6` for `set x 5; expr {$x} + 1` — and `expr` reaches this same `Statement::Call` arm whenever it is written with more than one word, so that spelling stays a read. `apply` does not: its lambda runs in a fresh frame. The authority is the existing `ArgRole::braced_word_evaluated_in_frame`; the new `shimmer::hints::inert_braced_args` asks it rather than growing a second brace rule or naming commands.
- Asking it **per call site** had no owner, only copies, so the query moves into `CommandRegistry::arg_indices_evaluated_in_frame`, and `ssa::scan_command_words` — which asks the identical question of a statement's words — reads it from there.
- The lift needs no gate and gets none: a lifted `[cmd …]` carries its argument words as raw source text with the braces still on, which `is_pure_var_ref` already declines. That is why `set b [lindex {$x} 0]` was correct before this change and stays correct now that #1848 routes an assignment's words through the same lift. `InvocationSite` carries the statement's `CommandTokens` and answers `None` at the lifted site.

### Relationship to #1848 (merged into `rust` as `a1803406` while this was open)

The two changes meet in `shimmer/use_site.rs` and `ssa.rs`. The merge commit keeps **both** rules, and in particular keeps the two `ssa.rs` role queries distinct — they are asking different questions and must not be collapsed onto one answer:

| site | role set | why |
|---|---|---|
| `ssa::scan_command_words` (a **statement's** words) | full in-frame set (`Body` + `Expr`), via the new `CommandRegistry::arg_indices_evaluated_in_frame` | a statement's body gets its own CFG block, so `foreach x $l {…}` defines its loop variable where the body's reads are seen |
| `ssa::scan_nested_substitution_words` (a **nested substitution's** words) | `ArgRole::Expr` alone — #1848's narrowing, left untouched here | a nested substitution gets no block, so a nested body's reads would arrive with none of its own definitions |

`use_site::check_statement`'s `AssignValue` arm is #1848's version outright: the hand-rolled substitution parse is gone, replaced by `check_lifted_calls`. This branch's only edit there was an `InvocationSite` field that arm no longer constructs.

### Before / after

`tcl diag`, **one invocation per single-proc file**, baseline `origin/rust` @ `a1803406` (so #1848 is on *both* sides and only this change is measured) vs this branch's merge head `8b4e3f66`. S100/W21x rows only; each file is `proc f {l} { <setup>; <statement> }`.

| # | setup | statement | base `a1803406` | this branch |
|---|---|---|---|---|
| 01 | `set x [llength $l]` | `lindex {$x} 0` | `S100 … 'lindex' expects list (argument 1)` | **none** |
| 02 | `set x [llength $l]` | `lindex "$x" 0` | S100 int → list | S100 int → list |
| 03 | `set x [llength $l]` | `lindex $x 0` | S100 int → list | S100 int → list |
| 04 | `set x [lrange $l 0 1]` | `expr {$x} + 1` | S100 list → numeric | S100 list → numeric |
| 05 | `set x [lrange $l 0 1]` | `expr $x + 1` | S100 list → numeric | S100 list → numeric |
| 06 | `set x [lrange $l 0 1]` | `expr {$x + 1}` | S100 arithmetic operand | S100 arithmetic operand |
| 07 | `set x [lrange $l 0 1]` | `if {$x + 1} { puts hi }` | S100 arithmetic operand | S100 arithmetic operand |
| 08 | `set x [llength $l]` | `apply {{} {puts $x}}` | W210 read before set | W210 read before set |
| 09 | `set x [llength $l]` | `lindex {$x} 0` then `expr {$x + 1}` | **S100 ×2** — the FP plus its knock-on | **none** |
| 10 | `set x [llength $l]` | `puts [lindex {$x} 0]` | none | none |
| 11 | `set x [llength $l]` | `puts [lindex $x 0]` | S100 int → list | S100 int → list |
| 12 | `set x [llength $l]` | `set b [lindex {$x} 0]` | W211 only | W211 only |
| 13 | `set x [llength $l]` | `set b [lindex $x 0]` | W211 + S100 | W211 + S100 |
| 14 | — | `puts [lmap n {1 2 3} {apply {{x} {expr {$x + 100}}} $n}]` | none | none |
| 15 | `set x [llength $l]` | `set r [list [lindex $x 0]]` | S100 int → list | S100 int → list |
| 16 | `set x [llength $l]` | `set r [list [expr {0 in $x}]]` | S100 `in` membership | S100 `in` membership |

Exactly two rows change — 01 and 09 — and both are the false positive this PR removes. Rows 14–16 are #1848's own regression checks: no `W210` on the `lmap`/`apply` loop variable or lambda parameter, and both assignment-lift S100s still fire.

The issue's exact reproduction:

```
$ tcl-base1848 diag issue1845.tcl
issue1845.tcl:3:12: info    S100     variable 'x' has int intrep but 'lindex' expects list (argument 1)
diagnostics=1 across 1 input(s)

$ tcl-merged diag issue1845.tcl
no diagnostics
diagnostics=0 across 1 input(s)
```

One correction to the issue text: plain `if {$x}` never reported S100, before or after — a bare boolean branch condition is not a flagged read. `if {$x + 1}` is, and still is.

### Corpus differential

Baseline `a1803406` vs this branch, every `.tcl` file, one `tcl diag` invocation per file, diagnostics compared line for line:

| Corpus | files | compared | before | after | diff |
|---|---|---|---|---|---|
| `samples/` | 119 | 119 | 348 | 348 | **none** |
| `tmp/tcllib-2.0/modules` | 794 | 793 | 11233 | 11233 | **none** |

Across 912 real-world files the only diagnostic difference is the false positive removed above. The one skipped file is `modules/fumagic/filetypes.tcl` — 85 040 lines of generated Tcl, which takes over 25 minutes per invocation of the *debug* binary on both sides alike, so a per-file timeout excludes it; nothing about that is specific to this change.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

All of the below were run on the merge head, against a forced-fresh build (`touch` on the changed sources plus each crate's `lib.rs` before building, so cargo could not serve a sibling worktree's artefacts out of the shared `CARGO_TARGET_DIR`).

```
export CARGO_TARGET_DIR=/home/user/tcl-lsp/target
cargo fmt --all
make rust-check
cargo test -p tcl-compiler --lib
cargo test -p tcl-registry --lib
cargo test -p tcl-compiler --test checks
cargo test -p tcl-compiler --test taint
cargo test -p tcl-compiler --test analyser
cargo build -p tcl-cli --bin tcl
```

Results:

```
make rust-check                              exit 0
                                             owner-resolution: OK (34 owner row(s) resolve to live source and gates)
cargo test -p tcl-compiler --lib             ok. 6109 passed; 0 failed; 2 ignored
cargo test -p tcl-registry --lib             ok.  832 passed; 0 failed; 0 ignored
cargo test -p tcl-compiler --test checks     ok.  256 passed; 0 failed; 0 ignored
cargo test -p tcl-compiler --test taint      ok.  370 passed; 0 failed; 0 ignored
cargo test -p tcl-compiler --test analyser   ok.  501 passed; 0 failed; 0 ignored
```

The three integration suites are run as three separate commands on purpose: cargo does not print result lines in the order the `--test` flags are given, and an earlier revision of this PR body had those three counts misattributed. The numbers above are each from a single-suite run.

New tests, confirmed present in the built test binaries with `-- --list` before these counts were quoted:

- `shimmer::use_site::tests::a_braced_argument_reads_only_where_the_callee_evaluates_it_in_frame` — pins the braced / quoted / bare triple against each other for one non-evaluating command (`lindex`) and one evaluating one (`expr`), so the two halves of the rule cannot drift.
- `shimmer::use_site::tests::a_braced_argument_commits_no_intrep_for_later_reads` — the `commit` half: the braced word must not move the committed-intrep state either.
- `analyser::diagnostics::fp::sh::fp_sh_24_braced_list_argument_silent`, `…_substituting_list_argument_spellings_still_fire`, `…_braced_expr_operand_still_fires` — the FP fixture and its two TP controls, through the full `tcl diag` path.
- `registry::tests::arg_indices_evaluated_in_frame_names_only_caller_frame_code_words` — `expr` yes, `lindex` no, `apply` no.

Binary provenance was checked with discriminators before any measurement here was taken, since this workspace shares one `CARGO_TARGET_DIR` across worktrees:

- `lindex {$x} 0` — the baseline binary reports, the branch binary is silent (this change is in the branch binary);
- `set r [list [lindex $x 0]]` — **both** report (#1848 is in both, so the table isolates this change).

Not run, per the workspace's disk budget: `make prep-pr`, `make smoke`, `cargo nextest run --workspace`. CI carries those, and all 18 checks on `8b4e3f66` are green.

## Compiler / diagnostics checklist

- [x] Did this change alter a compiler fact contract? Yes — when a `Statement::Call` argument word is a variable read at all.
- [x] If yes, I updated the owning design doc: `docs/design/contracts/shimmer-reference-behaviour.md` gains *A braced argument word substitutes nothing* plus the matching coverage row (merged alongside #1848's additions to the same sections); `docs/design/compiler/def-use-chains.md`'s three-kinds table now names the registry entry point.
- [x] If I added or changed a diagnostic or optimisation code, I updated its page under `docs/kcs/codes/`: no new code, but `docs/kcs/codes/kcs-diagnostic-s100-shimmer-outside-loop.md` gains a *when it does not fire* section for the braced word, with the `expr` / `apply` exceptions. No index change — the page already exists and is linked.
- [x] If I added a design doc, I linked it from `docs/design/README.md`: no new design doc.

Closes #1845

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PKQ5b7ZLU5XPDaugte4Feb