### PR TITLE
perf(spec-studio): deduplicate exhaustive render sweeps

### DIFF
--- a/rust/tcl-spec-studio/src/render_spectcl.rs
+++ b/rust/tcl-spec-studio/src/render_spectcl.rs
@@ -69,7 +69,7 @@
 //!   spelling at all, and is reported as a [`Loss`] rather than written down
 //!   wrong — see [`word`].
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Write as _;
 
 use serde_json::Value;
@@ -723,6 +723,19 @@ pub struct Loss {
     pub reason: String,
 }
 
+/// Losses attributed to one command in a multi-command pack render.
+///
+/// The ordinary reporting entry point flattens these for UI callers. Exhaustive
+/// consumers can retain the command boundary while evaluating the rendered pack
+/// once instead of starting one evaluator per command.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommandLosses {
+    /// The rendered command name.
+    pub command: String,
+    /// Fields from that command which the renderer could not carry.
+    pub losses: Vec<Loss>,
+}
+
 impl Out {
     /// A buffer whose statements start at `indent` levels of four spaces.
     fn at(indent: usize) -> Self {
@@ -831,34 +844,49 @@ impl Out {
 /// `return-codes` do.
 #[derive(Debug, Default)]
 struct ValueTables {
-    /// `(name, values array)`, in declaration order.
-    tables: Vec<(String, Value)>,
+    /// Shared value tables, in declaration order.
+    tables: Vec<ValueTable>,
+}
+
+#[derive(Debug)]
+struct ValueTable {
+    name: String,
+    values: Value,
+    /// Top-level commands which refer to this table.
+    owners: BTreeSet<String>,
 }
 
 impl ValueTables {
     /// Register `values` under a name derived from `hint`, reusing an
     /// identical table when one is already declared.
-    fn intern(&mut self, hint: &str, values: &Value) -> String {
-        if let Some((name, _)) = self.tables.iter().find(|(_, table)| table == values) {
-            return name.clone();
+    fn intern(&mut self, hint: &str, values: &Value, owner: &str) -> String {
+        if let Some(table) = self.tables.iter_mut().find(|table| table.values == *values) {
+            table.owners.insert(owner.to_owned());
+            return table.name.clone();
         }
         let base = slug(hint);
         let mut name = base.clone();
         let mut n = 2;
-        while self.tables.iter().any(|(taken, _)| *taken == name) {
+        while self.tables.iter().any(|table| table.name == name) {
             name = format!("{base}-{n}");
             n += 1;
         }
-        self.tables.push((name.clone(), values.clone()));
+        self.tables.push(ValueTable {
+            name: name.clone(),
+            values: values.clone(),
+            owners: BTreeSet::from([owner.to_owned()]),
+        });
         name
     }
 
-    fn render(&self, out: &mut Out) {
-        for (name, values) in &self.tables {
+    fn render(&self, out: &mut Out) -> BTreeMap<String, Vec<Loss>> {
+        let mut by_command: BTreeMap<String, Vec<Loss>> = BTreeMap::new();
+        for table in &self.tables {
+            let losses_before = out.losses.len();
             out.gap();
-            out.line(&format!("values {name} {{"));
+            out.line(&format!("values {} {{", table.name));
             out.indented(|out| {
-                for value in as_array(values) {
+                for value in as_array(&table.values) {
                     let Some(spelling) = word(str_of(&value["value"])) else {
                         unwritable(out, "arg_values");
                         continue;
@@ -891,7 +919,15 @@ impl ValueTables {
                 }
             });
             out.line("}");
+            let losses = &out.losses[losses_before..];
+            for owner in &table.owners {
+                by_command
+                    .entry(owner.clone())
+                    .or_default()
+                    .extend_from_slice(losses);
+            }
         }
+        by_command
     }
 }
 
@@ -1487,6 +1523,8 @@ struct Ctx<'a> {
     defaults: &'a Draft,
     /// The `-native` id prefix — `lsort`, or `string::is` for a subcommand.
     scope: String,
+    /// The top-level command which owns any shared table interned here.
+    owner: String,
     tables: &'a mut ValueTables,
     /// Whether the pack being rendered declares `SpecTcl` 2.0, and may
     /// therefore use the availability algebra.
@@ -2070,7 +2108,7 @@ fn push_values(
             .collect();
         push_flag(row, lost, "-values", list_word(&words));
     } else {
-        let name = ctx.tables.intern(hint, values);
+        let name = ctx.tables.intern(hint, values, &ctx.owner);
         row.push("-values-from".to_owned());
         row.push(name);
     }
@@ -2807,6 +2845,7 @@ fn object_class_block(out: &mut Out, ctx: &mut Ctx<'_>, draft: &Draft) {
     let mut scope = Ctx {
         defaults: ctx.defaults,
         scope: format!("{}::{}", ctx.scope, str_of(&class["class_name"])),
+        owner: ctx.owner.clone(),
         tables: ctx.tables,
         availability: ctx.availability,
         resolver_capabilities: ctx.resolver_capabilities,
@@ -2838,6 +2877,7 @@ fn subcommand_block(out: &mut Out, parent: &mut Ctx<'_>, sub: &Draft, keyword: &
     let mut ctx = Ctx {
         defaults: &defaults,
         scope: format!("{}::{name}", parent.scope),
+        owner: parent.owner.clone(),
         tables: parent.tables,
         availability: parent.availability,
         resolver_capabilities: parent.resolver_capabilities,
@@ -3102,6 +3142,19 @@ pub fn render_pack_reporting(drafts: &[Draft], pack_name: &str) -> (String, Vec<
     render_pack_reporting_with_version(drafts, pack_name, DSL_VERSION)
 }
 
+/// [`render_pack_reporting`], retaining which command produced each loss.
+///
+/// This is useful for exhaustive round-trip checks which render a whole pack
+/// at once but still need per-command loss accounting.
+#[must_use]
+pub fn render_pack_reporting_by_command(
+    drafts: &[Draft],
+    pack_name: &str,
+) -> (String, Vec<CommandLosses>) {
+    let (text, _, losses) = render_pack_reporting_impl(drafts, pack_name, DSL_VERSION);
+    (text, losses)
+}
+
 /// [`render_pack_reporting`] with an explicit `speclib` vocabulary version.
 ///
 /// Kept separate from the default entry point so exports continue to target
@@ -3113,6 +3166,15 @@ pub fn render_pack_reporting_with_version(
     pack_name: &str,
     dsl_version: &str,
 ) -> (String, Vec<Loss>) {
+    let (text, losses, _) = render_pack_reporting_impl(drafts, pack_name, dsl_version);
+    (text, losses)
+}
+
+fn render_pack_reporting_impl(
+    drafts: &[Draft],
+    pack_name: &str,
+    dsl_version: &str,
+) -> (String, Vec<Loss>, Vec<CommandLosses>) {
     let mut tables = ValueTables::default();
     let mut bodies: Vec<(String, Out)> = Vec::new();
     // The header decides the vocabulary the body may use, never the other way
@@ -3132,6 +3194,7 @@ pub fn render_pack_reporting_with_version(
             let mut ctx = Ctx {
                 defaults: &defaults,
                 scope: name.clone(),
+                owner: name.clone(),
                 tables: &mut tables,
                 availability,
                 resolver_capabilities,
@@ -3158,7 +3221,7 @@ pub fn render_pack_reporting_with_version(
     // The ports do not indent a pack's own declarations — a `.tclspec` is one
     // long file of `command` blocks, and a second level of indentation buys
     // nothing.
-    tables.render(&mut out);
+    let mut table_losses = tables.render(&mut out);
     for (name, body) in &bodies {
         out.gap();
         out.line(&format!("command {} {{", name_word(name)));
@@ -3167,7 +3230,15 @@ pub fn render_pack_reporting_with_version(
     }
     out.gap();
     out.line("}");
-    (out.text, out.losses)
+    let losses_by_command = bodies
+        .into_iter()
+        .map(|(command, body)| {
+            let mut losses = body.losses;
+            losses.extend(table_losses.remove(&command).unwrap_or_default());
+            CommandLosses { command, losses }
+        })
+        .collect();
+    (out.text, out.losses, losses_by_command)
 }
 
 #[cfg(test)]
@@ -3520,6 +3591,90 @@ mod tests {
                     && loss.reason == "requires SpecTcl 2.1 vocabulary"
             }),
             "{losses:#?}"
+        );
+    }
+
+    #[test]
+    fn multi_command_reporting_keeps_each_loss_with_its_command() {
+        let clean = drafted("clean");
+        let mut lossy = drafted("lossy");
+        lossy.insert(draft::UNRENDERABLE_KEY.into(), json!(["frame_effect"]));
+
+        let (_, reports) = render_pack_reporting_by_command(&[clean, lossy], "probe");
+        assert_eq!(reports.len(), 2);
+        assert_eq!(reports[0].command, "clean");
+        assert!(reports[0].losses.is_empty());
+        assert_eq!(reports[1].command, "lossy");
+        assert_eq!(reports[1].losses.len(), 1);
+        assert_eq!(reports[1].losses[0].key, "frame_effect");
+    }
+
+    #[test]
+    fn shared_value_table_losses_are_reported_for_every_owning_command() {
+        let values = json!([{
+            "index": 0,
+            "values": [
+                { "value": "{", "detail": "Unwritable value.", "min_tcl": null, "code": null },
+            ],
+        }]);
+        let mut first = drafted("first");
+        first.insert("arg_values".into(), values.clone());
+        let mut second = drafted("second");
+        second.insert("arg_values".into(), values);
+
+        let (_, reports) = render_pack_reporting_by_command(&[first, second], "probe");
+        assert_eq!(reports.len(), 2);
+        for report in reports {
+            assert_eq!(report.losses.len(), 1, "{}", report.command);
+            assert_eq!(report.losses[0].key, "arg_values");
+        }
+    }
+
+    #[test]
+    fn shared_value_table_losses_include_nested_command_owners() {
+        let values = json!([{
+            "index": 0,
+            "values": [
+                { "value": "{", "detail": "Unwritable value.", "min_tcl": null, "code": null },
+            ],
+        }]);
+        let mut subcommand = draft::default_subcommand_draft();
+        subcommand.insert("name".into(), json!("nested"));
+        subcommand.insert("arg_values".into(), values.clone());
+        let mut method = draft::default_subcommand_draft();
+        method.insert("name".into(), json!("method"));
+        method.insert("arg_values".into(), values);
+
+        let mut command = drafted("parent");
+        command.insert("subcommands".into(), json!([subcommand]));
+        command.insert(
+            "object_class".into(),
+            json!({
+                "class_name": "Thing",
+                "superclasses": [],
+                "allow_unknown_methods": false,
+                "method_prefix_matching": "Disabled",
+                "instance_methods": [method],
+            }),
+        );
+
+        let (text, reports) = render_pack_reporting_by_command(&[command], "probe");
+        assert_eq!(reports.len(), 1);
+        assert_eq!(reports[0].command, "parent");
+        assert_eq!(reports[0].losses.len(), 1);
+        assert_eq!(reports[0].losses[0].key, "arg_values");
+        let table_names: Vec<_> = text
+            .lines()
+            .filter_map(|line| {
+                line.split_once("-values-from ")
+                    .and_then(|(_, name)| name.split_whitespace().next())
+            })
+            .collect();
+        assert_eq!(table_names.len(), 2, "{text}");
+        assert_eq!(table_names[0], table_names[1], "{text}");
+        assert!(
+            text.contains(&format!("values {} {{", table_names[0])),
+            "{text}"
         );
     }
 

--- a/rust/tcl-spec-studio/tests/render_sweep.rs
+++ b/rust/tcl-spec-studio/tests/render_sweep.rs
@@ -21,9 +21,10 @@
 //! The studio's promise is that a spec loaded out of the registry renders back
 //! to a file you can drop into `tcl-registry` — so the renderer has to survive
 //! the whole real command surface, not a handful of hand-picked examples. This
-//! sweep runs the renderer over every command in every dialect the studio
-//! offers (several thousand specs) and asserts the structural invariants a
-//! valid spec file has.
+//! sweep visits every command in every dialect the studio offers and asserts
+//! the structural invariants a valid spec file has. Profiles inherit the same
+//! immutable `CommandSpec` allocation, so that allocation is rendered once
+//! and its output is checked at every dialect/name position where it appears.
 //!
 //! ## Checking that the output actually compiles
 //!
@@ -44,7 +45,9 @@
 //! # …and revert both when done.
 //! ```
 
-use tcl_spec_studio::{browsable_dialects, command_names, draft, load_command, render_rs};
+use std::collections::HashMap;
+
+use tcl_spec_studio::{browsable_dialects, command_names, draft, environment, render_rs};
 
 /// Whether every delimiter in `source` is balanced, ignoring the contents of
 /// string literals and line comments (where a stray brace is legitimate prose).
@@ -94,16 +97,21 @@ fn delimiters_balanced(source: &str) -> bool {
 #[test]
 fn every_command_in_every_dialect_renders() {
     let mut rendered = 0usize;
+    let mut rendered_specs: HashMap<*const tcl_registry::CommandSpec, String> = HashMap::new();
     for (dialect, _) in browsable_dialects() {
+        let registry = environment::store_for_dialect(dialect);
         for name in command_names(dialect) {
-            let Some(value) = load_command(name, dialect) else {
+            let Some(spec) = registry.get(name) else {
                 panic!("{name} is listed in {dialect} but does not load");
             };
-            let draft = value
-                .as_object()
-                .unwrap_or_else(|| panic!("{name} did not load as an object"))
-                .clone();
-            let source = render_rs::render(&draft);
+            // Profiles share the same immutable `CommandSpec` allocation for an
+            // inherited command. The Rust renderer consumes that spec's draft;
+            // the Studio-only source-dialect marker is deliberately not Rust
+            // output, so render an allocation once and validate its output at
+            // every dialect/name position where it is browsable.
+            let source = rendered_specs
+                .entry(std::ptr::from_ref(spec))
+                .or_insert_with(|| render_rs::render(&draft::from_command_spec(spec)));
 
             assert!(
                 source.starts_with(render_rs::COPYRIGHT_BANNER),
@@ -126,7 +134,7 @@ fn every_command_in_every_dialect_renders() {
                 "{dialect}/{name}: the DEFAULT fill is missing, so unset fields would be dropped"
             );
             assert!(
-                delimiters_balanced(&source),
+                delimiters_balanced(source),
                 "{dialect}/{name}: unbalanced delimiters in the rendered source"
             );
             // A bitflags `|` chain is not const-evaluable inside the hoisted
@@ -142,6 +150,11 @@ fn every_command_in_every_dialect_renders() {
     assert!(
         rendered > 2000,
         "expected the full command surface, rendered only {rendered}"
+    );
+    assert!(
+        rendered_specs.len() > 2000,
+        "expected the full distinct spec surface, rendered only {} allocations",
+        rendered_specs.len()
     );
 }
 

--- a/rust/tcl-spec-studio/tests/spectcl_roundtrip.rs
+++ b/rust/tcl-spec-studio/tests/spectcl_roundtrip.rs
@@ -21,11 +21,12 @@
 //! [`render_spectcl`](tcl_spec_studio::render_spectcl) is the inverse of
 //! [`spectcl::evaluate_pack`](tcl_spec_studio::spectcl::evaluate_pack), so the honest
 //! test of it is the round trip, run over the *whole* command surface rather
-//! than a handful of examples: every command in every browsable dialect is
-//! drafted from the live registry, rendered to `SpecTcl`, loaded back, drafted
-//! again, and the two drafts are compared **field by field** — the same
-//! comparison `tests/spectcl_ports.rs` makes between a ported pack and the
-//! shipped spec it was ported from.
+//! than a handful of examples: every distinct immutable command spec is
+//! drafted from the live registries, rendered to `SpecTcl`, loaded back, and
+//! drafted again. The reloaded draft is then compared **field by field** at
+//! every browsable dialect/name position where that exact spec appears — the
+//! same comparison `tests/spectcl_ports.rs` makes between a ported pack and
+//! the shipped spec it was ported from.
 //!
 //! ## What "unequal" is allowed to mean
 //!
@@ -47,7 +48,7 @@
 //! so the eight function-pointer families round-trip *equal*, and the gate
 //! checks that they do rather than excusing them.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fmt::Write as _;
 
 use serde_json::Value;
@@ -261,8 +262,6 @@ struct Trip {
     notices: Vec<String>,
     /// The rendered pack.
     text: String,
-    /// Fields the renderer said up front it could not carry.
-    losses: Vec<render_spectcl::Loss>,
 }
 
 /// Render `shipped`, load the pack back, and report what happened.
@@ -276,7 +275,7 @@ fn round_trip(shipped: &Value) -> Trip {
         .and_then(Value::as_str)
         .unwrap_or("pack")
         .to_owned();
-    let (text, losses) = render_spectcl::render_pack_reporting(&[draft], &pack_name);
+    let text = render_spectcl::render_pack(&[draft], &pack_name);
     let pack = spectcl::evaluate_pack(&text);
     let name = shipped["name"].as_str().unwrap_or_default();
     // Naming a lowering or codegen hook is *reported* by design — "this
@@ -296,7 +295,6 @@ fn round_trip(shipped: &Value) -> Trip {
         reloaded,
         notices,
         text,
-        losses,
     }
 }
 
@@ -459,37 +457,116 @@ fn every_command_in_every_dialect_round_trips_through_spectcl() {
     let mut lossy: BTreeMap<String, (usize, String)> = BTreeMap::new();
     let mut noticed: BTreeMap<String, (usize, String)> = BTreeMap::new();
 
-    for (dialect, _) in browsable_dialects() {
+    let dialects: Vec<_> = browsable_dialects()
+        .map(|(dialect, _)| {
+            let names = command_names(dialect);
+            let registry = tcl_spec_studio::environment::store_for_dialect(dialect);
+            let specs: Vec<&'static tcl_registry::CommandSpec> = names
+                .iter()
+                .map(|name| {
+                    registry.get(name).unwrap_or_else(|| {
+                        panic!("{name} is listed in {dialect} but does not load")
+                    })
+                })
+                .collect();
+            (dialect, names, specs)
+        })
+        .collect();
+
+    // A command name can resolve to different immutable specs on different
+    // version/dialect surfaces, so those variants cannot share one pack. Put
+    // the first variant of every name in pack zero, the second in pack one,
+    // and so on. Every distinct spec is rendered and evaluated exactly once,
+    // while every dialect/name position below still compares its exact spec.
+    let mut variants: BTreeMap<&'static str, Vec<&'static tcl_registry::CommandSpec>> =
+        BTreeMap::new();
+    for (_, _, specs) in &dialects {
+        for &spec in specs {
+            let same_name = variants.entry(spec.name).or_default();
+            if !same_name.iter().any(|other| std::ptr::eq(*other, spec)) {
+                same_name.push(spec);
+            }
+        }
+    }
+    let pack_count = variants.values().map(Vec::len).max().unwrap_or_default();
+    let mut groups = vec![Vec::new(); pack_count];
+    for same_name in variants.values() {
+        for (index, &spec) in same_name.iter().enumerate() {
+            groups[index].push(spec);
+        }
+    }
+
+    // spec allocation → (source draft, reloaded draft, losses, fixture text)
+    let mut trips: HashMap<
+        *const tcl_registry::CommandSpec,
+        (Value, Value, Vec<render_spectcl::Loss>, usize),
+    > = HashMap::new();
+    let mut fixture_texts = Vec::with_capacity(groups.len());
+    for (index, specs) in groups.into_iter().enumerate() {
+        let drafts: Vec<draft::Draft> = specs
+            .iter()
+            .map(|spec| draft::from_command_spec(spec))
+            .collect();
+        let (text, command_losses) = render_spectcl::render_pack_reporting_by_command(
+            &drafts,
+            &format!("round-trip-{index}"),
+        );
+        let losses: BTreeMap<&str, &[render_spectcl::Loss]> = command_losses
+            .iter()
+            .map(|report| (report.command.as_str(), report.losses.as_slice()))
+            .collect();
+        let pack = spectcl::evaluate_pack(&text);
+        for notice in pack
+            .notices
+            .iter()
+            .filter(|notice| !is_policy_report(&notice.message))
+        {
+            let notice = notice.to_string();
+            let entry = noticed
+                .entry(notice_shape(&notice))
+                .or_insert_with(|| (0, format!("fixture {index}: {notice}")));
+            entry.0 += 1;
+        }
+        for (spec, draft) in specs.into_iter().zip(drafts) {
+            let reloaded = pack.command(spec.name).map_or(Value::Null, |command| {
+                Value::Object(draft::from_command_spec(command.spec))
+            });
+            trips.insert(
+                std::ptr::from_ref(spec),
+                (
+                    Value::Object(draft),
+                    reloaded,
+                    losses.get(spec.name).copied().unwrap_or_default().to_vec(),
+                    index,
+                ),
+            );
+        }
+        fixture_texts.push(text);
+    }
+
+    for (dialect, names, specs) in dialects {
         let mut dialect_total = 0usize;
         let mut dialect_clean = 0usize;
-        for name in command_names(dialect) {
-            let shipped = load_command(name, dialect)
-                .unwrap_or_else(|| panic!("{name} is listed in {dialect} but does not load"));
-            let trip = round_trip(&shipped);
+        for (name, spec) in names.into_iter().zip(specs) {
+            let (shipped, reloaded, losses, fixture_index) = trips
+                .get(&std::ptr::from_ref(spec))
+                .unwrap_or_else(|| panic!("{dialect}/{name}: spec was not round-tripped"));
+            let text = &fixture_texts[*fixture_index];
             total += 1;
             dialect_total += 1;
 
             assert!(
-                !trip.reloaded.is_null(),
-                "{dialect}/{name}: the rendered pack does not declare the command:\n{}",
-                trip.text
+                !reloaded.is_null(),
+                "{dialect}/{name}: the rendered pack does not declare the command:\n{text}"
             );
 
-            for notice in &trip.notices {
-                let entry = noticed
-                    .entry(notice_shape(notice))
-                    .or_insert_with(|| (0, format!("{dialect}/{name}: {notice}")));
-                entry.0 += 1;
-            }
-
-            let found = diffs(&trip.reloaded, &shipped);
+            let found = diffs(reloaded, shipped);
             if found.is_empty() {
                 clean += 1;
                 dialect_clean += 1;
                 continue;
             }
-            let reported: BTreeSet<&str> =
-                trip.losses.iter().map(|loss| loss.key.as_str()).collect();
+            let reported: BTreeSet<&str> = losses.iter().map(|loss| loss.key.as_str()).collect();
             for diff in &found {
                 let field = field_of(&diff.key);
                 // Three ways a difference is legitimate: the field is in the
@@ -505,8 +582,8 @@ fn every_command_in_every_dialect_round_trips_through_spectcl() {
                     })
                     .or_else(|| {
                         (field == "arg_roles"
-                            && at_level(&diff.key, &trip.reloaded)
-                                .zip(at_level(&diff.key, &shipped))
+                            && at_level(&diff.key, reloaded)
+                                .zip(at_level(&diff.key, shipped))
                                 .is_some_and(|(a, b)| only_implied_command_prefix_roles(a, b)))
                         .then(|| "arg_roles (implied by -appends)".to_owned())
                     });
@@ -538,6 +615,12 @@ fn every_command_in_every_dialect_round_trips_through_spectcl() {
     let _ = writeln!(
         report,
         "\n     total: {clean} / {total} commands round-trip with no difference at all"
+    );
+    let _ = writeln!(
+        report,
+        "     distinct specs rendered and evaluated once: {} in {} conflict-free packs",
+        trips.len(),
+        fixture_texts.len()
     );
     let _ = writeln!(report, "\nDocumented losses, by field:");
     for (key, (count, example)) in &lossy {


### PR DESCRIPTION
## Summary

- render each shared immutable `CommandSpec` allocation once while still checking its Rust output at every browsable dialect/name position
- batch all 3,734 distinct SpecTcl command specs into three conflict-free packs, so every exact spec variant is rendered and evaluated once without duplicate command names
- retain per-command renderer-loss attribution for batched packs, including losses from a hoisted value table shared by multiple top-level or nested commands
- preserve all 46,722 dialect/command comparisons, structural assertions, notice rejection, documented-loss accounting, and surface floors

## Root cause

The exhaustive gates repeated identical immutable specs across 19 inherited dialect surfaces. The Rust sweep rebuilt and rendered the same allocation many times, while the SpecTcl gate also started a separate pack evaluator for every dialect/command occurrence.

## Experimental proof

Warm exact tests on the same worktree and machine:

- `render_sweep`: 20.41s before, 2.66s after — 17.75s / 87.0% faster
- `spectcl_roundtrip`: 46.12s before, 8.03s after — 38.09s / 82.6% faster
- round-trip result remains exactly 44,283 clean out of 46,722 dialect/command comparisons, with the same per-field documented-loss counts and zero loader notices
- 3,734 distinct immutable specs are rendered/evaluated in three conflict-free packs; every dialect/name position resolves back to its exact spec allocation
- nested subcommand/object-method coverage proves a shared table is emitted once and its loss remains attributed to the owning top-level command
- full `cargo nextest run -p tcl-spec-studio`: 281/281 passed in 8.66s on current `rust`
- `make rust-check` passed
- `make prep-pr` passed with 30/30 smoke tests

No command, dialect, assertion, notice check, or loss comparison is sampled or moved out of CI.

Closes #1839
