### PR TITLE
test(ext): converge on the post-toggle publish in the W100 suppression test

### DIFF
--- a/editors/vscode/src/test/configSettings.test.ts
+++ b/editors/vscode/src/test/configSettings.test.ts
@@ -1254,30 +1254,30 @@ suite("Configuration Settings", () => {
         label: "W100 disabled",
       });
 
-      // Re-trigger: touch the document so the server re-analyses, then
-      // wait for a publish that actually reflects the toggle.
+      // Re-trigger analysis under the new setting, and anchor the read on
+      // the server's own marker for *that* pass.
       //
-      // A bare next-publish barrier is not enough. It resolves on the
-      // first onDidChangeDiagnostics naming this URI, and a publish
-      // computed *before* the toggle can still be in flight and satisfy
-      // it — the server is known to deliver a publish long after the turn
-      // that produced it (#1678, #1849, #1865). The assertion then reads
-      // a pre-toggle set and fails on timing rather than on behaviour.
+      // A bare publish barrier is wrong here twice over. It resolves on the
+      // first onDidChangeDiagnostics naming this URI, so a publish computed
+      // before the toggle and delivered late satisfies it — this server is
+      // known to deliver a publish long after the turn that produced it
+      // (#1678, #1849, #1865). And the config change itself re-analyses open
+      // documents, so a W100-free set can already be published before the
+      // edit is even sent. In the first case the assertion reads a stale
+      // pre-toggle set and fails on timing; in the second it passes without
+      // ever observing the edit, leaving a defective edit-triggered pass free
+      // to republish W100 afterwards.
       //
-      // LSP diagnostics are eventually consistent, so the contract worth
-      // asserting is that suppression converges: retry across publishes
-      // and let the timeout fail the test if W100 never goes away.
-      //
-      // The predicate also requires a non-empty set. `awaitSignal` probes
-      // before it waits, and a transiently cleared set would satisfy a
-      // bare "no W100" immediately — passing without the server having
-      // published anything. The fixture raises many codes besides W100,
-      // so a real post-toggle publish is still non-empty.
+      // `waitForDeepDiagnostics` with `since` captured *before* the edit keys
+      // on the `[timing] deep diagnostics` line from the run the edit caused,
+      // which settles both: the pass is the edit's own, and it has finished
+      // publishing. Same discipline as the optimiser toggle test below, made
+      // that way for the same reason.
       const editor = vscode.window.activeTextEditor!;
+      const sinceEdit = getServerLogSize();
       await setTestContent(editor, editor.document.getText() + " ");
-      const after = await waitForDiagnostics(docUri, {
-        predicate: (diags) => diags.length > 0 && !diags.some((d) => codeOf(d) === "W100"),
-      });
+      await waitForDeepDiagnostics(docUri, { since: sinceEdit });
+      const after = vscode.languages.getDiagnostics(docUri);
       assert.ok(
         !after.some((d) => codeOf(d) === "W100"),
         `W100 should be suppressed when disabled, got [${after.map(codeOf)}]`,

--- a/editors/vscode/src/test/configSettings.test.ts
+++ b/editors/vscode/src/test/configSettings.test.ts
@@ -23,7 +23,6 @@ import {
   getDocUri,
   activate,
   getServerLogSize,
-  nextDiagnosticsPublish,
   pollUntil,
   waitForDeepDiagnostics,
   waitForDiagnostics,
@@ -1255,17 +1254,32 @@ suite("Configuration Settings", () => {
         label: "W100 disabled",
       });
 
-      // Re-trigger: touch the document so the server re-analyses.
-      // Register the publish listener *before* the edit so the fresh
-      // publish event is not missed and we do not read stale
-      // pre-toggle results.
+      // Re-trigger: touch the document so the server re-analyses, then
+      // wait for a publish that actually reflects the toggle.
+      //
+      // A bare next-publish barrier is not enough. It resolves on the
+      // first onDidChangeDiagnostics naming this URI, and a publish
+      // computed *before* the toggle can still be in flight and satisfy
+      // it — the server is known to deliver a publish long after the turn
+      // that produced it (#1678, #1849, #1865). The assertion then reads
+      // a pre-toggle set and fails on timing rather than on behaviour.
+      //
+      // LSP diagnostics are eventually consistent, so the contract worth
+      // asserting is that suppression converges: retry across publishes
+      // and let the timeout fail the test if W100 never goes away.
+      //
+      // The predicate also requires a non-empty set. `awaitSignal` probes
+      // before it waits, and a transiently cleared set would satisfy a
+      // bare "no W100" immediately — passing without the server having
+      // published anything. The fixture raises many codes besides W100,
+      // so a real post-toggle publish is still non-empty.
       const editor = vscode.window.activeTextEditor!;
-      const freshDiags = nextDiagnosticsPublish(docUri);
       await setTestContent(editor, editor.document.getText() + " ");
-      const after = await freshDiags;
-      const hasW100After = after.some((d) => codeOf(d) === "W100");
+      const after = await waitForDiagnostics(docUri, {
+        predicate: (diags) => diags.length > 0 && !diags.some((d) => codeOf(d) === "W100"),
+      });
       assert.ok(
-        !hasW100After,
+        !after.some((d) => codeOf(d) === "W100"),
         `W100 should be suppressed when disabled, got [${after.map(codeOf)}]`,
       );
     } finally {


### PR DESCRIPTION
## Summary

`Configuration Settings > disabling diagnostics.W100 suppresses that diagnostic` failed on #1855 — a Python-only diff — reporting the **full default diagnostic set**, W100 included, *after* the effective-config wait had already confirmed the server had the toggle:

```
AssertionError: W100 should be suppressed when disabled,
got [W100,W101,W105,W302,W110,W304,W304,E001,E100,E102,W123,O111,T103,T102,O120]
```

The barrier was the problem, not the behaviour. The test used `nextDiagnosticsPublish`, which resolves on the first `onDidChangeDiagnostics` naming the URI — proving *a* publish happened, not that the publish came from the run the test cares about. Two distinct things go wrong with that:

1. **A stale publish satisfies it.** A set computed before the toggle can still be in flight; this server delivers publishes long after the turn that produced them (#1678 records a ~70s hold on the open-document map before a send; #1849 and #1865 are the wedged-holder cases). The assertion then reads a pre-toggle set and fails on timing rather than on behaviour. That is the observed failure.
2. **The config pass satisfies it.** Changing configuration re-analyses open documents by itself, so a W100-free set can be published before the edit is even sent — and the assertion passes without ever observing the edit.

The old comment claimed that registering the listener before the edit meant "we do not read stale pre-toggle results". It does not: ordering the registration before the edit only avoids *missing* a publish, and does nothing about a stale or unrelated one arriving first.

## The fix

Anchor the read on the server's own marker for the edit's analysis pass, rather than on any publish event:

```ts
const sinceEdit = getServerLogSize();
await setTestContent(editor, editor.document.getText() + " ");
await waitForDeepDiagnostics(docUri, { since: sinceEdit });
const after = vscode.languages.getDiagnostics(docUri);
```

`waitForDeepDiagnostics` keys on `[timing] deep diagnostics uri=…`, and `since` captured before the edit restricts the match to the run that edit caused. Neither a late pre-toggle publish nor the config-triggered pass can satisfy it, because neither emits that marker after that point — and when it returns, the pass has finished publishing.

This is the discipline the **optimiser toggle test immediately below already uses**, whose own comment records that it was written that way after the same class of flake:

> Both O1xx snapshots are anchored on an *edit*, because an edit is the only action that is guaranteed to make the server re-analyse and emit a fresh `[timing] deep diagnostics` line … which is exactly the race that made this test flaky.

The two toggle tests now share one discipline instead of two.

> **Revised after review.** The first version of this PR waited for the diagnostics to *converge* on a W100-free set. Codex pointed out that this passes on the config pass without observing the edit, which turns an intermittent false failure into a silent false pass — strictly worse. The marker-anchored version above replaces it, and the eventual-consistency argument that argument rested on no longer applies: the read is of one identified pass.

## What this does not do

**Client-side only.** It does not fix the publish-lateness or document-map holder bugs and should not be read as fixing them — those need the server-side work and telemetry described in #1678, #1849 and #1865. The final `test-ext` run on #1855 wedged at `did_open: db_source_matches` with 7 hook failures, which is #1849 and entirely separate from this.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

```
cd editors/vscode
npx tsc --noEmit -p ./          → clean
npm run lint                    → clean (eslint + prettier)
```

Traced the helper semantics rather than assuming them: `waitForDiagnostics` (`helper.ts:1250`) delegates to `awaitSignal` (`signal.ts:437`), whose loop probes at the top of every iteration **before** waiting on the subscription — which is precisely why a predicate-based wait cannot serve as a post-edit barrier here, and why the marker is the right anchor. `waitForDeepDiagnostics` (`helper.ts:247`) is documented for exactly this use, including why keying on the server's marker beats waiting on `onDidChangeDiagnostics`.

**Not run here:** `make test-ext` needs a built `tcl-lsp-server`, a VS Code download and a display; this container has ~9 GB of disk left and already hit ENOSPC once on a Rust build this session, so I did not risk a half-finished run and a misleading result. CI runs the job on this PR, which is the check that matters — the test is the thing being changed.

## Compiler / diagnostics checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

Not applicable — one extension test's wait discipline. No compiler behaviour, diagnostic, optimisation code or analysis contract changes; W100 itself is untouched.

- [ ] Did this change alter a compiler fact contract?
- [ ] If yes, I updated the owning design doc under `docs/design/compiler/` or `docs/design/contracts/`.
- [ ] If I added or changed a diagnostic or optimisation code, I updated its page under `docs/kcs/codes/` and linked it from `docs/kcs/codes/README.md`.
- [ ] If I added a design doc, I linked it from `docs/design/README.md` (`cargo xtask kcs-index-links` enforces this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)