### PR TITLE
ci: pin the uv installer by digest and scope the release token to its jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -565,9 +565,11 @@ jobs:
         id: vscode-version
         run: |
           set -uo pipefail
-          ver=$(curl -fsSL --max-time 20 \
-            https://update.code.visualstudio.com/api/update/linux-x64/stable/latest \
-            | python3 -c 'import json,sys; print(json.load(sys.stdin)["name"])' 2>/dev/null || true)
+          ver=""
+          if curl -fsSL --max-time 20 -o /tmp/vscode-stable.json \
+               https://update.code.visualstudio.com/api/update/linux-x64/stable/latest; then
+            ver=$(python3 -c 'import json; print(json.load(open("/tmp/vscode-stable.json"))["name"])' 2>/dev/null || true)
+          fi
           if [ -z "$ver" ]; then
             ver="unresolved-$(date -u +%Y-%m-%d)"
             echo "::warning::could not resolve VS Code stable version; using $ver"
@@ -711,9 +713,11 @@ jobs:
         id: vscode-web-version
         run: |
           set -uo pipefail
-          ver=$(curl -fsSL --max-time 20 \
-            https://update.code.visualstudio.com/api/update/web-standalone/insider/latest \
-            | python3 -c 'import json,sys; print(json.load(sys.stdin)["version"])' 2>/dev/null || true)
+          ver=""
+          if curl -fsSL --max-time 20 -o /tmp/vscode-web.json \
+               https://update.code.visualstudio.com/api/update/web-standalone/insider/latest; then
+            ver=$(python3 -c 'import json; print(json.load(open("/tmp/vscode-web.json"))["version"])' 2>/dev/null || true)
+          fi
           if [ -z "$ver" ]; then
             ver="unresolved-$(date -u +%Y-%m-%d)"
             echo "::warning::could not resolve the VS Code web build; using $ver"
@@ -1451,13 +1455,22 @@ jobs:
           key: ${{ runner.os }}-venv-typecheck-${{ steps.pykey.outputs.pyver }}-${{ hashFiles('rust/bigip-report-gen/python/**') }}
 
       # Pinned installer rather than a floating action, so the uv that resolves
-      # the pinned tool versions is itself pinned.
+      # the pinned tool versions is itself pinned.  The installer is fetched to
+      # a file and checked against its digest before it runs — a version tag
+      # alone still trusts whatever astral.sh serves under it.  If Astral
+      # regenerates the script this fails loudly; re-pin with
+      # `curl -fsSL https://astral.sh/uv/<version>/install.sh | sha256sum`.
       - name: Install uv
         if: env.RUN_PY == 'true'
         env:
           UV_VERSION: "0.11.28"
+          UV_INSTALLER_SHA256: "b7b3fe80cad1142a2a5794050b7db7b3291d1bac1423b0732571dd9366e8ca8b"
         run: |
-          curl -LsSf "https://astral.sh/uv/${UV_VERSION}/install.sh" | sh
+          set -euo pipefail
+          curl -LsSf --max-time 120 -o /tmp/uv-installer.sh \
+            "https://astral.sh/uv/${UV_VERSION}/install.sh"
+          echo "${UV_INSTALLER_SHA256}  /tmp/uv-installer.sh" | sha256sum -c -
+          sh /tmp/uv-installer.sh
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Verify uv version

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -211,10 +211,16 @@ jobs:
       # Pages serves it: the page loads under its own CSP, Monaco mounts, and
       # the language server worker answers `initialize`. The check skips itself
       # where chromium is unavailable rather than failing.
+      #
+      # Version-pinned: an unpinned `npm install playwright` resolves whatever
+      # is newest at run time, so the browser this smoke test drives could
+      # change under us between two deploys of the same commit.
       - name: Install playwright chromium
+        env:
+          PLAYWRIGHT_VERSION: "1.63.0"
         run: |
           cd rust/tcl-spec-studio/web
-          npm install --no-save playwright
+          npm install --no-save "playwright@${PLAYWRIGHT_VERSION}"
           npx playwright install --with-deps chromium
 
       - name: Boot the assembled spec studio in headless chromium
@@ -233,7 +239,7 @@ jobs:
         run: |
           python -m venv .venv
           . .venv/bin/activate
-          python -m pip install --upgrade pip maturin
+          python -m pip install "pip==26.2.1" "maturin==1.15.0"
           # maturin develop installs f5report editable against the source tree,
           # so the vendored Mermaid + wasm engine (committed under
           # python/f5report/vendor/) are embedded — GitHub Pages has no strict

--- a/.github/workflows/report-pyz.yml
+++ b/.github/workflows/report-pyz.yml
@@ -33,11 +33,15 @@ on:
     types: [published]
   workflow_dispatch:
 
+# Read-only by default; the two jobs that attach artefacts to the release opt
+# in to `contents: write` themselves, so a step added to neither inherits it.
 permissions:
-  contents: write # attach artefacts to the release
+  contents: read
 
 jobs:
   build:
+    permissions:
+      contents: write # softprops/action-gh-release attaches the .pyz
     name: ${{ matrix.os }} (${{ matrix.arch }})
     runs-on: ${{ matrix.os }}
     strategy:
@@ -110,7 +114,10 @@ jobs:
           GIT_HASH: ${{ github.sha }}
         run: |
           set -euo pipefail
-          python -m pip install --upgrade pip maturin shiv
+          # Pinned: an unpinned install resolves whatever is newest at run
+          # time, so a release cut twice from one tag could be built by two
+          # different maturin/shiv versions.  Bump deliberately.
+          python -m pip install "pip==26.2.1" "maturin==1.15.0" "shiv==1.0.8"
 
           # Version tag for the filename: the release tag (minus a leading `v`)
           # on a release, else the short commit.
@@ -181,6 +188,8 @@ jobs:
   single-file-html:
     name: single-file HTML generator
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write # softprops/action-gh-release attaches the HTML generator
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/rust/bigip-report-gen/python/deploy/github-pages.yml
+++ b/rust/bigip-report-gen/python/deploy/github-pages.yml
@@ -211,10 +211,16 @@ jobs:
       # Pages serves it: the page loads under its own CSP, Monaco mounts, and
       # the language server worker answers `initialize`. The check skips itself
       # where chromium is unavailable rather than failing.
+      #
+      # Version-pinned: an unpinned `npm install playwright` resolves whatever
+      # is newest at run time, so the browser this smoke test drives could
+      # change under us between two deploys of the same commit.
       - name: Install playwright chromium
+        env:
+          PLAYWRIGHT_VERSION: "1.63.0"
         run: |
           cd rust/tcl-spec-studio/web
-          npm install --no-save playwright
+          npm install --no-save "playwright@${PLAYWRIGHT_VERSION}"
           npx playwright install --with-deps chromium
 
       - name: Boot the assembled spec studio in headless chromium
@@ -233,7 +239,7 @@ jobs:
         run: |
           python -m venv .venv
           . .venv/bin/activate
-          python -m pip install --upgrade pip maturin
+          python -m pip install "pip==26.2.1" "maturin==1.15.0"
           # maturin develop installs f5report editable against the source tree,
           # so the vendored Mermaid + wasm engine (committed under
           # python/f5report/vendor/) are embedded — GitHub Pages has no strict

--- a/rust/bigip-report-gen/python/deploy/report-pyz.yml
+++ b/rust/bigip-report-gen/python/deploy/report-pyz.yml
@@ -33,11 +33,15 @@ on:
     types: [published]
   workflow_dispatch:
 
+# Read-only by default; the two jobs that attach artefacts to the release opt
+# in to `contents: write` themselves, so a step added to neither inherits it.
 permissions:
-  contents: write # attach artefacts to the release
+  contents: read
 
 jobs:
   build:
+    permissions:
+      contents: write # softprops/action-gh-release attaches the .pyz
     name: ${{ matrix.os }} (${{ matrix.arch }})
     runs-on: ${{ matrix.os }}
     strategy:
@@ -110,7 +114,10 @@ jobs:
           GIT_HASH: ${{ github.sha }}
         run: |
           set -euo pipefail
-          python -m pip install --upgrade pip maturin shiv
+          # Pinned: an unpinned install resolves whatever is newest at run
+          # time, so a release cut twice from one tag could be built by two
+          # different maturin/shiv versions.  Bump deliberately.
+          python -m pip install "pip==26.2.1" "maturin==1.15.0" "shiv==1.0.8"
 
           # Version tag for the filename: the release tag (minus a leading `v`)
           # on a release, else the short commit.
@@ -181,6 +188,8 @@ jobs:
   single-file-html:
     name: single-file HTML generator
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write # softprops/action-gh-release attaches the HTML generator
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/scripts/dev/ensure-test-deps.sh
+++ b/scripts/dev/ensure-test-deps.sh
@@ -1158,7 +1158,13 @@ ensure_rgxg() {
 # uv — the Python environment manager used by the repo's remaining Python
 # dev scripts.  No distro packages it reliably, so on Linux we use Astral's
 # official installer (drops the binary in ~/.local/bin); macOS gets the
-# Homebrew formula.
+# Homebrew formula.  The installer is version-pinned to match CI's UV_VERSION
+# and checked against its digest before it runs, so a dev box and a CI runner
+# install the same uv from the same script.  Re-pin both together:
+#   curl -fsSL https://astral.sh/uv/<version>/install.sh | sha256sum
+UV_VERSION="0.11.28"
+UV_INSTALLER_SHA256="b7b3fe80cad1142a2a5794050b7db7b3291d1bac1423b0732571dd9366e8ca8b"
+
 ensure_uv() {
     if [ "${SKIP_UV:-}" = "1" ]; then info "SKIP_UV=1 — skipping uv"; return 0; fi
     if command -v uv >/dev/null 2>&1; then
@@ -1174,9 +1180,25 @@ ensure_uv() {
             run_install "uv (Homebrew)" uv
             ;;
         *)
-            info "Installing uv via Astral installer (~/.local/bin)"
-            if ! curl -fsSL --connect-timeout 15 --max-time 600 \
-                    https://astral.sh/uv/install.sh | sh; then
+            local tmpdir actual_sha
+            tmpdir="$(mktemp -d)"
+            # shellcheck disable=SC2064
+            trap "rm -rf '$tmpdir'" RETURN
+
+            info "Installing uv ${UV_VERSION} via Astral installer (~/.local/bin)"
+            if ! fetch_with_retry "https://astral.sh/uv/${UV_VERSION}/install.sh" \
+                    "$tmpdir/uv-installer.sh"; then
+                warn "uv installer download failed"
+                note_missing "uv (Python environment manager)"
+                return 1
+            fi
+            actual_sha="$(sha256_file "$tmpdir/uv-installer.sh")"
+            if [ "$actual_sha" != "$UV_INSTALLER_SHA256" ]; then
+                warn "uv installer sha256 mismatch (expected $UV_INSTALLER_SHA256, got $actual_sha)"
+                note_missing "uv (Python environment manager)"
+                return 1
+            fi
+            if ! sh "$tmpdir/uv-installer.sh"; then
                 warn "uv install script failed"
                 note_missing "uv (Python environment manager)"
                 return 1


### PR DESCRIPTION
## Summary

Scorecard's `Token-Permissions` (**0/10**) and `Pinned-Dependencies` (**8/10**) checks against `rust`. 6 of 6 PRs covering the Security tab.

### Token-Permissions

`report-pyz.yml` granted `contents: write` at the **top** level, so every step in the workflow carried it — which is exactly the pattern `SECURITY.md` § *Required repo settings* says the repo's default-read posture exists to avoid. It is `contents: read` now, with the write declared on each of the two jobs that actually attach artefacts to the release (`build`, `single-file-html` — both call `softprops/action-gh-release`).

Both copies move together: the canonical one under `rust/bigip-report-gen/python/deploy/`, then `cargo xtask workflow-sync` reinstalls it, which is what the drift gate checks. Every `contents: write` in `ci.yml` was reviewed and left alone — each is a `gh release upload`, an attestation write, or an artifact deletion that genuinely needs it.

### Pinned-Dependencies, four kinds

- **`curl … /uv/${UV_VERSION}/install.sh | sh`** in `ci.yml`, and the same call *with no version at all* in `ensure-test-deps.sh`. A version tag still trusts whatever `astral.sh` serves under it, so both now fetch the script to a file and check it against a pinned SHA-256 before running it. The dev script also pins the same version CI does — the two had drifted apart — and reuses the repo's own `fetch_with_retry` / `sha256_file` helpers, the way the Wasmtime and wasi-sdk installs already do. If Astral regenerates the script this fails loudly; the comment says how to re-pin, and the existing `uv --version` assertion in CI still backs it up.
- **Two `curl … | python3 -c` version probes** for the VS Code download. Nothing remote is executed there — python reads JSON on stdin — but piping a remote response into an interpreter is the shape worth not having. They fetch to a file and parse it, keeping the date-stamp fallback for an unreachable endpoint.
- **`npm install --no-save playwright`**, unpinned, in the Pages deploy: the browser this smoke test drives could change between two deploys of the same commit. Pinned to 1.63.0.
- **`pip install --upgrade pip maturin [shiv]`** in the Pages deploy and the release-artefact build. Pinned, so a release cut twice from one tag is built by one maturin and one shiv.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

```
cargo xtask workflow-sync --check   → workflow-sync: 2 workflow pair(s) in sync
make xtask-check                    → 27 gates OK (drift, codegen, catalogues,
                                       command-backing, callback-inventory,
                                       retired-api, workflow regressions)
cargo fmt --all --check             → clean
bash -n scripts/dev/ensure-test-deps.sh   → clean
python3 -c "yaml.safe_load(...)"    → all four workflow files + both canonical
                                       copies parse
```

The uv digest was taken from the pinned URL itself:
`curl -fsSL https://astral.sh/uv/0.11.28/install.sh | sha256sum` → `b7b3fe80…8ca8b`.

**Not verified locally, by nature:** the workflows themselves only run on GitHub. The `report-pyz.yml` permission split is the one change whose failure mode is a release-time `403` rather than a red PR — worth a look before the next tag, though both jobs that upload now declare the write they use and no other job in that file touches the release.

## Compiler / diagnostics checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

Not applicable — CI workflows and a dev bootstrap script only.

- [ ] Did this change alter a compiler fact contract?
- [ ] If yes, I updated the owning design doc under `docs/design/compiler/` or `docs/design/contracts/`.
- [ ] If I added or changed a diagnostic or optimisation code, I updated its page under `docs/kcs/codes/` and linked it from `docs/kcs/codes/README.md`.
- [ ] If I added a design doc, I linked it from `docs/design/README.md` (`cargo xtask kcs-index-links` enforces this).

---

`SECURITY.md` is deliberately untouched: it scopes itself to repo settings and says workflow-level controls "live in `.github/`".

Sibling PRs: #1855 (Python), #1856 (report front-end), #1857 (editors), #1858 (CodeQL scan scope), #1859 (dependency advisories).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XLgBd8h9SpPKTDF65KdABP

---
_Generated by [Claude Code](https://claude.ai/code/session_01XLgBd8h9SpPKTDF65KdABP)_