### PR TITLE
perf(spectcl): index codegen source lines

### DIFF
--- a/rust/tcl-compiler/src/codegen/emitter/mod.rs
+++ b/rust/tcl-compiler/src/codegen/emitter/mod.rs
@@ -87,10 +87,10 @@ pub fn codegen_function_with_procs(
 /// name resolves to). Bundled rather than threaded as parallel parameters —
 /// the argument list is already at `clippy::too_many_arguments`'s ceiling, and
 /// these always travel together.
-#[derive(Clone, Copy)]
 struct ModuleEmit<'a> {
     registry: &'a CommandRegistry,
-    source: &'a str,
+    source: std::rc::Rc<str>,
+    line_index: tcl_lexer::LineIndex,
     dialect: Option<&'static tcl_dialect::DialectProfile>,
     numbers: tcl_dialect::NumberSyntax,
     escapes: tcl_dialect::EscapeSyntax,
@@ -113,7 +113,7 @@ fn codegen_function_src(
     params: &[&str],
     is_proc: bool,
     proc_defs: &[IrProcedure],
-    module: ModuleEmit<'_>,
+    module: &ModuleEmit<'_>,
     base_line: u32,
 ) -> FunctionAsm {
     let mut ctx = CodegenCtx::new(is_proc, params, module.registry);
@@ -124,24 +124,13 @@ fn codegen_function_src(
     ctx.expr_grammar = module.expr_grammar;
     ctx.dialect = module.dialect;
     ctx.command_bindings = Some(module.command_bindings);
-    ctx.set_source(module.source);
+    ctx.set_indexed_source(
+        std::rc::Rc::clone(&module.source),
+        module.line_index.clone(),
+    );
     let mut asm = generate::generate(&mut ctx, cfg, proc_defs);
     asm.body_base_line = base_line;
     asm
-}
-
-/// The 1-based line of byte offset `off` within `source`.
-fn line_of(source: &str, off: u32) -> u32 {
-    let end = (off as usize).min(source.len());
-    1 + u32::try_from(
-        source
-            .get(..end)
-            .unwrap_or("")
-            .bytes()
-            .filter(|&b| b == b'\n')
-            .count(),
-    )
-    .unwrap_or(0)
 }
 
 /// Resolve the compile's dialect name to the profile [`ModuleEmit`] carries.
@@ -173,7 +162,8 @@ pub fn codegen_module(
     ir_module: &IrModule,
     registry: &CommandRegistry,
 ) -> ModuleAsm {
-    let src = &ir_module.source;
+    let source: std::rc::Rc<str> = ir_module.source.as_str().into();
+    let line_index = tcl_lexer::LineIndex::new(&source);
     // The compile's target release: a named dialect's own numeric grammar, else
     // the permissive 9.x default.
     let dialect = ir_module.dialect.as_deref();
@@ -194,7 +184,8 @@ pub fn codegen_module(
         crate::command_binding::scan_module_command_mutations(ir_module, registry);
     let module = ModuleEmit {
         registry,
-        source: src,
+        source,
+        line_index,
         dialect: emit_profile(dialect),
         numbers,
         escapes,
@@ -203,7 +194,7 @@ pub fn codegen_module(
         expr_grammar,
         command_bindings: &command_bindings,
     };
-    let top = codegen_function_src(&cfg_module.top_level, &[], false, &[], module, 0);
+    let top = codegen_function_src(&cfg_module.top_level, &[], false, &[], &module, 0);
     let mut procs: HashMap<String, FunctionAsm> = HashMap::new();
     for (qname, cfg_func) in &cfg_module.procedures {
         let ir_proc = ir_module.procedures.get(qname);
@@ -218,10 +209,16 @@ pub fn codegen_module(
             .map(|p| p.params.iter().map(String::as_str).collect())
             .unwrap_or_default();
         // The proc's definition line drives proc-relative `errorInfo` lines.
-        let base_line = ir_proc.map_or(0, |p| line_of(src, p.span.start()));
+        let base_line = ir_proc.map_or(0, |p| {
+            module
+                .line_index
+                .position_at(p.span.start())
+                .line
+                .saturating_add(1)
+        });
         procs.insert(
             qname.clone(),
-            codegen_function_src(cfg_func, &params, true, &[], module, base_line),
+            codegen_function_src(cfg_func, &params, true, &[], &module, base_line),
         );
     }
     ModuleAsm {

--- a/rust/tcl-compiler/src/codegen/mod.rs
+++ b/rust/tcl-compiler/src/codegen/mod.rs
@@ -231,6 +231,9 @@ pub struct CodegenCtx<'r> {
     /// each command's surface text for `errorInfo` (`while executing "…"`).
     /// Empty when the caller did not supply it (hand-built test contexts).
     source: std::rc::Rc<str>,
+    /// The lexer-owned line index for [`Self::source`]. Production module
+    /// emission shares one Arc-backed index across every function context.
+    line_index: Option<tcl_lexer::LineIndex>,
     /// Per-argument "is a braced (`{…}`) word" flags for the command currently
     /// dispatching to a codegen hook (`try_bytecoded`). Set by [`Self::emit_call`]
     /// from the command's tokens and consulted by [`Self::emit_word_arg`] so a
@@ -298,6 +301,7 @@ impl<'r> CodegenCtx<'r> {
             registry,
             command_bindings: None,
             source: "".into(),
+            line_index: None,
             cmd_arg_braced: Vec::new(),
         }
     }
@@ -306,6 +310,18 @@ impl<'r> CodegenCtx<'r> {
     /// carry their command's surface text for `errorInfo`.
     pub fn set_source(&mut self, source: &str) {
         self.source = source.into();
+        self.line_index = (!source.is_empty()).then(|| tcl_lexer::LineIndex::new(source));
+    }
+
+    /// Install the module source and its already-built line index. The module
+    /// emitter uses this path so procedure contexts share both allocations.
+    pub(super) fn set_indexed_source(
+        &mut self,
+        source: std::rc::Rc<str>,
+        line_index: tcl_lexer::LineIndex,
+    ) {
+        self.line_index = (!source.is_empty()).then_some(line_index);
+        self.source = source;
     }
 
     /// Whether `name` still denotes its original builtin everywhere in this
@@ -359,21 +375,27 @@ impl<'r> CodegenCtx<'r> {
         if self.source.is_empty() {
             return 0;
         }
-        let start = span.start() as usize;
-        let prefix = self.source.get(..start).unwrap_or("");
-        1 + u32::try_from(prefix.bytes().filter(|&b| b == b'\n').count()).unwrap_or(0)
+        self.line_at(span.start())
+    }
+
+    /// The indexed 1-based line containing `offset`.
+    fn line_at(&self, offset: u32) -> u32 {
+        let Some(line_index) = &self.line_index else {
+            return 1;
+        };
+        if usize::try_from(offset).map_or(true, |offset| offset > self.source.len()) {
+            return 1;
+        }
+        line_index.position_at(offset).line.saturating_add(1)
     }
 
     /// The 1-based line of `current_span` within the module source — the line a
     /// command reports in `errorInfo` (`(procedure … line N)` / `("while" body
-    /// line N)`). `0` when no span / source is available.
+    /// line N)`). `0` when no span is available. A hand-built context with a
+    /// span but no source retains the historical line-one fallback.
     fn span_line(&self) -> u32 {
         match self.current_span {
-            Some(sp) => {
-                let start = sp.start() as usize;
-                let prefix = self.source.get(..start).unwrap_or("");
-                1 + u32::try_from(prefix.bytes().filter(|&b| b == b'\n').count()).unwrap_or(0)
-            }
+            Some(sp) => self.line_at(sp.start()),
             None => 0,
         }
     }
@@ -431,5 +453,47 @@ impl<'r> CodegenCtx<'r> {
             body_base_line: 0,
             error_regions: Vec::new(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn source_lines_are_indexed_at_byte_boundaries() {
+        let registry = CommandRegistry::build_default();
+        let mut ctx = CodegenCtx::new(false, &[], &registry);
+        ctx.set_source("alpha\nβeta\n\ngamma");
+
+        for (offset, expected) in [(0, 1), (5, 1), (6, 2), (11, 2), (12, 3), (13, 4)] {
+            assert_eq!(ctx.source_line(Span::empty(offset)), expected, "{offset}");
+        }
+
+        assert_eq!(ctx.source_line(Span::empty(99)), 1);
+
+        ctx.current_span = Some(Span::empty(13));
+        let instruction = ctx.emit(Op::NOP, Vec::new());
+        assert_eq!(ctx.instructions[instruction].source_line, 4);
+
+        let mut empty = CodegenCtx::new(false, &[], &registry);
+        assert_eq!(empty.source_line(Span::empty(0)), 0);
+        empty.current_span = Some(Span::empty(0));
+        let instruction = empty.emit(Op::NOP, Vec::new());
+        assert_eq!(empty.instructions[instruction].source_line, 1);
+
+        let source: std::rc::Rc<str> = "shared\nsource".into();
+        let source_clone = std::rc::Rc::clone(&source);
+        let line_index = tcl_lexer::LineIndex::new(&source);
+        let line_index_clone = line_index.clone();
+        let mut shared = CodegenCtx::new(false, &[], &registry);
+        shared.set_indexed_source(source, line_index);
+        assert!(std::rc::Rc::ptr_eq(&shared.source, &source_clone));
+        assert!(
+            shared
+                .line_index
+                .as_ref()
+                .is_some_and(|index| index.shares_storage_with(&line_index_clone)),
+        );
     }
 }


### PR DESCRIPTION
Closes #1840.

## Root cause

The evaluator and 2.0-upgrade gates independently compile every shipped pack, as required. Large EDA packs expose a compiler cost that ordinary Tcl sources do not: code generation stamped each emitted instruction with a source line by rescanning the whole source prefix. That made line attribution quadratic in source size.

Phase instrumentation attributed 13.611s of the evaluator parity run to code generation across 1,691 compilation calls. One 1,267,519-byte Xilinx `speclib` body accounted for 11.406s; parsing, lowering, CFG construction, evaluator execution, file reads, and result comparison were not the dominant costs.

## Fix

- Build the lexer-owned, Arc-backed `LineIndex` once per compilation module and share it across the top-level and every procedure code-generation context.
- Share the module source allocation across those contexts as well, instead of cloning the full source for each procedure.
- Resolve both per-instruction source lines and procedure base lines through the shared index instead of rescanning source prefixes.
- Preserve the existing explicit-span and hand-built-context behaviour for empty or out-of-range sources.
- Add a byte-boundary regression spanning ASCII, newlines, a multibyte UTF-8 character, an empty line, and emitted-instruction stamping.

No pack inventory, evaluator/static-loader independence, upgrade path, command comparison, notice comparison, provenance check, golden, or semantic assertion is removed.

## Experimental proof

Warm exact tests on the same machine and isolated Cargo target:

| Gate | Before | After | Improvement |
| --- | ---: | ---: | ---: |
| evaluator/static fast-path parity | 16.27s | 3.22s | 80.2% |
| 2.0 upgrade/golden parity | 18.25s | 5.06s | 72.3% |

The evaluator gate still reports 24 packs, 1,515 commands (1,513 registry entries), and 43 notices compared.

- Source-line and allocation-sharing regression: 1/1 passed.
- `cargo nextest run -p tcl-compiler`: 9,228 passed, 6 skipped, 70.837s.
- `cargo nextest run -p tcl-spectcl`: 274 passed, 1 skipped, 22.551s.
- `make rust-check`: passed.
- `make prep-pr`: passed with 29/29 smoke tests.
