### PR TITLE
fix(expr): round() follows C's modf, and the numeric-tower cluster closes out

### DIFF
--- a/docs/design/contracts/shared-utility-contracts-rust.md
+++ b/docs/design/contracts/shared-utility-contracts-rust.md
@@ -49,6 +49,7 @@ entry point, or gate moves without this contract being updated.
 | sort numeric parsing | `rust/tcl-cmd-core/src/sort.rs` | `parse_wide`; `parse_real` | `NumberSyntax` per release | none |
 | command errors | `rust/tcl-cmd-core/src/error.rs` | `CmdError`; `wrong_args`; `bad_choice` | invariant | none |
 | expression grammar / evaluation | `rust/tcl-syntax/src/expr/parser.rs`; `rust/tcl-syntax/src/expr/eval.rs`; `rust/tcl-registry/src/expr_surface.rs` | `parse_expr`; `eval`; `RuntimeExprSurface` | `RuntimeExprSurface` per release | none |
+| expr math functions and the `rand` generator | `rust/tcl-syntax/src/expr/mathfunc.rs`; `rust/tcl-syntax/src/expr/rand.rs` | `NumValue`; `dispatch`; `dispatch_with_backend_int_width`; `try_dispatch_with_backend_int_width`; `IntWidth`; `MathFuncError`; `MathFuncSince`; `spec`; `all`; `added_in`; `seed_from_wide`; `next_draw`; `seed_and_draw` | `MathFuncSince` per release for the function surface and `IntWidth` for `int()`'s width; the Park-Miller generator is release-invariant | none |
 | command / word segmentation | `rust/tcl-lexer/src/script.rs`; `rust/tcl-compiler/src/segmenter.rs`; `rust/tcl-compiler/src/parsing/syntax/build.rs`; `rust/tcl-compiler/src/parsing/syntax/segment.rs` | `group_commands`; `CommandSpan`; `WordSpan`; `WordKind`; `SegmentedCommand`; `segment_commands` | `LexerConfig` per document dialect | `xtask-segmentation-drift` |
 | nested command-substitution words | `rust/tcl-compiler/src/word_subst.rs` | `nested_command_words`; `NestedWordsDecline`; `lifted_calls`; `lifted_exprs`; `LiftedCall` | `LexerConfig` per document dialect, inherited from the segmentation owner it runs | none |
 | parse-error cut | `rust/tcl-lexer/src/parse_cut.rs` | `first_parse_cut`; `first_parse_cut_in`; `ParseCut`; `EXTRA_AFTER_CLOSE_QUOTE` | `LexerConfig` per emulated release, inherited from the segmentation and word-component owners it walks | `xtask-segmentation-drift` |
@@ -174,7 +175,13 @@ entry point, or gate moves without this contract being updated.
   option-table matcher below — boolean words have a fixed six-word
   vocabulary with cross-set ambiguity (`o`), so it stays here.
 - `expr` — the expression AST, parser, evaluator seam, and walk
-  (`ExprOps`, `mathfunc`).
+  (`ExprOps`, `mathfunc`). The math-function table is one dispatch over
+  `NumValue<B>` for both engines and the const-folder, with the two release
+  axes (`MathFuncSince`, `IntWidth`) and the typed refusals (`MathFuncError`)
+  owned here rather than re-derived per engine.
+- `rand` — the Park-Miller `rand()`/`srand()` generator both engines call
+  (step, seed nudge, and C's reciprocal-multiply scaling). Only seed storage
+  and the first-seed policy are per engine (#1432).
 - `backslash` — the byte-slice convenience over the lexer's decoder
   (see next); deliberately no second decode implementation.
 

--- a/docs/design/lanes/wasm-native-lowering.md
+++ b/docs/design/lanes/wasm-native-lowering.md
@@ -976,6 +976,15 @@ sheets live as tests, so a reader can re-derive any row in a real shell.
   `tcl_vm::expr::arith`/`unary`, which bytecode opcodes call with no
   interpreter in hand; `errors::ambient_release()` reads the same ambient both
   engines already install with `number::set_runtime_syntax`.
+- **`round()` is `f64::round`, not `floor(d + 0.5)`.** C's `ExprRoundFunc`
+  splits the operand with `modf` and steps the integer part by one when the
+  fraction reaches one half in magnitude. The shared arm originally spelled
+  that as `floor(d + 0.5)` / `ceil(d - 0.5)`, which rounds twice: tclsh
+  8.6.16/9.0.4 answer `round(0.49999999999999994)` with `0` and
+  `round(4503599627370497.0)` with `4503599627370497`, where the doubled
+  rounding gives `1` and `4503599627370498`. `f64::round` is the `modf` form
+  computed exactly, and the const-folder was baking the wrong constants in
+  until it landed.
 - **`dispatch` keeps its `Option` adapter; the fallible entry point is
   additive.** `try_dispatch_with_backend_int_width` returns
   `Result<_, MathFuncError>`; `dispatch*` map `Err` to `None`. The const-folder
@@ -1022,12 +1031,20 @@ before you trust a buffer.
   accepts a *typed* double NaN as an arithmetic operand. That is an
   operand-acceptance gap, not an error-taxonomy one, so the row is dropped
   from the #1581 sheet with a note at the call site rather than fixed here.
-- The VM's `int`/`wide`/`entier`/`round`/`isqrt` are still VM-local functions
-  rather than the shared arms (#1430's re-type). They now agree with the
-  shared arms row for row and read the same release axis, so they cannot drift
-  on the covered semantics.
 - `srand`'s 9.0 empty-message quirk (C hands `TclGetWideBitsFromObj` a NULL
   interp) is not reproduced; both engines use 8.6's wording at every release.
+- `isqrt(-Inf)` answers `integer value too large to represent`
+  (`ARITH IOVERFLOW`) on both engines, where tclsh 8.6.16/9.0.4 answer
+  `square root of negative argument` (`ARITH DOMAIN`). C's `ExprIsqrtFunc`
+  tests `d < 0` before it reaches `Tcl_InitBignumFromDouble`, while the shared
+  `try_dispatch_with_backend_int_width` runs its non-finite operand loop
+  before `isqrt`'s own sign refusal. One reordering in the shared arm (after
+  the NaN check, which C also takes first) fixes both engines at once.
+- `::tcl::mathfunc::entier 0x10` and `round 0x10` return `16` on the VM where
+  tclsh returns `0x10` (9.0.4 also keeps the spelling for `int`; 8.6.16 does
+  not). The VM's `Value::int` drops the operand's string rep; the runtime
+  keeps it for `int`/`entier` through its integer fast path but not for
+  `round`. A string-rep-preservation axis, not a numeric one.
 
 ## p3-native-lowering
 

--- a/runtime/rust/src/builtins.rs
+++ b/runtime/rust/src/builtins.rs
@@ -926,7 +926,13 @@ pub(crate) fn eval_bool_expr(interp: &mut Interp, cond: *mut TclObj) -> Result<b
         interp.restore_line_base(old);
     }
     match result {
-        Ok(r) => crate::expr::to_bool(r.as_ptr()).map_err(|e| interp.set_error(&e.msg)),
+        // The boolean-context refusal keeps its own `-errorcode` (tclsh:
+        // `set x o; if {$x} {}` is `TCL VALUE NUMBER`, a NaN condition is
+        // `TCL VALUE DOUBLE NAN`), exactly as the eval failure below does.
+        Ok(r) => crate::expr::to_bool(r.as_ptr()).map_err(|e| match e.code {
+            Some(c) => interp.error_with_code(&e.msg, &c),
+            None => interp.set_error(&e.msg),
+        }),
         // A propagated sub-eval code unwinds the condition: an error keeps its
         // trace (no condition `expr` frame); a `return`/`break`/`continue` from a
         // `[cmd]` substitution carries that code out of the loop/`if`.

--- a/runtime/rust/src/cmd_dict.rs
+++ b/runtime/rust/src/cmd_dict.rs
@@ -342,7 +342,7 @@ fn filter(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
                 match dict_filter_bool(interp.get_obj_result()) {
                     Ok(true) => kept.push((k, v)),
                     Ok(false) => {}
-                    Err(msg) => return interp.set_error(&msg),
+                    Err(e) => return interp.error_with_code(&e.message, e.code),
                 }
             }
             Code::Continue => {}
@@ -354,21 +354,12 @@ fn filter(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     Code::Ok
 }
 
-/// Coerce a `dict filter -filter script` body result to a boolean like C's
-/// `Tcl_GetBooleanFromObj`, returning the C error message bytes on a non-boolean.
-/// On the numeric-tower build this is the canonical `expr`
-/// parser (arbitrary-precision non-zero test); the degraded no-`tommath` wasm
-/// build (where `expr` is compiled out) falls back to the boolean keywords plus a
-/// `parse_whole` numeric non-zero test — enough to keep `dict filter` building and
-/// working for the common results in that reduced runtime.
-#[cfg(have_tommath)]
-fn dict_filter_bool(o: *mut TclObj) -> Result<bool, Vec<u8>> {
-    crate::expr::to_bool(o).map_err(|e| e.msg)
-}
-
-#[cfg(not(have_tommath))]
-fn dict_filter_bool(o: *mut TclObj) -> Result<bool, Vec<u8>> {
-    crate::typed_value::boolean(o).map_err(|e| e.message)
+/// Coerce a `dict filter … script` body result to a boolean like C's
+/// `Tcl_GetBooleanFromObj` — the runtime's one typed-read owner, so this
+/// accepts exactly what `if` and `expr` do, and refuses with the same
+/// message and `-errorcode` (tclsh: `TCL VALUE NUMBER` for a non-boolean).
+fn dict_filter_bool(o: *mut TclObj) -> Result<bool, crate::typed_value::TypedError> {
+    crate::typed_value::boolean(o)
 }
 
 // -- variable-mutating subcommands (copy-on-write) -------------------------

--- a/runtime/rust/src/expr.rs
+++ b/runtime/rust/src/expr.rs
@@ -577,38 +577,12 @@ pub fn eval_mathop(
 
 // ---- value helpers ---------------------------------------------------------
 
-/// Tcl boolean coercion (`Tcl_GetBoolean`): the keywords or any non-zero number.
+/// Tcl boolean context (`Tcl_GetBooleanFromObj`) as an `expr` error: the
+/// runtime's one typed-read owner ([`crate::typed_value::boolean`]) — the
+/// shared boolean words by unique prefix, else any number against zero, a NaN
+/// refused — with C's message and `-errorcode` carried into [`ExprError`].
 pub(crate) fn to_bool(o: *mut TclObj) -> Result<bool, ExprError> {
-    let bytes = obj::bytes_of(o);
-    let s = core::str::from_utf8(&bytes).unwrap_or("");
-    if let Some(value) = tcl_syntax::boolean::parse_boolean_word(s.trim()) {
-        return Ok(value);
-    }
-    // Any number: non-zero ⇒ true. NaN is numeric but not a boolean —
-    // tclsh: `expr {NaN ? 1 : 0}` → "floating point value is Not a Number".
-    let zero = Owned::fresh(obj::new_wide_int_obj(0));
-    match bignum::compare(o, zero.ptr()) {
-        Some(NumericCompare::Ordered(ord)) => Ok(!ord.is_eq()),
-        // A NaN is numeric but not a boolean; C stamps its own code here
-        // (tclsh: `-errorcode TCL VALUE DOUBLE NAN`) — #1581.
-        Some(NumericCompare::Unordered) => Err(ExprError::with_code(
-            tcl_syntax::expr::errors::NAN_MESSAGE.as_bytes(),
-            tcl_syntax::expr::errors::NAN_CODE.as_bytes(),
-        )),
-        None => {
-            // The `got <here>` tail matches C: a multi-token well-formed list
-            // reads as `a list`, anything else is quoted (truncated to 50 bytes),
-            // so `expr {"a b" ? 1 : 0}` reports `… but got a list`, not `"a b"`.
-            let mut m = b"expected boolean value but got ".to_vec();
-            m.extend_from_slice(tcl_syntax::list::describe_bad_value(s).as_bytes());
-            Err(ExprError::from_parts(
-                m,
-                tcl_syntax::expr::errors::BOOLEAN_OPERAND_CODE
-                    .as_bytes()
-                    .to_vec(),
-            ))
-        }
-    }
+    crate::typed_value::boolean(o).map_err(|e| ExprError::from_parts(e.message, e.code.to_vec()))
 }
 
 fn bool_obj(b: bool) -> Owned {

--- a/runtime/rust/tests/numeric_tower_semantics.rs
+++ b/runtime/rust/tests/numeric_tower_semantics.rs
@@ -539,3 +539,96 @@ fn operand_type_errors_use_the_8_6_wording_at_8_6() {
         );
     }
 }
+
+// ---------------------------------------------------------------------------
+// #1425 — boolean context: the shared `tcl_syntax::boolean` words, by unique
+// prefix, in every context the runtime evaluates.
+// ---------------------------------------------------------------------------
+
+/// tclsh 8.6.16/9.0.4: every unique prefix of a boolean word is accepted in
+/// `expr`'s `?:`, in `if`, in `while`, and in `dict filter … script` — the
+/// issue's own repro (`set x tru; expr {$x ? "T" : "F"}` is `T`).
+#[test]
+fn boolean_prefixes_are_accepted_in_every_boolean_context() {
+    let (code, result, _) = run("set x tru; expr {$x ? \"T\" : \"F\"}");
+    assert_eq!((code, result.as_str()), (Code::Ok, "T"));
+    for (word, want) in [
+        ("t", "yes"),
+        ("tr", "yes"),
+        ("tru", "yes"),
+        ("y", "yes"),
+        ("ye", "yes"),
+        ("on", "yes"),
+        ("f", "no"),
+        ("fa", "no"),
+        ("fal", "no"),
+        ("n", "no"),
+        ("of", "no"),
+        ("off", "no"),
+    ] {
+        let (code, result, _) = run(&format!("set x {word}; if {{$x}} {{list yes}} {{list no}}"));
+        assert_eq!((code, result.as_str()), (Code::Ok, want), "if {{{word}}}");
+        let (code, result, _) = run(&format!(
+            "set x {word}; set n 0; while {{$x}} {{incr n; set x 0}}; set n"
+        ));
+        let laps = if want == "yes" { "1" } else { "0" };
+        assert_eq!(
+            (code, result.as_str()),
+            (Code::Ok, laps),
+            "while {{{word}}}"
+        );
+    }
+    let (code, result, _) = run("set x tru; dict filter {a 1 b 2} script {k v} {set x}");
+    assert_eq!((code, result.as_str()), (Code::Ok, "a 1 b 2"));
+}
+
+/// tclsh 8.6.16/9.0.4: `o` is shared by `on` and `off`, so it is refused —
+/// with the same message and `TCL VALUE NUMBER` in every boolean context —
+/// and a NaN is `TCL VALUE DOUBLE NAN`. A multi-element list is described as
+/// `a list` at 9.0 (8.6.16 quotes it, `"a b"`; that wording axis is #1581's,
+/// which `describe_bad_value` does not yet carry, so only the 9.0 row is
+/// pinned).
+#[test]
+fn the_ambiguous_prefix_and_nan_are_refused_in_every_boolean_context() {
+    for script in [
+        "set x o; if {$x} {}",
+        "set x o; while {$x} {}",
+        "set x o; expr {$x ? 1 : 0}",
+        "set x o; dict filter {a 1} script {k v} {set x}",
+    ] {
+        let (code, result, error_code) = run(script);
+        assert_eq!(code, Code::Error, "{script}");
+        assert_eq!(result, "expected boolean value but got \"o\"", "{script}");
+        assert_eq!(error_code, "TCL VALUE NUMBER", "{script}");
+    }
+    let (code, result, error_code) = run("set x NaN; if {$x} {}");
+    assert_eq!(
+        (code, result.as_str(), error_code.as_str()),
+        (
+            Code::Error,
+            "floating point value is Not a Number",
+            "TCL VALUE DOUBLE NAN"
+        )
+    );
+    let (code, result, error_code) = run("set x {a b}; if {$x} {}");
+    assert_eq!(
+        (code, result.as_str(), error_code.as_str()),
+        (
+            Code::Error,
+            "expected boolean value but got a list",
+            "TCL VALUE NUMBER"
+        )
+    );
+}
+
+/// A boolean word is coerced only where a boolean is actually needed: as a
+/// whole expression it keeps its own spelling (tclsh: `expr {tru}` is `tru`,
+/// not `1`), while `!` and `&&` — which do want a boolean — read it through
+/// the same acceptor as `if`.
+#[test]
+fn a_boolean_word_keeps_its_spelling_outside_a_boolean_context() {
+    expr_is("tru", "tru");
+    expr_is("yes", "yes");
+    expr_is("!of", "1");
+    expr_is("tru && 1", "1");
+}

--- a/runtime/rust/tests/numeric_tower_semantics.rs
+++ b/runtime/rust/tests/numeric_tower_semantics.rs
@@ -217,14 +217,25 @@ fn entier_of_a_beyond_wide_float_is_the_exact_integer() {
 }
 
 /// `round()` is unbounded in both releases too (tclsh: `round(1e300)` is the
-/// same 301-digit integer, `round(1e20)` the same 21-digit one).
+/// same 301-digit integer, `round(1e20)` the same 21-digit one), and it is
+/// half away from zero on the *exact* operand rather than `floor(d + 0.5)`,
+/// which rounds twice: tclsh 8.6.16/9.0.4 answer `round(0.49999999999999994)`
+/// with `0` while `floor(0.49999999999999994 + 0.5)` is `1.0`.
 #[test]
 fn round_of_a_beyond_wide_float_is_the_exact_integer() {
     expr_is("round(1e300)", E1E300);
     expr_is("round(-1e300)", &format!("-{E1E300}"));
     expr_is("round(1e20)", "100000000000000000000");
+    expr_is("round(0.5)", "1");
+    expr_is("round(1.5)", "2");
     expr_is("round(2.5)", "3");
     expr_is("round(-2.5)", "-3");
+    expr_is("round(0.49999999999999994)", "0");
+    expr_is("round(-0.49999999999999994)", "0");
+    expr_is("round(4503599627370497.0)", "4503599627370497");
+    expr_is("round(-4503599627370497.0)", "-4503599627370497");
+    expr_is("round(4503599627370497.5)", "4503599627370498");
+    expr_is("round(2251799813685248.5)", "2251799813685249");
 }
 
 /// `wide()` truncates then takes the low 64 bits, in every release

--- a/rust/tcl-compiler/src/tcl_expr_eval.rs
+++ b/rust/tcl-compiler/src/tcl_expr_eval.rs
@@ -2522,6 +2522,33 @@ mod tests {
         assert_eq!(eval_str("round(2.5)"), Some(TclValue::Int(3)));
     }
 
+    /// The fold is C's `modf` form, not `floor(d + 0.5)`, which rounds twice
+    /// and would bake `1` and `4503599627370498` into the compiled code where
+    /// tclsh 8.6.16/9.0.4 answer `0` and `4503599627370497`.
+    #[test]
+    fn math_round_folds_the_exact_value_not_d_plus_a_half() {
+        assert_eq!(
+            eval_str("round(0.49999999999999994)"),
+            Some(TclValue::Int(0))
+        );
+        assert_eq!(
+            eval_str("round(-0.49999999999999994)"),
+            Some(TclValue::Int(0))
+        );
+        assert_eq!(
+            eval_str("round(4503599627370497.0)"),
+            Some(TclValue::Int(4_503_599_627_370_497))
+        );
+        assert_eq!(
+            eval_str("round(-4503599627370497.0)"),
+            Some(TclValue::Int(-4_503_599_627_370_497))
+        );
+        assert_eq!(
+            eval_str("round(2251799813685248.5)"),
+            Some(TclValue::Int(2_251_799_813_685_249))
+        );
+    }
+
     #[test]
     fn math_ceil_and_floor_return_floats() {
         assert_eq!(eval_str("ceil(1.2)"), Some(TclValue::Float(2.0)));

--- a/rust/tcl-syntax/src/expr/mathfunc.rs
+++ b/rust/tcl-syntax/src/expr/mathfunc.rs
@@ -827,19 +827,23 @@ fn wide_window<B: super::super::number_tower::BigIntOps>(v: NumValue<B>) -> NumV
     }
 }
 
-/// `round()`'s exact conversion: half away from zero (C's
-/// `floor(d + 0.5)` / `ceil(d - 0.5)`), then the same exact truncation —
-/// tclsh's `round(1e300)` is the full 301-digit integer in every release.
+/// `round()`'s exact conversion: half away from zero on the *exact* operand,
+/// then the same exact truncation — tclsh's `round(1e300)` is the full
+/// 301-digit integer in every release.
+///
+/// C's `ExprRoundFunc` splits the operand with `modf` and steps the integer
+/// part by one when the fraction reaches one half in magnitude;
+/// [`f64::round`] is that operation, computed exactly. It is **not**
+/// `floor(d + 0.5)` / `ceil(d - 0.5)`, which rounds twice and so disagrees
+/// wherever `d ± 0.5` itself rounds: `0.49999999999999994 + 0.5` is exactly
+/// `1.0` in binary64 and `4503599627370497.0 + 0.5` ties to even, so that
+/// spelling answered `1` and `4503599627370498` where tclsh 8.6.16/9.0.4
+/// answer `0` and `4503599627370497`.
 fn round_exact<B: super::super::number_tower::BigIntOps>(f: f64) -> Option<NumValue<B>> {
     if !f.is_finite() {
         return None;
     }
-    let rounded = if f >= 0.0 {
-        (f + 0.5).floor()
-    } else {
-        (f - 0.5).ceil()
-    };
-    trunc_exact(rounded)
+    trunc_exact(f.round())
 }
 
 /// The exact integer square root of a non-negative `i`, `isqrt`'s core.
@@ -1258,6 +1262,33 @@ mod tests {
             dispatch("isinf", &[Num::Float(f64::NAN)]),
             Some(Num::Int(0))
         );
+    }
+
+    /// `round()` is half away from zero on the *exact* operand — C's `modf`
+    /// form, not `floor(d + 0.5)`, which rounds twice and answers `1` for
+    /// `0.49999999999999994` and `4503599627370498` for `2**52 + 1`. Rows
+    /// measured on tclsh 8.6.16 and 9.0.4.
+    #[test]
+    fn round_is_half_away_from_zero_on_the_exact_value() {
+        for (operand, want) in [
+            (0.499_999_999_999_999_94, 0),
+            (-0.499_999_999_999_999_94, 0),
+            (0.500_000_000_000_000_1, 1),
+            (0.5, 1),
+            (1.5, 2),
+            (2.5, 3),
+            (-2.5, -3),
+            (4_503_599_627_370_497.0, 4_503_599_627_370_497),
+            (-4_503_599_627_370_497.0, -4_503_599_627_370_497),
+            (2_251_799_813_685_248.5, 2_251_799_813_685_249),
+            (-2_251_799_813_685_248.5, -2_251_799_813_685_249),
+        ] {
+            assert_eq!(
+                dispatch("round", &[Num::Float(operand)]),
+                Some(Num::Int(want)),
+                "round({operand:?})"
+            );
+        }
     }
 
     #[cfg(feature = "num-bigint")]

--- a/rust/tcl-vm/src/cmd_math.rs
+++ b/rust/tcl-vm/src/cmd_math.rs
@@ -18,12 +18,9 @@
 
 //! `expr` math functions, registered as `tcl::mathfunc::*` (the names the
 //! compiler invokes and `ExprEval::call` routes to).
-// The math functions intentionally coerce between i64 and f64 (`int`/`round`/
-// `entier`/… follow Tcl's expr numeric conversions, not lossless casts).
-#![allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
 
 use num_bigint::BigInt;
-use num_traits::{FromPrimitive, Signed, ToPrimitive};
+use num_traits::Signed;
 use tcl_runtime_api::Completion;
 use tcl_syntax::expr::mathfunc::{IntWidth, NumValue, try_dispatch_with_backend_int_width};
 use tcl_syntax::number::{self, Number};
@@ -72,26 +69,6 @@ fn num_or_nan(v: &Value) -> Result<f64, String> {
     }
 }
 
-fn finite_num_arg(v: &Value) -> Result<f64, String> {
-    let f = num_or_nan(v)?;
-    if f.is_nan() {
-        return Err("floating point value is Not a Number".to_string());
-    }
-    if f.is_infinite() {
-        return Err("integer value too large to represent".to_string());
-    }
-    Ok(f)
-}
-
-fn exact_trunc(f: f64) -> BigInt {
-    BigInt::from_f64(f.trunc()).unwrap_or_default()
-}
-
-fn wide_window(b: &BigInt) -> i64 {
-    let low = b & &BigInt::from(u64::MAX);
-    low.to_u64().map_or(0, u64::cast_signed)
-}
-
 /// The message and `errorCode` C raises (`tclExecute.c`, errno `EDOM`) when a
 /// math function's argument is out of range — `sqrt(-1)`, `acos(2)`, `fmod(x,0)`,
 /// … . `isqrt` of a negative reuses the same code with its own message.
@@ -117,9 +94,9 @@ fn math_func_err(e: tcl_syntax::expr::mathfunc::MathFuncError) -> Completion<Val
     err_with_code(message, e.error_code())
 }
 
-/// A `finite_num_arg` / `num_or_nan` failure as a completion, with C's
-/// `-errorcode`: the VM had the right message text for a NaN and an infinity
-/// but left `errorCode` as `NONE` (#1581).
+/// A [`num_or_nan`] failure as a completion, with C's `-errorcode`: the VM
+/// had the right message text for a NaN and an infinity but left `errorCode`
+/// as `NONE` (#1581).
 fn num_err(message: String) -> Completion<Value> {
     use tcl_syntax::expr::errors;
     if message == errors::NAN_MESSAGE {
@@ -198,23 +175,23 @@ fn shared_math(name: &str, args: &[Value], int_width: IntWidth) -> Completion<Va
 ///
 /// Most functions fall through to [`shared_math`], which drives
 /// `tcl_syntax::expr::mathfunc::dispatch_with_backend` — the same shared
-/// implementation `expr` itself uses. The arms named here are the ones whose
-/// VM bodies are deliberately *not* the shared ones: the integer conversions
-/// retain the VM's exact finite-double-to-bignum path (the shared value seam
-/// has no float-to-arbitrary-integer operation, so routing them through it
-/// would turn `int(1e300)` and `round(1e300)` into spurious domain errors),
-/// and `rand`/`srand` carry interpreter state.
+/// implementation `expr` itself uses. The integer conversions
+/// (`int`/`wide`/`entier`/`round`/`isqrt`) are shared arms too since
+/// #1382/#1795 gave the shared seam an exact float-to-bignum operation
+/// (`BigIntOps::from_f64_trunc`), so `int(1e300)` and `round(1e300)` keep
+/// their exact answers there.
+///
+/// The arms named here are the ones whose VM bodies are deliberately *not*
+/// the shared ones: `abs` takes an i128 fast path before the bignum rung,
+/// `double` is the VM's own value coercion, `bool` accepts a boolean *word*
+/// operand (`bool(tru)` is `1`, which `shared_math`'s numeric operand
+/// conversion would refuse), and `rand`/`srand` carry interpreter state.
 fn m_mathfunc(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     let invoked = vm.invoked_name().unwrap_or_default();
     let name = invoked.rsplit("::").next().unwrap_or(invoked).to_owned();
     match name.as_str() {
         "abs" => m_abs(args),
-        "int" => m_int(vm, args),
-        "wide" => m_wide(args),
-        "entier" => m_entier(args),
         "double" => m_double(args),
-        "round" => m_round(args),
-        "isqrt" => m_isqrt(args),
         "bool" => m_bool(args),
         "srand" => m_srand(vm, args),
         "rand" => m_rand(vm, args),
@@ -283,47 +260,6 @@ fn m_abs(args: &[Value]) -> Completion<Value> {
     }
 }
 
-fn m_wide(args: &[Value]) -> Completion<Value> {
-    int_window(args, "wide")
-}
-
-/// `int(x)` — the one **release-split** conversion. Tcl 9.0 binds `int` and
-/// `entier` to the same unbounded `ExprIntFunc` (`tclBasic.c`), so
-/// `int(1e20)` is `100000000000000000000` and `int(2**64+1)` is
-/// `18446744073709551617`; Tcl 8.4-8.6 keep `int`'s signed-64-bit window, so
-/// the same two are `7766279631452241920` and `1`. Measured against
-/// tclsh8.6.16 and tclsh9.0.4 (#1382). The width itself is the shared owner's
-/// ([`IntWidth`]), so the VM and the WASM runtime cannot disagree about which
-/// release windows.
-fn m_int(vm: &Vm, args: &[Value]) -> Completion<Value> {
-    match IntWidth::for_tcl_version(vm.runtime_version()) {
-        IntWidth::Unbounded => entier_named(args, "int"),
-        IntWidth::Windowed | IntWidth::Unresolved => int_window(args, "int"),
-    }
-}
-
-/// `int(x)` / `wide(x)` — one conversion since 8.6 (`int` is no longer the
-/// narrower "long"): an integer of any magnitude is taken modulo 2^64,
-/// two's-complement folded (`int(2**64 + 1)` is `1`, `int(-(2**64 + 1))` is
-/// `-1`); a double truncates toward zero first, then wraps the same way
-/// (`int(1e300)` is `0` — 10^300 divides by 2^64). The integer path is exact —
-/// never round-tripped through `f64`, which would lose precision above 2^53
-/// (`int(9007199254740993)` must stay `…993`).
-fn int_window(args: &[Value], name: &str) -> Completion<Value> {
-    let x = match one(args, name) {
-        Ok(v) => v,
-        Err(c) => return c,
-    };
-    // `as_wide` is exactly this window for integer inputs of any size.
-    if let Ok(n) = x.as_wide() {
-        return ok(Value::int(n));
-    }
-    match finite_num_arg(x) {
-        Ok(f) => ok(Value::int(wide_window(&exact_trunc(f)))),
-        Err(m) => num_err(m),
-    }
-}
-
 fn m_double(args: &[Value]) -> Completion<Value> {
     let x = match one(args, "double") {
         Ok(v) => v,
@@ -344,109 +280,6 @@ fn m_double(args: &[Value]) -> Completion<Value> {
             }
             err(e.message)
         }
-    }
-}
-
-fn m_round(args: &[Value]) -> Completion<Value> {
-    let x = match one(args, "round") {
-        Ok(v) => v,
-        Err(c) => return c,
-    };
-    // Integers of any magnitude pass through exactly (tclsh: `round(2**200)`
-    // is 2^200 itself).
-    if let Ok(n) = x.as_int() {
-        return ok(Value::int(n));
-    }
-    if let Some(b) = crate::expr::value_as_bigint(x) {
-        return ok(crate::expr::big_value(&b));
-    }
-    // Round half away from zero, then keep the result *exact*: tclsh's
-    // `round(1e300)` is the full 309-digit integer, not a saturated wide.
-    match finite_num_arg(x) {
-        Ok(f) => ok(crate::expr::big_value(
-            &num_bigint::BigInt::from_f64(f.round()).unwrap_or_default(),
-        )),
-        Err(m) => num_err(m),
-    }
-}
-
-/// VM-facing `isqrt` keeps Tcl's specialised negative-argument diagnostic;
-/// the exact positive bignum root is the same shared tower operation used by
-/// the other backends.
-fn m_isqrt(args: &[Value]) -> Completion<Value> {
-    let x = match one(args, "isqrt") {
-        Ok(v) => v,
-        Err(c) => return c,
-    };
-    if let Ok(n) = x.as_int() {
-        if n < 0 {
-            return err_with_code("square root of negative argument", DOMAIN_CODE);
-        }
-        return ok(Value::int(isqrt_i64(n)));
-    }
-    if let Some(b) = crate::expr::value_as_bigint(x) {
-        if b.is_negative() {
-            return err_with_code("square root of negative argument", DOMAIN_CODE);
-        }
-        return ok(crate::expr::big_value(&num_integer::Roots::sqrt(&b)));
-    }
-    // `finite_num_arg`, not `num_arg`: an infinity is `ARITH IOVERFLOW` and a
-    // NaN is `TCL VALUE DOUBLE NAN` here, exactly as for the other integer
-    // conversions (tclsh: `isqrt(Inf)` / `isqrt(NaN)`) — #1581.
-    let f = match finite_num_arg(x) {
-        Ok(f) => f,
-        Err(m) => return num_err(m),
-    };
-    if f < 0.0 {
-        return err_with_code("square root of negative argument", DOMAIN_CODE);
-    }
-    // Truncate exactly first: `isqrt(1e300)` is a 151-digit integer, not the
-    // root of a saturated wide (tclsh 8.6.16/9.0.4).
-    ok(crate::expr::big_value(&num_integer::Roots::sqrt(
-        &exact_trunc(f),
-    )))
-}
-
-fn isqrt_i64(n: i64) -> i64 {
-    if n < 2 {
-        return n;
-    }
-    let nn = i128::from(n);
-    let mut r = (n as f64).sqrt() as i64;
-    while r > 0 && i128::from(r) * i128::from(r) > nn {
-        r -= 1;
-    }
-    while i128::from(r + 1) * i128::from(r + 1) <= nn {
-        r += 1;
-    }
-    r
-}
-
-/// `entier(x)` — the exact integer value of `x`, truncated toward zero and
-/// **unbounded** (TIP 237): an integer of any magnitude passes through; a
-/// double becomes the full exact integer (`entier(1e300)` is all 309 digits),
-/// with no 64-bit window — that wrap is `int`/`wide`'s ([`int_window`]).
-fn m_entier(args: &[Value]) -> Completion<Value> {
-    entier_named(args, "entier")
-}
-
-/// [`m_entier`]'s body under a caller-chosen function name, so Tcl 9.0's
-/// `int()` — which C binds to the same unbounded `ExprIntFunc` as `entier`
-/// (`tclBasic.c`) — reuses it while keeping its own arity wording.
-fn entier_named(args: &[Value], name: &str) -> Completion<Value> {
-    let x = match one(args, name) {
-        Ok(v) => v,
-        Err(c) => return c,
-    };
-    if let Ok(n) = x.as_int() {
-        return ok(Value::int(n));
-    }
-    if let Some(b) = crate::expr::value_as_bigint(x) {
-        return ok(crate::expr::big_value(&b));
-    }
-    match finite_num_arg(x) {
-        Ok(f) => ok(crate::expr::big_value(&exact_trunc(f))),
-        Err(m) => num_err(m),
     }
 }
 

--- a/rust/tcl-vm/tests/cmd_math_expr_e2e.rs
+++ b/rust/tcl-vm/tests/cmd_math_expr_e2e.rs
@@ -1545,32 +1545,25 @@ fn bug_mathfunc_arity_error_wording() {
     );
 }
 
-// tcl::mathfunc: rand / srand (gap — not implemented in the VM)
+// tcl::mathfunc: rand / srand — the shared Park-Miller generator (#1432)
 
-// BUG: rand()/srand() are missing from the VM. tclsh implements both; the VM
-// has no `tcl::mathfunc::rand` / `::srand` registration, so an `expr` using
-// them fails with "invalid command name" instead of returning a number.
-// srand(N) is deterministic in tclsh: srand(1) seeds and returns the first
-// random number, 7.826369259425611e-6, on both 8.6 and 9.0.
-//   script:        expr {srand(1)}
-//   tclsh 8.6/9.0: 7.826369259425611e-6
-//   tcl-vm:        invalid command name "tcl::mathfunc::srand" (ok=false)
+/// `srand(N)` seeds the generator and returns its first draw, so it is
+/// deterministic: tclsh 8.6.16 and 9.0.4 both answer `srand(1)` with
+/// `7.826369259425611e-6`. The whole stream is pinned against the oracle in
+/// `numeric_tower_e2e.rs`; this row is the smoke test that the VM registers
+/// the function at all.
 #[test]
-fn bug_srand_is_deterministic_and_missing() {
-    // tclsh 8.6/9.0: expr {srand(1)} -> 7.826369259425611e-6
+fn srand_is_deterministic() {
     expr_eq("srand(1)", "7.826369259425611e-6");
 }
 
-// BUG: rand() is likewise missing; in tclsh it returns a double in [0,1).
-//   script:        srand(7); set x [expr {rand()}]; expr {$x >= 0 && $x < 1}
-//   tclsh 8.6/9.0: 1
-//   tcl-vm:        invalid command name "tcl::mathfunc::rand" (ok=false)
+/// `rand()` returns a double in `[0, 1)` (tclsh 8.6.16/9.0.4), drawn from the
+/// seed `srand` installed.
 #[test]
-fn bug_rand_returns_unit_interval_and_missing() {
-    // Seed first (deterministic), then check rand() lands in [0,1).
+fn rand_returns_the_unit_interval() {
     let (ok, result, _) = run("expr {srand(99)}; set x [expr {rand()}]; expr {$x >= 0 && $x < 1}");
     assert!(ok, "rand() should produce a number in [0,1): {result}");
-    assert_eq!(result, "1"); // tclsh 8.6/9.0
+    assert_eq!(result, "1");
 }
 
 // ::tcl::mathop::* operator commands

--- a/rust/tcl-vm/tests/numeric_tower_e2e.rs
+++ b/rust/tcl-vm/tests/numeric_tower_e2e.rs
@@ -266,6 +266,11 @@ fn both_at(body: &str, want: &str, version: tcl_dialect::TclVersion) {
     );
 }
 
+/// `round()` is half away from zero on the *exact* operand — not
+/// `floor(d + 0.5)`, which rounds twice (tclsh 8.6.16/9.0.4:
+/// `round(0.49999999999999994)` is `0` while `floor(0.49999999999999994+0.5)`
+/// is `1.0`). `both` runs the braced form too, so these rows also pin the
+/// const-folder's answer.
 #[test]
 fn entier_and_round_of_a_beyond_wide_float_are_exact() {
     both("entier(1e300)", &format!("ok {E1E300}"));
@@ -276,8 +281,16 @@ fn entier_and_round_of_a_beyond_wide_float_are_exact() {
     both("entier(2**64+1)", "ok 18446744073709551617");
     both("round(1e300)", &format!("ok {E1E300}"));
     both("round(1e20)", "ok 100000000000000000000");
+    both("round(0.5)", "ok 1");
+    both("round(1.5)", "ok 2");
     both("round(2.5)", "ok 3");
     both("round(-2.5)", "ok -3");
+    both("round(0.49999999999999994)", "ok 0");
+    both("round(-0.49999999999999994)", "ok 0");
+    both("round(4503599627370497.0)", "ok 4503599627370497");
+    both("round(-4503599627370497.0)", "ok -4503599627370497");
+    both("round(4503599627370497.5)", "ok 4503599627370498");
+    both("round(2251799813685248.5)", "ok 2251799813685249");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

The four `expr`/number issues on the `wasm-runtime` label — #1425, #1382, #1432, #1428 — were **already implemented** by `138f69e` (#1795) but were never closed. This PR verifies that, fixes one genuinely new bug found while verifying, and sweeps the residuals so the four can be closed.

**The new bug (high severity).** `tcl_syntax::expr::mathfunc::round_exact` computed `floor(d + 0.5)` / `ceil(d - 0.5)`. C's `ExprRoundFunc` (`tclBasic.c:7903-7925`) splits with `modf` and steps the integer part. The two disagree wherever `d ± 0.5` itself rounds in binary64, so the arm rounded twice:

| expression | tclsh 8.6.16 / 9.0.4 | before | after |
|---|---|---|---|
| `round(0.49999999999999994)` | `0` | `1` | `0` |
| `round(-0.49999999999999994)` | `0` | `-1` | `0` |
| `round(4503599627370497.0)` | `4503599627370497` | `4503599627370498` | `4503599627370497` |

The runtime **and the const-folder** took the wrong answer, so the folder baked a wrong constant into compiled code. `f64::round` is C's `modf` split computed exactly.

**Residual sweep**

- `round` fix, with rows in the shared unit test, the const-folder's own sheet, and both engines' oracle sheets (#1382).
- The VM's private `m_int`/`m_wide`/`m_entier`/`m_round`/`m_isqrt` + `exact_trunc`/`wide_window`/`int_window`/`isqrt_i64` are deleted and fall to the shared arms — their justifying doc comment had become factually false. Lands **after** the `round` fix, or the VM regresses (#1382).
- One boolean-context reader in the runtime: `expr::to_bool` is now a thin `ExprError` adapter over `typed_value::boolean`, and `cmd_dict`'s `#[cfg]` pair collapses. The issues' own repros are pinned (#1425).
- Owner-manifest rows for `expr/mathfunc.rs` and `expr/rand.rs`; `cargo xtask owner-resolution` resolves 35 rows. AGENTS.md: *never add an owner-shaped implementation without updating the contract and its gate* (#1432).
- Lane-doc close-out; stale `bug_*` test names rewritten as oracle notes.

**Two unpredicted fixes.** Pinning #1425's repro exposed real `-errorcode` drops: `if`/`while`/`for` conditions and `dict filter … script` reported `NONE` where tclsh reports `TCL VALUE NUMBER` (and `TCL VALUE DOUBLE NAN` for a NaN condition). Both now mirror what the condition's *parse* failure already did. Step B could not pass without this.

Net **-4 lines** overall, removing 197 lines of duplicated VM code.

Closes #1425
Closes #1382
Closes #1432
Closes #1428

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

```
cargo test -p tcl-syntax
cargo test -p tcl-vm
cargo test --manifest-path runtime/rust/Cargo.toml
make rust-check
```

All green — 62 suites, 2357 tests, 0 failures; `make rust-check` exit 0; no `make codegen` drift. `make rust-check` was confirmed green on the base commit first, so the gate result is attributable.

Step C's behavioural equivalence was verified empirically rather than by reading: an 85-row probe (all five functions — beyond-wide floats, bignums, ±Inf, NaN, arity, non-numeric operands, and the `::tcl::mathfunc::` command form) replayed through `tclvm` at all five release pins, byte-identical before and after.

## Compiler / diagnostics checklist

- [x] Did this change alter a compiler fact contract? Yes — `round()`'s exact conversion, which the const-folder consumes.
- [x] If yes, I updated the owning design doc under `docs/design/compiler/` or `docs/design/contracts/` — `shared-utility-contracts-rust.md` gains the `mathfunc`/`rand` owner rows; the lane doc records the `round` decision.
- [x] If I added or changed a diagnostic or optimisation code, I updated its page under `docs/kcs/codes/` — n/a, no diagnostic or optimisation code changed.
- [x] If I added a design doc, I linked it from `docs/design/README.md` — n/a, no new design doc.

## Deliberately not in this PR

- **`isqrt(-Inf)`** — both engines say `integer value too large to represent` / `ARITH IOVERFLOW`; tclsh says `square root of negative argument` / `ARITH DOMAIN`. C's `ExprIsqrtFunc` tests `d < 0` before `Tcl_InitBignumFromDouble`, while the shared arm runs its non-finite loop before `isqrt`'s sign refusal. One reorder fixes both engines, but it is outside these four issues. Recorded in the lane doc.
- **`::tcl::mathfunc::entier 0x10` / `round 0x10`** return `16` on the VM vs tclsh's `0x10` — a string-rep axis, unchanged here.
- **`int_pow` → `Result` hardening** (#1428's optional cleanup) — ships separately.
- **Fuzz generator gap**, answered but not acted on: `generator.rs::expr_leaf` emits only `$var`, `0..19`, or single-digit `N.M`, and `mathfunc_call`'s `ARITY1` omits `entier` and `isqrt`, so the generator can never reach a beyond-wide or half-ulp float operand — which is why the campaign never surfaced any of this. Extending it needs a campaign run to validate against new noise; clean standalone follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XV29AoTSsaCBgsJuf2EvEK

---
_Generated by [Claude Code](https://claude.ai/code/session_01XV29AoTSsaCBgsJuf2EvEK)_