### PR TITLE
build(deps): close the qs and DOMPurify advisories, and watch every dependency root

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -65,6 +65,49 @@ updates:
         exclude-patterns:
           - "npm"
 
+  # Every npm project in the tree needs its own entry — Dependabot does not
+  # walk sub-directories.  The spec-studio web app was the gap that let four
+  # DOMPurify advisories sit unnoticed (they only surfaced through the
+  # Scorecard `Vulnerabilities` check, which reads the lockfiles directly).
+  - package-ecosystem: npm
+    directory: /rust/tcl-spec-studio/web
+    schedule:
+      interval: weekly
+    groups:
+      npm:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: /rust/bigip-report-gen/frontend
+    schedule:
+      interval: weekly
+    groups:
+      npm:
+        patterns:
+          - "*"
+
+  # The three cargo workspaces: the main one at the root (~45 crates — the
+  # language server, compiler and CLIs), the WASM runtime, and the Zed
+  # extension.  Only the last was tracked.
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      cargo:
+        patterns:
+          - "*"
+
+  - package-ecosystem: cargo
+    directory: /runtime/rust
+    schedule:
+      interval: weekly
+    groups:
+      cargo:
+        patterns:
+          - "*"
+
   - package-ecosystem: cargo
     directory: /editors/zed
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -87,29 +87,29 @@ updates:
         patterns:
           - "*"
 
-  # The three cargo workspaces: the main one at the root (~45 crates — the
-  # language server, compiler and CLIs), the WASM runtime, and the Zed
-  # extension.  Only the last was tracked.
+  # Every cargo root in the tree, not just the workspace at `/`.  The root
+  # `[workspace] exclude` list (Cargo.toml) holds each target that cannot
+  # inherit the workspace lints or targets wasm32 — every one is a separate
+  # crate with its own Cargo.lock, so Dependabot has to be pointed at it
+  # explicitly.  Only `editors/zed` was tracked, which left the shipped `.pyz`
+  # bindings, the report and query WASM builds, both browser/WASI language
+  # server transports and the VM unmonitored.  `directories` keeps that as one
+  # grouped PR a week rather than twelve.  Keep this list in step with
+  # `[workspace] exclude`; `git ls-files '*Cargo.lock'` is the check.
   - package-ecosystem: cargo
-    directory: /
-    schedule:
-      interval: weekly
-    groups:
-      cargo:
-        patterns:
-          - "*"
-
-  - package-ecosystem: cargo
-    directory: /runtime/rust
-    schedule:
-      interval: weekly
-    groups:
-      cargo:
-        patterns:
-          - "*"
-
-  - package-ecosystem: cargo
-    directory: /editors/zed
+    directories:
+      - /
+      - /runtime/rust
+      - /editors/zed
+      - /rust/bigip-query-wasm
+      - /rust/bigip-report-gen/python
+      - /rust/bigip-report-gen/wasm
+      - /rust/tcl-explorer-wasm
+      - /rust/tcl-lsp-server-wasi
+      - /rust/tcl-lsp-server-wasm
+      - /rust/tcl-spec-studio-wasm
+      - /rust/tcl-vm-wasm
+      - /rust/zed-query-check
     schedule:
       interval: weekly
     groups:

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -7596,9 +7596,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -9538,6 +9538,7 @@
       "@azure/msal-node": "^5.1.5"
     },
     "lodash": "^4.18.1",
+    "qs": "^6.16.0",
     "undici": "^7.28.0",
     "@vscode/wasm-wasi-lsp": {
       "vscode-languageclient": "$vscode-languageclient"

--- a/rust/tcl-spec-studio/web/package-lock.json
+++ b/rust/tcl-spec-studio/web/package-lock.json
@@ -1002,9 +1002,9 @@
       "license": "MIT"
     },
     "node_modules/dompurify": {
-      "version": "3.4.8",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.8.tgz",
-      "integrity": "sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==",
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.14.tgz",
+      "integrity": "sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==",
       "dev": true,
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {

--- a/rust/tcl-spec-studio/web/package.json
+++ b/rust/tcl-spec-studio/web/package.json
@@ -26,5 +26,8 @@
     "vscode-languageserver-protocol": "^3.18.2",
     "vscode-oniguruma": "^2.0.1",
     "vscode-textmate": "^9.3.2"
+  },
+  "overrides": {
+    "dompurify": "^3.4.14"
   }
 }


### PR DESCRIPTION
## Summary

Scorecard's `Vulnerabilities` check scores **3/10** against `rust`, reporting seven OSV advisories. Six are fixable here. 5 of 6 PRs covering the Security tab.

| Advisory | Package | Fix |
|---|---|---|
| GHSA-4mjr-xmp4-gh2g | `qs` <6.16.0 | DoS via attacker-controlled `isBuffer` |
| GHSA-x5fp-wj9c-mxmx | `qs` <6.16.0 | array-limit bypass via bracket-key comma parsing |
| GHSA-55q2-fjhq-7xh7 | `dompurify` ≤3.4.12 | `IN_PLACE` hook removal leaves a detached subtree executable → XSS |
| GHSA-cmwh-pvxp-8882 | `dompurify` ≤3.4.10 | permanent `ALLOWED_ATTR` pollution via `setConfig()` |
| GHSA-c2j3-45gr-mqc4 | `dompurify` ≤3.4.11 | `CUSTOM_ELEMENT_HANDLING` bypasses `afterSanitizeElements` |
| GHSA-vxr8-fq34-vvx9 | `dompurify` ≤3.4.8 | Trusted Types policy survives `clearConfig()` |

- **`qs`** arrives transitively under `@vscode/vsce` → `typed-rest-client`. Pinned through `overrides`, alongside the `lodash` and `undici` pins already there.
- **`dompurify` 3.4.8** is pinned *exactly* by `monaco-editor` 0.56.0 — which is the current release, so there is no upgrade path. `npm audit`'s suggested fix is a semver-major **downgrade** of monaco to 0.53.0; an `overrides` pin to `^3.4.14` keeps monaco current instead. The `monaco-editor` "low" alert was only its `dompurify` dependency, so it clears with it.

The seventh, **RUSTSEC-2023-0071** (Marvin timing side-channel in `rsa`), has no fixed release upstream and is already waived with its rationale in `deny.toml`. Nothing to do.

### The reason those four DOMPurify advisories sat unnoticed

Dependabot watched **5 of the 16 dependency roots** in this tree.

**npm** — `rust/tcl-spec-studio/web`, where DOMPurify lives, had no entry, so no PR was ever opened; the advisories only surfaced through the Scorecard check, which reads the lockfiles directly. `rust/bigip-report-gen/frontend` was also untracked. Both are added. (`grammars/tree-sitter-apl` and `grammars/tree-sitter-bigip` declare no dependencies at all, and `editors/sublime-text/sublime-package.json` is a Sublime package descriptor, not an npm manifest — so npm coverage is now complete at three roots.)

**cargo** — only `editors/zed` was tracked, out of **twelve** roots. The root `[workspace] exclude` list holds a crate for every target that cannot inherit the workspace lints or that builds for wasm32, and each one is a separate cargo root with its own `Cargo.lock`. That left unmonitored, among others, the PyO3 crate behind the released `.pyz` and wheel (`rust/bigip-report-gen/python`), both WASM report/query builds that ship in the VSIX and on Pages, and the browser and WASI language-server transports. It is also why `deny.toml` carries the `rsa` waiver by hand.

All twelve are now listed under one `directories:` entry, so the weekly update stays a single grouped PR — the "bump the cargo group across N directories" shape already in this repo's history — rather than twelve. The list is exactly `git ls-files '*Cargo.lock'`, and the comment records that it must be kept in step with `[workspace] exclude`.

> Corrected after review: an earlier revision of this description said "the three cargo workspaces" and added only three roots. That was wrong — Codex caught it, and the nine standalone roots are now covered too.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

```
npm audit           → 0 vulnerabilities, in all four npm projects
                      (was: 1 moderate in editors/vscode, 1 moderate + 1 low
                       in rust/tcl-spec-studio/web)

# lockfiles regenerated with --package-lock-only; resolved versions verified
qs        6.15.3 -> 6.16.0
dompurify 3.4.8  -> 3.4.14   (monaco-editor stays at 0.56.0)

cd rust/tcl-spec-studio/web && npm ci && npm run typecheck && npm run lint  → clean
                               npm run build                                → clean
                               npm test                                     → 32/32 pass
cd editors/vscode && npx tsc --noEmit -p ./ && npm run lint                 → clean
```

`.github/dependabot.yml` parses, and the cargo directory list was diffed against the repo in both directions:

```
listed : 12       missing from config:   none
on disk: 12       configured but absent: none
```

`cargo xtask gen-vscode-package --check` confirms `editors/vscode/package.json`'s generated sections are still in sync — the `overrides` block is hand-maintained and outside them.

## Compiler / diagnostics checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

Not applicable — dependency pins and Dependabot configuration only.

- [ ] Did this change alter a compiler fact contract?
- [ ] If yes, I updated the owning design doc under `docs/design/compiler/` or `docs/design/contracts/`.
- [ ] If I added or changed a diagnostic or optimisation code, I updated its page under `docs/kcs/codes/` and linked it from `docs/kcs/codes/README.md`.
- [ ] If I added a design doc, I linked it from `docs/design/README.md` (`cargo xtask kcs-index-links` enforces this).

---

Sibling PRs: #1855 (Python), #1856 (report front-end), #1857 (editors), #1858 (CodeQL scan scope), #1860 (supply-chain pinning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XLgBd8h9SpPKTDF65KdABP