### PR TITLE
feat(spec-studio): packs as the browser's top level

### DIFF
--- a/docs/design/compiler/command-registry.md
+++ b/docs/design/compiler/command-registry.md
@@ -1381,6 +1381,25 @@ Because each profile's registry is built once and cached, there is no
 invalidation protocol to observe — a consumer holds an immutable registry
 for the dialect it asked about.
 
+### Authoring pack -- where a spec is written down
+
+A shipped spec also knows which `commands/<id>/` module declares it.
+`SPEC_PACKS` (`commands/mod.rs`) is the table of the thirteen authoring
+modules, with a label and blurb each, and
+`spec_pack_of(&'static CommandSpec)` (`registry.rs`) names the one that
+declares a resolved spec. This is provenance, not availability: `SpecSurface`
+says where a command is *reachable from*, a pack says where its spec is
+*written down*, and the two disagree whenever a dialect surfaces a spec it
+did not author — iRules' `open` is `commands/tcl/`'s. The lookup takes the
+spec rather than its name because seventeen names are declared in more than
+one pack and each dialect registers one of them; `spec_packs_of(name)` is
+the by-name question, for a caller that means it. `tmsh` is not a row (its
+specs are a filtered view of `commands/iapps/`), and neither are the EDA
+libraries: a `.tclspec`'s provenance is the file, which the loader reports,
+so `spec_pack_of` answers `None` for any pack-loaded spec. The reasoning,
+and the studio's use of it, is in
+[`command-spec-studio.md`](../contracts/command-spec-studio.md#the-browser-is-a-stack-of-packs).
+
 ### How registry feeds the compiler
 
 | Stage | Registry fields used |
@@ -1600,10 +1619,13 @@ is what that looks like from the outside.
   `CommandSpec` ending in `..CommandSpec::DEFAULT`, then declare it (`mod
   foo_;`) and list `foo_::spec(),` in the pack's `<pack>_command_specs()`
   collector.  For a new dialect pack, add its collector to
-  `CommandRegistry::load_dialect`.  An EDA/vendor *library* is not a Rust
-  module: add or edit its `.tclspec` under `specs/` instead — those packs are
-  the source of truth for their commands and there is no generator to re-run
-  (see [`../spec-packs.md`](../spec-packs.md)).
+  `CommandRegistry::load_dialect`, a `SPEC_PACKS` row in `commands/mod.rs`,
+  and an `authored_groups` entry in `registry.rs` —
+  `tests/spec_pack_provenance.rs` fails by command name until both exist.
+  An EDA/vendor *library* is not a Rust module: add or edit its `.tclspec`
+  under `specs/` instead — those packs are the source of truth for their
+  commands and there is no generator to re-run (see
+  [`../spec-packs.md`](../spec-packs.md)).
 - To add taint tracking: set `taint_source` / `taint_transform` / the
   `taint_*_sink*` fields on the spec, and the `TAINT_SOURCE` / `TAINT_SINK`
   trait bits that go with them.

--- a/docs/design/contracts/command-spec-studio.md
+++ b/docs/design/contracts/command-spec-studio.md
@@ -1,10 +1,10 @@
 # Contract: the command-registry spec studio
 
 The spec studio is a browser front-end over `tcl-registry`: it browses the
-live command surface, edits every field of a `CommandSpec`, and renders the
-result back to a registry `.rs` module or a Tcl dialect stub. This document
-describes the contract between its four layers and the invariants that keep it
-from drifting away from the registry it edits.
+live command surface pack by pack, edits every field of a `CommandSpec`, and
+renders the result back to a registry `.rs` module or a Tcl dialect stub.
+This document describes the contract between its layers and the invariants
+that keep it from drifting away from the registry it edits.
 
 Related: [`command-registry.md`](../compiler/command-registry.md) (the field
 reference), [`dialect-stubs.md`](dialect-stubs.md) (the stub language),
@@ -14,6 +14,7 @@ reference), [`dialect-stubs.md`](dialect-stubs.md) (the stub language),
 
 | Layer | Crate / path | Role |
 |---|---|---|
+| Provenance | `rust/tcl-registry` (`commands/mod.rs`, `registry.rs`) | `SPEC_PACKS`, the table of `commands/<id>/` authoring modules, and `spec_pack_of`, which of them declares a resolved spec. The registry's, not the studio's: the studio reads it through `command_index` and `pack_catalogue`. |
 | Schema + renderers | `rust/tcl-spec-studio` | One table describing every spec field; the draft model; the `.rs` and stub renderers; package inference. No browser, no WASM. |
 | WASM facade | `rust/tcl-spec-studio-wasm` | `wasm-bindgen` cdylib. Every export takes and returns a JSON string. Excluded from the workspace (the glue needs `unsafe`). |
 | Front-end | `rust/tcl-spec-studio/web` | Strict TypeScript, bundled by esbuild into two files: the controller (an IIFE, inlined into the page) and the editor chunk (an ES module, loaded on demand). Generates its form from the schema; knows no field names. |
@@ -206,6 +207,69 @@ over a plain enum has a `covered` witness in the test module: an exhaustive
 comment naming the catalogue to update alongside. `AppendedArity` and
 `BodyKind` are `#[non_exhaustive]`, so their witnesses need a wildcard and
 cannot compile-gate; that limitation is stated at each one.
+
+## The browser is a stack of packs
+
+A dialect's command surface is not one list. It is `commands/tcl/` plus
+whatever layers on it, and that is the shape a spec author works in: the
+`.rs` renderer emits a path into one of those directories, and "which pack
+does this belong in" is the first question an author has, not the last. So
+the registry names **provenance**. `SPEC_PACKS`
+(`rust/tcl-registry/src/commands/mod.rs`) is the table of the thirteen
+`commands/<id>/` authoring modules, each with the label and blurb a browser
+uses for it, and `spec_pack_of` (`registry.rs`) says which of them declares a
+spec.
+
+**Provenance is not availability.** `SpecSurface` already says where a
+command is *reachable from*; a pack says where its spec is *written down*.
+The two answer different questions and legitimately disagree — `open` is
+surfaced by core Tcl and by iRules but authored once, in `tcl`; `wm` is
+surfaced by the `Tk` package and authored in `tk`. A browser grouped by
+surface would send the author to a directory that does not hold the file.
+
+**Keyed by spec identity, not by name.** Seventeen names are declared in two
+or three packs — `close` in `tcl`, `expect` and `irules`; `send` in `tk`,
+`expect` and `irules` — and each dialect registers exactly one of them. A
+by-name table could only pick a fixed winner, and would file the iRules
+`close` under `tcl` while browsing iRules. `spec_pack_of` therefore takes the
+very `&'static CommandSpec` the registry handed back, indexed by address over
+the same leaked `shared_group!` slices the registry inserts, so it cannot
+disagree with the registry. `spec_packs_of(name)` is the by-name question
+asked on purpose: it backs the "also declared in" note, where the question
+really is about the name.
+
+Two things are deliberately not rows in `SPEC_PACKS`:
+
+| Absent | Why |
+|---|---|
+| `tmsh` | The tmsh shell's specs are a filtered view of the same `commands/iapps/` sources, so their provenance is `iapps` — the directory an author would open. A consumer that wants the tmsh *surface* is asking `SpecSurface`'s question, and asks it there. |
+| The EDA vendor libraries | They ship as bundled `.tclspec` loadables under `specs/` and reach a registry through `tcl_spectcl::bundled`, so their provenance is the pack *file*, which the loader reports. `spec_pack_of` answers `None` for any pack-loaded spec — a bundled library, a workspace pack, the document under the author's cursor — rather than guessing. |
+
+`command_index` carries `pack` and `also_in` per command, and
+`pack_catalogue(dialect)` lists only the packs that reach the dialect, with a
+command count each, so the Tcl 8.4 picker never offers an empty **F5 iRules**
+heading. Both come through the wasm facade.
+
+### What the browser shows
+
+`web/src/packs.ts` holds the decisions — grouping, filtering, what the
+headers and the count line say — as pure functions of what the wasm module
+reports; `studio.ts` paints them.
+
+| Behaviour | Rule |
+|---|---|
+| Sections | One collapsible section per pack, in catalogue order. The pack under edit is the first section, not a differently-shaped panel beside the list: it is a pack that happens to be editable. Behind each shipped section's **?**: the blurb and the repository path. |
+| Open state | Shut, except the section holding the open command; a filter opens every section it leaves something in; a dialect with one pack has no navigation to do. A section the row cap left empty stays shut — open and empty reads as a bug, not as "narrow the filter". |
+| Remembered | A person's expand and collapse of the shipped sections rides the IndexedDB session record, across dialect switches and reloads. It is recorded from the summary's click, not the `toggle` event, so a section the studio opened for them is not mistaken for a preference. |
+| Filtering | Only packs with a match are shown; each header carries `N of M`; the count line says what is being viewed — `187 Tcl 9.0 commands in 4 packs`, `12 of 187 Tcl 9.0 commands, in 3 packs` — instead of a bare number. |
+| Chips | A command's pack is a chip wherever the heading is not already saying it — the command palette, the editor's source line — and a name several packs declare says so: `close is also declared in expect, irules.` |
+| Unfiled | A command whose pack the catalogue does not describe is filed under a bare heading rather than dropped: an unknown dialect has an empty catalogue, and a browser showing nothing would be worse. |
+
+Gate: `rust/tcl-registry/tests/spec_pack_provenance.rs` proves every command
+in every browsable dialect resolves to a pack that is a real `commands/<id>/`
+directory, and that the iRules `close` files under `irules` while Tcl 9.0's
+files under `tcl`. The studio's own tests prove the catalogue's counts sum to
+the index, so no command can fall between sections.
 
 ## The draft model
 

--- a/docs/kcs/features/kcs-feature-spec-studio.md
+++ b/docs/kcs/features/kcs-feature-spec-studio.md
@@ -30,14 +30,33 @@ rendering, and importing files: browsers block the editor and the language
 server on `file://` URLs, so the page falls back to its plain text editor and
 says so. Serve the directory to get the full editor.
 
-1. **Pick a dialect** at the top left. The command list underneath is that
-   dialect's real registry, so Tcl 8.4 shows what Tcl 8.4 has.
-2. **Choose a command** to load its live specification into the form, or press
-   **New command** to start from scratch. If you already know the name, type it
-   into the box and press **Load** (or Enter) — the box also offers the
-   matching names as you type. An ambiguous or unknown name is reported rather
-   than guessed at, since loading the wrong command silently is worse than
-   saying nothing matched.
+1. **Pick a dialect** at the top left. The registry browser underneath is
+   that dialect's real command surface, so Tcl 8.4 shows what Tcl 8.4 has. It
+   is grouped by **pack** — the directory each command's specification is
+   written in: Tcl core first, then the libraries that layer on it (the
+   standard library, Tcllib, Tk, …), then the vendor and authoring surfaces.
+   Only the packs the dialect actually reaches are listed, and the count line
+   above says what you are looking at: `187 Tcl 9.0 commands in 4 packs`. A
+   pack you are building yourself is the first section, not a separate panel.
+2. **Open a pack and choose a command** to load its live specification into
+   the form, or press **New command** to start from scratch. Sections start
+   closed except the one holding the command you have open; a section you
+   open or close yourself stays that way across dialect switches and reloads,
+   as part of live save. Each section's **?** says what the pack holds and
+   where it lives in the repository, which is the directory a rendered `.rs`
+   file goes into. Typing in the filter box narrows the browser to the packs
+   with a match — each header reads `12 of 96`, and the count line becomes
+   `12 of 187 Tcl 9.0 commands, in 3 packs`. If you already know the name,
+   type it into the same box and press **Load** (or Enter); the box also
+   offers the matching names as you type. An ambiguous or unknown name is
+   reported rather than guessed at, since loading the wrong command silently
+   is worse than saying nothing matched.
+
+   A few names are specified in more than one pack — `close` is one
+   specification in Tcl core, another in Expect, a third in iRules — and the
+   dialect decides which one you get. The line above the form names that pack
+   as a chip and says which other packs declare the name, so you are editing
+   the one you meant.
 3. **Edit any field.** The form is grouped — Identity, Availability, Arity and
    arguments, Types, and so on. A field that differs from the default is
    marked **set**, and each group heading counts how many of its fields are
@@ -56,10 +75,10 @@ says so. Serve the directory to get the full editor.
 
 The studio is usable on a phone, not merely reachable from one. Below 34rem
 every toolbar control takes the full width, the tab strip scrolls sideways
-instead of stacking, and touch targets meet the 44px minimum. The command list
-sits below the editor rather than beside it — which is why typing a name and
-pressing **Load** matters there: the list is off-screen, so filtering alone
-would look like nothing had happened.
+instead of stacking, and touch targets meet the 44px minimum. The registry
+browser sits below the editor rather than beside it — which is why typing a
+name and pressing **Load** matters there: the browser is off-screen, so
+filtering alone would look like nothing had happened.
 
 ![The spec studio on a phone, with a command loaded by name](../../screenshots/spec-studio-mobile.png)
 
@@ -157,8 +176,9 @@ Beside the form, `.rs` module, and stub, the **Pack DSL** tab holds the
 [SpecTcl pack](../../design/spec-packs.md)'s `.tclspec` source directly —
 the studio's one authoritative document for a pack you are building.
 Edit a field in the form and the DSL text updates; edit the text and the
-form, the command list, and the collision report all follow. Open an
-existing `.tclspec` with **Open a .tclspec…**, or start one from scratch
+form, the pack's section of the browser, and the collision report all
+follow. Open an existing `.tclspec` with **Open a .tclspec…**, or start one
+from scratch
 and **Download** or **Add to files** when you are done. **Re-render
 canonically** rebuilds the whole document from its commands — useful
 after a lot of form editing, at the cost of your own comments and layout.

--- a/rust/tcl-registry/src/commands/mod.rs
+++ b/rust/tcl-registry/src/commands/mod.rs
@@ -37,3 +37,137 @@ pub mod tcl;
 pub mod tcllib;
 pub mod ticklecharts;
 pub mod tk;
+
+use crate::CommandSpec;
+
+/// One **authoring pack**: the `commands/<id>/` module a group of shipped
+/// specs is declared in, with the words a registry browser uses to name it.
+///
+/// This is provenance, not availability.
+/// [`SpecSurface`](tcl_dialect::model::SpecSurface) already says *where a
+/// command is reachable from*; a pack says *where its spec is written down*.
+/// The two answer different questions and legitimately disagree: `open` is
+/// surfaced by core Tcl **and** by iRules, but it is authored once, in the
+/// `tcl` pack; `wm` is surfaced by the `Tk` package and authored in `tk`.
+/// Provenance is what a spec author navigates by, and it is the directory
+/// the studio's `.rs` renderer emits a path into
+/// (`rust/tcl-registry/src/commands/<id>/<stem>.rs`).
+///
+/// The EDA vendor libraries are deliberately absent. They ship as bundled
+/// `.tclspec` loadables under `specs/` and reach a registry through
+/// `tcl_spectcl::bundled`, so their provenance is the pack *file*, which the
+/// loader reports — see [`spec-packs.md`](../../../../docs/design/spec-packs.md).
+#[derive(Debug, Clone, Copy)]
+pub struct SpecPack {
+    /// The module directory name, and the id every surface keys on.
+    pub id: &'static str,
+    /// Author-facing name.
+    pub label: &'static str,
+    /// One line saying what the pack holds.
+    pub blurb: &'static str,
+    /// The specs the module declares.
+    ///
+    /// Held as the builder rather than a slice because a pack's specs are
+    /// built lazily and leaked once, by the registry's own `shared_group!`
+    /// cells; calling this directly builds a fresh `Vec` and is for callers
+    /// that want one (the provenance index does not — see
+    /// [`crate::registry::spec_pack_of`]).
+    pub specs: fn() -> Vec<CommandSpec>,
+}
+
+/// Every authoring pack, in the order a browser lists them: the core
+/// language, then the libraries that layer on it, then the vendor surfaces
+/// and the authoring DSLs.
+///
+/// `tmsh` is **not** a row. The tmsh shell's commands are a filtered view of
+/// the same `commands/iapps/` sources (`tmsh_command_specs`), so their
+/// provenance is `iapps`; a surface that wants the tmsh *surface* asks
+/// `SpecSurface`, which is the question it is actually asking.
+pub const SPEC_PACKS: &[SpecPack] = &[
+    SpecPack {
+        id: "tcl",
+        label: "Tcl core",
+        blurb: "The core interpreter's own commands, across the 8.4-9.1 ladder.",
+        specs: tcl::tcl_command_specs,
+    },
+    SpecPack {
+        id: "stdlib",
+        label: "Tcl standard library",
+        blurb: "The packages shipped with Tcl itself: http, msgcat, platform, registry.",
+        specs: stdlib::stdlib_command_specs,
+    },
+    SpecPack {
+        id: "tcllib",
+        label: "Tcllib",
+        blurb: "The Tcllib collection: base64, cmdline, csv, json, md5, struct and the rest.",
+        specs: tcllib::tcllib_command_specs,
+    },
+    SpecPack {
+        id: "argparse",
+        label: "argparse",
+        blurb: "The argparse option-parsing package.",
+        specs: argparse::argparse_command_specs,
+    },
+    SpecPack {
+        id: "ticklecharts",
+        label: "ticklecharts",
+        blurb: "The ticklecharts ECharts binding.",
+        specs: ticklecharts::ticklecharts_command_specs,
+    },
+    SpecPack {
+        id: "itcl",
+        label: "[incr Tcl]",
+        blurb: "The itcl class system's declaration and instance commands.",
+        specs: itcl::itcl_command_specs,
+    },
+    SpecPack {
+        id: "tk",
+        label: "Tk",
+        blurb: "Tk's widgets, geometry managers, and window-system commands.",
+        specs: tk::tk_command_specs,
+    },
+    SpecPack {
+        id: "expect",
+        label: "Expect",
+        blurb: "The Expect extension's spawn / expect / interact surface.",
+        specs: expect::expect_command_specs,
+    },
+    SpecPack {
+        id: "bpf",
+        label: "BPF-Tcl",
+        blurb: "The BPF-Tcl packet-filter dialect.",
+        specs: bpf::bpf_command_specs,
+    },
+    SpecPack {
+        id: "irules",
+        label: "F5 iRules",
+        blurb: "The F5 BIG-IP iRules events and namespace commands.",
+        specs: irules::irules_command_specs,
+    },
+    SpecPack {
+        id: "iapps",
+        label: "F5 iApps & tmsh",
+        blurb: "The iApps templating surface and the tmsh:: commands it shares with the shell.",
+        specs: iapps::iapps_command_specs,
+    },
+    SpecPack {
+        id: "spectcl",
+        label: "SpecTcl",
+        blurb: "The .tclspec authoring DSL's own declaration words.",
+        specs: spectcl::spectcl_command_specs,
+    },
+    SpecPack {
+        id: "sslictcl",
+        label: "SslicTcl",
+        blurb: "The .sslictcl TLS-assurance authoring DSL's declaration words.",
+        specs: sslictcl::sslictcl_command_specs,
+    },
+];
+
+impl SpecPack {
+    /// The pack with this id.
+    #[must_use]
+    pub fn by_id(id: &str) -> Option<&'static Self> {
+        SPEC_PACKS.iter().find(|pack| pack.id == id)
+    }
+}

--- a/rust/tcl-registry/src/registry.rs
+++ b/rust/tcl-registry/src/registry.rs
@@ -801,6 +801,99 @@ shared_group!(
     crate::commands::sslictcl::sslictcl_command_specs
 );
 
+/// Which authoring pack declares each shipped command, built once from the
+/// same leaked `shared_group!` slices the registry inserts.
+///
+/// Keyed **by spec identity**, not by name. Seventeen names are declared in
+/// two or three packs — `close` in `tcl`, `expect` and `irules`; `send` in
+/// `tk`, `expect` and `irules` — and each dialect registers exactly one of
+/// them. Asking by name could only answer with a fixed winner and would file
+/// the iRules `close` under `tcl` in the iRules dialect; asking with the very
+/// `&'static CommandSpec` the registry handed back cannot be wrong.
+fn spec_pack_by_identity() -> &'static FxHashMap<usize, &'static str> {
+    static INDEX: OnceLock<FxHashMap<usize, &'static str>> = OnceLock::new();
+    INDEX.get_or_init(|| {
+        let mut index = FxHashMap::default();
+        for (pack, specs) in authored_groups() {
+            for spec in specs {
+                index.insert(std::ptr::from_ref(spec) as usize, pack);
+            }
+        }
+        index
+    })
+}
+
+/// Which packs declare each name, in [`SPEC_PACKS`](crate::commands::SPEC_PACKS)
+/// order. Backs the "also declared in" answer, where the question really is
+/// about the name rather than about one resolved spec.
+fn spec_packs_by_name() -> &'static FxHashMap<&'static str, Vec<&'static str>> {
+    static INDEX: OnceLock<FxHashMap<&'static str, Vec<&'static str>>> = OnceLock::new();
+    INDEX.get_or_init(|| {
+        let mut index: FxHashMap<&'static str, Vec<&'static str>> = FxHashMap::default();
+        for (pack, specs) in authored_groups() {
+            for spec in specs {
+                // The same bare-normalisation `all_dialect_command_names`
+                // applies, for the same reason: a caller strips a literal
+                // `::` head before asking.
+                let name = spec.name.strip_prefix("::").unwrap_or(spec.name);
+                let packs = index.entry(name).or_default();
+                if !packs.contains(&pack) {
+                    packs.push(pack);
+                }
+            }
+        }
+        index
+    })
+}
+
+/// Every authored group paired with the pack directory it lives in.
+///
+/// `tmsh_specs` is a filtered view of the same `commands/iapps/` sources, so
+/// it reports `iapps` — the directory a spec author would open.
+fn authored_groups() -> [(&'static str, &'static [CommandSpec]); 14] {
+    [
+        ("tcl", tcl_specs()),
+        ("stdlib", stdlib_specs()),
+        ("tcllib", tcllib_specs()),
+        ("argparse", argparse_specs()),
+        ("ticklecharts", ticklecharts_specs()),
+        ("itcl", itcl_specs()),
+        ("tk", tk_specs()),
+        ("expect", expect_specs()),
+        ("bpf", bpf_specs()),
+        ("irules", irules_specs()),
+        ("iapps", iapps_specs()),
+        ("iapps", tmsh_specs()),
+        ("spectcl", spectcl_specs()),
+        ("sslictcl", sslictcl_specs()),
+    ]
+}
+
+/// The `commands/<pack>/` module that declares `spec`.
+///
+/// `None` for a spec that reached the registry from a `.tclspec` pack — the
+/// bundled EDA libraries, a workspace pack, the document under a spec
+/// author's cursor. Provenance for those is the pack file, which the loader
+/// reports; this deliberately does not guess one.
+#[must_use]
+pub fn spec_pack_of(spec: &'static CommandSpec) -> Option<&'static str> {
+    spec_pack_by_identity()
+        .get(&(std::ptr::from_ref(spec) as usize))
+        .copied()
+}
+
+/// Every authoring pack that declares `name`, in browser order.
+///
+/// Nearly always one, and empty for a pack-loaded name. More than one means
+/// a vendor or DSL surface re-declares the name with its own facts, and a
+/// browser can say so instead of silently filing it under one of them.
+#[must_use]
+pub fn spec_packs_of(name: &str) -> &'static [&'static str] {
+    spec_packs_by_name()
+        .get(name.strip_prefix("::").unwrap_or(name))
+        .map_or(&[][..], |packs| packs.as_slice())
+}
+
 impl CommandRegistry {
     /// Build the default registry with core Tcl + stdlib + tcllib commands.
     #[must_use]

--- a/rust/tcl-registry/tests/spec_pack_provenance.rs
+++ b/rust/tcl-registry/tests/spec_pack_provenance.rs
@@ -1,0 +1,125 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Every shipped spec knows which `commands/<pack>/` module declares it.
+//!
+//! Provenance is what a spec author navigates by, so a command with no pack
+//! is a command the studio's pack browser would drop on the floor.
+
+use tcl_dialect::DialectProfile;
+use tcl_registry::commands::SPEC_PACKS;
+use tcl_registry::registry::{spec_pack_of, spec_packs_of};
+
+/// A pack id is the directory name, so it has to be a legal one — and the
+/// table may not list the same directory twice.
+#[test]
+fn pack_ids_are_unique_directory_names() {
+    let mut seen = Vec::new();
+    for pack in SPEC_PACKS {
+        assert!(
+            !seen.contains(&pack.id),
+            "{} is listed twice in SPEC_PACKS",
+            pack.id
+        );
+        assert!(
+            pack.id
+                .chars()
+                .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_'),
+            "{} is not a directory name",
+            pack.id
+        );
+        assert!(!pack.label.is_empty(), "{} has no label", pack.id);
+        assert!(
+            pack.blurb.len() > 20,
+            "{}'s blurb is too short to say anything",
+            pack.id
+        );
+        seen.push(pack.id);
+    }
+}
+
+/// The directory a pack names really exists, so the studio's rendered path
+/// points somewhere a contributor can put the file.
+#[test]
+fn every_pack_names_a_real_module_directory() {
+    let root = concat!(env!("CARGO_MANIFEST_DIR"), "/src/commands");
+    for pack in SPEC_PACKS {
+        let dir = std::path::Path::new(root).join(pack.id);
+        assert!(
+            dir.is_dir(),
+            "SPEC_PACKS names {}, but {} is not a directory",
+            pack.id,
+            dir.display()
+        );
+    }
+}
+
+/// The load-bearing one: in every dialect the studio browses, every command
+/// resolves to a pack, and that pack is one of the declared rows.
+#[test]
+fn every_shipped_command_in_every_dialect_has_a_pack() {
+    let ids: Vec<&str> = SPEC_PACKS.iter().map(|pack| pack.id).collect();
+    for profile in DialectProfile::all() {
+        let registry = tcl_registry::model::static_context_for(profile.name).commands();
+        for name in registry.command_names() {
+            let Some(spec) = registry.get(name) else {
+                continue;
+            };
+            let pack = spec_pack_of(spec).unwrap_or_else(|| {
+                panic!(
+                    "{name} has no authoring pack in the {} dialect",
+                    profile.name
+                )
+            });
+            assert!(
+                ids.contains(&pack),
+                "{name} claims pack {pack}, which is not in SPEC_PACKS"
+            );
+        }
+    }
+}
+
+/// A dialect that re-declares a core command is filed under the pack whose
+/// spec it actually registered, not under a fixed by-name winner.
+#[test]
+fn a_redeclared_command_is_filed_where_the_dialect_registered_it() {
+    let tcl = tcl_registry::model::static_context_for("tcl9.0").commands();
+    let irules = tcl_registry::model::static_context_for("f5-irules").commands();
+
+    let core_close = tcl.get("close").expect("Tcl 9.0 has close");
+    let irules_close = irules.get("close").expect("iRules has close");
+    assert_eq!(spec_pack_of(core_close), Some("tcl"));
+    assert_eq!(spec_pack_of(irules_close), Some("irules"));
+
+    // Both declarations are still reported for the name itself.
+    let packs = spec_packs_of("close");
+    assert!(
+        packs.contains(&"tcl"),
+        "close is declared in tcl: {packs:?}"
+    );
+    assert!(
+        packs.contains(&"irules"),
+        "close is declared in irules: {packs:?}"
+    );
+}
+
+/// A name no shipped pack declares has no provenance to report.
+#[test]
+fn a_pack_loaded_name_has_no_authoring_pack() {
+    assert!(spec_packs_of("definitely::not::a::command").is_empty());
+}

--- a/rust/tcl-spec-studio-wasm/src/lib.rs
+++ b/rust/tcl-spec-studio-wasm/src/lib.rs
@@ -88,6 +88,14 @@ pub fn command_index(dialect: &str) -> String {
     to_string(&tcl_spec_studio::command_index(dialect))
 }
 
+/// The authoring packs `dialect` browses, with a command count each — the
+/// studio's top-level navigation.
+#[wasm_bindgen]
+#[must_use]
+pub fn pack_catalogue(dialect: &str) -> String {
+    to_string(&tcl_spec_studio::pack_catalogue(dialect))
+}
+
 /// A draft seeded from the live registry's spec for `name` under `dialect`.
 #[wasm_bindgen]
 #[must_use]

--- a/rust/tcl-spec-studio/src/lib.rs
+++ b/rust/tcl-spec-studio/src/lib.rs
@@ -142,6 +142,17 @@ pub fn command_index(dialect: &str) -> Value {
                 "subcommands": spec.subcommands.len(),
                 "options": spec.options.len(),
                 "deprecated": spec.deprecated_replacement.is_some(),
+                // Provenance: the `commands/<pack>/` module this very spec is
+                // declared in. Asked with the resolved spec, not the name, so
+                // a dialect that re-declares a core command is filed under the
+                // declaration it actually registered.
+                "pack": tcl_registry::registry::spec_pack_of(spec),
+                // The other packs that declare the same name, when there are
+                // any — `close` is authored in `tcl`, `expect` and `irules`.
+                "also_in": tcl_registry::registry::spec_packs_of(name)
+                    .iter()
+                    .filter(|id| Some(**id) != tcl_registry::registry::spec_pack_of(spec))
+                    .collect::<Vec<_>>(),
             }))
         })
         .collect();
@@ -157,6 +168,41 @@ pub fn load_command(name: &str, dialect: &str) -> Option<Value> {
     let mut d = draft::from_command_spec(spec);
     d.insert(draft::SOURCE_DIALECT_KEY.to_owned(), json!(dialect));
     Some(Value::Object(d))
+}
+
+/// The authoring packs `dialect` actually browses, with the commands each
+/// contributes — the studio's top-level navigation.
+///
+/// Only packs that reach this dialect are listed, so the Tcl 8.4 picker does
+/// not offer an empty **F5 iRules** heading. Ordering is
+/// [`SPEC_PACKS`](tcl_registry::commands::SPEC_PACKS)': core language, then
+/// the libraries that layer on it, then the vendor and authoring surfaces.
+#[must_use]
+pub fn pack_catalogue(dialect: &str) -> Value {
+    let registry = environment::store_for_dialect(dialect);
+    let mut counts: std::collections::HashMap<&'static str, usize> =
+        std::collections::HashMap::new();
+    for name in registry.command_names() {
+        if let Some(spec) = registry.get(name)
+            && let Some(pack) = tcl_registry::registry::spec_pack_of(spec)
+        {
+            *counts.entry(pack).or_default() += 1;
+        }
+    }
+    let packs: Vec<Value> = tcl_registry::commands::SPEC_PACKS
+        .iter()
+        .filter_map(|pack| {
+            let commands = counts.get(pack.id).copied()?;
+            Some(json!({
+                "id": pack.id,
+                "label": pack.label,
+                "blurb": pack.blurb,
+                "commands": commands,
+                "path": format!("rust/tcl-registry/src/commands/{}", pack.id),
+            }))
+        })
+        .collect();
+    json!({ "dialect": dialect, "packs": packs })
 }
 
 /// The dialect list the studio's picker shows.
@@ -201,6 +247,61 @@ mod tests {
         }
         assert_eq!(loaded["name"], json!("lappend"));
         assert_eq!(loaded[draft::SOURCE_DIALECT_KEY], json!("tcl9.0"));
+    }
+
+    #[test]
+    fn every_indexed_command_names_the_pack_that_declares_it() {
+        for dialect in ["tcl9.0", "f5-irules", "spectcl"] {
+            let index = command_index(dialect);
+            for entry in index["commands"].as_array().expect("commands array") {
+                assert!(
+                    entry["pack"].is_string(),
+                    "{} has no pack in {dialect}",
+                    entry["name"]
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn the_pack_catalogue_covers_every_indexed_command() {
+        for dialect in ["tcl8.4", "tcl9.0", "f5-irules"] {
+            let catalogue = pack_catalogue(dialect);
+            let packs = catalogue["packs"].as_array().expect("packs array");
+            assert!(!packs.is_empty(), "{dialect} browses no packs");
+            let total: usize = packs
+                .iter()
+                .map(|p| {
+                    assert!(
+                        p["commands"].as_u64().unwrap_or(0) > 0,
+                        "{dialect} lists an empty pack {}",
+                        p["id"]
+                    );
+                    usize::try_from(p["commands"].as_u64().unwrap_or(0)).unwrap_or(0)
+                })
+                .sum();
+            let indexed = command_index(dialect)["commands"]
+                .as_array()
+                .expect("commands array")
+                .len();
+            assert_eq!(total, indexed, "{dialect} pack counts miss commands");
+        }
+    }
+
+    /// iRules declares its own `close`, so browsing iRules files it under
+    /// `irules` while Tcl 9.0 still files the core one under `tcl`.
+    #[test]
+    fn a_redeclared_command_follows_the_dialect_that_registered_it() {
+        let pack_of = |dialect: &str, name: &str| {
+            command_index(dialect)["commands"]
+                .as_array()
+                .expect("commands array")
+                .iter()
+                .find(|entry| entry["name"] == name)
+                .map(|entry| entry["pack"].as_str().unwrap_or("").to_owned())
+        };
+        assert_eq!(pack_of("tcl9.0", "close").as_deref(), Some("tcl"));
+        assert_eq!(pack_of("f5-irules", "close").as_deref(), Some("irules"));
     }
 
     #[test]

--- a/rust/tcl-spec-studio/web/src/idb.ts
+++ b/rust/tcl-spec-studio/web/src/idb.ts
@@ -41,6 +41,13 @@ export interface Session {
   dialect: string;
   /** The Test tab's sample code — as much a part of the work as the pack. */
   sample?: string;
+  /**
+   * The registry browser's opened pack sections.
+   *
+   * Absent in a record written before packs were the browser's top level,
+   * which restores as "nothing opened" rather than as a failure to restore.
+   */
+  expanded?: string[];
 }
 
 const DB_NAME = "tcl-spec-studio";
@@ -131,6 +138,9 @@ export async function load(): Promise<Session | null> {
         open: typeof row.open === "string" ? row.open : null,
         dialect: typeof row.dialect === "string" ? row.dialect : "tcl9.0",
         sample: typeof row.sample === "string" ? row.sample : undefined,
+        expanded: Array.isArray(row.expanded)
+          ? row.expanded.filter((id): id is string => typeof id === "string")
+          : undefined,
       });
     };
     request.onerror = () => resolve(null);

--- a/rust/tcl-spec-studio/web/src/packs.ts
+++ b/rust/tcl-spec-studio/web/src/packs.ts
@@ -1,0 +1,152 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Packs as the browser's top level: which authoring pack declares a command,
+// and how a dialect's commands divide between them.
+//
+// A dialect is not a flat thousand names — it is `commands/tcl/` plus
+// `commands/tk/` plus whatever else reaches it, and that is the shape a spec
+// author works in. Everything here is a pure function of what the wasm module
+// reports, so the DOM half stays a rendering of a decision made here.
+
+import type { IndexEntry, PackRow } from "./types.js";
+
+/** The heading commands with no declared pack are filed under. */
+export const UNFILED_LABEL = "Other commands";
+
+/** One section of the registry browser. */
+export interface PackSection {
+  pack: PackRow;
+  /** Every command this dialect gets from the pack, alphabetical. */
+  commands: IndexEntry[];
+  /** Those the filter admits — all of them when there is no filter. */
+  matches: IndexEntry[];
+}
+
+/** Group an index by the pack that declares each command, names ascending. */
+export function groupByPack(index: IndexEntry[]): Map<string, IndexEntry[]> {
+  const byPack = new Map<string, IndexEntry[]>();
+  for (const entry of index) {
+    const list = byPack.get(entry.pack) ?? [];
+    list.push(entry);
+    byPack.set(entry.pack, list);
+  }
+  // Code-unit order, which is what the Rust index is already sorted in; doing
+  // it again keeps this a function of its argument alone.
+  for (const list of byPack.values()) list.sort((a, b) => (a.name < b.name ? -1 : 1));
+  return byPack;
+}
+
+/** Look a pack up by id, for the chips that name one. */
+export function packIndex(catalogue: PackRow[]): Map<string, PackRow> {
+  return new Map(catalogue.map((pack) => [pack.id, pack]));
+}
+
+/**
+ * Whether `entry` survives `query`, which the caller has already trimmed and
+ * lower-cased. An empty query admits everything.
+ */
+export function matchesQuery(entry: IndexEntry, query: string): boolean {
+  return (
+    !query ||
+    entry.name.toLowerCase().includes(query) ||
+    (entry.summary ?? "").toLowerCase().includes(query)
+  );
+}
+
+/**
+ * A pack the catalogue does not describe but the index puts commands in.
+ *
+ * Defensive rather than theoretical: an unknown dialect has an empty
+ * catalogue, and a browser that showed nothing at all would be worse than one
+ * that shows the commands under a bare heading.
+ */
+function fallbackPack(id: string, commands: number): PackRow {
+  return { id, label: id || UNFILED_LABEL, blurb: "", commands, path: "" };
+}
+
+/**
+ * The browser's sections, over a [`groupByPack`] grouping: the catalogue's
+ * packs in its own order, then any pack only the index knows about.
+ *
+ * With a filter active, only packs with a match are returned — an author
+ * looking for `grid` should not have to read past eleven empty headings.
+ */
+export function packSections(
+  catalogue: PackRow[],
+  byPack: Map<string, IndexEntry[]>,
+  query: string,
+): PackSection[] {
+  const sections: PackSection[] = [];
+  const listed = new Set<string>();
+  const section = (pack: PackRow, commands: IndexEntry[]): PackSection => ({
+    pack,
+    commands,
+    matches: commands.filter((entry) => matchesQuery(entry, query)),
+  });
+
+  for (const pack of catalogue) {
+    const commands = byPack.get(pack.id);
+    if (!commands?.length) continue;
+    listed.add(pack.id);
+    sections.push(section(pack, commands));
+  }
+  for (const id of [...byPack.keys()].filter((id) => !listed.has(id)).sort()) {
+    const commands = byPack.get(id) ?? [];
+    sections.push(section(fallbackPack(id, commands.length), commands));
+  }
+
+  return query ? sections.filter((entry) => entry.matches.length > 0) : sections;
+}
+
+function plural(count: number, noun: string): string {
+  return `${count} ${noun}${count === 1 ? "" : "s"}`;
+}
+
+/** One pack header's count: its size, or its share of a filtered result. */
+export function packCountLabel(matched: number, total: number): string {
+  return matched === total ? plural(total, "command") : `${matched} of ${total}`;
+}
+
+/**
+ * The line above the browser: what is being viewed, in which dialect, and —
+ * once a filter narrows it — across how many packs.
+ */
+export function browserCountLine(
+  dialect: string,
+  total: number,
+  shown: number,
+  packs: number,
+): string {
+  if (!total) return `no commands in ${dialect}`;
+  const commands = total === 1 ? "command" : "commands";
+  if (shown === total) return `${total} ${dialect} ${commands} in ${plural(packs, "pack")}`;
+  if (!shown) return `no match in ${total} ${dialect} ${commands}`;
+  return `${shown} of ${total} ${dialect} ${commands}, in ${plural(packs, "pack")}`;
+}
+
+/**
+ * What to say when the same command name is authored in more than one pack.
+ *
+ * Real information for a spec author: `close` is three different specs, and
+ * which one an editor uses is the dialect's choice, not the name's.
+ */
+export function alsoInSentence(name: string, alsoIn: string[]): string {
+  const others = alsoIn.filter((id) => id);
+  return others.length ? `${name} is also declared in ${others.join(", ")}.` : "";
+}

--- a/rust/tcl-spec-studio/web/src/studio.css
+++ b/rust/tcl-spec-studio/web/src/studio.css
@@ -301,22 +301,38 @@ input[type=file] { display: none; }
 .found .hdr .nm { font-family: var(--mono); font-weight: 600; }
 .found .hdr button { margin-left: auto; }
 
-/* The pack panel — the library under edit, always visible above the registry.
-   Its list is capped and scrolls on its own so a forty-command pack cannot
-   push the registry browser off the bottom of the sidebar. */
-.packpanel { padding-bottom: .6rem; margin-bottom: .5rem; border-bottom: 1px solid var(--border); }
-.packpanel .packname { font-family: var(--mono); font-weight: 400; font-size: .8rem; color: var(--accent); }
-.packpanel .packmeta { color: var(--muted); font-size: .78rem; margin-top: .25rem; overflow-wrap: anywhere; }
-.packpanel .packmeta[hidden] { display: none; }
-.packlist { max-height: 15rem; flex: 0 0 auto; }
+/* The registry browser is a stack of packs: yours, pinned at the top and the
+   only editable one, then the dialect's shipped packs in catalogue order. Both
+   are the same kind of thing — a `.group` section whose body is a `.cmdlist` —
+   so the only difference an author sees is the one that is real. */
+.packs { overflow-y: auto; flex: 1 1 auto; min-height: 0; }
+.browser > .group { flex: 0 0 auto; margin-bottom: .5rem; }
+.packsection > summary { font-size: .86rem; padding: .45rem .55rem; }
+.packsection > .body { padding: 0 .35rem .45rem; }
+.packsection .packblurb { font-size: .78rem; margin: .1rem .25rem .35rem; }
+.packsection .packblurb code { display: inline-block; margin-left: .35rem; font-size: .72rem; }
+/* Yours is the one section here that can be edited; the accent border says so
+   without turning it into a different kind of thing. */
+.packsection.mine { border-color: color-mix(in srgb, var(--accent) 45%, var(--border)); }
+.packsection .packname { font-family: var(--mono); font-weight: 400; font-size: .8rem; color: var(--accent); }
+.packsection .packmeta { color: var(--muted); font-size: .78rem; margin: .2rem .25rem; overflow-wrap: anywhere; }
+.packsection .packmeta[hidden] { display: none; }
+.packs .more { color: var(--muted); font-size: .78rem; padding: .45rem .3rem; }
+/* Capped and scrolling on its own so a forty-command pack cannot push the
+   shipped packs off the bottom of the sidebar. */
+.packlist { max-height: 15rem; }
 .packlist .state { display: flex; gap: .3rem; flex-wrap: wrap; margin-top: .15rem; }
-.packlist .tag {
+/* The pill that names a pack or a command's state, wherever one is named. */
+.packlist .tag, .palette .tag, #editorSource .tag {
   font-size: .66rem; line-height: 1.5; border: 1px solid var(--border); border-radius: 999px;
   padding: 0 .35rem; color: var(--muted); white-space: nowrap;
 }
 .packlist .tag.warn { border-color: var(--warn-bd); color: var(--warn-fg); }
 .packlist .tag.live { border-color: var(--accent); color: var(--accent); }
 .packlist .empty { color: var(--muted); font-size: .78rem; display: block; padding: .45rem .3rem; }
+/* The command in the form: which pack ships the name, and who else declares it. */
+#editorSource .tag.pack { font-family: var(--mono); }
+#editorSource .alsoin { display: block; margin-top: .25rem; }
 /* Name-and-state on the left, "remove from pack" on the right, one row. */
 .packlist li.packrow { display: flex; align-items: flex-start; }
 .packlist li.packrow > button:first-child { flex: 1 1 auto; min-width: 0; }
@@ -398,6 +414,8 @@ pre.testview { white-space: pre-wrap; overflow-wrap: anywhere; margin-bottom: 1r
 .palette .sm { color: var(--muted); font-size: .78rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .palette .where { margin-left: auto; font-size: .7rem; color: var(--muted); border: 1px solid var(--border);
   border-radius: 999px; padding: 0 .4rem; white-space: nowrap; }
+.palette .tag.pack { margin-left: auto; font-family: var(--mono); }
+.palette .tag.pack + .where { margin-left: .3rem; }
 .palette .foot { color: var(--muted); font-size: .76rem; padding: .45rem 1rem; border-top: 1px solid var(--border); }
 .navbtns { display: flex; gap: .2rem; }
 .navbtns button { padding: .3rem .55rem; }

--- a/rust/tcl-spec-studio/web/src/studio.ts
+++ b/rust/tcl-spec-studio/web/src/studio.ts
@@ -40,6 +40,15 @@ import { asRecord, asString, makeEditors, STRUCTURAL_KINDS, type Editor } from "
 import type { EditorHost, MonacoHostModule } from "./editorHost.js";
 import * as idb from "./idb.js";
 import { initReleasesPanel } from "./importReleases.js";
+import {
+  alsoInSentence,
+  browserCountLine,
+  groupByPack,
+  packCountLabel,
+  packIndex,
+  packSections,
+  type PackSection,
+} from "./packs.js";
 import type {
   CommandIndex,
   CodeExample,
@@ -51,7 +60,9 @@ import type {
   IndexEntry,
   InferredCommand,
   Json,
+  PackCatalogue,
   PackCommandView,
+  PackRow,
   PackStoreView,
   PackWrite,
   Rendered,
@@ -150,6 +161,20 @@ interface State {
   defaultSubcommand: Draft;
   dialect: string;
   index: IndexEntry[];
+  /** The dialect's authoring packs, in the order the browser shows them. */
+  packs: PackRow[];
+  /** The same packs by id, for the chips that name one. */
+  packById: Map<string, PackRow>;
+  /** `state.index` divided between those packs — the browser's own shape. */
+  byPack: Map<string, IndexEntry[]>;
+  /**
+   * Which shipped pack sections the author has opened.
+   *
+   * Kept across dialect switches and reloads: a spec author works in one or
+   * two packs for an afternoon, and re-opening `commands/tk/` on every visit
+   * is a tax on that.
+   */
+  expandedPacks: Set<string>;
   draft: Draft | null;
   files: StagedFile[];
   imported: InferredCommand[];
@@ -407,45 +432,126 @@ function buildField(
 
 /* Registry browser ------------------------------------------------------ */
 
+// Packs are the top level here, not a flat alphabet. A dialect is
+// `commands/tcl/` plus whatever layers on it, and an author browsing for
+// somewhere to put a command is looking for the pack first. The decisions —
+// what is in which pack, what a filter leaves, what the headers say — live in
+// `packs.ts`; this half only paints them.
+
+/** One command row, the same markup the browser has always used. */
+function commandRow(entry: IndexEntry, current: string | null): HTMLElement {
+  const name = el("span", { class: "nm", text: entry.name });
+  if (entry.subcommands || entry.options) {
+    const badge = [
+      entry.subcommands ? `${entry.subcommands} sub` : null,
+      entry.options ? `${entry.options} opt` : null,
+    ]
+      .filter(Boolean)
+      .join(" · ");
+    name.appendChild(el("span", { class: "badge", text: ` ${badge}` }));
+  }
+  const button = el(
+    "button",
+    {
+      type: "button",
+      "aria-current": current === entry.name ? "true" : "false",
+      onclick: () => openCommand(entry.name),
+    },
+    [name, el("span", { class: "sm", text: entry.summary || entry.synopsis || "" })],
+  );
+  return el("li", {}, [button]);
+}
+
+/** A chip naming the pack a command is declared in. */
+function packChip(id: string): HTMLElement {
+  const pack = state.packById.get(id);
+  return el("span", {
+    class: "tag pack",
+    text: id,
+    title: pack ? `${pack.label} — ${pack.path}` : `declared in ${id}`,
+  });
+}
+
+/** Record a section's open state, which outlives both filter and dialect. */
+function setPackExpanded(id: string, open: boolean): void {
+  if (open) state.expandedPacks.add(id);
+  else state.expandedPacks.delete(id);
+  scheduleSave();
+}
+
+/**
+ * One pack's section of the browser.
+ *
+ * `rows` is what the cap left room for, which can be fewer than the section
+ * matched; the header always reports the real numbers.
+ */
+function packSectionNode(
+  section: PackSection,
+  rows: IndexEntry[],
+  open: boolean,
+  current: string | null,
+): HTMLElement {
+  const { pack } = section;
+  const summary = el("summary", {}, [
+    document.createTextNode(pack.label),
+    el("span", {
+      class: "n",
+      text: packCountLabel(section.matches.length, section.commands.length),
+    }),
+  ]);
+  const body = el("div", { class: "body" });
+  if (pack.blurb || pack.path) {
+    const blurb = el("div", { class: "helptext packblurb" }, [
+      pack.blurb ? el("span", { text: pack.blurb }) : null,
+      pack.path ? el("code", { text: pack.path }) : null,
+    ]);
+    summary.appendChild(helpButton(blurb, `the ${pack.label} pack`));
+    body.appendChild(blurb);
+  }
+  const list = el("ul", { class: "cmdlist" });
+  for (const entry of rows) list.appendChild(commandRow(entry, current));
+  body.appendChild(list);
+
+  const details = el("details", { class: "group packsection" }, [summary, body]);
+  if (open) details.setAttribute("open", "");
+  // Read from the click rather than the `toggle` event: only a person clicking
+  // (or pressing Enter on) the summary is a preference worth remembering, and
+  // the state has not flipped yet when this runs.
+  summary.addEventListener("click", () => setPackExpanded(pack.id, !details.open));
+  return details;
+}
+
 function renderList(): void {
   const query = byId<HTMLInputElement>("filter").value.trim().toLowerCase();
-  const list = byId("cmdlist");
-  clear(list);
+  const browser = byId("cmdlist");
+  clear(browser);
 
-  const matches = state.index.filter(
-    (entry) =>
-      !query ||
-      entry.name.toLowerCase().includes(query) ||
-      (entry.summary ?? "").toLowerCase().includes(query),
+  const sections = packSections(state.packs, state.byPack, query);
+  const shown = sections.reduce((total, section) => total + section.matches.length, 0);
+  byId("count").textContent = browserCountLine(
+    dialectLabel(state.dialect),
+    state.index.length,
+    shown,
+    sections.length,
   );
 
-  byId("count").textContent =
-    matches.length === state.index.length
-      ? `${state.index.length} commands`
-      : `${matches.length} of ${state.index.length} commands`;
-
   const current = typeof state.draft?.name === "string" ? state.draft.name : null;
-  for (const entry of matches.slice(0, MAX_LISTED)) {
-    const name = el("span", { class: "nm", text: entry.name });
-    if (entry.subcommands || entry.options) {
-      const badge = [
-        entry.subcommands ? `${entry.subcommands} sub` : null,
-        entry.options ? `${entry.options} opt` : null,
-      ]
-        .filter(Boolean)
-        .join(" · ");
-      name.appendChild(el("span", { class: "badge", text: ` ${badge}` }));
-    }
-    const button = el(
-      "button",
-      {
-        type: "button",
-        "aria-current": current === entry.name ? "true" : "false",
-        onclick: () => openCommand(entry.name),
-      },
-      [name, el("span", { class: "sm", text: entry.summary || entry.synopsis || "" })],
-    );
-    list.appendChild(el("li", {}, [button]));
+  let room = MAX_LISTED;
+  for (const section of sections) {
+    const rows = section.matches.slice(0, room);
+    room -= rows.length;
+    // A filter has already thrown away the packs with nothing in them, so what
+    // survives it is worth opening; so is the pack holding the open command,
+    // and a dialect with one pack has no navigation to do. A section the cap
+    // left no rows for stays shut whatever else is true — an open, empty
+    // section reads as a bug rather than as "narrow the filter".
+    const open =
+      rows.length > 0 &&
+      (Boolean(query) ||
+        sections.length === 1 ||
+        state.expandedPacks.has(section.pack.id) ||
+        section.commands.some((entry) => entry.name === current));
+    browser.appendChild(packSectionNode(section, rows, open, current));
   }
 
   // Feed the native autocomplete. The list itself matches summaries too, but
@@ -464,15 +570,12 @@ function renderList(): void {
     }
   }
 
-  if (matches.length > MAX_LISTED) {
-    list.appendChild(
-      el("li", {}, [
-        el("span", {
-          class: "sm",
-          style: "display:block;padding:.5rem .3rem",
-          text: `…and ${matches.length - MAX_LISTED} more — narrow the filter`,
-        }),
-      ]),
+  if (shown > MAX_LISTED) {
+    browser.appendChild(
+      el("div", {
+        class: "more",
+        text: `…and ${shown - MAX_LISTED} more — narrow the filter`,
+      }),
     );
   }
 }
@@ -691,9 +794,19 @@ function renderPackList(): void {
   byId("packCount").textContent = rows.length
     ? `${rows.length} command${rows.length === 1 ? "" : "s"}` +
       (view && view.summary.notices ? ` · ${view.summary.notices} notice(s)` : "")
-    : "empty — add a command, or open a .tclspec on the Pack DSL tab";
+    : "empty";
 
-  if (!rows.length) return;
+  if (!rows.length) {
+    list.appendChild(
+      el("li", {}, [
+        el("span", {
+          class: "empty",
+          text: "add a command, or open a .tclspec on the Pack DSL tab",
+        }),
+      ]),
+    );
+    return;
+  }
 
   for (const row of rows) {
     const name = el("span", { class: "nm", text: row.name });
@@ -816,6 +929,7 @@ function scheduleSave(): void {
       open: state.pack.open,
       dialect: state.dialect,
       sample: state.sample,
+      expanded: [...state.expandedPacks],
     });
   }, SAVE_MS);
 }
@@ -843,7 +957,7 @@ function loadDraft(draft: Draft, origin: string, packCommand: string | null = nu
   state.draft = draft;
   state.pack.open = packCommand;
   formDirty = false;
-  byId("editorSource").textContent = origin;
+  renderEditorSource(origin, typeof draft.name === "string" ? draft.name : null);
 
   renderUnrenderableWarning(draft);
 
@@ -853,6 +967,23 @@ function loadDraft(draft: Draft, origin: string, packCommand: string | null = nu
   renderList();
   renderPackList();
   onDraftChanged();
+}
+
+/**
+ * The sentence above the form, plus the provenance the sentence leaves out:
+ * which pack ships this name, and — the thing a spec author cannot guess —
+ * which other packs declare it too.
+ */
+function renderEditorSource(origin: string, name: string | null): void {
+  const node = byId("editorSource");
+  clear(node);
+  node.appendChild(document.createTextNode(origin));
+  const entry = name ? state.index.find((candidate) => candidate.name === name) : undefined;
+  if (!entry) return;
+  node.appendChild(document.createTextNode(" "));
+  node.appendChild(packChip(entry.pack));
+  const also = alsoInSentence(entry.name, entry.also_in ?? []);
+  if (also) node.appendChild(el("span", { class: "alsoin", text: ` ${also}` }));
 }
 
 /**
@@ -1617,7 +1748,7 @@ function renderPalette(): void {
   const query = byId<HTMLInputElement>("paletteInput").value.trim().toLowerCase();
   const packRows = (state.pack.view?.commands ?? [])
     .filter((c) => !query || c.name.toLowerCase().includes(query))
-    .map((c) => ({ name: c.name, where: "pack" as const, summary: c.summary }));
+    .map((c) => ({ name: c.name, where: "pack" as const, summary: c.summary, pack: "" }));
   const registryRows = state.index
     .filter(
       (e) =>
@@ -1625,7 +1756,7 @@ function renderPalette(): void {
         e.name.toLowerCase().includes(query) ||
         (e.summary ?? "").toLowerCase().includes(query),
     )
-    .map((e) => ({ name: e.name, where: "registry" as const, summary: e.summary }));
+    .map((e) => ({ name: e.name, where: "registry" as const, summary: e.summary, pack: e.pack }));
   const rows = [...packRows, ...registryRows].slice(0, MAX_PALETTE);
   paletteRows = rows.map((r) => ({ name: r.name, where: r.where }));
   paletteAt = Math.min(paletteAt, Math.max(0, rows.length - 1));
@@ -1645,6 +1776,9 @@ function renderPalette(): void {
           [
             el("span", { class: "nm", text: row.name }),
             el("span", { class: "sm", text: row.summary || "" }),
+            // A palette row is out of the browser's context, so it says where
+            // the command is declared as well as which model it came from.
+            row.pack ? packChip(row.pack) : null,
             el("span", {
               class: "where",
               text: row.where === "pack" ? "pack" : dialectLabel(state.dialect),
@@ -2057,7 +2191,7 @@ function bindUi(): void {
 
   byId<HTMLSelectElement>("dialect").addEventListener("change", () => {
     state.dialect = byId<HTMLSelectElement>("dialect").value;
-    loadIndex();
+    loadDialect();
     // The dialect decides what a pack collides with, so the merged world has
     // to be recomputed too.
     setPackSource(state.pack.source);
@@ -2231,9 +2365,19 @@ function bindUi(): void {
   });
 }
 
-function loadIndex(): void {
+/**
+ * Read the dialect's command index and its pack catalogue together.
+ *
+ * The two are one fact seen twice — which commands there are, and which packs
+ * declare them — so nothing may hold one without the other.
+ */
+function loadDialect(): void {
   const index = JSON.parse(wasm.command_index(state.dialect)) as CommandIndex;
   state.index = index.commands ?? [];
+  const catalogue = JSON.parse(wasm.pack_catalogue(state.dialect)) as PackCatalogue;
+  state.packs = catalogue.packs ?? [];
+  state.packById = packIndex(state.packs);
+  state.byPack = groupByPack(state.index);
   renderList();
 }
 
@@ -2257,12 +2401,16 @@ async function restoreSession(): Promise<void> {
     byId("liveSave").textContent = "Live save is on: every edit is kept in this browser.";
     return;
   }
+  if (session.expanded) {
+    state.expandedPacks = new Set(session.expanded);
+    renderList();
+  }
   // A session saved before a dialect left the catalogue keeps the default
   // rather than restoring a picker value that no longer exists.
   if (session.dialect && session.dialect !== state.dialect && dialectLabels.has(session.dialect)) {
     state.dialect = session.dialect;
     byId<HTMLSelectElement>("dialect").value = session.dialect;
-    loadIndex();
+    loadDialect();
   }
   setPackSource(session.source);
   if (typeof session.sample === "string") {
@@ -2297,6 +2445,10 @@ function boot(): void {
         defaultSubcommand: JSON.parse(wasm.new_subcommand()) as Draft,
         dialect: "spectcl",
         index: [],
+        packs: [],
+        packById: new Map(),
+        byPack: new Map(),
+        expandedPacks: new Set(),
         draft: null,
         files: [],
         imported: [],
@@ -2335,7 +2487,7 @@ function boot(): void {
       picker.value = state.dialect;
 
       bindUi();
-      loadIndex();
+      loadDialect();
       renderFiles();
       buildReference();
       byId<HTMLTextAreaElement>("testText").value = state.sample;

--- a/rust/tcl-spec-studio/web/src/studio.ts
+++ b/rust/tcl-spec-studio/web/src/studio.ts
@@ -176,6 +176,13 @@ interface State {
    */
   expandedPacks: Set<string>;
   draft: Draft | null;
+  /**
+   * The sentence above the form, kept so the provenance beside it can be
+   * redrawn without reloading the draft — a dialect switch can change which
+   * pack wins a name (`close` is `tcl`'s in Tcl 9.0 and `irules`' in iRules)
+   * without changing the draft at all.
+   */
+  editorOrigin: string;
   files: StagedFile[];
   imported: InferredCommand[];
   pack: PackState;
@@ -957,7 +964,8 @@ function loadDraft(draft: Draft, origin: string, packCommand: string | null = nu
   state.draft = draft;
   state.pack.open = packCommand;
   formDirty = false;
-  renderEditorSource(origin, typeof draft.name === "string" ? draft.name : null);
+  state.editorOrigin = origin;
+  renderEditorSource();
 
   renderUnrenderableWarning(draft);
 
@@ -974,10 +982,11 @@ function loadDraft(draft: Draft, origin: string, packCommand: string | null = nu
  * which pack ships this name, and — the thing a spec author cannot guess —
  * which other packs declare it too.
  */
-function renderEditorSource(origin: string, name: string | null): void {
+function renderEditorSource(): void {
   const node = byId("editorSource");
   clear(node);
-  node.appendChild(document.createTextNode(origin));
+  node.appendChild(document.createTextNode(state.editorOrigin));
+  const name = typeof state.draft?.name === "string" ? state.draft.name : null;
   const entry = name ? state.index.find((candidate) => candidate.name === name) : undefined;
   if (!entry) return;
   node.appendChild(document.createTextNode(" "));
@@ -2379,6 +2388,9 @@ function loadDialect(): void {
   state.packById = packIndex(state.packs);
   state.byPack = groupByPack(state.index);
   renderList();
+  // Which pack wins a name is the dialect's choice, so the chip beside the
+  // open command is stale the moment the picker moves.
+  renderEditorSource();
 }
 
 /**
@@ -2450,6 +2462,7 @@ function boot(): void {
         byPack: new Map(),
         expandedPacks: new Set(),
         draft: null,
+        editorOrigin: "Pick a command on the left, or start a new one.",
         files: [],
         imported: [],
         pack: { source: "", view: null, open: null },

--- a/rust/tcl-spec-studio/web/src/types.ts
+++ b/rust/tcl-spec-studio/web/src/types.ts
@@ -133,11 +133,35 @@ export interface IndexEntry {
   subcommands: number;
   options: number;
   deprecated: boolean;
+  /** The `commands/<pack>/` module this very spec is declared in. */
+  pack: string;
+  /** The other packs declaring the same name — `close` is tcl, expect, irules. */
+  also_in: string[];
 }
 
 export interface CommandIndex {
   dialect: string;
   commands: IndexEntry[];
+}
+
+/** One authoring pack, from `pack_catalogue`. */
+export interface PackRow {
+  id: string;
+  label: string;
+  blurb: string;
+  /** How many of this dialect's commands the pack contributes. */
+  commands: number;
+  /** Where the pack lives in the repository, for an author who wants to look. */
+  path: string;
+}
+
+/**
+ * The packs a dialect browses, in the order the studio shows them: the core
+ * language, then what layers on it, then the vendor and authoring surfaces.
+ */
+export interface PackCatalogue {
+  dialect: string;
+  packs: PackRow[];
 }
 
 /** A dialect the studio can browse. */
@@ -420,6 +444,7 @@ export interface StudioWasm {
   schema(): string;
   dialects(): string;
   command_index(dialect: string): string;
+  pack_catalogue(dialect: string): string;
   load_command(name: string, dialect: string): string;
   new_command(): string;
   new_subcommand(): string;

--- a/rust/tcl-spec-studio/web/studio.html
+++ b/rust/tcl-spec-studio/web/studio.html
@@ -64,22 +64,32 @@ __STYLES__
 
     <div class="split">
       <div class="card browser" id="browser">
-        <!-- The pack under edit, always visible: defining a library is constant
-             motion between its own commands, not a trip back through a search
-             box. Every row is one click from any other. -->
-        <div class="packpanel" id="packPanel">
-          <label class="fld">Pack <code class="packname" id="packName">—</code></label>
-          <div class="packmeta" id="packMeta" hidden></div>
-          <div class="count" id="packCount">—</div>
-          <ul class="cmdlist packlist" id="packlist"></ul>
-          <div class="packactions">
-            <button type="button" class="ghost" id="packAdd" title="Copy the command in the editor into the pack">+ Add to pack</button>
-            <button type="button" class="ghost" id="packNew" title="Start an empty pack">New pack</button>
+        <!-- The browser is a stack of packs. Yours comes first — the one pack
+             here that is editable — and the dialect's shipped packs follow in
+             `commands/`'s own order, because "which pack does this belong in"
+             is the first question a spec author has, not the last.
+
+             The pack under edit is always visible: defining a library is
+             constant motion between its own commands, not a trip back through
+             a search box. Every row is one click from any other. -->
+        <details class="group packsection mine" id="packPanel" open>
+          <summary>
+            Pack <code class="packname" id="packName">—</code>
+            <span class="n" id="packCount">—</span>
+          </summary>
+          <div class="body">
+            <div class="packmeta" id="packMeta" hidden></div>
+            <ul class="cmdlist packlist" id="packlist"></ul>
+            <div class="packactions">
+              <button type="button" class="ghost" id="packAdd" title="Copy the command in the editor into the pack">+ Add to pack</button>
+              <button type="button" class="ghost" id="packNew" title="Start an empty pack">New pack</button>
+            </div>
           </div>
-        </div>
+        </details>
         <label class="fld">Registry</label>
         <div class="count" id="count">—</div>
-        <ul class="cmdlist" id="cmdlist"></ul>
+        <!-- One collapsible section per shipped pack, filled by renderList(). -->
+        <div class="packs" id="cmdlist"></div>
       </div>
 
       <div>

--- a/rust/tcl-spec-studio/web/test/units.test.ts
+++ b/rust/tcl-spec-studio/web/test/units.test.ts
@@ -49,7 +49,16 @@ import {
   versionFromFileName,
   type Release,
 } from "../src/releases.js";
+import {
+  alsoInSentence,
+  browserCountLine,
+  groupByPack,
+  packCountLabel,
+  packIndex,
+  packSections,
+} from "../src/packs.js";
 import { mapSelectionThroughFormat } from "../src/textSelection.js";
+import type { IndexEntry, PackRow } from "../src/types.js";
 
 describe("mapSelectionThroughFormat", () => {
   it("keeps a caret after its text when formatting inserts indentation", () => {
@@ -404,5 +413,170 @@ describe("lifecycleOf", () => {
       retired: null,
       deprecated: null,
     });
+  });
+});
+
+/* The registry browser's pack navigator -------------------------------- */
+
+/** One row of the command index, with only the fields the browser reads set. */
+function entry(name: string, pack: string, summary = "", alsoIn: string[] = []): IndexEntry {
+  return {
+    name,
+    summary,
+    synopsis: "",
+    subcommands: 0,
+    options: 0,
+    deprecated: false,
+    pack,
+    also_in: alsoIn,
+  };
+}
+
+/** One catalogue row; only the id and the counts change between them. */
+function pack(id: string, commands: number): PackRow {
+  return {
+    id,
+    label: id.toUpperCase(),
+    blurb: `the ${id} pack`,
+    commands,
+    path: `rust/tcl-registry/src/commands/${id}`,
+  };
+}
+
+describe("groupByPack", () => {
+  it("files each command under the pack that declares it, names ascending", () => {
+    const grouped = groupByPack([
+      entry("lsort", "tcl"),
+      entry("grid", "tk"),
+      entry("append", "tcl"),
+      entry("bind", "tk"),
+    ]);
+    assert.deepEqual(
+      [...grouped.keys()],
+      ["tcl", "tk"],
+      "a pack appears where its first command does",
+    );
+    assert.deepEqual(
+      grouped.get("tcl")?.map((e) => e.name),
+      ["append", "lsort"],
+    );
+    assert.deepEqual(
+      grouped.get("tk")?.map((e) => e.name),
+      ["bind", "grid"],
+    );
+  });
+
+  it("has no pack at all for an empty index", () => {
+    assert.equal(groupByPack([]).size, 0);
+  });
+});
+
+describe("packSections", () => {
+  const index = [
+    entry("append", "tcl"),
+    entry("lsort", "tcl", "sort a list"),
+    entry("grid", "tk", "the grid geometry manager"),
+    entry("spawn", "expect"),
+  ];
+  const catalogue = [pack("tcl", 2), pack("tk", 1), pack("expect", 1), pack("itcl", 0)];
+
+  it("keeps the catalogue's order and drops the packs this dialect never reaches", () => {
+    const sections = packSections(catalogue, groupByPack(index), "");
+    assert.deepEqual(
+      sections.map((s) => s.pack.id),
+      ["tcl", "tk", "expect"],
+    );
+    assert.deepEqual(
+      sections.map((s) => s.matches.length),
+      [2, 1, 1],
+      "an empty filter matches everything",
+    );
+  });
+
+  it("keeps only the packs a filter leaves something in", () => {
+    const sections = packSections(catalogue, groupByPack(index), "sort");
+    assert.deepEqual(
+      sections.map((s) => s.pack.id),
+      ["tcl"],
+    );
+    assert.deepEqual(
+      sections[0].matches.map((e) => e.name),
+      ["lsort"],
+      "a summary match counts as much as a name match",
+    );
+    assert.equal(sections[0].commands.length, 2, "the section still knows its real size");
+  });
+
+  it("still browses a dialect the catalogue does not describe", () => {
+    // An unknown dialect has an empty pack list; showing nothing would be
+    // worse than showing the commands under a bare heading.
+    const sections = packSections([], groupByPack(index), "");
+    assert.deepEqual(
+      sections.map((s) => s.pack.id),
+      ["expect", "tcl", "tk"],
+    );
+    assert.equal(sections[0].pack.blurb, "", "an invented pack claims no documentation");
+  });
+
+  it("files a command with no declared pack rather than losing it", () => {
+    const sections = packSections(
+      [pack("tcl", 1)],
+      groupByPack([entry("append", "tcl"), entry("mystery", "")]),
+      "",
+    );
+    assert.deepEqual(
+      sections.map((s) => s.pack.label),
+      ["TCL", "Other commands"],
+    );
+  });
+});
+
+describe("packIndex", () => {
+  it("answers a chip's question: what is this pack id called, and where is it", () => {
+    const byId = packIndex([pack("tcl", 2), pack("tk", 1)]);
+    assert.equal(byId.get("tk")?.path, "rust/tcl-registry/src/commands/tk");
+    assert.equal(byId.get("nosuch"), undefined);
+  });
+});
+
+describe("packCountLabel", () => {
+  it("names the pack's size when nothing is filtered out", () => {
+    assert.equal(packCountLabel(199, 199), "199 commands");
+    assert.equal(packCountLabel(1, 1), "1 command");
+  });
+
+  it("gives the share of the pack a filter left", () => {
+    assert.equal(packCountLabel(3, 199), "3 of 199");
+    assert.equal(packCountLabel(0, 199), "0 of 199");
+  });
+});
+
+describe("browserCountLine", () => {
+  it("says what is being viewed and where it lives", () => {
+    assert.equal(browserCountLine("Tcl 9.0", 187, 187, 4), "187 Tcl 9.0 commands in 4 packs");
+    assert.equal(browserCountLine("Tcl 9.0", 1, 1, 1), "1 Tcl 9.0 command in 1 pack");
+  });
+
+  it("names the packs a filter matched as well as the commands", () => {
+    assert.equal(browserCountLine("Tcl 9.0", 187, 12, 3), "12 of 187 Tcl 9.0 commands, in 3 packs");
+  });
+
+  it("says so plainly when there is nothing to show", () => {
+    assert.equal(browserCountLine("Tcl 9.0", 187, 0, 0), "no match in 187 Tcl 9.0 commands");
+    assert.equal(browserCountLine("nosuch", 0, 0, 0), "no commands in nosuch");
+  });
+});
+
+describe("alsoInSentence", () => {
+  it("names the other packs that declare the same command", () => {
+    assert.equal(
+      alsoInSentence("close", ["expect", "irules"]),
+      "close is also declared in expect, irules.",
+    );
+  });
+
+  it("says nothing about a name only one pack declares", () => {
+    assert.equal(alsoInSentence("lsort", []), "");
+    assert.equal(alsoInSentence("lsort", [""]), "");
   });
 });


### PR DESCRIPTION
## Summary

- The registry now answers **which pack declares a spec**. `SPEC_PACKS` (`commands/mod.rs`) is the table of the thirteen `commands/<id>/` authoring modules; `spec_pack_of` names the one that declares a resolved spec, and `spec_packs_of(name)` reports every pack that declares a name.
- **Provenance is not availability.** `SpecSurface` says where a command is *reachable from*; a pack says where its spec is *written down*. They disagree whenever a dialect surfaces a spec it did not author — iRules' `open` is `commands/tcl/`'s file.
- **Keyed by spec identity, not by name.** Seventeen names are declared in two or three packs (`close` in tcl/expect/irules, `send` in tk/expect/irules) and each dialect registers exactly one of them. A by-name table could only pick a fixed winner, and would file the iRules `close` under `tcl` while browsing iRules.
- `command_index` carries `pack` and `also_in`; new `pack_catalogue(dialect)` lists only the packs that reach a dialect, so the Tcl 8.4 picker never offers an empty **F5 iRules** heading. Both reach the browser through the wasm facade.
- The studio's registry browser becomes **one collapsible section per pack** instead of a flat alphabetical list of a dialect's whole surface. The pack under edit is the first section rather than a differently-shaped panel: it is a pack that happens to be editable.
- Section open state is remembered across dialect switches and reloads, recorded from the summary's *click* so a section the studio opens for you is not mistaken for a preference.
- **Filtering says what is being viewed**: only packs with a match are shown, each header carries `N of M`, and the count line reads `12 of 187 Tcl 9.0 commands, in 3 packs` rather than a bare number. A command's pack shows as a chip where the heading is not already saying it, and a name several packs declare says so.

Two things are deliberately not rows in `SPEC_PACKS`: `tmsh`, whose specs are a filtered view of the same `commands/iapps/` sources, and the EDA vendor libraries, which ship as bundled `.tclspec` loadables — a pack-loaded spec's provenance is its file, which the loader reports, so `spec_pack_of` answers `None` rather than guessing.

Part of the Spec Studio work for #1712 / #1714 / #1693; this PR is the navigation half. Follow-ups in flight: the trait-catalogue audit, per-setting documentation and examples, and the live documentation dock.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

```
make rust-check                       # fmt + clippy + xtask drift gates
make prep-pr                          # format + codegen + lint/typecheck + smoke tier
cargo test -p tcl-registry --test spec_pack_provenance   # 5 passed
cargo test -p tcl-spec-studio                            # 239 passed
cargo test -p tcl-spec-studio --test web_contract --test mobile_layout
make typecheck-spec-studio-ts && make lint-spec-studio-ts
make spec-studio-test                 # 46 passed
cargo xtask kcs-index-links           # KCS docs checks passed
```

`rust/tcl-registry/tests/spec_pack_provenance.rs` is the new gate: every command in every browsable dialect must resolve to a pack that is a real `commands/<id>/` directory, and a dialect that re-declares a core command must be filed where *it* registered it.

Not run: `make spec-studio-boot` needs an assembled `dist/` and a browser this environment does not have. The DOM ids the new markup targets were checked statically instead.

## Compiler / diagnostics checklist

- [x] Did this change alter a compiler fact contract? — No compiler fact changed. It adds a query over where a spec is authored; no `CommandSpec` field, diagnostic, or optimisation was touched.
- [x] If yes, I updated the owning design doc — `docs/design/contracts/command-spec-studio.md` gains "The browser is a stack of packs"; `docs/design/compiler/command-registry.md` gains the authoring-pack subsection and names the two places a new dialect pack must now be listed; `docs/kcs/features/kcs-feature-spec-studio.md`'s walkthrough stops describing a flat command list.
- [x] If I added or changed a diagnostic or optimisation code — none added or changed.
- [x] If I added a design doc, I linked it — no new doc; existing pages updated, and `cargo xtask kcs-index-links` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AWimhq6f4xQHmdN8Gr6CY2

---
_Generated by [Claude Code](https://claude.ai/code/session_01AWimhq6f4xQHmdN8Gr6CY2)_