### PR TITLE
fix(python): contain uploaded paths, close files, and say why an error is swallowed

### DIFF
--- a/.claude/skills/bytecode-compare/bytecode_compare.py
+++ b/.claude/skills/bytecode-compare/bytecode_compare.py
@@ -74,9 +74,6 @@ DEFAULT_VERSION = "9.0"
 # Pattern matching instruction lines: "    (N) opcode ..."
 _INSTR_RE = re.compile(r"^\s*\((\d+)\)\s+(.+)$")
 
-# Pattern for tclsh jumpTable entries: \t\t["pattern"->pc N, ...]
-_JUMPTABLE_RE = re.compile(r"^\s*\[.*->.*\]\s*$")
-
 # Pattern for ByteCode section headers (both our format and tclsh's)
 _BYTECODE_RE = re.compile(r"^ByteCode\s")
 

--- a/.claude/skills/lsp-client/lsp_client.py
+++ b/.claude/skills/lsp-client/lsp_client.py
@@ -647,10 +647,13 @@ class LspClient:
                 try:
                     self.send_request("shutdown", {}, timeout=5.0)
                 except Exception:
+                    # Best-effort courtesy: a server that will not answer
+                    # `shutdown` is killed below regardless.
                     pass
                 try:
                     self.send_notification("exit")
                 except Exception:
+                    # Same — a broken pipe here only means `exit` never landed.
                     pass
                 try:
                     self.process.wait(timeout=3.0)
@@ -662,6 +665,7 @@ class LspClient:
                 try:
                     self.process.kill()
                 except Exception:
+                    # Already reaped, which is the outcome this wanted.
                     pass
 
 
@@ -2086,6 +2090,7 @@ examples:
         print(f"LSP error: {e}", file=sys.stderr)
         sys.exit(1)
     except KeyboardInterrupt:
+        # Ctrl-C is a normal way to stop; `finally` still shuts the server down.
         pass
     finally:
         client.shutdown()

--- a/editors/sublime-text/plugin.py
+++ b/editors/sublime-text/plugin.py
@@ -31,6 +31,7 @@ import json
 import os
 import re
 import shutil
+import stat
 import tempfile
 import urllib.request
 
@@ -115,9 +116,11 @@ def _ensure_executable(path):
     if path and os.name != "nt":
         try:
             mode = os.stat(path).st_mode
-            if not (mode & 0o111):
-                os.chmod(path, 0o755)
+            if not (mode & stat.S_IXUSR):
+                os.chmod(path, mode | stat.S_IXUSR)
         except OSError:
+            # Best-effort: a missing or foreign-owned binary cannot be fixed
+            # here, and the launch attempt reports the real problem.
             pass
     return path
 

--- a/experiments/mro_eval/gen_labels.py
+++ b/experiments/mro_eval/gen_labels.py
@@ -54,7 +54,8 @@ def truth_for(row):
 
 
 def main(src="label_worksheet.csv", dst="labeled_sample.csv"):
-    rows = list(csv.DictReader(open(src)))
+    with open(src) as f:
+        rows = list(csv.DictReader(f))
     # Stratified sample: all resolved-unknown, all non-ctor resolved, a
     # stride over resolved-known, and a stride over abstentions.
     resolved = [r for r in rows if r["resolver_verdict"].startswith("resolved")]

--- a/experiments/mro_eval/score_labels.py
+++ b/experiments/mro_eval/score_labels.py
@@ -29,7 +29,8 @@ def tail(qname: str) -> str:
 
 
 def main(path: str) -> None:
-    rows = list(csv.DictReader(open(path)))
+    with open(path) as f:
+        rows = list(csv.DictReader(f))
     labeled = [r for r in rows if r.get("truth_class", "").strip()]
 
     # --- class-resolution precision (resolved rows with a concrete truth) ---

--- a/rust/bigip-report-gen/python/python/f5report/__main__.py
+++ b/rust/bigip-report-gen/python/python/f5report/__main__.py
@@ -42,7 +42,8 @@ def _logo_data_uri(path: str) -> str:
     than referenced. The MIME type is guessed from the extension (``.svg`` →
     ``image/svg+xml``); an unknown type falls back to ``application/octet-stream``.
     """
-    data = open(path, "rb").read()
+    with open(path, "rb") as fh:
+        data = fh.read()
     mime, _ = mimetypes.guess_type(path)
     if mime is None:
         mime = (
@@ -145,7 +146,8 @@ def main(argv: list[str] | None = None) -> int:
     master_key = args.f5mku
     if args.f5mku_file:
         try:
-            master_key = open(args.f5mku_file, encoding="utf-8").read().strip()
+            with open(args.f5mku_file, encoding="utf-8") as fh:
+                master_key = fh.read().strip()
         except OSError as exc:
             print(f"f5-report: could not read --f5mku-file: {exc}", file=sys.stderr)
             return 2
@@ -153,9 +155,8 @@ def main(argv: list[str] | None = None) -> int:
     copyright_notice = args.copyright or ""
     if args.copyright_file:
         try:
-            copyright_notice = (
-                open(args.copyright_file, encoding="utf-8").read().strip()
-            )
+            with open(args.copyright_file, encoding="utf-8") as fh:
+                copyright_notice = fh.read().strip()
         except OSError as exc:
             print(f"f5-report: could not read --copyright-file: {exc}", file=sys.stderr)
             return 2
@@ -163,7 +164,8 @@ def main(argv: list[str] | None = None) -> int:
     front_matter = ""
     if args.front_matter:
         try:
-            front_matter = open(args.front_matter, encoding="utf-8").read()
+            with open(args.front_matter, encoding="utf-8") as fh:
+                front_matter = fh.read()
         except OSError as exc:
             print(f"f5-report: could not read --front-matter: {exc}", file=sys.stderr)
             return 2

--- a/rust/bigip-report-gen/python/python/f5report/graph.py
+++ b/rust/bigip-report-gen/python/python/f5report/graph.py
@@ -121,7 +121,6 @@ def parse_listener(v: dict[str, Any]) -> dict[str, Any]:
     port = 0 if port_raw in ("", "0", "any", "*") else _port_num(port_raw)
 
     src = v.get("source", "") or ("::/0" if is_v6 else "0.0.0.0/0")
-    src_addr, src_rd = _split_rd(src.split("/")[0])
     try:
         src_net = ipaddress.ip_network(_normalise_cidr(src), strict=False)
         src_prefix = src_net.prefixlen

--- a/rust/bigip-report-gen/python/python/f5report/web.py
+++ b/rust/bigip-report-gen/python/python/f5report/web.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import tempfile
 import uuid as _uuid
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -124,6 +125,20 @@ def _parse_multipart(body: bytes, content_type: str) -> list[Part]:
     return parts
 
 
+_UNSAFE_UPLOAD_CHARS = re.compile(r"[^A-Za-z0-9._-]")
+
+
+def _upload_basename(filename: str | None) -> str:
+    """Reduce a client-supplied upload filename to a bare, inert basename.
+
+    ``os.path.basename`` alone is not enough: on POSIX it keeps Windows
+    separators and drive letters, and it lets ``.``, ``..`` and the empty name
+    through. The extension survives because `load_paths` dispatches on it.
+    """
+    name = (filename or "").replace("\\", "/").rsplit("/", 1)[-1]
+    return _UNSAFE_UPLOAD_CHARS.sub("_", name).lstrip(".") or "upload"
+
+
 # ---- request handling ------------------------------------------------------
 
 
@@ -155,13 +170,24 @@ class _Handler(BaseHTTPRequestHandler):
         full cert PEMs), returning (sources, tmpdir) — caller cleans tmpdir."""
         files = [p for p in parts if p.filename]
         tmp = tempfile.mkdtemp(prefix="f5report-")
-        paths = []
-        for p in files:
-            dest = os.path.join(tmp, os.path.basename(p.filename or "upload"))
-            with open(dest, "wb") as fh:
-                fh.write(p.data)
-            paths.append(dest)
-        sources = load_paths(paths, passphrase=passphrase or None) if paths else []
+        try:
+            # `tmp` itself may sit behind a symlink (/var -> /private/var on
+            # macOS), so both sides of the containment check are resolved.
+            root = os.path.realpath(tmp)
+            paths = []
+            for p in files:
+                dest = os.path.realpath(
+                    os.path.join(root, _upload_basename(p.filename))
+                )
+                if not dest.startswith(root + os.sep):
+                    raise ValueError(f"unsafe upload filename: {p.filename!r}")
+                with open(dest, "wb") as fh:
+                    fh.write(p.data)
+                paths.append(dest)
+            sources = load_paths(paths, passphrase=passphrase or None) if paths else []
+        except Exception:
+            _rmtree(tmp)
+            raise
         return sources, tmp
 
     @staticmethod
@@ -270,6 +296,7 @@ def serve(host: str = "127.0.0.1", port: int = 8080) -> None:
     try:
         httpd.serve_forever()
     except KeyboardInterrupt:
+        # Ctrl-C is the advertised way to stop; `finally` closes the socket.
         pass
     finally:
         httpd.server_close()

--- a/rust/bigip-report-gen/python/python/f5report/web.py
+++ b/rust/bigip-report-gen/python/python/f5report/web.py
@@ -165,7 +165,8 @@ class _Handler(BaseHTTPRequestHandler):
         length = int(self.headers.get("Content-Length", 0))
         return self.rfile.read(length) if length else b""
 
-    def _sources_from_parts(self, parts: list[Part], passphrase: str):
+    @staticmethod
+    def _sources_from_parts(parts: list[Part], passphrase: str):
         """Spill uploaded files to a temp dir and load them (UCS extract +
         full cert PEMs), returning (sources, tmpdir) — caller cleans tmpdir."""
         files = [p for p in parts if p.filename]
@@ -175,11 +176,20 @@ class _Handler(BaseHTTPRequestHandler):
             # macOS), so both sides of the containment check are resolved.
             root = os.path.realpath(tmp)
             paths = []
-            for p in files:
+            for i, p in enumerate(files):
+                # One directory per upload. Two distinct names can sanitise to
+                # the same basename ("prod east.ucs" and "prod_east.ucs"), and
+                # in a shared directory the second would overwrite the first —
+                # dropping one device from the report and duplicating another.
+                # Renaming instead would not do: the basename is what
+                # `_device_name` falls back to for a config with no hostname,
+                # and the extension is how the engine spots a UCS.
+                spill = os.path.join(root, str(i))
+                os.mkdir(spill)
                 dest = os.path.realpath(
-                    os.path.join(root, _upload_basename(p.filename))
+                    os.path.join(spill, _upload_basename(p.filename))
                 )
-                if not dest.startswith(root + os.sep):
+                if not dest.startswith(spill + os.sep):
                     raise ValueError(f"unsafe upload filename: {p.filename!r}")
                 with open(dest, "wb") as fh:
                     fh.write(p.data)

--- a/rust/bigip-report-gen/python/tests/test_certs.py
+++ b/rust/bigip-report-gen/python/tests/test_certs.py
@@ -71,11 +71,11 @@ def test_cert_model_and_crossref():
     c = certs[0]
     assert c["name"] == "www.example.com.crt"
     assert c["fullPath"] == "/Common/www.example.com.crt"
-    assert "www.example.com" in c["subject"]
+    assert c["subject"] == "CN=www.example.com,O=Example,C=US"
     assert "Example Root CA" in c["issuer"]
     assert c["expirationDate"] == "1893456000"
     assert "2030" in c["expirationString"]
-    assert "example.com" in c["subjectAlternativeName"]
+    assert c["subjectAlternativeName"] == "DNS:www.example.com, DNS:example.com"
     assert "www_clientssl" in c["usedByProfiles"]
     assert "www_https_vs" in c["usedByVirtuals"]
     assert d["counts"]["certificates"] == 1

--- a/rust/bigip-report-gen/python/tests/test_engine.py
+++ b/rust/bigip-report-gen/python/tests/test_engine.py
@@ -25,7 +25,6 @@ import pathlib
 import pytest
 
 import f5report
-from f5report import _engine
 
 DATA = pathlib.Path(__file__).parent / "data"
 UCS1 = str(DATA / "lab-device-01.ucs")
@@ -33,8 +32,8 @@ CONF1 = str(DATA / "device-01.bigip.conf")
 
 
 def test_version_exposed():
-    assert isinstance(_engine.__version__, str)
-    assert f5report.engine_version() == _engine.__version__
+    assert isinstance(f5report._engine.__version__, str)
+    assert f5report.engine_version() == f5report._engine.__version__
 
 
 def test_load_plain_conf():
@@ -110,19 +109,19 @@ def test_merge_refuses_colliding_identities():
     # engine, surfaced verbatim as a QueryError).
     a = ("a.conf", "ltm pool /Common/dup { }\n")
     b = ("b.conf", "ltm pool /Common/dup { }\n")
-    with pytest.raises(_engine.QueryError):
+    with pytest.raises(f5report._engine.QueryError):
         f5report.query(".ltm.pool[]", [a, b], merge=True)
 
 
 def test_bad_query_raises_queryerror():
     sources = f5report.load_paths([UCS1])
-    with pytest.raises(_engine.QueryError):
+    with pytest.raises(f5report._engine.QueryError):
         f5report.query(".ltm.virtual[", sources)
 
 
 def test_mutating_query_rejected():
     sources = f5report.load_paths([UCS1])
-    with pytest.raises(_engine.QueryError):
+    with pytest.raises(f5report._engine.QueryError):
         f5report.query('.ltm.pool[] | .name = "x"', sources)
 
 

--- a/rust/bigip-report-gen/python/tests/test_graph.py
+++ b/rust/bigip-report-gen/python/tests/test_graph.py
@@ -22,8 +22,7 @@ from __future__ import annotations
 
 import pathlib
 
-import f5report
-from f5report import graph
+from f5report import graph, load_paths
 from f5report.report import collect_model
 
 DATA = pathlib.Path(__file__).parent / "data"
@@ -31,7 +30,7 @@ UCS1 = str(DATA / "lab-device-01.ucs")
 
 
 def _device():
-    return collect_model(f5report.load_paths([UCS1]))["devices"][0]
+    return collect_model(load_paths([UCS1]))["devices"][0]
 
 
 def test_graph_nodes_and_edges():

--- a/rust/bigip-report-gen/python/tests/test_web.py
+++ b/rust/bigip-report-gen/python/tests/test_web.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import os
 import threading
 import time
 import urllib.request
@@ -69,3 +70,25 @@ def test_generate_plaintext_config(server):
     assert resp.headers.get("X-Device-Count") == "1"
     assert 'data-report-id="abc-123"' in html
     assert "vs" in html  # the virtual server made it into the report
+
+
+def test_uploads_with_colliding_sanitised_names_stay_distinct():
+    """Two filenames that sanitise to one basename must not overwrite each
+    other: the report would lose a device and show another twice."""
+    parts = [
+        web.Part("files", "prod east.ucs", b"ltm virtual /Common/east { }\n"),
+        web.Part("files", "prod_east.ucs", b"ltm virtual /Common/west { }\n"),
+    ]
+    sources, tmp = web._Handler._sources_from_parts(parts, "")
+    try:
+        assert len({uri for uri, _ in sources}) == 2
+        # The basename still has to survive the spill — `_device_name` falls
+        # back to it, and the engine reads the extension to spot a UCS.
+        assert [os.path.basename(uri) for uri, _ in sources] == [
+            "prod_east.ucs",
+            "prod_east.ucs",
+        ]
+        assert "/Common/east" in sources[0][1]
+        assert "/Common/west" in sources[1][1]
+    finally:
+        web._rmtree(tmp)

--- a/scripts/dev/bigip-probes/lib/gen-context-parity.py
+++ b/scripts/dev/bigip-probes/lib/gen-context-parity.py
@@ -14,20 +14,21 @@ import os
 import sys
 
 cases = []
-for line in open(sys.argv[1]):
-    if line.startswith("#") or not line.strip():
-        continue
-    cid, cat, src = line.rstrip("\n").split("\t")
-    # Un-escape here rather than in Tcl: the case list is emitted inside {...},
-    # which performs no substitution, so the file must already hold real braces
-    # and real newlines. $ and [ deliberately survive to eval time.
-    src = (
-        src.replace("\\{", "{")
-        .replace("\\}", "}")
-        .replace('\\"', '"')
-        .replace("\\n", "\n")
-    )
-    cases.append((cid, cat, src))
+with open(sys.argv[1]) as fh:
+    for line in fh:
+        if line.startswith("#") or not line.strip():
+            continue
+        cid, cat, src = line.rstrip("\n").split("\t")
+        # Un-escape here rather than in Tcl: the case list is emitted inside {...},
+        # which performs no substitution, so the file must already hold real braces
+        # and real newlines. $ and [ deliberately survive to eval time.
+        src = (
+            src.replace("\\{", "{")
+            .replace("\\}", "}")
+            .replace('\\"', '"')
+            .replace("\\n", "\n")
+        )
+        cases.append((cid, cat, src))
 out = sys.argv[2]
 os.makedirs(out, exist_ok=True)
 
@@ -69,31 +70,36 @@ def body_for(ctxname, emit):
 
 
 # 1. iRule — RULE_INIT, logs to /var/log/ltm
-open(os.path.join(out, "ctx_irule.conf"), "w").write(
-    "ltm rule __tcl_lsp_probe_ctx_irule {\nwhen RULE_INIT {"
-    + body_for("TmmIRule", "log local0.")
-    + "}\n}\n"
-)
+with open(os.path.join(out, "ctx_irule.conf"), "w") as fh:
+    fh.write(
+        "ltm rule __tcl_lsp_probe_ctx_irule {\nwhen RULE_INIT {"
+        + body_for("TmmIRule", "log local0.")
+        + "}\n}\n"
+    )
 
 # 2. tmsh cli script — puts to stdout
-open(os.path.join(out, "ctx_cli.conf"), "w").write(
-    "cli script __tcl_lsp_probe_ctx_cli {\nproc script::run {} {"
-    + body_for("TmshCliScript", "puts")
-    + "}\n}\n"
-)
+with open(os.path.join(out, "ctx_cli.conf"), "w") as fh:
+    fh.write(
+        "cli script __tcl_lsp_probe_ctx_cli {\nproc script::run {} {"
+        + body_for("TmshCliScript", "puts")
+        + "}\n}\n"
+    )
 
 # 3. iApp implementation — tmsh::log err (info level never reaches /var/log/ltm)
-open(os.path.join(out, "ctx_iapp.conf"), "w").write(
-    "sys application template __tcl_lsp_probe_ctx_iapp {\n  actions {\n    definition {\n"
-    "      implementation {"
-    + body_for("IAppImplementation", "tmsh::log err")
-    + "      }\n      presentation {\n      }\n    }\n  }\n}\n"
-)
-open(os.path.join(out, "ctx_iapp_svc.conf"), "w").write(
-    "sys application service __tcl_lsp_probe_ctx_iapp_svc {\n"
-    "  template __tcl_lsp_probe_ctx_iapp\n}\n"
-)
+with open(os.path.join(out, "ctx_iapp.conf"), "w") as fh:
+    fh.write(
+        "sys application template __tcl_lsp_probe_ctx_iapp {\n  actions {\n    definition {\n"
+        "      implementation {"
+        + body_for("IAppImplementation", "tmsh::log err")
+        + "      }\n      presentation {\n      }\n    }\n  }\n}\n"
+    )
+with open(os.path.join(out, "ctx_iapp_svc.conf"), "w") as fh:
+    fh.write(
+        "sys application service __tcl_lsp_probe_ctx_iapp_svc {\n"
+        "  template __tcl_lsp_probe_ctx_iapp\n}\n"
+    )
 
 # 4. host tclsh control
-open(os.path.join(out, "ctx_host.tcl"), "w").write(body_for("HostShellTcl", "puts"))
+with open(os.path.join(out, "ctx_host.tcl"), "w") as fh:
+    fh.write(body_for("HostShellTcl", "puts"))
 print("wrote 5 wrappers for %d cases -> %s" % (len(cases), out))

--- a/scripts/perf/bench.py
+++ b/scripts/perf/bench.py
@@ -857,6 +857,8 @@ def host_info() -> dict:
                     cpu = line.split(":", 1)[1].strip()
                     break
         except OSError:
+            # /proc is not always readable (container, hardened host); the
+            # `platform.processor()` fallback below covers it.
             pass
         try:
             for line in Path("/proc/meminfo").read_text().splitlines():
@@ -864,6 +866,8 @@ def host_info() -> dict:
                     mem = round(int(line.split()[1]) / 1024**2)
                     break
         except (OSError, ValueError, IndexError):
+            # Same, plus an unexpected MemTotal line: `mem` stays 0, which is
+            # the documented "could not be determined" value.
             pass
     # Machine load at the moment of measurement. A developer laptop has a
     # busy desktop on it (browser, editor, chat) and will never be quiet, so

--- a/scripts/perf/get_server.py
+++ b/scripts/perf/get_server.py
@@ -187,12 +187,13 @@ def main() -> int:
     with args.manifest.open("rb") as fh:
         manifest = tomllib.load(fh)
 
-    if args.all:
-        tags = sorted(manifest["versions"]["tags"], key=version_key)
-    elif args.tag:
-        tags = [args.tag]
-    else:
+    if not (args.all or args.tag):
         ap.error("pass --tag or --all")
+    tags = (
+        sorted(manifest["versions"]["tags"], key=version_key)
+        if args.all
+        else [args.tag]
+    )
 
     missing = []
     for tag in tags:

--- a/scripts/stress/stress_lsp.py
+++ b/scripts/stress/stress_lsp.py
@@ -381,18 +381,18 @@ class LspClient:
         return result if isinstance(result, dict) else {}
 
     def notify(self, method: str, params: dict) -> None:
-        # Best-effort: a notification has no response to fail on, so a dead
-        # server is swallowed here rather than raised — the caller's *next*
-        # `request()` call (every scenario's loop always follows a burst of
-        # notifies with a request) hits the same dead-server condition and
-        # raises `LspError` there, where it's already handled. This is what
-        # stops a `didOpen`/`didChange`/`didClose` call site (none of which
-        # wrap `notify()` in try/except, since normally there is nothing to
-        # handle) from raising an unhandled exception straight out of a
-        # worker thread the instant the server dies mid-run.
         try:
             self._send({"jsonrpc": "2.0", "method": method, "params": params})
         except LspError:
+            # Best-effort: a notification has no response to fail on, so a dead
+            # server is swallowed here rather than raised — the caller's *next*
+            # `request()` call (every scenario's loop always follows a burst of
+            # notifies with a request) hits the same dead-server condition and
+            # raises `LspError` there, where it's already handled. This is what
+            # stops a `didOpen`/`didChange`/`didClose` call site (none of which
+            # wrap `notify()` in try/except, since normally there is nothing to
+            # handle) from raising an unhandled exception straight out of a
+            # worker thread the instant the server dies mid-run.
             pass
 
     def initialize(self, root_uri: str) -> dict:
@@ -422,6 +422,8 @@ class LspClient:
             self.request("shutdown", {}, timeout=5.0)
             self.notify("exit", {})
         except LspError:
+            # A server that is already dead needs no polite shutdown; the
+            # wait/kill below reaps it either way.
             pass
         try:
             self.process.wait(timeout=5.0)


### PR DESCRIPTION
## Summary

Clears all **32 `py/*` CodeQL alerts** on `rust`. 1 of 6 PRs covering the Security tab; the others are linked at the bottom.

The two that matter:

- **`py/path-injection`** — `f5report/web.py` joined a client-supplied multipart `filename` into its temp dir behind nothing but `os.path.basename`, which on POSIX keeps Windows separators and drive letters and lets `.`, `..` and the empty name through. `_upload_basename()` now reduces the name to a bare inert basename, and the spill loop resolves both sides with `realpath` before refusing a destination outside the temp root. The loop is wrapped so a failure removes the temp dir before re-raising — `_probe`/`_generate` call this outside their `try/finally`, so without that the new raise would leak it.
- **`py/overly-permissive-file`** — the Sublime plugin made a downloaded server binary `0o755` outright, so a `0600` private binary came back world-readable and world-executable. It now ORs in owner-execute only, and the guard tests the same bit it sets (`0600→0700`, `0644→0744`, `0755` unchanged).

The remaining 30 are hygiene, and each was checked rather than pattern-matched:

- 12 × `py/file-not-closed` → `with` blocks.
- 10 × `py/empty-except` → the explanatory comment CodeQL asks for. Every one is a deliberate best-effort swallow (teardown, `/proc` probes, `KeyboardInterrupt`). None widened, none suppressed. In `stress_lsp.py` the existing nine-line rationale sat *above* the `try`, where CodeQL does not count it; it moved verbatim into the handler rather than gaining a second comment.
- 2 × `py/incomplete-url-substring-sanitization` → `test_certs.py` substring `in` checks became exact equalities, which strictly imply what they proved before.
- 1 × `py/uninitialized-local-variable`, 2 × `py/unused-local-variable`, 1 × `py/unused-global-variable`, 2 × `py/import-and-import-from`.

Two of the dead-code finds were checked for a dropped call site before deletion: `_JUMPTABLE_RE` is genuinely unreachable because `extract_instructions` filters *positively* on `_INSTR_RE`, and `graph.py`'s `src_addr, src_rd` is dead in the Rust port too.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

```
# CodeQL 2.26.4 — the exact bundle .github/workflows/codeql.yml pins —
# security-extended,security-and-quality, fresh DB over the whole source root
codeql database create … --language=python --build-mode=none
codeql database analyze … python-security-extended.qls python-security-and-quality.qls
  → 0 results outside node_modules/ (was 32)

ruff check   → All checks passed!
ruff format --check → 15 files already formatted

# the f5report suite, against a maturin-built native _engine (make py-venv)
.venv-typecheck/bin/python -m pytest -q   → 54 passed
```

`gen-context-parity.py` was additionally differential-tested against its `HEAD` version (byte-identical output on a synthetic cases file), as were `parse_listener`, `_ensure_executable`, `_upload_basename` (13 inputs including `../../etc/passwd`, `..\..\windows\system32\cfg`, `C:a.ucs`, `..`, `""`) and `get_server.py`'s three argument branches.

## Compiler / diagnostics checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

Not applicable — no compiler behaviour, diagnostic, optimisation code or analysis contract is touched.

- [ ] Did this change alter a compiler fact contract?
- [ ] If yes, I updated the owning design doc under `docs/design/compiler/` or `docs/design/contracts/`.
- [ ] If I added or changed a diagnostic or optimisation code, I updated its page under `docs/kcs/codes/` and linked it from `docs/kcs/codes/README.md`.
- [ ] If I added a design doc, I linked it from `docs/design/README.md` (`cargo xtask kcs-index-links` enforces this).

---

Sibling PRs for the rest of the Security tab: report front-end XSS, editor/webview hardening, CodeQL scan scope, dependency advisories, supply-chain pinning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XLgBd8h9SpPKTDF65KdABP

---
_Generated by [Claude Code](https://claude.ai/code/session_01XLgBd8h9SpPKTDF65KdABP)_