### PR TITLE
fix(compiler): reconcile a quoted word's overlapping token spans

### DIFF
--- a/rust/tcl-compiler/src/value_shapes.rs
+++ b/rust/tcl-compiler/src/value_shapes.rs
@@ -282,10 +282,30 @@ pub fn parse_command_substitution_with_spans_and_config(
         } else {
             // Adjacent tokens with no separator concatenate onto the
             // previous word (e.g. `$a$b` or `foo$x`).
+            //
+            // Extend by slicing `inner` from where the word so far ends,
+            // never by appending this token's own raw text: raw token spans
+            // *overlap* when a quoted word opens directly on a substitution.
+            // `parse_quoted`'s documented empty-content clamp extends a
+            // zero-content `Esc` one byte over the `$`/`[` that stopped the
+            // scan — so `"[lindex $x 0]"` lexes `Esc 5..7` (`"[`) followed by
+            // `Cmd 6..18`, and both claim the `[`. The clamp is the lexer's
+            // convention, resolved there by `SourceMap::token_text`; a
+            // consumer that wants the raw source spelling has to reconcile
+            // it. Appending raw text emitted the shared byte twice
+            // (`"[[lindex $x 0]"`), leaving the text disagreeing with its own
+            // (correct) span. Slicing the gap keeps the two in lockstep by
+            // construction: the word's text is always exactly the source
+            // covered by the word's span (#1846).
             let (last_text, last_span) =
                 words.last_mut().expect("words is non-empty in this branch");
-            last_text.push_str(&word_text);
-            *last_span = Span::new(last_span.start(), abs_span.end());
+            let joined_end = abs_span.end().max(last_span.end());
+            if joined_end > last_span.end() {
+                let from = usize::try_from(last_span.end() - base).ok()?;
+                let to = usize::try_from(joined_end - base).ok()?;
+                last_text.push_str(inner.get(from..to)?);
+            }
+            *last_span = Span::new(last_span.start(), joined_end);
         }
         prev_kind = tok.kind;
     }
@@ -659,5 +679,77 @@ mod tests {
             &text[args[1].1.start() as usize..args[1].1.end() as usize],
             "\"a$b\""
         );
+    }
+
+    /// A quoted word that opens *directly* on a command substitution used
+    /// to come back with a doubled `[` and no closing `]`
+    /// (`"[[lindex $x 0]"`, #1846). The raw token spans overlap in this
+    /// shape — `parse_quoted`'s empty-content clamp extends the opening
+    /// `Esc` one byte over the `[` that stopped its scan, and the `Cmd`
+    /// token starts on that same `[` — so concatenating raw token text
+    /// emitted the shared byte twice.
+    #[test]
+    fn spans_quoted_word_opening_on_command_sub_is_not_doubled() {
+        let text = r#"[list "[lindex $x 0]"]"#;
+        let (cmd, args) = parse_command_substitution_with_spans_and_config(
+            text,
+            tcl_lexer::LexerConfig::default(),
+        )
+        .unwrap();
+        assert_eq!(cmd, "list");
+        assert_eq!(args.len(), 1);
+        assert_eq!(args[0].0, "\"[lindex $x 0]\"");
+        assert_eq!(
+            &text[args[0].1.start() as usize..args[0].1.end() as usize],
+            "\"[lindex $x 0]\""
+        );
+    }
+
+    /// The same clamp extends the opening `Esc` over a `$` introducer, so
+    /// a quoted word opening directly on a variable substitution is the
+    /// other half of the overlap family fixed with #1846.
+    #[test]
+    fn spans_quoted_word_opening_on_var_sub_is_not_doubled() {
+        let text = r#"[list "$x"]"#;
+        let (cmd, args) = parse_command_substitution_with_spans_and_config(
+            text,
+            tcl_lexer::LexerConfig::default(),
+        )
+        .unwrap();
+        assert_eq!(cmd, "list");
+        assert_eq!(args[0].0, "\"$x\"");
+        assert_eq!(
+            &text[args[0].1.start() as usize..args[0].1.end() as usize],
+            "\"$x\""
+        );
+    }
+
+    /// The #1846 table: the one broken shape plus the three neighbouring
+    /// shapes that were already right, each pinned on the invariant the
+    /// bug broke — a returned argument's text is exactly the source its
+    /// own span covers, so the two can never disagree again.
+    #[test]
+    fn spans_argument_text_always_matches_its_own_span() {
+        for text in [
+            r#"[list "[lindex $x 0]"]"#,
+            r#"[list "a[foo]"]"#,
+            r"[list a[lindex $x 0]b]",
+            r"[list ${p}]",
+            r#"[list "$x"]"#,
+            r#"[list "a$b" {c d} [e]]"#,
+        ] {
+            let (_cmd, args) = parse_command_substitution_with_spans_and_config(
+                text,
+                tcl_lexer::LexerConfig::default(),
+            )
+            .unwrap_or_else(|| panic!("{text} should parse as one command substitution"));
+            for (arg_text, span) in &args {
+                assert_eq!(
+                    arg_text.as_str(),
+                    &text[span.start() as usize..span.end() as usize],
+                    "argument text and span disagree for {text}"
+                );
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

- `value_shapes::parse_command_substitution_with_spans_and_config` returned a corrupted argument **text** — a doubled `[` and a lost `]` — for a double-quoted word that opens directly on a substitution. The span alongside it was always right, so the returned string was 16 bytes under a span covering 15: text and span disagreed with each other as well as with the source.
- Measured on `rust` at `51af4671`, `plain_tcl` profile:

  | input | argument text before | after |
  |---|---|---|
  | `[list "[lindex $x 0]"]` | `"[[lindex $x 0]"` ❌ | `"[lindex $x 0]"` ✅ |
  | `[list "$x"]` | `"$$x"` ❌ | `"$x"` ✅ |
  | `[list "a[foo]"]` | `"a[foo]"` ✅ | unchanged |
  | `[list a[lindex $x 0]b]` | `a[lindex $x 0]b` ✅ | unchanged |
  | `[list ${p}]` | `${p}` ✅ | unchanged |

  The `"$x"` row is the same defect through the `$` introducer rather than `[`; the issue recorded only the `[` half.

- **Root cause.** The raw token spans overlap in that shape. `Lexer::parse_quoted`'s empty-content clamp deliberately extends a zero-content `Esc` one byte over the `$` / `[` that stopped its scan, so `list "[lindex $x 0]"` lexes as

  ```
  Esc span=0..4   raw="list"
  Sep span=4..5   raw=" "
  Esc span=5..7   raw="\"["          <-- ends at 7
  Cmd span=6..18  raw="[lindex $x 0" <-- starts at 6
  Esc span=19..20 raw="\""
  ```

  Both the `Esc` and the `Cmd` claim the `[` at offset 6. `"a[foo]"` is unaffected because the `a` gives that `Esc` real content and the two spans abut exactly (`Esc 5..7`, `Cmd 7..11`). The private word grouper in `value_shapes.rs` then concatenated adjacent tokens by appending raw token text, with no regard for a next token whose span starts before the previous one ended, so the shared byte was emitted twice. The orphaned-closer recovery above it is not at fault — it correctly contributed the trailing `"`.

- **Why the fix sits in `value_shapes` and not the lexer.** The overlap is not a lexer defect. The one-byte extension is a documented span convention with its own accessor: `SourceMap::token_text` clamps exactly these tokens back to `""`, and the semantic-tokens fragment logic reads the `content_offset` that goes with it. A consumer that wants the raw *source spelling* rather than the token text has to reconcile the convention, and this was the only one that did not. Narrowing the `Esc` span at the lexer would move a convention several consumers depend on to fix one that misreads it.

- **The fix.** The concatenation branch now extends the word by slicing `inner` from where the word so far ends, instead of appending the next token's raw text. A word's text is therefore, by construction, exactly the source its span covers — the invariant the bug broke, and the one the new table-driven test asserts for every row above.

- **#1786.** Checked, as the issue asked. #1786 landed on 2026-09-04 (`tcl_lexer::script::group_commands` is the owner), but the fold of *this* grouper onto it did not happen and is not imminent — it is an unscheduled follow-up in the tcl-lexer owner section of `shared-utility-contracts-rust.md`, next to the `scan_pure_var_ref` / `is_braced_whole_name_array_ref` / `whole_word_scalar_var_name` sweep. It would also not have fixed this on its own: `WordSpan::span` is documented as first-fragment start to last-fragment end *in the inner-end convention*, so a folded version still needs the two orphaned-closer recoveries this function carries, and still has to derive the word's text from the source rather than from token text. Deriving the text from the span — what this change does — is the answer either way, and it survives the fold as a one-line word-span slice. The `segmentation-drift-ok` waiver is left in place unchanged.

- **Impact — latent, honestly.** The span was always correct, so nothing was anchored wrongly and no diagnostic difference is demonstrated (see Validation). What was wrong is the text every consumer classifies arguments by: `shimmer/use_site.rs` (`check_invocation`'s `args`), `taint.rs` (argument span resolution), and `word_subst.rs` (`LiftedCall::args`, so a lifted nested call carried the malformed spelling). Any test on that text — a pure-var-ref check, a `[`-prefix test, an option-scan match — was answering about a string that does not appear in the source.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

All with `CARGO_TARGET_DIR=/home/user/tcl-lsp/target`:

| command | result |
|---|---|
| `cargo fmt --all` | clean, no diff |
| `make rust-check` | pass (fmt + clippy + xtask drift gates) |
| `cargo test -p tcl-compiler --lib` | `6112 passed; 0 failed; 2 ignored` |
| `cargo test -p tcl-compiler --test checks` | `256 passed; 0 failed` |
| `cargo test -p tcl-compiler --test taint` | `370 passed; 0 failed` |
| `cargo test -p tcl-compiler --test analyser` | `501 passed; 0 failed` |

The three new tests were confirmed to fail before the fix and pass after — reverting only the concatenation hunk gives `"[[lindex $x 0]"` and `"$$x"` in the assertion output.

**Corpus differential.** `tcl diag`, **one invocation per file** (never batched — fixtures that each define `proc f` contaminate a multi-file run), with a pre-fix binary built from `51af4671` with this change stashed and a post-fix binary built from this commit, over 1286 `.tcl` files: the repository's 462, plus Tcl 9.0.4's `library/` and tcllib 2.0's `modules/`.

**1285 of 1286 files byte-identical, 0 differing.** The one file not compared is `tmp/tcllib-2.0/modules/fumagic/filetypes.tcl` — 85,000 generated lines, which a debug-profile `tcl diag` does not finish in a reasonable wall time; it was excluded rather than waited on. No behaviour change is expected here, so byte-identical output is the result being looked for: it is the evidence that the fix is inert at the diagnostic level, which is exactly the claim. 14 hand-written probes aimed at the affected consumers (`[expr "[…]"]` bodies, `[list "[…]"]` folding, tainted `exec` / `open` / `eval` arguments, `after` / `trace` callback prefixes, `foreach` list folding) were run through the same differential and were also identical.

## Compiler / diagnostics checklist

- [x] Did this change alter a compiler fact contract? **No** — the span contract is unchanged and was already correct; only the argument *text* is corrected to match it.
- [x] If yes, I updated the owning design doc — n/a.
- [x] If I added or changed a diagnostic or optimisation code, I updated its page under `docs/kcs/codes/` — n/a, no diagnostic code added or changed.
- [x] If I added a design doc, I linked it from `docs/design/README.md` — n/a.

Closes #1846

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PKQ5b7ZLU5XPDaugte4Feb


---
_Generated by [Claude Code](https://claude.ai/code/session_01PKQ5b7ZLU5XPDaugte4Feb)_