### PR TITLE
fix(report): build the topology selectors as DOM instead of markup

### DIFF
--- a/rust/bigip-report-gen/frontend/dist/input.js
+++ b/rust/bigip-report-gen/frontend/dist/input.js
@@ -265,6 +265,11 @@
       } catch {
       }
     }
+    const LOGO_URI = /^data:image\/[\w.+-]+;base64,[A-Za-z0-9+/=]*$/;
+    function cleanLogoUri(uri) {
+      const s = String(uri || "").replace(/[^\w+/=:;,.-]/g, "");
+      return LOGO_URI.test(s) ? s : "";
+    }
     function currentSettings() {
       return {
         frontMatter: frontMatterEl.value,
@@ -292,7 +297,7 @@
     function applySettings(s) {
       frontMatterEl.value = s.frontMatter || "";
       copyrightEl.value = s.copyright || "";
-      logoDataUri = s.logo || "";
+      logoDataUri = cleanLogoUri(s.logo);
       reflectLogo();
     }
     function restoreSettings() {

--- a/rust/bigip-report-gen/frontend/dist/topology.js
+++ b/rust/bigip-report-gen/frontend/dist/topology.js
@@ -794,9 +794,10 @@ nat-map     -file nat.csv           ;# source,dest[,source_cidr,dest_cidr]
         var nodes = ix.d.graph.nodes.slice().sort(function(a, b) {
           return (a.type + a.name).localeCompare(b.type + b.name);
         });
-        srcSel.innerHTML = nodes.map(function(n) {
-          return '<option value="' + n.oid + '"' + (n.oid === selectedOid ? " selected" : "") + ">" + esc(optLabel(ix, n.oid)) + "</option>";
-        }).join("");
+        srcSel.textContent = "";
+        nodes.forEach(function(n) {
+          srcSel.appendChild(optionEl(n.oid, optLabel(ix, n.oid), n.oid === selectedOid));
+        });
       }
       function fillDests(ix) {
         var reach = reachableFrom(ix, srcSel.value).map(function(o) {
@@ -804,12 +805,13 @@ nat-map     -file nat.csv           ;# source,dest[,source_cidr,dest_cidr]
         }).sort(function(a, b) {
           return a.label.localeCompare(b.label);
         });
+        dstSel.textContent = "";
         if (!reach.length) {
-          dstSel.innerHTML = '<option value="">(nothing reachable downstream)</option>';
+          dstSel.appendChild(optionEl("", "(nothing reachable downstream)", false));
         } else {
-          dstSel.innerHTML = reach.map(function(r) {
-            return '<option value="' + r.oid + '">' + esc(r.label) + "</option>";
-          }).join("");
+          reach.forEach(function(r) {
+            dstSel.appendChild(optionEl(r.oid, r.label, false));
+          });
         }
         build();
       }
@@ -898,9 +900,12 @@ nat-map     -file nat.csv           ;# source,dest[,source_cidr,dest_cidr]
       };
     }
     var IDX = MODEL.devices.map(indexDevice);
-    function activeDeviceIndex() {
-      var el = document.querySelector(".device.active");
-      return el ? parseInt(el.dataset.dev, 10) : 0;
+    function optionEl(value, label, selected) {
+      var o = document.createElement("option");
+      o.value = value;
+      o.textContent = label;
+      if (selected) o.selected = true;
+      return o;
     }
     var ESC_MAP = { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" };
     function esc(s) {
@@ -911,6 +916,12 @@ nat-map     -file nat.csv           ;# source,dest[,source_cidr,dest_cidr]
     function escConf(s) {
       return String(s).replace(/[&<>"]/g, function(c) {
         return ESC_MAP[c];
+      });
+    }
+    var SAFE_MARKUP = /^(?:<\/span>|<span class="tk-[\w -]+">|&(?:amp|lt|gt|quot);)$/;
+    function sanitiseHtml(markup) {
+      return String(markup).replace(/<[^<>]*>|&[^\s&;]*;?|[<>"]/g, function(m0) {
+        return SAFE_MARKUP.test(m0) ? m0 : escConf(m0);
       });
     }
     function stanzaFor(cfg, fullPath) {
@@ -954,7 +965,7 @@ nat-map     -file nat.csv           ;# source,dest[,source_cidr,dest_cidr]
       if (n.type === "rule") {
         var r = ruleByPath(ix, n.fullPath);
         if (r && (r.bodyHtml || r.body)) {
-          return '<pre class="code tcl">' + (r.bodyHtml || escConf(r.body || "")) + "</pre>";
+          return '<pre class="code tcl">' + (r.bodyHtml ? sanitiseHtml(r.bodyHtml) : escConf(r.body || "")) + "</pre>";
         }
       }
       var stanza = stanzaFor(ix.d.configText, n.fullPath);
@@ -1213,11 +1224,7 @@ nat-map     -file nat.csv           ;# source,dest[,source_cidr,dest_cidr]
       eventsIn("lb").forEach(function(e) {
         steps.push({ t: "event", l: e });
       });
-      var poolIdx = -1;
-      if (vs.pool) {
-        poolIdx = steps.length;
-        steps.push({ t: "pool", l: vs.pool.split("/").pop(), oid: "pool:" + vs.pool });
-      }
+      if (vs.pool) steps.push({ t: "pool", l: vs.pool.split("/").pop(), oid: "pool:" + vs.pool });
       eventsIn("server").forEach(function(e) {
         steps.push({ t: "event", l: e });
       });
@@ -1368,13 +1375,13 @@ nat-map     -file nat.csv           ;# source,dest[,source_cidr,dest_cidr]
       var focusSel = panel.querySelector(".topo-focus");
       var depthSel = panel.querySelector(".topo-depth");
       var typeBoxes = panel.querySelectorAll(".topo-type");
-      var opts = ['<option value="">\u2014 whole estate \u2014</option>'];
+      focusSel.textContent = "";
+      focusSel.appendChild(optionEl("", "\u2014 whole estate \u2014", false));
       ix.d.graph.nodes.slice().sort(function(a, b) {
         return (a.type + a.name).localeCompare(b.type + b.name);
       }).forEach(function(n) {
-        opts.push('<option value="' + n.oid + '">' + TYPE_LABEL[n.type] + ": " + esc(n.name) + "</option>");
+        focusSel.appendChild(optionEl(n.oid, TYPE_LABEL[n.type] + ": " + n.name, false));
       });
-      focusSel.innerHTML = opts.join("");
       function activeTypes() {
         var t = {};
         typeBoxes.forEach(function(b) {
@@ -1424,7 +1431,12 @@ nat-map     -file nat.csv           ;# source,dest[,source_cidr,dest_cidr]
       var drawer = document.getElementById("objDrawer");
       var body = drawer.querySelector(".drawer-body");
       var titleEl = drawer.querySelector(".drawer-title");
-      titleEl.innerHTML = '<span class="tag ' + n.type + '">' + TYPE_LABEL[n.type] + "</span> " + esc(n.name);
+      var titleTag = document.createElement("span");
+      titleTag.className = "tag " + n.type;
+      titleTag.textContent = TYPE_LABEL[n.type];
+      titleEl.textContent = "";
+      titleEl.appendChild(titleTag);
+      titleEl.appendChild(document.createTextNode(" " + n.name));
       drawer.querySelector(".drawer-sub").textContent = n.fullPath;
       if (TYPE_PANEL[n.type]) {
         titleEl.classList.add("drawer-title-link");
@@ -1507,7 +1519,7 @@ nat-map     -file nat.csv           ;# source,dest[,source_cidr,dest_cidr]
       if (!v) return "";
       var L = v.listener || {};
       var rows = [
-        ["Destination", esc(L.address || "-") + (L.prefix != null && L.prefix < L.maxPrefix ? "/" + L.prefix : "") + (L.routeDomain ? " %" + L.routeDomain : "")],
+        ["Destination", esc(L.address || "-") + (L.prefix != null && L.prefix < L.maxPrefix ? "/" + esc(L.prefix) : "") + (L.routeDomain ? " %" + esc(L.routeDomain) : "")],
         ["Port", esc(L.portRaw || "-")],
         ["Protocol", esc(L.protocol || "-")],
         ["Source", esc(L.source || "-")],
@@ -1872,10 +1884,6 @@ nat-map     -file nat.csv           ;# source,dest[,source_cidr,dest_cidr]
     }
     function simulate(ix, v, req) {
       var stages = [];
-      var L = v.listener || {};
-      var isHttp = (v.profiles || []).some(function(p) {
-        return /\/http\b|http$/.test(p) || /_http/.test(p);
-      });
       var ssl = pickSslProfile(ix, v, req.sni);
       if (ssl) {
         stages.push({
@@ -2001,9 +2009,6 @@ nat-map     -file nat.csv           ;# source,dest[,source_cidr,dest_cidr]
     function renderSim(ix, v, host) {
       var L = v.listener || {};
       var hasSsl = !!pickSslProfile(ix, v, "");
-      var isHttp = (v.profiles || []).some(function(p) {
-        return /http/.test(p);
-      });
       var h = ['<div class="sim-head"><b>Processing for ' + esc(v.name) + '</b> <span class="mono muted">' + esc(L.address) + ":" + esc(L.portRaw) + " \xB7 " + esc(L.protocol) + "</span></div>"];
       h.push('<div class="sim-req">');
       if (hasSsl) h.push('<div class="fld"><label>TLS SNI</label><input class="sim-sni lm-field" placeholder="www.example.com"></div>');
@@ -2119,11 +2124,11 @@ nat-map     -file nat.csv           ;# source,dest[,source_cidr,dest_cidr]
         html.push('<div class="tiers">');
         tiers.forEach(function(t, ti) {
           html.push('<div class="tier' + (ti === 0 ? " match" : "") + '">');
-          html.push('<div class="tier-key">/' + t.prefix + " \xB7 " + (t.port ? "port " + t.port : "any port") + "</div>");
+          html.push('<div class="tier-key">/' + esc(t.prefix) + " \xB7 " + (t.port ? "port " + esc(t.port) : "any port") + "</div>");
           html.push('<div class="tier-vs">');
           t.vs.forEach(function(v) {
             var L = v.listener;
-            html.push('<button class="lm-card" data-fp="' + esc(v.fullPath) + '"' + (v === focus ? ' data-focus="1"' : "") + '><span class="lm-name">' + esc(v.name) + (v === focus ? ' <span class="tag green">match</span>' : "") + '</span><span class="lm-dest mono">' + esc(L.address) + (L.prefix < L.maxPrefix ? "/" + L.prefix : "") + (L.routeDomain ? "%" + L.routeDomain : "") + ":" + esc(L.portRaw) + '</span><span class="lm-meta mono">' + esc(L.protocol) + (v.pool ? " \u2192 " + esc(v.pool.split("/").pop()) : " \xB7 no pool") + "</span></button>");
+            html.push('<button class="lm-card" data-fp="' + esc(v.fullPath) + '"' + (v === focus ? ' data-focus="1"' : "") + '><span class="lm-name">' + esc(v.name) + (v === focus ? ' <span class="tag green">match</span>' : "") + '</span><span class="lm-dest mono">' + esc(L.address) + (L.prefix < L.maxPrefix ? "/" + esc(L.prefix) : "") + (L.routeDomain ? "%" + esc(L.routeDomain) : "") + ":" + esc(L.portRaw) + '</span><span class="lm-meta mono">' + esc(L.protocol) + (v.pool ? " \u2192 " + esc(v.pool.split("/").pop()) : " \xB7 no pool") + "</span></button>");
           });
           html.push("</div></div>");
           if (ti < tiers.length - 1) html.push('<div class="tier-arrow">falls through to \u25BE</div>');
@@ -2241,10 +2246,6 @@ nat-map     -file nat.csv           ;# source,dest[,source_cidr,dest_cidr]
     (function initSearch() {
       var search = document.getElementById("globalSearch");
       if (!search) return;
-      function detailOf(row) {
-        var d = row.nextElementSibling;
-        return d && d.classList.contains("detail") ? d : null;
-      }
       function toNet(s) {
         var m = /^([0-9a-fA-F:.]+)(?:\/(\d+))?$/.exec(s);
         if (!m) return null;
@@ -2465,7 +2466,7 @@ nat-map     -file nat.csv           ;# source,dest[,source_cidr,dest_cidr]
             var r = ruleByPath(ix, n.fullPath);
             if (r) {
               if (r.flowchart) html += '<div class="app-obj-flow diag-host" data-flow="' + esc(encodeURIComponent(r.flowchart)) + '">flow\u2026</div>';
-              html += '<pre class="code tcl">' + (r.bodyHtml || esc(r.body || "")) + "</pre>";
+              html += '<pre class="code tcl">' + (r.bodyHtml ? sanitiseHtml(r.bodyHtml) : esc(r.body || "")) + "</pre>";
             }
           } else {
             var stanza = stanzaFor(ix.d.configText, n.fullPath);

--- a/rust/bigip-report-gen/frontend/src/pages/input.ts
+++ b/rust/bigip-report-gen/frontend/src/pages/input.ts
@@ -117,6 +117,16 @@ const LS_SETTINGS = "f5report-settings";
   }
 
   // --- report settings (front matter / copyright / logo) --------------------
+  // A logo is an inlined base64 data: image URI, produced here by
+  // FileReader.readAsDataURL. A stored or imported setting is not, so strip
+  // every character that cannot appear in one and drop the value unless what
+  // remains still is one — it goes on to <img src> and into the report.
+  const LOGO_URI = /^data:image\/[\w.+-]+;base64,[A-Za-z0-9+/=]*$/;
+  function cleanLogoUri(uri: string | undefined): string {
+    const s = String(uri || "").replace(/[^\w+/=:;,.-]/g, "");
+    return LOGO_URI.test(s) ? s : "";
+  }
+
   function currentSettings(): ReportSettings {
     return {
       frontMatter: frontMatterEl.value,
@@ -145,7 +155,7 @@ const LS_SETTINGS = "f5report-settings";
   function applySettings(s: ReportSettings): void {
     frontMatterEl.value = s.frontMatter || "";
     copyrightEl.value = s.copyright || "";
-    logoDataUri = s.logo || "";
+    logoDataUri = cleanLogoUri(s.logo);
     reflectLogo();
   }
   function restoreSettings(): void {

--- a/rust/bigip-report-gen/frontend/src/pages/topology.ts
+++ b/rust/bigip-report-gen/frontend/src/pages/topology.ts
@@ -192,21 +192,20 @@ import { initArchEditor } from "../arch/editor";
       var nodes = ix.d.graph.nodes.slice().sort(function (a, b) {
         return (a.type + a.name).localeCompare(b.type + b.name);
       });
-      srcSel.innerHTML = nodes.map(function (n) {
-        return '<option value="' + n.oid + '"' + (n.oid === selectedOid ? " selected" : "") + ">" +
-          esc(optLabel(ix, n.oid)) + "</option>";
-      }).join("");
+      srcSel.textContent = "";
+      nodes.forEach(function (n) {
+        srcSel.appendChild(optionEl(n.oid, optLabel(ix, n.oid), n.oid === selectedOid));
+      });
     }
     function fillDests(ix) {
       var reach = reachableFrom(ix, srcSel.value)
         .map(function (o) { return { oid: o, label: optLabel(ix, o) }; })
         .sort(function (a, b) { return a.label.localeCompare(b.label); });
+      dstSel.textContent = "";
       if (!reach.length) {
-        dstSel.innerHTML = '<option value="">(nothing reachable downstream)</option>';
+        dstSel.appendChild(optionEl("", "(nothing reachable downstream)", false));
       } else {
-        dstSel.innerHTML = reach.map(function (r) {
-          return '<option value="' + r.oid + '">' + esc(r.label) + "</option>";
-        }).join("");
+        reach.forEach(function (r) { dstSel.appendChild(optionEl(r.oid, r.label, false)); });
       }
       build();
     }
@@ -267,9 +266,14 @@ import { initArchEditor } from "../arch/editor";
   }
   var IDX = MODEL.devices.map(indexDevice);
 
-  function activeDeviceIndex() {
-    var el = document.querySelector(".device.active");
-    return el ? parseInt(el.dataset.dev, 10) : 0;
+  // Build a <select> option as an element rather than as markup: the value and
+  // the label are both config-derived, so neither may be parsed as HTML.
+  function optionEl(value, label, selected) {
+    var o = document.createElement("option");
+    o.value = value;
+    o.textContent = label;
+    if (selected) o.selected = true;
+    return o;
   }
 
   // Escape HTML metacharacters — these strings are config-derived (object names,
@@ -287,6 +291,18 @@ import { initArchEditor } from "../arch/editor";
   // its line breaks must survive.
   function escConf(s) {
     return String(s).replace(/[&<>"]/g, function (c) { return ESC_MAP[c]; });
+  }
+
+  // The model's pre-highlighted iRule body is the one field the report hands us
+  // as markup instead of text. The highlighter emits nothing but
+  // `<span class="tk-...">` wrappers around escaped text, so hold it to that
+  // here rather than trusting it: every other tag, entity or stray
+  // metacharacter is escaped back to literal text.
+  var SAFE_MARKUP = /^(?:<\/span>|<span class="tk-[\w -]+">|&(?:amp|lt|gt|quot);)$/;
+  function sanitiseHtml(markup) {
+    return String(markup).replace(/<[^<>]*>|&[^\s&;]*;?|[<>"]/g, function (m0) {
+      return SAFE_MARKUP.test(m0) ? m0 : escConf(m0);
+    });
   }
 
   // Extract one object's raw bigip.conf stanza (brace-matched) from the device
@@ -336,7 +352,7 @@ import { initArchEditor } from "../arch/editor";
     if (n.type === "rule") {
       var r = ruleByPath(ix, n.fullPath);
       if (r && (r.bodyHtml || r.body)) {
-        return '<pre class="code tcl">' + (r.bodyHtml || escConf(r.body || "")) + "</pre>";
+        return '<pre class="code tcl">' + (r.bodyHtml ? sanitiseHtml(r.bodyHtml) : escConf(r.body || "")) + "</pre>";
       }
     }
     var stanza = stanzaFor(ix.d.configText, n.fullPath);
@@ -558,8 +574,7 @@ import { initArchEditor } from "../arch/editor";
     var proxyIdx = steps.length;
     steps.push({ t: "proxy", l: "Proxy · client ⇄ server" });
     eventsIn("lb").forEach(function (e) { steps.push({ t: "event", l: e }); });
-    var poolIdx = -1;
-    if (vs.pool) { poolIdx = steps.length; steps.push({ t: "pool", l: vs.pool.split("/").pop(), oid: "pool:" + vs.pool }); }
+    if (vs.pool) steps.push({ t: "pool", l: vs.pool.split("/").pop(), oid: "pool:" + vs.pool });
     eventsIn("server").forEach(function (e) { steps.push({ t: "event", l: e }); });
     if (l7label) steps.push({ t: "prof", l: l7label });
     serverSSL.forEach(function (p) { steps.push({ t: "ssl", l: p.name, oid: p.oid }); });
@@ -721,13 +736,13 @@ import { initArchEditor } from "../arch/editor";
     var typeBoxes = panel.querySelectorAll(".topo-type");
 
     // populate focus selector
-    var opts = ['<option value="">— whole estate —</option>'];
+    focusSel.textContent = "";
+    focusSel.appendChild(optionEl("", "— whole estate —", false));
     ix.d.graph.nodes.slice().sort(function (a, b) {
       return (a.type + a.name).localeCompare(b.type + b.name);
     }).forEach(function (n) {
-      opts.push('<option value="' + n.oid + '">' + TYPE_LABEL[n.type] + ": " + esc(n.name) + "</option>");
+      focusSel.appendChild(optionEl(n.oid, TYPE_LABEL[n.type] + ": " + n.name, false));
     });
-    focusSel.innerHTML = opts.join("");
 
     function activeTypes() {
       var t = {};
@@ -772,8 +787,12 @@ import { initArchEditor } from "../arch/editor";
     var drawer = document.getElementById("objDrawer");
     var body = drawer.querySelector(".drawer-body");
     var titleEl = drawer.querySelector(".drawer-title");
-    titleEl.innerHTML =
-      '<span class="tag ' + n.type + '">' + TYPE_LABEL[n.type] + "</span> " + esc(n.name);
+    var titleTag = document.createElement("span");
+    titleTag.className = "tag " + n.type;
+    titleTag.textContent = TYPE_LABEL[n.type];
+    titleEl.textContent = "";
+    titleEl.appendChild(titleTag);
+    titleEl.appendChild(document.createTextNode(" " + n.name));
     drawer.querySelector(".drawer-sub").textContent = n.fullPath;
     // When this object type has a listing tab, make the title a link that jumps
     // to the object's expanded row there (e.g. iRule popover -> iRules tab).
@@ -842,8 +861,8 @@ import { initArchEditor } from "../arch/editor";
     var v = findVirtual(ix, oid); if (!v) return "";
     var L = v.listener || {};
     var rows = [
-      ["Destination", esc(L.address || "-") + (L.prefix != null && L.prefix < L.maxPrefix ? "/" + L.prefix : "") +
-        (L.routeDomain ? " %" + L.routeDomain : "")],
+      ["Destination", esc(L.address || "-") + (L.prefix != null && L.prefix < L.maxPrefix ? "/" + esc(L.prefix) : "") +
+        (L.routeDomain ? " %" + esc(L.routeDomain) : "")],
       ["Port", esc(L.portRaw || "-")],
       ["Protocol", esc(L.protocol || "-")],
       ["Source", esc(L.source || "-")],
@@ -1238,8 +1257,6 @@ import { initArchEditor } from "../arch/editor";
 
   function simulate(ix, v, req) {
     var stages = [];
-    var L = v.listener || {};
-    var isHttp = (v.profiles || []).some(function (p) { return /\/http\b|http$/.test(p) || /_http/.test(p); });
 
     // 1. client SSL
     var ssl = pickSslProfile(ix, v, req.sni);
@@ -1346,7 +1363,6 @@ import { initArchEditor } from "../arch/editor";
   function renderSim(ix, v, host) {
     var L = v.listener || {};
     var hasSsl = !!pickSslProfile(ix, v, "");
-    var isHttp = (v.profiles || []).some(function (p) { return /http/.test(p); });
     var h = ['<div class="sim-head"><b>Processing for ' + esc(v.name) + '</b> <span class="mono muted">' +
       esc(L.address) + ":" + esc(L.portRaw) + " · " + esc(L.protocol) + '</span></div>'];
     h.push('<div class="sim-req">');
@@ -1443,14 +1459,14 @@ import { initArchEditor } from "../arch/editor";
       html.push('<div class="tiers">');
       tiers.forEach(function (t, ti) {
         html.push('<div class="tier' + (ti === 0 ? " match" : "") + '">');
-        html.push('<div class="tier-key">/' + t.prefix + ' · ' + (t.port ? "port " + t.port : "any port") + '</div>');
+        html.push('<div class="tier-key">/' + esc(t.prefix) + ' · ' + (t.port ? "port " + esc(t.port) : "any port") + '</div>');
         html.push('<div class="tier-vs">');
         t.vs.forEach(function (v) {
           var L = v.listener;
           html.push('<button class="lm-card" data-fp="' + esc(v.fullPath) + '"' + (v === focus ? ' data-focus="1"' : "") + '>' +
             '<span class="lm-name">' + esc(v.name) + (v === focus ? ' <span class="tag green">match</span>' : "") + '</span>' +
-            '<span class="lm-dest mono">' + esc(L.address) + (L.prefix < L.maxPrefix ? "/" + L.prefix : "") +
-            (L.routeDomain ? "%" + L.routeDomain : "") + ':' + esc(L.portRaw) + '</span>' +
+            '<span class="lm-dest mono">' + esc(L.address) + (L.prefix < L.maxPrefix ? "/" + esc(L.prefix) : "") +
+            (L.routeDomain ? "%" + esc(L.routeDomain) : "") + ':' + esc(L.portRaw) + '</span>' +
             '<span class="lm-meta mono">' + esc(L.protocol) + (v.pool ? " → " + esc(v.pool.split("/").pop()) : " · no pool") + '</span>' +
             '</button>');
         });
@@ -1586,11 +1602,6 @@ import { initArchEditor } from "../arch/editor";
   (function initSearch() {
     var search = document.getElementById("globalSearch");
     if (!search) return;
-
-    function detailOf(row) {
-      var d = row.nextElementSibling;
-      return (d && d.classList.contains("detail")) ? d : null;
-    }
 
     // Parse "ip" or "ip/prefix" (v4/v6) into a network, else null.
     function toNet(s) {
@@ -1797,7 +1808,7 @@ import { initArchEditor } from "../arch/editor";
           var r = ruleByPath(ix, n.fullPath);
           if (r) {
             if (r.flowchart) html += '<div class="app-obj-flow diag-host" data-flow="' + esc(encodeURIComponent(r.flowchart)) + '">flow…</div>';
-            html += '<pre class="code tcl">' + (r.bodyHtml || esc(r.body || "")) + "</pre>";
+            html += '<pre class="code tcl">' + (r.bodyHtml ? sanitiseHtml(r.bodyHtml) : esc(r.body || "")) + "</pre>";
           }
         } else {
           var stanza = stanzaFor(ix.d.configText, n.fullPath);


### PR DESCRIPTION
## Summary

Clears all **24 CodeQL alerts under `rust/bigip-report-gen/frontend/`** — 12 in `src/`, and their twins in the esbuild output `dist/`, which `npm run build` regenerates here. 2 of 6 PRs covering the Security tab.

**`js/xss-through-dom` ×6.** The path-builder source/destination selectors, the topology focus selector and the drawer title all assembled `<option>` and `<span>` markup by string concatenation from config-derived values — several interpolating an `oid`, a `TYPE_LABEL` or a `class` unescaped even where the adjacent label *was* escaped, and one writing an unquoted `value=` attribute. Those now build elements (`createElement`, `.value`, `.textContent`), which removes the sink class rather than patching one hole. Labels, values, sort order, selection state and both placeholder rows (`— whole estate —`, `(nothing reachable downstream)`) are unchanged. `fillDests` was not separately flagged but had the identical unquoted-`value` hole, so it moved too.

Two sites could not become DOM:

- `r.bodyHtml` is the one model field that is markup by contract, and escaping it would destroy the syntax highlighting. `sanitiseHtml()` holds it to exactly what the producer emits — `tcl_lexer::highlight::wrap` writes nothing but `<span class="tk-…">` around `&amp;`/`&lt;`/`&gt;`/`&quot;`-escaped text (`push_escaped`), and the five classes it can emit are `tk-cmd`, `tk-comment`, `tk-event`, `tk-ns`, `tk-var` — and escapes every other tag, entity or stray metacharacter back to literal text. Legitimate `bodyHtml` passes through byte-identical; `<img onerror=…>`, `<script>` and a `<span>` carrying an event handler are all neutralised.
- The listener rows escaped `L.address` but interpolated `L.prefix` and `L.routeDomain` raw. Same defect appears twice more in the listener-matcher cards (plus `t.prefix`/`t.port`); all now escaped.

**`js/unused-local-variable` ×5 and `js/useless-assignment-to-local` ×1.** Each was checked for a dropped call site before deletion — `activeDeviceIndex` duplicates an inline query whose result is already stored in `bar.dataset.dev`; `detailOf` is inlined in two other scopes; `poolIdx`'s branches correctly anchor at `nodeIdx`.

> **One worth a reviewer's eye:** `renderSim`'s `isHttp` sat beside a `hasSsl` that **is** used, to gate the TLS-SNI field. `isHttp` looks like it was meant to gate the URI / Host / extra-header fields the same way for non-HTTP virtuals. I deleted it rather than invent that gating — say the word if the feature was intended and I'll wire it up instead.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

```
cd rust/bigip-report-gen/frontend
npm run typecheck   → clean
npm run lint        → clean (eslint + prettier)
npm run build       → regenerated dist/ (only input.js and topology.js changed,
                      so the build is reproducible against the committed output)

# CodeQL 2.26.4 — the exact bundle .github/workflows/codeql.yml pins
codeql database analyze … javascript-security-extended.qls javascript-security-and-quality.qls
  → 0 results under rust/bigip-report-gen/frontend/, src/ and dist/ alike (was 24)
```

`make check-report-assets` (the committed-`dist`/f5report-sync drift gate) and the 27 `make xtask-check` gates pass.

## Compiler / diagnostics checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

Not applicable — no compiler behaviour, diagnostic, optimisation code or analysis contract is touched. `sanitiseHtml()` depends on `tcl-lexer`'s highlighter output format but does not change it.

- [ ] Did this change alter a compiler fact contract?
- [ ] If yes, I updated the owning design doc under `docs/design/compiler/` or `docs/design/contracts/`.
- [ ] If I added or changed a diagnostic or optimisation code, I updated its page under `docs/kcs/codes/` and linked it from `docs/kcs/codes/README.md`.
- [ ] If I added a design doc, I linked it from `docs/design/README.md` (`cargo xtask kcs-index-links` enforces this).

---

Sibling PRs for the rest of the Security tab: #1855 (Python) plus editor/webview hardening, CodeQL scan scope, dependency advisories, supply-chain pinning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XLgBd8h9SpPKTDF65KdABP

---
_Generated by [Claude Code](https://claude.ai/code/session_01XLgBd8h9SpPKTDF65KdABP)_