### PR TITLE
ci(codeql): stop scanning generated and vendored JavaScript

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -69,10 +69,20 @@ jobs:
           # the repo uses it in ~220 ``if TYPE_CHECKING:`` mixin forward-decls;
           # the rule is a recommendation-severity style check that is pure noise
           # here, so exclude it rather than contort idiomatic stubs into ``pass``.
+          #
+          # `paths-ignore` drops machine-generated and vendored JavaScript.
+          # `frontend/dist/*.js` is esbuild output whose banner says DO NOT
+          # EDIT — every alert there is a duplicate of one in the `src/` .ts it
+          # was bundled from, which IS scanned.  `assets/*.js` is wasm-bindgen
+          # glue plus the vendored ELK bundle: neither is written here, so an
+          # alert in one is unactionable and would never close.
           config: |
             query-filters:
               - exclude:
                   id: py/ineffectual-statement
+            paths-ignore:
+              - rust/bigip-report-gen/frontend/dist
+              - rust/bigip-report-gen/assets/*.js
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9


### PR DESCRIPTION
## Summary

The last **4 CodeQL alerts** (`js/useless-assignment-to-local`) live in `rust/bigip-report-gen/assets/f5query_wasm.js`, which is wasm-bindgen output — the dead store before each `throw` is simply how the generator emits a fallible return:

```js
var ptr3 = ret[0];
var len3 = ret[1];
if (ret[3]) {
    ptr3 = 0; len3 = 0;   // ← flagged; overwritten by the throw below
    throw takeFromExternrefTable0(ret[2]);
}
```

Nothing in this repo writes that file, so the alerts are unactionable and would never close. 4 of 6 PRs covering the Security tab.

`paths-ignore` now drops three things:

- `rust/bigip-report-gen/assets/*.js` — the wasm-bindgen glue above, plus the vendored ELK bundle beside it. Neither is authored here.
- `rust/bigip-report-gen/frontend/dist` — esbuild output whose banner already says *"Generated from … src — DO NOT EDIT"*. Every alert there is a duplicate of one in the `src/` TypeScript it was bundled from, which stays scanned, so a real defect is still caught exactly once and in the place it can be fixed.

This is scoping, not suppression: the source of every excluded file is either scanned (`dist`) or not ours to change (`assets`). The `py/ineffectual-statement` filter already in the config is untouched.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

Verified against the resulting database's own source archive rather than by reading the glob — the extraction is what `paths-ignore` actually controls:

```
codeql database create … --codescanning-config=<this config> --language=javascript-typescript
python3 -c "…zipfile.ZipFile('src.zip').namelist()…"

  assets/f5query_wasm.js          -> False   (excluded)
  assets/elk.bundled.js           -> False   (excluded)
  frontend/dist/topology.js       -> False   (excluded)
  frontend/src/pages/topology.ts  -> True    (still scanned)
```

The workflow YAML parses, and the inline `config:` block round-trips to the intended `{query-filters, paths-ignore}`. CodeQL 2.26.4 throughout — the exact bundle `codeql-action@cdf488f` pins.

## Compiler / diagnostics checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

Not applicable — CI configuration only.

- [ ] Did this change alter a compiler fact contract?
- [ ] If yes, I updated the owning design doc under `docs/design/compiler/` or `docs/design/contracts/`.
- [ ] If I added or changed a diagnostic or optimisation code, I updated its page under `docs/kcs/codes/` and linked it from `docs/kcs/codes/README.md`.
- [ ] If I added a design doc, I linked it from `docs/design/README.md` (`cargo xtask kcs-index-links` enforces this).

---

Independent of the sibling PRs, in either merge order: #1856 fixes the `src/` that `dist/` is built from, so those alerts close either way.

Sibling PRs: #1855 (Python), #1856 (report front-end), #1857 (editors), plus dependency advisories and supply-chain pinning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XLgBd8h9SpPKTDF65KdABP

---
_Generated by [Claude Code](https://claude.ai/code/session_01XLgBd8h9SpPKTDF65KdABP)_