### PR TITLE
fix(runtime): raise on a welded close-quote (#1828)

### DIFF
--- a/docs/design/contracts/shared-utility-contracts-rust.md
+++ b/docs/design/contracts/shared-utility-contracts-rust.md
@@ -903,9 +903,10 @@ helper without reading the rationale:
   was considered and rejected — it would make `runtime/rust` re-lex every
   command it evaluates, and its parse is infallible by design where the
   owner's returns an `Option`. This differential is what keeps the two
-  applications one policy; it runs under `make runtime-rust-test`, and it
-  pins the close-quote weld (`"a"b`) as the one shape they still answer
-  differently.
+  applications one policy; it runs under `make runtime-rust-test`. It once
+  pinned the close-quote weld (`"a"b`) as the one shape the two answered
+  differently; #1828 closed that through
+  `WordSpan::welded_after_close_quote`, and no divergence is pinned.
 
 ## Discoverability
 

--- a/docs/kcs/codes/kcs-diagnostic-e205-extra-characters-after-close-quote.md
+++ b/docs/kcs/codes/kcs-diagnostic-e205-extra-characters-after-close-quote.md
@@ -26,6 +26,9 @@ you catch it while editing.
 The usual cause is a quote that closes earlier than intended, so the rest
 of the intended string spills outside the quoted word.
 
+The Rust runtime raises the same error when it evaluates such a script, so
+the diagnostic and the run agree.
+
 ## Symptoms
 
 - A red squiggle at the character following the `"`, with the message

--- a/runtime/rust/src/parse.rs
+++ b/runtime/rust/src/parse.rs
@@ -56,8 +56,8 @@
 //! *lowering*: turning the owner's borrow-free spans into this crate's
 //! borrow-based `Command`/`Word` tree, and applying the eval-facing
 //! word-delimiter rules on the way (`{braced}` is literal; `"quoted"` must
-//! close; text welded onto a close-brace is C's `extra characters after
-//! close-brace`).
+//! close; text welded onto a close-brace or a close-quote is C's `extra
+//! characters after close-brace` / `…close-quote`).
 //!
 //! This crate used to carry its own copy of the decomposer (`scan_parts`,
 //! `scan_var_name`, `skip_command_subst`, `parse_var_ref`) with `subst.rs`
@@ -411,12 +411,15 @@ fn script_parse_error(
 /// C's parse errors for the word delimiters this module owns — spelled by
 /// the shared owner, not re-typed here.
 ///
-/// The lexer itself stays lenient about all three — it is shared with the LSP,
+/// The lexer itself stays lenient about all four — it is shared with the LSP,
 /// which must keep tokenizing broken source — so this eval-facing parser is
 /// the one that fails closed, carrying the failure as a
 /// [`WordPart::ParseError`] the evaluator raises when it reaches the word
 /// (issues #1576, #1586).
-use tcl_lexer::word_parts::{EXTRA_AFTER_CLOSE_BRACE, MISSING_CLOSE_BRACE, MISSING_QUOTE};
+use tcl_lexer::{
+    word_parts::{EXTRA_AFTER_CLOSE_BRACE, MISSING_CLOSE_BRACE, MISSING_QUOTE},
+    EXTRA_AFTER_CLOSE_QUOTE,
+};
 
 /// Whether a `Str` token that **opens a brace** never found its closing `}`
 /// before end of input. Delegates to [`tcl_lexer::word_closer_offset`] — the
@@ -473,6 +476,23 @@ fn build_word<'s>(
             kind,
             expand,
             body: WordBody::Parts(vec![WordPart::ParseError(EXTRA_AFTER_CLOSE_BRACE)]),
+            start,
+        };
+    }
+    // The sibling shape on a quote (`"a"b`, `""b`, `"a"$b`, `"a"[b]`,
+    // `"a"{b}`, `"a$x"b`, `"a[x]"c`) is C's `extra characters after
+    // close-quote`, also raised while the command is parsed — measured on
+    // 8.4.20, 8.5.19, 8.6.16, 9.0.4 and 9.1b0, `list [sfx inner] "a"b`
+    // reports it without running `sfx`. `tcl_lexer::first_parse_cut` already
+    // answered it from source; this engine concatenated to `ab` instead, the
+    // one divergence `tests/parse_cut_agreement.rs` had to pin (#1828). Same
+    // order as the brace: before anything else in the word, because C stops
+    // at the `"`.
+    if word.welded_after_close_quote {
+        return Word {
+            kind,
+            expand,
+            body: WordBody::Parts(vec![WordPart::ParseError(EXTRA_AFTER_CLOSE_QUOTE)]),
             start,
         };
     }
@@ -1076,6 +1096,28 @@ mod tests {
             WordBody::Literal(b) => assert!(std::ptr::eq(b.as_ptr(), src.as_ptr())),
             _ => panic!("expected zero-copy Literal"),
         }
+    }
+
+    /// The welded close-quote is a `ParseError` part, ahead of anything else
+    /// in the word — and `"$"` is still the text `$`, not a weld (the #527
+    /// empty-content clamp; see `tcl_lexer::script`).
+    #[test]
+    fn a_welded_close_quote_is_a_parse_error_part() {
+        for src in [
+            &b"set y \"a\"b"[..],
+            b"set y \"\"b",
+            b"set y \"a$x\"b",
+            b"set y \"a\"$b",
+        ] {
+            let c = nth(src, 0);
+            assert_eq!(
+                parts(&c.words[2]),
+                &[WordPart::ParseError(EXTRA_AFTER_CLOSE_QUOTE)],
+                "{}",
+                String::from_utf8_lossy(src)
+            );
+        }
+        assert_eq!(lit(&nth(b"puts \"$\"", 0).words[1]), b"$");
     }
 
     #[test]

--- a/runtime/rust/src/parse.rs
+++ b/runtime/rust/src/parse.rs
@@ -488,7 +488,14 @@ fn build_word<'s>(
     // one divergence `tests/parse_cut_agreement.rs` had to pin (#1828). Same
     // order as the brace: before anything else in the word, because C stops
     // at the `"`.
-    if word.welded_after_close_quote {
+    //
+    // Unlike the brace, this shape has a dialect axis: the boundary owner's
+    // flag is advisory and set blind, and under
+    // `QuoteTermination::Concatenating` (`JimTcl`) the run after the close
+    // quote joins the same word instead, so `"abc"def` is `abcdef` and the
+    // diagnostic never fires. The lexer's own `strict_quoting` gate reads the
+    // same policy, so honour it here rather than raising unconditionally.
+    if word.welded_after_close_quote && config.quote_termination.is_strict() {
         return Word {
             kind,
             expand,
@@ -1118,6 +1125,39 @@ mod tests {
             );
         }
         assert_eq!(lit(&nth(b"puts \"$\"", 0).words[1]), b"$");
+    }
+
+    /// The weld flag is advisory and set blind, so the raise must read the
+    /// dialect's quote-termination policy. `JimTcl` concatenates
+    /// (`jim.c` has no such check), and its lexer emits no warning for the
+    /// same source — the evaluator must agree rather than invent an error.
+    #[test]
+    fn a_concatenating_dialect_welds_instead_of_raising() {
+        let config = LexerConfig::from_grammar(tcl_dialect::grammar_of_dialect_name(Some("jim")));
+        assert!(
+            !config.quote_termination.is_strict(),
+            "jim must be the concatenating dialect for this test to mean anything"
+        );
+        for (src, joined) in [
+            (&b"set y \"abc\"def"[..], &b"abcdef"[..]),
+            (b"set y \"a\"b", b"ab"),
+        ] {
+            let cmd = parse_script_with_config(src, config)
+                .into_iter()
+                .next()
+                .expect("command");
+            let text = match &cmd.words[2].body {
+                WordBody::Literal(bytes) => bytes.to_vec(),
+                WordBody::Parts(parts) => parts.iter().fold(Vec::new(), |mut acc, part| {
+                    match part {
+                        WordPart::Text(bytes) => acc.extend_from_slice(bytes),
+                        other => panic!("unexpected part {other:?}"),
+                    }
+                    acc
+                }),
+            };
+            assert_eq!(text, joined, "{}", String::from_utf8_lossy(src));
+        }
     }
 
     #[test]

--- a/runtime/rust/tests/parse_cut_agreement.rs
+++ b/runtime/rust/tests/parse_cut_agreement.rs
@@ -50,8 +50,9 @@ fn owner_cut(src: &str, config: LexerConfig) -> Option<(usize, &'static str)> {
 }
 
 /// The malformed shapes, one per message C can raise, plus the two the
-/// warning-stream scan the owner replaced answered wrongly and the one it
-/// could not see at all.
+/// warning-stream scan the owner replaced answered wrongly, the one it could
+/// not see at all, and the close-quote weld this crate once pinned as a
+/// divergence (#1828).
 const SHEET: &[&str] = &[
     "puts pre; puts \"x${abc\"",
     "puts pre; puts \"unterminated",
@@ -59,6 +60,20 @@ const SHEET: &[&str] = &[
     "puts pre; set y {a}b",
     "puts pre; puts $a(",
     "puts pre; puts \"a\"b",
+    // The close-quote weld in every token shape the lexer gives it (#1828):
+    // the empty `""` whose span sits on its closer, a bare closing marker
+    // after a `$x` and after a `[…]`, and a weld a level down.
+    "puts pre; set y \"\"b",
+    "puts pre; set y \"a\"$b",
+    "puts pre; set y \"a$x\"b",
+    "puts pre; set y \"a[x]\"c",
+    "puts pre; list [sfx one] [set y \"a\"b]",
+    "puts pre; sfx \"q\"{*}$z",
+    // Not welds: a `$` that names nothing is text, and a `"` inside a bare
+    // word is literal — both must stay `None` on both engines.
+    "puts pre; puts \"$\"",
+    "puts pre; puts \"a$ b\"",
+    "puts pre; puts a\"b\"c",
     "puts pre; set y {unclosed",
     // An unterminated quote whose word already failed inside a bracket:
     // C reports the bracket, not the quote.
@@ -81,53 +96,15 @@ const SHEET: &[&str] = &[
     "lappend ev pre-[lindex $args end]",
 ];
 
-/// The one shape the two engines still answer differently, pinned rather
-/// than hidden: a word welded onto its **closing quote**.
-///
-/// C rejects `set y "a"b` with `extra characters after close-quote` on all
-/// five shells; the owner reports it, and this crate silently concatenates
-/// to `ab`. It is the exact sibling of the welded *close-brace* #1818
-/// taught this crate to raise, and the boundary owner says so in as many
-/// words — `WordSpan::welded_after_close` "is deliberately brace-only —
-/// the analogous close-quote weld (`"a"b`) is a different C error and is
-/// not reported here."
-///
-/// Raising a new error from the evaluator is a behaviour change with its
-/// own oracle sheet, so it is a follow-up, not a rider on the owner. Until
-/// then this row is the record that the divergence is known and measured,
-/// not that the two engines agree.
-const KNOWN_DIVERGENCES: &[&str] = &["puts pre; puts \"a\"b"];
-
 #[test]
 fn the_two_engines_agree_on_the_sheet() {
     for src in SHEET {
         for dialect in ["tcl8.4", "tcl8.6", "tcl9.0"] {
             let config = LexerConfig::for_dialect(dialect);
             let (runtime, owner) = (runtime_cut(src, config), owner_cut(src, config));
-            if KNOWN_DIVERGENCES.contains(src) {
-                assert_ne!(
-                    runtime, owner,
-                    "{dialect}: {src:?} no longer diverges — \
-                     drop it from KNOWN_DIVERGENCES"
-                );
-                continue;
-            }
             assert_eq!(runtime, owner, "{dialect}: {src:?}");
         }
     }
-}
-
-/// The pinned divergence is exactly one shape, and it is the one described.
-#[test]
-fn the_close_quote_weld_is_the_only_pinned_divergence() {
-    let config = LexerConfig::default();
-    assert_eq!(
-        KNOWN_DIVERGENCES
-            .iter()
-            .map(|src| (runtime_cut(src, config), owner_cut(src, config)))
-            .collect::<Vec<_>>(),
-        vec![(None, Some((1, "extra characters after close-quote")))],
-    );
 }
 
 /// Real Tcl, where the two must agree that there is nothing to cut.
@@ -158,13 +135,6 @@ fn the_two_engines_agree_over_the_corpus() {
             continue;
         };
         let (runtime, owner) = (runtime_cut(&src, config), owner_cut(&src, config));
-        // The pinned close-quote weld: `samples/tcl/05_warning_examples.tcl`
-        // is a deliberate demonstration file and carries one.
-        if runtime.is_none()
-            && owner.is_some_and(|(_, m)| m == "extra characters after close-quote")
-        {
-            continue;
-        }
         if runtime != owner {
             disagreements.push(format!(
                 "{}: runtime {runtime:?} owner {owner:?}",

--- a/runtime/rust/tests/parser_gaps.rs
+++ b/runtime/rust/tests/parser_gaps.rs
@@ -460,6 +460,9 @@ probe two-cmd-brkt  [format {sfx pre; list [sfx one; set y "a$%sbcd"]} $ob]
 probe var-first     [format {sfx pre; list $nosuchvar [set y "a$%sbcd"]} $ob]
 probe runtime-err   {sfx pre; list [sfx inner] [set y $nosuchvar]}
 probe all-well      {sfx pre; list [sfx inner] [list ok]}
+probe quote-weld    {sfx pre; list [sfx inner] "a"b}
+probe empty-quote-weld {sfx pre; list [sfx inner] ""b}
+probe nested-quote-weld {sfx pre; list [sfx inner] [set y "a"b]}
 join $::out \n"#;
 
 /// tclsh 8.6.16 and tclsh 9.0.4, identical.
@@ -473,7 +476,10 @@ nested-weld -> error {extra characters after close-brace} ran {pre}
 two-cmd-brkt -> error {missing close-brace for variable name} ran {pre}
 var-first -> error {missing close-brace for variable name} ran {pre}
 runtime-err -> error {can't read "nosuchvar": no such variable} ran {pre inner}
-all-well -> ok {Sinner ok} ran {pre inner}"#;
+all-well -> ok {Sinner ok} ran {pre inner}
+quote-weld -> error {extra characters after close-quote} ran {pre}
+empty-quote-weld -> error {extra characters after close-quote} ran {pre}
+nested-quote-weld -> error {extra characters after close-quote} ran {pre}"#;
 
 /// Every row of the sheet, against the recorded shells.
 ///
@@ -594,4 +600,109 @@ fn a_brace_that_really_is_one_still_raises() {
     }
     let (code, result, _) = run("set y x{a}{b");
     assert_eq!((code, result.as_str()), (Code::Ok, "x{a}{b"));
+}
+
+// ---------------------------------------------------------------------------
+// #1828 — text welded straight onto a `"…"` word's close-quote, the sibling of
+// the #1786 close-brace weld above. The boundary owner records it as
+// `WordSpan::welded_after_close_quote`; this eval-facing engine turns it into
+// C's hard error. It was the one shape `tests/parse_cut_agreement.rs` had to
+// pin as a known divergence: `tcl_lexer::first_parse_cut` already reported it,
+// and this crate concatenated `"a"b` to `ab`.
+//
+// Oracle, measured on tclsh 8.4.20 / 8.5.19 / 8.6.16 / 9.0.4 / 9.1b0, one
+// script per file — every row identical on every release:
+//
+//   "a"b     ""b     "a"$b     "a"[b]     "a"{b}     "a""b"     "a\"b"c
+//   "a[list b]"c     "a$x"b     "$x"b     "a$"b     "a"\ b     "a"]     "a"}
+//   set y "a"b       set y ""b        list [list a] "a"b       list "q"{*}$z
+//     -> code 1, `extra characters after close-quote`, -errorcode NONE
+//
+// and, as for the brace, it is a *parse*-time failure of the whole command:
+// `set ::x "a"[sfx inner]` leaves `x` unset and never runs `sfx`, while the
+// earlier `sfx pre` has run (`Tcl_EvalEx` parses one command at a time).
+//
+// Not welds, and still accepted (measured the same on 8.6.16 / 9.0.4): `"$"`
+// is the text `$` (C's `justADollarSign`) — the empty-content clamp the owner
+// has to read correctly, since the `"$` token's span sits on the `$`, not on a
+// closer; a `"` inside a bare word (`a"b"c`) is literal; a separator or a
+// backslash-newline after the `"` starts a new word; an empty `""` on its own
+// is the empty string.
+// ---------------------------------------------------------------------------
+
+/// Every welded shape raises C's message, with `-errorcode NONE`.
+#[test]
+fn text_welded_onto_a_close_quote_raises_extra_characters() {
+    for sheet in [
+        "\"a\"b",
+        "\"\"b",
+        "\"a\"$b",
+        "\"a\"[b]",
+        "\"a\"{b}",
+        "\"a\"\"b\"",
+        "\"a\\\"b\"c",
+        "\"a[list b]\"c",
+        "set x X\n\"a$x\"b",
+        "set x X\n\"$x\"b",
+        "\"a$\"b",
+        "\"a\"\\ b",
+        "\"a\"]",
+        "\"a\"}",
+        "set y \"a\"b",
+        "set y \"\"b",
+        "list [list a] \"a\"b",
+        "list \"q\"{*}$z",
+    ] {
+        let (code, result, error_code) = run(sheet);
+        assert_eq!(code, Code::Error, "{sheet}");
+        assert_eq!(result, "extra characters after close-quote", "{sheet}");
+        assert_eq!(error_code, "NONE", "{sheet}");
+    }
+}
+
+/// The failure is the command's: nothing it would have substituted runs and
+/// its target stays unset, while the earlier command has run.
+///
+/// Oracle (8.6.16 / 9.0.4): `{extra characters after close-quote} pre 0` for
+/// both the `"a"` and the empty-`""` spelling.
+#[test]
+fn a_welded_close_quote_fails_the_command_before_it_substitutes_anything() {
+    for weld in ["\"a\"", "\"\""] {
+        let sheet = format!(
+            "set ::ran {{}}\n\
+             proc sfx {{t}} {{ lappend ::ran $t; return S$t }}\n\
+             sfx pre\n\
+             catch {{set ::x {weld}[sfx inner]}} e\n\
+             list $e $::ran [info exists ::x]"
+        );
+        let (code, result, _) = run(&sheet);
+        assert_eq!(code, Code::Ok, "{weld}: {result}");
+        assert_eq!(
+            result, "{extra characters after close-quote} pre 0",
+            "{weld}"
+        );
+    }
+}
+
+/// A `"` away from word start, a `$` that names nothing, an empty `""`, and a
+/// real separator after the closer are not welds — none may trip the new
+/// error.
+#[test]
+fn a_quote_away_from_word_start_or_after_a_separator_is_not_a_weld() {
+    for (sheet, want) in [
+        ("string cat a\"b\"c", "a\"b\"c"),
+        ("set a A\nstring cat $a\"b\"c", "A\"b\"c"),
+        ("list \"a\" \"b\"", "a b"),
+        ("list \"a\"", "a"),
+        ("string cat \"$\"", "$"),
+        ("string cat \"a$ b\"", "a$ b"),
+        ("string length \"\"", "0"),
+        ("list \"a\"\\\nb", "a b"),
+        ("set x X\nstring cat \"$x\"", "X"),
+        ("string cat \"a[list b]\"", "ab"),
+    ] {
+        let (code, result, _) = run(sheet);
+        assert_eq!(code, Code::Ok, "{sheet}: {result}");
+        assert_eq!(result, want, "{sheet}");
+    }
 }

--- a/rust/tcl-compiler/tests/differential_group.rs
+++ b/rust/tcl-compiler/tests/differential_group.rs
@@ -530,6 +530,25 @@ fn expand_after_close_brace_takes_the_segmenter_boundary() {
             .collect();
         assert_eq!(flags, expected, "{src:?}");
     }
+
+    // Its sibling: `extra characters after close-quote` (#1828). `{*}` after
+    // a closed quote is ordinary content, so `foo "q"{*}$z` is one welded
+    // quoted word — the row the brace loop above reads as `false, false`.
+    for (src, expected) in [
+        ("foo \"q\"{*}$z", vec![false, true]),
+        ("{a}{*}$b", vec![false, false]),
+        ("foo {*}$b", vec![false, false]),
+    ] {
+        let config = LexerConfig::default();
+        let tokens = Lexer::with_config(src, config).tokenise_all().unwrap();
+        let grouped = group_commands(&tokens, src, config);
+        let flags: Vec<bool> = grouped[0]
+            .words
+            .iter()
+            .map(|w| w.welded_after_close_quote)
+            .collect();
+        assert_eq!(flags, expected, "{src:?}");
+    }
 }
 
 // ---------------------------------------------------------------------

--- a/rust/tcl-lexer/src/lexer.rs
+++ b/rust/tcl-lexer/src/lexer.rs
@@ -1191,7 +1191,7 @@ impl<'src> Lexer<'src> {
                         || after == b']'
                         || is_bs_nl;
                     if !ok {
-                        self.warn_or_error("extra characters after close-quote")?;
+                        self.warn_or_error(crate::EXTRA_AFTER_CLOSE_QUOTE)?;
                     }
                 }
             }

--- a/rust/tcl-lexer/src/parse_cut.rs
+++ b/rust/tcl-lexer/src/parse_cut.rs
@@ -83,8 +83,8 @@ use crate::{Lexer, LexerConfig, SourceMap, Token, word_closer_offset_at, word_sp
 /// Spelled here rather than in [`word_parts`](crate::word_parts) because
 /// only a *word in a command* can have anything after its closer — the
 /// content scan that module owns never sees past one.  The lexer raises the
-/// same text under `strict_quoting`; this is the shared constant both now
-/// name.
+/// same text under `strict_quoting`; this is the shared constant the lexer,
+/// the cut owner and `runtime/rust` all name.
 pub const EXTRA_AFTER_CLOSE_QUOTE: &str = "extra characters after close-quote";
 
 /// Where a script stops parsing, in C's order.

--- a/rust/tcl-lexer/src/script.rs
+++ b/rust/tcl-lexer/src/script.rs
@@ -68,7 +68,7 @@
 //! * A command consisting only of dangling `{*}` markers — no real word —
 //!   is discarded, exactly as the segmenter discards it.
 //!
-//! # `welded_after_close`
+//! # `welded_after_close` and `welded_after_close_quote`
 //!
 //! New here, and advisory only: [`WordSpan::welded_after_close`] records
 //! that a content token followed a braced (`Str`) token with **no
@@ -79,8 +79,13 @@
 //! severity.  The analyser stays lenient and diagnoses, since it must keep
 //! tokenising broken source; the eval-facing `runtime/rust` raises C's error
 //! from it (`parse.rs` `build_word`).
-//! It is deliberately brace-only — the analogous close-quote weld (`"a"b`)
-//! is a different C error and is not reported here.
+//!
+//! [`WordSpan::welded_after_close_quote`] is its sibling for the
+//! close-quote weld (`"a"b`, `""b`, `"a$x"b`), C's
+//! [`EXTRA_AFTER_CLOSE_QUOTE`](crate::EXTRA_AFTER_CLOSE_QUOTE) (issue
+//! #1828).  The two are kept apart because C raises different messages and
+//! stops at whichever closer comes first: `{a}"b"c` carries only the brace
+//! flag.
 
 use std::ops::Range;
 
@@ -141,6 +146,23 @@ pub struct WordSpan {
     /// this module never acts on it — but `runtime/rust`'s eval-facing parser
     /// does, raising C's error for the word that carries it.
     pub welded_after_close: bool,
+    /// A content token followed a **quoted** fragment of this word after its
+    /// closing `"`, with no separator between them — `"a"b`, `""b`,
+    /// `"a"$b`, `"a"[b]`, `"a"{b}`, `"a$x"b`, `"a[x]"c`.
+    ///
+    /// C rejects every one of those with
+    /// [`EXTRA_AFTER_CLOSE_QUOTE`](crate::EXTRA_AFTER_CLOSE_QUOTE), the
+    /// sibling of the close-brace flag above (issue #1828).  Like it, this
+    /// is advisory — the module never acts on it, the analyser stays
+    /// lenient — and `runtime/rust`'s eval-facing parser raises C's error
+    /// from it.  It is dialect-blind, as the whole grouper is: under
+    /// `JimTcl`'s concatenating quote rule the flag is still set and the
+    /// consumer decides, exactly as
+    /// [`first_parse_cut`](crate::first_parse_cut) already reports the shape
+    /// regardless of dialect.  Never set on a word that opened with `{` — C
+    /// stops at the close-brace first, so `{a}"b"c` carries
+    /// [`welded_after_close`](Self::welded_after_close) only.
+    pub welded_after_close_quote: bool,
 }
 
 impl WordSpan {
@@ -232,6 +254,7 @@ struct PendingWord {
     end: usize,
     expand: bool,
     welded: bool,
+    welded_quote: bool,
 }
 
 /// In-flight grouping state, mirroring `build.rs`'s `Builder` minus
@@ -319,6 +342,14 @@ impl<'a> Grouper<'a> {
                             word.end = i;
                             word.welded = true;
                         }
+                    } else if self.prev_closed_a_quote() {
+                        // After the brace test, never before it: C stops at
+                        // whichever closer comes first, so `{a}"b"c` is a
+                        // close-*brace* error and carries only that flag.
+                        if let Some(word) = self.cur.as_mut() {
+                            word.end = i;
+                            word.welded_quote = true;
+                        }
                     } else if let Some(word) = self.cur.as_mut() {
                         word.end = i;
                     } else {
@@ -339,6 +370,7 @@ impl<'a> Grouper<'a> {
             end: i,
             expand: !self.markers.is_empty(),
             welded: false,
+            welded_quote: false,
         });
         self.markers.clear();
     }
@@ -360,6 +392,52 @@ impl<'a> Grouper<'a> {
                 .and_then(|i| self.tokens.get(i))
                 .and_then(|t| self.src.as_bytes().get(t.span.start() as usize))
                 == Some(&b'{')
+    }
+
+    /// Did the previous token close the **quoted** word in progress?
+    ///
+    /// Only an `Esc` can: inside a quote the lexer dispatches `$` and `[` to
+    /// their own parsers and everything else — the closing `"` included — to
+    /// `parse_quoted`, so the byte that closes a quote is always consumed by
+    /// an `Esc` (the content run that stopped at it, or a zero-content
+    /// marker when a `$x` / `[…]` ran straight into it). The word must have
+    /// *opened* with `"`: a `"` inside a bare word is literal (`a"b"c`), and
+    /// a word that opened with `{` is C's close-*brace* case whatever
+    /// follows (`{a}"b"c`).
+    ///
+    /// Where the closer sits follows the #527 convention, not
+    /// `span.end() + 1`: one past the span for a non-empty run (`"a`), but
+    /// *inside* the span for the empty-content clamp — `""`, and the bare
+    /// closing `"` after a substitution — whose span was extended to cover
+    /// the stop byte. `token_text_in` — the body of `SourceMap::token_text`
+    /// — is the one owner of "is this token's content empty", so the same
+    /// call that distinguishes the two also rejects the opening `"$` / `"[`
+    /// clamp: its last byte is the introducer, not a `"`, and `puts "$"`
+    /// must stay the text `$`.
+    fn prev_closed_a_quote(&self) -> bool {
+        if self.prev_type != TokenType::Esc {
+            return false;
+        }
+        let bytes = self.src.as_bytes();
+        let opened_with_quote = self
+            .cur
+            .as_ref()
+            .and_then(|word| self.tokens.get(word.start))
+            .and_then(|first| bytes.get(first.span.start() as usize))
+            == Some(&b'"');
+        if !opened_with_quote {
+            return false;
+        }
+        let Some(prev) = self.prev_tok.and_then(|i| self.tokens.get(i)) else {
+            return false;
+        };
+        let end = prev.span.end() as usize;
+        let closer = if crate::source_map::token_text_in(self.src, *prev).is_empty() {
+            end.checked_sub(1)
+        } else {
+            Some(end)
+        };
+        closer.and_then(|at| bytes.get(at)) == Some(&b'"')
     }
 
     fn note_weld(&mut self) {
@@ -394,6 +472,7 @@ impl<'a> Grouper<'a> {
             tokens: word.start..word.end + 1,
             span: Span::new(first.span.start(), last.span.end()),
             welded_after_close: word.welded,
+            welded_after_close_quote: word.welded_quote,
         });
     }
 
@@ -576,9 +655,9 @@ mod tests {
         assert_eq!(word_texts(src, &cmds[0], &toks), ["foo", "\"q\"{*}$z"]);
         assert!(cmds[0].expand_markers.is_empty());
         assert!(cmds[0].words.iter().all(|w| !w.expand));
-        // Brace-only: the close-*quote* weld is a different C error and is
-        // not reported through this flag.
+        // The close-quote weld is the sibling flag, not this one.
         assert!(!cmds[0].words[1].welded_after_close);
+        assert!(cmds[0].words[1].welded_after_close_quote);
     }
 
     #[test]
@@ -665,7 +744,7 @@ mod tests {
             ("puts {a}", false),
             ("puts {a} b", false),
             ("puts a{b}", false),   // `{` mid-word is literal, not a Str token
-            ("puts \"a\"b", false), // close-quote weld: not this flag
+            ("puts \"a\"b", false), // close-quote weld: the sibling flag
             // A nameless `$` is also a `Str` token, with no brace anywhere:
             // `$$x` is `Str,Var` and Tcl reports no error for it (the first
             // `$` is literal, `$x` substitutes). Keying the weld on the token
@@ -686,6 +765,90 @@ mod tests {
         let (_toks, cmds) = group(src);
         let flags: Vec<bool> = cmds[0].words.iter().map(|w| w.welded_after_close).collect();
         assert_eq!(flags, [false, true, false, false]);
+    }
+
+    // ---------------------------------------------------------------
+    // welded_after_close_quote
+    // ---------------------------------------------------------------
+
+    /// Measured on tclsh 8.4.20, 8.5.19, 8.6.16, 9.0.4 and 9.1b0 (#1828):
+    /// every `true` row is `extra characters after close-quote`; every
+    /// `false` row is accepted.
+    #[test]
+    fn quote_weld_shapes() {
+        for (src, welded) in [
+            ("puts \"a\"b", true),
+            ("puts \"\"b", true), // empty `""`: the #527 clamp, closer inside the span
+            ("puts \"a\"$b", true),
+            ("puts \"a\"[b]", true),
+            ("puts \"a\"{b}", true),
+            ("puts \"a\"\"b\"", true),
+            ("puts \"a\\\"b\"c", true), // escaped quote inside the run
+            ("puts \"a$x\"b", true),    // bare closing marker after a `$x`
+            ("puts \"$x\"b", true),
+            ("puts \"a[x]\"c", true), // bare closing marker after a `[…]`
+            ("puts \"a$\"b", true),
+            ("puts \"$\"b", true),
+            ("puts \"a\"$", true),
+            ("puts \"a\"\\ b", true),
+            ("puts \"a\"}", true),
+            ("puts \"a\"]", true),
+            ("puts \"q\"{*}$z", true),
+            ("puts \"a\"", false),
+            ("puts \"a\" b", false),
+            ("puts \"\"", false),
+            ("puts \"$\"", false), // `$` with no name: text, not a weld
+            ("puts \"a$ b\"", false),
+            ("puts \"$x\"", false),
+            ("puts \"a[x]\"", false),
+            ("puts a\"b\"c", false), // `"` inside a bare word is literal
+            ("puts $a\"b\"c", false),
+            ("puts \"a\"\\\nb", false), // backslash-newline is a separator
+        ] {
+            let (_toks, cmds) = group(src);
+            let word = &cmds[0].words[1];
+            assert_eq!(word.welded_after_close_quote, welded, "{src:?}");
+            assert!(
+                !word.welded_after_close,
+                "{src:?}: brace flag stays brace-only"
+            );
+        }
+    }
+
+    /// C stops at the close-brace, so a quote welded onto a braced word is
+    /// still the *brace* error and only that flag carries it.
+    #[test]
+    fn a_brace_weld_followed_by_a_quote_carries_only_the_brace_flag() {
+        for src in ["puts {a}\"b\"", "puts {a}\"b\"c", "puts {a}\"b"] {
+            let (_toks, cmds) = group(src);
+            let word = &cmds[0].words[1];
+            assert!(word.welded_after_close, "{src:?}");
+            assert!(!word.welded_after_close_quote, "{src:?}");
+        }
+    }
+
+    #[test]
+    fn quote_weld_is_per_word_not_per_command() {
+        let src = "puts \"a\"b \"c\" d";
+        let (_toks, cmds) = group(src);
+        let flags: Vec<bool> = cmds[0]
+            .words
+            .iter()
+            .map(|w| w.welded_after_close_quote)
+            .collect();
+        assert_eq!(flags, [false, true, false, false]);
+    }
+
+    #[test]
+    fn f5_ghost_separator_after_a_close_quote_is_not_a_weld() {
+        // F5 splits `"a"b` into two words with no diagnostic
+        // (bigip-irule-parser-measurements.md, "Word-formation evidence");
+        // the ghost `Sep` the lexer emits starts a new word here, so nothing
+        // is welded.
+        let src = "set y \"a\"b";
+        let (_toks, cmds) = group_with(src, LexerConfig::for_dialect("f5-irules"));
+        assert_eq!(cmds[0].words.len(), 4);
+        assert!(cmds[0].words.iter().all(|w| !w.welded_after_close_quote));
     }
 
     // ---------------------------------------------------------------

--- a/rust/tcl-lexer/src/source_map.rs
+++ b/rust/tcl-lexer/src/source_map.rs
@@ -154,67 +154,7 @@ impl<'src> SourceMap<'src> {
     /// inner-content text should use it too.
     #[must_use]
     pub fn token_text(&self, tok: Token) -> &'src str {
-        let raw = self.text(tok.span);
-        // Strip the lexer-computed prefix (`$`, `${`, `[`, `{`, `"`,
-        // etc.) to get to the content.
-        let stripped = &raw[tok.content_offset as usize..];
-        // Kind-specific trailing-strip or empty-clamp rules.
-        match tok.kind {
-            TokenType::Var => {
-                // `${}` degenerate: the span is extended by one byte to
-                // cover the closing `}`, so the only remainder that is a
-                // bare `}` is that empty-name case. A non-degenerate braced
-                // name may legitimately *end* with a `}` — `${a{b}}` names
-                // the variable `a{b}` (brace-nesting), `${a\}b}` names
-                // `a\}b` — and the closing `}` is already excluded from the
-                // span. So, like the `Cmd` / `Str` arms, clear only the
-                // exact 1-character `}` remainder rather than stripping
-                // unconditionally.
-                if stripped == "}" { "" } else { stripped }
-            }
-            TokenType::Cmd => {
-                // `[]` degenerate: span extended by one to cover
-                // the `]`. Non-empty nested commands like
-                // `[+ 1 [inner]]` also end with `]` as a
-                // legitimate inner bracket, so we must NOT
-                // unconditionally strip — check for the exact
-                // 1-character `]` remainder instead.
-                if stripped == "]" { "" } else { stripped }
-            }
-            TokenType::Str => {
-                // `{}` degenerate: same shape as `[]`.
-                if stripped == "}" { "" } else { stripped }
-            }
-            TokenType::Esc => {
-                // Empty-content clamp for quoted sub-tokens.  When the quoted
-                // scanner stops with zero content, the span is extended by one
-                // byte over the terminator — the opening `"` extended over a
-                // following `$` / `[` substitution introducer, or a mid-string
-                // `$` / `[` fragment.  After stripping the opening delimiter
-                // (via `content_offset`), a one-character remainder that is a
-                // terminator (`"` / `$` / `[`) is that empty-body case and
-                // clamps to `""`.
-                //
-                // The clamp fires only for genuine quoted/wrapper tokens: those
-                // that stripped an opening delimiter (`content_offset != 0`) or
-                // sit inside a quoted run (`in_quote`, e.g. a mid-string
-                // introducer before `$var`, or the bare closing quote which
-                // `parse_quoted` marks with `content_offset == 1`).  A *literal*
-                // `"` / `$` / `[` in a bare word is emitted by `parse_esc` with
-                // `content_offset == 0` and `in_quote == false`, so it is left
-                // as its own text — `set x $a"` resolves the trailing `"`, not
-                // `""` (issue 160).
-                if (tok.content_offset != 0 || tok.in_quote)
-                    && stripped.len() == 1
-                    && matches!(stripped.chars().next(), Some('"' | '$' | '['))
-                {
-                    ""
-                } else {
-                    stripped
-                }
-            }
-            _ => stripped,
-        }
+        token_text_in(self.source, tok)
     }
 
     /// Resolve a byte offset to a full `SourcePosition`. O(log n).
@@ -250,6 +190,75 @@ impl<'src> SourceMap<'src> {
         };
         let end = self.position_at(end_offset);
         (start, end)
+    }
+}
+
+/// [`SourceMap::token_text`] without the map: the inner text of `tok` read
+/// straight from `source`, for a caller that holds the source but no line
+/// index — the boundary grouper, which must not build one per call. The
+/// stripping and empty-clamp rules live here and nowhere else; the method
+/// above is this function plus the map's own buffer.
+pub(crate) fn token_text_in(source: &str, tok: Token) -> &str {
+    let raw = &source[tok.span.as_range()];
+    // Strip the lexer-computed prefix (`$`, `${`, `[`, `{`, `"`,
+    // etc.) to get to the content.
+    let stripped = &raw[tok.content_offset as usize..];
+    // Kind-specific trailing-strip or empty-clamp rules.
+    match tok.kind {
+        TokenType::Var => {
+            // `${}` degenerate: the span is extended by one byte to
+            // cover the closing `}`, so the only remainder that is a
+            // bare `}` is that empty-name case. A non-degenerate braced
+            // name may legitimately *end* with a `}` — `${a{b}}` names
+            // the variable `a{b}` (brace-nesting), `${a\}b}` names
+            // `a\}b` — and the closing `}` is already excluded from the
+            // span. So, like the `Cmd` / `Str` arms, clear only the
+            // exact 1-character `}` remainder rather than stripping
+            // unconditionally.
+            if stripped == "}" { "" } else { stripped }
+        }
+        TokenType::Cmd => {
+            // `[]` degenerate: span extended by one to cover
+            // the `]`. Non-empty nested commands like
+            // `[+ 1 [inner]]` also end with `]` as a
+            // legitimate inner bracket, so we must NOT
+            // unconditionally strip — check for the exact
+            // 1-character `]` remainder instead.
+            if stripped == "]" { "" } else { stripped }
+        }
+        TokenType::Str => {
+            // `{}` degenerate: same shape as `[]`.
+            if stripped == "}" { "" } else { stripped }
+        }
+        TokenType::Esc => {
+            // Empty-content clamp for quoted sub-tokens.  When the quoted
+            // scanner stops with zero content, the span is extended by one
+            // byte over the terminator — the opening `"` extended over a
+            // following `$` / `[` substitution introducer, or a mid-string
+            // `$` / `[` fragment.  After stripping the opening delimiter
+            // (via `content_offset`), a one-character remainder that is a
+            // terminator (`"` / `$` / `[`) is that empty-body case and
+            // clamps to `""`.
+            //
+            // The clamp fires only for genuine quoted/wrapper tokens: those
+            // that stripped an opening delimiter (`content_offset != 0`) or
+            // sit inside a quoted run (`in_quote`, e.g. a mid-string
+            // introducer before `$var`, or the bare closing quote which
+            // `parse_quoted` marks with `content_offset == 1`).  A *literal*
+            // `"` / `$` / `[` in a bare word is emitted by `parse_esc` with
+            // `content_offset == 0` and `in_quote == false`, so it is left
+            // as its own text — `set x $a"` resolves the trailing `"`, not
+            // `""` (issue 160).
+            if (tok.content_offset != 0 || tok.in_quote)
+                && stripped.len() == 1
+                && matches!(stripped.chars().next(), Some('"' | '$' | '['))
+            {
+                ""
+            } else {
+                stripped
+            }
+        }
+        _ => stripped,
     }
 }
 


### PR DESCRIPTION
## Summary

`runtime/rust` accepted `set y "a"b` and concatenated it to `ab`; C Tcl raises `extra characters after close-quote` — identically on 8.4.20, 8.5.19, 8.6.16, 9.0.4 and 9.1b0. `tcl_lexer::first_parse_cut` already computed the right answer structurally; the runtime's borrowed word tree simply lacked the signal.

This is the quote half of #1818, which taught the runtime the welded close-**brace** (`set y {a}b`) via `WordSpan::welded_after_close`. That flag stays brace-only and keeps its name and meaning; this adds the sibling `WordSpan::welded_after_close_quote`, set in the content arm *after* the brace check so `{a}"b"c` carries only the brace flag, as C does.

Measured end to end, now byte-identical to tclsh 9.0.4:

```
$ printf 'puts pre; set y "a"b; puts $y' > /tmp/q.tcl
$ cargo run --manifest-path runtime/rust/Cargo.toml --example run_script -- /tmp/q.tcl
pre
error: extra characters after close-quote        # exit 1
```

The prefix command still runs before the error — C's cut semantics, per #1787.

### The `end.offset` trap

Per AGENTS.md § *Word-token closing delimiters* (#527), a quoted token's `end.offset` is the last **inner** character and the closer is one past it — **except** an empty `""`, whose `end` sits *on* the closer. Naively testing `src[span.end()]` would flag `puts "$"` (the `"$` clamp) and miss `""b`.

So emptiness is routed through the existing clamp rule rather than re-derived: `SourceMap::token_text`'s body is extracted verbatim to a crate-private `token_text_in(source, tok)`, letting the grouper reuse it without a `SourceMap`. Empty content ⇒ closer at `end - 1`, otherwise at `end`. `""b`, `"a$x"b` and `"a[x]"c` flag; the `"$` clamp does not.

Pinned by the `quote_weld_shapes` rows `puts "$"` / `puts "$"b`, the runtime unit test's `lit(nth(b"puts \"$\"")) == b"$"`, `a_quote_away_from_word_start_or_after_a_separator_is_not_a_weld`, the new `SHEET` rows, and the untouched `BARE_DOLLAR_SHEET`.

### The dialect axis (`ccc2d97`)

Raised by Codex review, and a real defect in the first two commits. The weld flag is **advisory and set blind** — `group_commands` takes a `LexerConfig` and deliberately discards it (`let _ = config;`), recording the *shape* and leaving policy to the consumer. `build_word` was converting it into a hard error unconditionally.

That is right for Tcl and wrong for `JimTcl`: under `QuoteTermination::Concatenating` the run after a close quote joins the same word, so `"abc"def` is `abcdef` and the diagnostic never fires — `LexerConfig::quote_termination`'s own doc says exactly that, `jim.c` has no such check, and the lexer's `strict_quoting` gate already reads the policy.

The raise is now guarded on `config.quote_termination.is_strict()`. `a_concatenating_dialect_welds_instead_of_raising` pins `set y "abc"def` → `abcdef` under the jim grammar and asserts the dialect really is non-strict, so the guard cannot rot into a no-op. The brace sibling has no such axis — `extra characters after close-brace` is strict in every dialect — so only the quote branch is guarded.

### Guards that flip

`KNOWN_DIVERGENCES`, `the_close_quote_weld_is_the_only_pinned_divergence`, and the corpus-test skip block in `parse_cut_agreement.rs` are all **deleted** — `the_two_engines_agree_on_the_sheet` now covers the shape, with 9 new `SHEET` rows. `parser_gaps.rs` gains the `#1828` trio (an 18-shape sheet with `-errorcode NONE`, cut semantics, and non-welds), mirroring the existing `#1786` trio. The boundary owner's module doc no longer says the flag is "deliberately brace-only".

Closes #1828

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

```
source scripts/dev/agent-build-env.sh      # per-worktree CARGO_TARGET_DIR, per AGENTS.md #1052
cargo test --manifest-path runtime/rust/Cargo.toml
cargo test -p tcl-lexer
make rust-check
cargo test -p tcl-compiler --test differential_group --test per_item_corpus \
                           --test differential_word_expr --test wasm_tiers
cargo test -p tcl-spectcl --test spec_corpus
```

All exit 0. `make rust-check` was confirmed green on the base commit first, so the gate result is attributable. No `#[allow]` added; `clippy::pedantic` clean. The dialect guard was re-verified separately: full `runtime/rust` suite green (0 failures), `cargo fmt --check` clean, `cargo clippy --all-targets -D warnings` clean.

Every oracle row was re-measured on `tmp/tcl8.6.16` and `tmp/tcl9.0.4`: all 18 weld shapes, `-errorcode NONE`, both cut rows (`{extra characters after close-quote} pre 0`), and the 14-row parse-order sheet — byte-identical on both shells, with the existing 11 rows unchanged.

**Corpus.** `samples/tcl/05_warning_examples.tcl` is untouched and no test changes verdict on it; the only consumer affected is `the_two_engines_agree_over_the_corpus`, which passes because both engines now report the same cut. The corpus test was additionally run against the full 1361 files (`samples/`, `tmp/tcl9.0.4/library`, `tmp/tcllib-2.0/modules`), green with and without.

## Compiler / diagnostics checklist

- [x] Did this change alter a compiler fact contract? Yes — the runtime now raises a new hard parse error under strict-quoting dialects, and the boundary owner carries a new word flag.
- [x] If yes, I updated the owning design doc — `shared-utility-contracts-rust.md` (no divergence pinned any more) and the `parse_cut`/`script.rs` module docs.
- [x] If I added or changed a diagnostic or optimisation code, I updated its page under `docs/kcs/codes/` — the E205 note (`kcs-diagnostic-e205-extra-characters-after-close-quote.md`) gains a currency line.
- [x] If I added a design doc, I linked it from `docs/design/README.md` — n/a, no new design doc.

## Note for the reviewer

Two rows in the plan this was built from expected `list a"b"c` and `list $a"b"c` to return bare strings; they actually return `a\"b\"c` / `A\"b\"c` under Tcl list quoting. Those two rows use `string cat` instead, measured as `a"b"c` / `A"b"c`.