### PR TITLE
fix(jetbrains): generate unique diagnostic panel variables

### DIFF
--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/settings/TclLspSettingsPanel.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/settings/TclLspSettingsPanel.kt
@@ -500,23 +500,23 @@ class TclLspSettingsPanel {
         builder.addComponent(diagIRulePanel)
 
         builder.addComponent(TitledSeparator("Diagnostics — BIG-IP Configuration"))
-        val diagPanel = JPanel(java.awt.GridLayout(0, 2, 8, 2))
+        val diagBigIpPanel = JPanel(java.awt.GridLayout(0, 2, 8, 2))
         listOf(
             diagBIGIP6001, diagBIGIP6002, diagBIGIP6003, diagBIGIP6004, diagBIGIP6005, diagBIGIP6006,
             diagBIGIP6007, diagBIGIP6008, diagBIGIP6009, diagBIGIP6010, diagBIGIP6011, diagBIGIP6012,
             diagBIGIP6013, diagBIGIP6014, diagBIGIP6038, diagBIGIP6039, diagIAPP7001, diagIAPP7002,
             diagIAPP7003,
-        ).forEach { diagPanel.add(it) }
-        builder.addComponent(diagPanel)
+        ).forEach { diagBigIpPanel.add(it) }
+        builder.addComponent(diagBigIpPanel)
 
         builder.addComponent(TitledSeparator("Diagnostics — SslicTcl"))
-        val diagPanel = JPanel(java.awt.GridLayout(0, 2, 8, 2))
+        val diagSslicTclPanel = JPanel(java.awt.GridLayout(0, 2, 8, 2))
         listOf(
             diagSSLIC1001, diagSSLIC1002, diagSSLIC1003, diagSSLIC1004, diagSSLIC1005, diagSSLIC1006,
             diagSSLIC1007, diagSSLIC1008, diagSSLIC1009, diagSSLIC1010, diagSSLIC1011, diagSSLIC1012,
             diagSSLIC1101, diagSSLIC1102, diagSSLIC1103,
-        ).forEach { diagPanel.add(it) }
-        builder.addComponent(diagPanel)
+        ).forEach { diagSslicTclPanel.add(it) }
+        builder.addComponent(diagSslicTclPanel)
         // @generated:diag-ui:end
 
         // Style section

--- a/rust/xtask/src/gen_jetbrains.rs
+++ b/rust/xtask/src/gen_jetbrains.rs
@@ -262,6 +262,9 @@ fn panel_var_for(title: &str) -> &'static str {
         "Diagnostics — Shimmer" => "diagShimmerPanel",
         "Diagnostics — Taint" => "diagTaintPanel",
         "Diagnostics — iRules" => "diagIRulePanel",
+        "Diagnostics — BIG-IP Configuration" => "diagBigIpPanel",
+        "Diagnostics — SslicTcl" => "diagSslicTclPanel",
+        "Diagnostics — Package Manager" => "diagPackagePanel",
         _ => "diagPanel",
     }
 }
@@ -454,6 +457,20 @@ mod tests {
         );
         // `$` is Kotlin-escaped.
         assert_eq!(short_label("X", "a $b"), "X: a \\$b");
+    }
+
+    #[test]
+    fn diagnostic_panel_variables_are_unique() {
+        let groups = diag_section_groups();
+        let names: std::collections::HashSet<_> = groups
+            .iter()
+            .map(|(title, _)| panel_var_for(title))
+            .collect();
+        assert_eq!(
+            names.len(),
+            groups.len(),
+            "each generated diagnostics section needs a distinct Kotlin local variable"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- give the generated BIG-IP, SslicTcl, and package-manager diagnostic sections distinct Kotlin panel variables
- regenerate `TclLspSettingsPanel.kt`
- add a generator regression test requiring every populated diagnostic section to have a unique variable

## Release blocker

The `v2.2.2` release workflow failed `build-jetbrains` because the BIG-IP and SslicTcl sections both generated a local `val diagPanel` in the same function:

https://github.com/bitwisecook/tcl-lsp/actions/runs/33912351627/job/101184818489

## Verification

- `cargo test -p xtask diagnostic_panel_variables_are_unique`
- `editors/jetbrains/gradlew compileKotlin`
- `make rust-check`
- `make prep-pr`
