### PR TITLE
fix: namespace command tables tear down in Tcl hash order, and a command trace belongs to a token (#1752)

### DIFF
--- a/docs/design/contracts/shared-utility-contracts-rust.md
+++ b/docs/design/contracts/shared-utility-contracts-rust.md
@@ -32,7 +32,7 @@ entry point, or gate moves without this contract being updated.
 <!-- owner-resolution-manifest -->
 | Surface | Owner source paths | Public entry points | Dialect/release axis | Drift gate |
 | --- | --- | --- | --- | --- |
-| names / namespaces | `rust/tcl-syntax/src/naming.rs`; `rust/tcl-cmd-core/src/namespace.rs` | `qualifier_segments`; `command_resolution_candidates`; `qualifiers`; `tail`; `exists`; `exists_bytes`; `parent`; `parent_bytes`; `children`; `children_bytes`; `which_request`; `which_command`; `which_command_bytes`; `which_variable`; `variable_fqn`; `variable_fqn_bytes`; `import_pattern`; `origin`; `origin_bytes` | invariant, except `which_variable`'s alternate (global) candidate, which 9.0 drops; absolute-marker contract from #1493 | `xtask-resolution-drift` |
+| names / namespaces | `rust/tcl-syntax/src/naming.rs`; `rust/tcl-cmd-core/src/namespace.rs` | `qualifier_segments`; `command_resolution_candidates`; `qualifiers`; `tail`; `exists`; `exists_bytes`; `parent`; `parent_bytes`; `children`; `children_bytes`; `which_request`; `which_command`; `which_command_bytes`; `which_variable`; `variable_fqn`; `variable_fqn_bytes`; `import_pattern`; `origin`; `origin_bytes`; `TclStringHashOrder` | invariant, except `which_variable`'s alternate (global) candidate, which 9.0 drops; absolute-marker contract from #1493 | `xtask-resolution-drift` |
 | lists | `rust/tcl-syntax/src/list.rs` | `find_element`; `split_list`; `list_element`; `join_list`; `append_list_element`; `junk_fragment` | invariant | none |
 | dicts | `rust/tcl-syntax/src/list.rs`; `rust/tcl-syntax/src/value.rs`; `rust/tcl-cmd-core/src/dict.rs` | `find_element`; `split_list`; `canonical_dict_slots`; `ValueOps::dict_pairs`; `worded_parse_error` | invariant | none |
 | glob matching | `rust/tcl-syntax/src/glob.rs` | `string_match`; `string_match_bytes`; `string_case_match` | invariant | none |
@@ -806,7 +806,10 @@ helper without reading the rationale:
   doctests; `rust/tcl-syntax/tests/command_resolution_conformance.rs`
   (tclsh-pinned; `tcl-compiler` and `tcl-vm` each carry a same-named suite
   for their own layer).
-- `rust/tcl-cmd-core/src/namespace.rs` — `qualifiers_and_tail_match_c`.
+- `rust/tcl-cmd-core/src/namespace.rs` — `qualifiers_and_tail_match_c`,
+  and the `tcl_string_hash_order_*` suite pinning the retained
+  `TCL_STRING_KEYS` table both namespace child and namespace command
+  teardown enumerate.
 - `rust/tcl-cmd-core/src/prefix.rs` — C-parity unit tests (empty-key,
   empty-entry, exact-mode wording).
 - `rust/tcl-cmd-core/src/ensemble.rs` — the two option tables, the

--- a/docs/design/runtime/command-introspection.md
+++ b/docs/design/runtime/command-introspection.md
@@ -58,7 +58,10 @@ qualified hidden names are rejected up front.
 
 `BTreeMap` (rather than a hash table) makes ``interp hidden`` listings
 sorted and deterministic, the same choice the namespace command tables
-make.
+make. C answers `interp hidden` — and `info commands` — in
+`Tcl_FirstHashEntry` order instead; that remains the divergence here. Only
+namespace *teardown* reads the retained Tcl hash order (issue #1752), because
+delete traces make it observable in a way an unsorted listing is not.
 
 There is nothing to invalidate downstream: no namespace path targets
 the hidden table, and command resolution never probes it.

--- a/docs/design/runtime/namespace-tree.md
+++ b/docs/design/runtime/namespace-tree.md
@@ -191,7 +191,11 @@ struct Namespace {
     name: Vec<u8>,
     parent: Option<NsId>,
     children: BTreeMap<Vec<u8>, NsId>,
-    commands: BTreeMap<Vec<u8>, Command>,
+    /// The child table's retained `TCL_STRING_KEYS` bucket order.
+    child_order: TclStringHashOrder,
+    /// Entries + the command table's retained bucket order + a per-entry
+    /// token generation.
+    commands: CommandTable,
     /// `namespace path` — namespaces searched for unqualified commands.
     path: Vec<NsId>,
     /// `namespace export` patterns, matched with `string match` glob.
@@ -218,10 +222,32 @@ Four fields of C's `Namespace` have no counterpart, deliberately:
   emptied, so there is no dying-but-reachable state to describe.
 
 `BTreeMap` (not `HashMap`) throughout gives deterministic storage and makes
-`info commands` / `info vars` stable run to run. `namespace children` is the
-exception where C's `Tcl_HashTable` bucket order is public behavior: the
-adapter supplies child ids in creation order and `tcl-cmd-core::namespace`
-reconstructs the Tcl string-hash enumeration, including resize reversals.
+`info commands` / `info vars` stable run to run. Two places are exceptions,
+where C's `Tcl_HashTable` bucket order is public behaviour: `namespace
+children` and namespace **teardown**. Both read a retained
+[`TclStringHashOrder`] kept beside the map — one per child table, one per
+command table — because Tcl quadruples the bucket array at a 3:1 load factor,
+never shrinks it, and reverses chains on every rebuild, so the order cannot be
+reconstructed from the live entries alone. `TclDeleteNamespaceChildren` and
+`TclTeardownNamespace` snapshot exactly that order before deleting each token,
+and delete traces make it observable.
+
+`CommandTable` also mints a **generation** per entry. It is the one piece of
+C's `Command` identity the table needs: a teardown snapshot names
+`(tail, generation)`, so a token a delete callback deleted or redefined is
+skipped rather than confused with whatever now holds the name — C's
+`CMD_DYING` early return, which leaves the replacement to the next snapshot.
+
+The bytecode VM reaches the same behaviour from a different shape: its command
+table is one flat map keyed by canonical FQN, so it keeps the order owners in
+`ns_command_order`, keyed by each command's holder namespace, and its teardown
+snapshot pairs each key with the `command_generations` entry. One caveat is
+the VM's alone: it registers its builtins in its own bootstrap order rather
+than `Tcl_CreateInterp`'s, so the **global** holder's order — what
+`namespace delete ::` would enumerate — is ours, not C's. Every per-namespace
+user table is exact.
+
+[`TclStringHashOrder`]: ../../../rust/tcl-cmd-core/src/namespace.rs
 
 ### `Command`
 
@@ -278,10 +304,23 @@ implemented, it is implemented differently — the pointer below says where.
 C Tcl uses `refCount`, `activationCount`, `NS_DYING` / `NS_DEAD`,
 `deleteProc`, `earlyDeleteProc`, `VarInHash.refCount`, `Command.refCount`, and
 `Command.cmdEpoch` to sequence a namespace teardown that can be re-entered by
-the very code it is tearing down. None of them is carried: there is no `flags`
-word on either `Namespace` or `Command`, because Rust ownership sequences the
-teardown instead — a removed entry is moved out of its map, so nothing can
-observe a half-dead one.
+the very code it is tearing down. Most of them are not carried: there is no
+`flags` word on either `Namespace` or `Command`, because Rust ownership
+sequences the teardown instead — a removed entry is moved out of its map, so
+nothing can observe a half-dead one.
+
+The one exception is what `CMD_DYING` + `Command.cmdEpoch` together decide:
+*is the thing at this name still the token I snapshotted?* `CommandTable`
+answers that with its per-entry generation, so `delete_namespace_token` can
+run C's loop — snapshot `cmdTable` in hash order, delete each snapshotted
+token in turn while its entry is still visible to its own delete trace, and
+re-snapshot while the table is non-empty. A callback that deletes a
+snapshotted sibling, or redefines the entry the loop is on, changes that
+entry's generation and the loop skips it; a command the callback *created*
+is torn down by the next snapshot.
+
+`activationCount` and the deferred teardown it drives are still not carried
+(#1751).
 
 `namespace delete` **is** implemented (`cmd_namespace.rs::ns_delete`, mirroring
 C's `NamespaceDeleteCmd`): it deletes each named namespace with its children,
@@ -560,6 +599,13 @@ pub fn rename(&mut self, current: NsId, old: &[u8], new: &[u8]) -> RenameOutcome
 pub fn command_names(&self, ns: NsId) -> Vec<&[u8]>;
 pub fn which_command(&self, current: NsId, name: &[u8]) -> Option<Vec<u8>>;
 pub fn command_origin(&self, current: NsId, name: &[u8]) -> Option<Vec<u8>>;
+/// The teardown snapshot: live `(simple name, generation)` slots in
+/// `Tcl_FirstHashEntry` order.
+pub(crate) fn command_hash_order(&self, ns: NsId) -> Vec<(Vec<u8>, u64)>;
+/// The generation currently bound at `(ns, name)` — the snapshot's
+/// still-the-same-token check.
+pub(crate) fn command_generation(&self, ns: NsId, name: &[u8]) -> Option<u64>;
+pub(crate) fn command_fqn_at(&self, ns: NsId, name: &[u8]) -> Vec<u8>;
 ```
 
 ### Variable table
@@ -613,9 +659,13 @@ pub(crate) fn set_unknown_handler(&mut self, ns: NsId, handler: &[u8]);
 
 There are no visitor helpers: `command_names`, `var_names`, `proc_names`,
 `const_names`, `children`, and `descendant_ids` each return an owned or
-borrowed listing directly. `children` returns creation order for the shared
-command core's Tcl-hash ordering step; the remaining table listings retain the
-cheap deterministic `BTreeMap` order.
+borrowed listing directly. Two listings are ordered by the retained Tcl hash
+table instead of the map: `children_hash_order` (which
+`TclDeleteNamespaceChildren` and `namespace children` need) and
+`command_hash_order` (which `TclTeardownNamespace` needs). The rest retain the
+cheap deterministic `BTreeMap` order — including `info commands` / `info
+procs`, which C also answers in hash order; that divergence is tracked
+separately and only ever shows through an unsorted listing.
 
 ## 8. Settled design points
 

--- a/docs/design/runtime/namespace-tree.md
+++ b/docs/design/runtime/namespace-tree.md
@@ -233,10 +233,13 @@ reconstructed from the live entries alone. `TclDeleteNamespaceChildren` and
 and delete traces make it observable.
 
 `CommandTable` also mints a **generation** per entry. It is the one piece of
-C's `Command` identity the table needs: a teardown snapshot names
-`(tail, generation)`, so a token a delete callback deleted or redefined is
-skipped rather than confused with whatever now holds the name — C's
-`CMD_DYING` early return, which leaves the replacement to the next snapshot.
+C's `Command` identity the table needs, and two things read it. A teardown
+snapshot names `(tail, generation)`, so a token a delete callback deleted or
+redefined is skipped rather than confused with whatever now holds the name —
+C's `CMD_DYING` early return, which leaves the replacement to the next
+snapshot. And every command-trace registration is stamped with it, so a
+deletion frees the dying token's trace list and no one else's
+([`trace-implementation.md`](trace-implementation.md)).
 
 The bytecode VM reaches the same behaviour from a different shape: its command
 table is one flat map keyed by canonical FQN, so it keeps the order owners in

--- a/docs/design/runtime/trace-implementation.md
+++ b/docs/design/runtime/trace-implementation.md
@@ -127,10 +127,23 @@ the order `TclTeardownNamespace` snapshots `nsPtr->cmdTable` — the retained
 #1752). Each token's traces fire while its entry is still in the table, then
 its imports retire depth-first, then the loop moves to the next entry; the
 table is re-snapshotted while it is non-empty, so a command a callback creates
-is torn down in a later pass. A deletion drops exactly the traces the dying
-token carried: a callback that redefines the command registers traces on a new
-token under the same name, and those survive, as C's per-`Command` trace list
-does.
+is torn down in a later pass.
+
+A deletion drops exactly the traces the **dying token** carried, which is what
+C's `Tcl_DeleteCommandFromToken` frees when it releases `cmdPtr->tracePtr`.
+Both registries are keyed by command *name*, so each registration is stamped
+with the generation of the token it was made against, and the deletion keeps
+only the stamps that are later than the dying one:
+
+- a trace a delete callback adds to the command **being deleted** attaches to
+  that same dying token, so it never fires — not in the walk in progress
+  (`CallCommandTraces` follows `active.nextTracePtr`), and not for a later
+  command that takes the vacated name;
+- a trace it registers on a **replacement** it bound at that name belongs to
+  the new token and survives, list intact.
+
+A hide, expose or rename moves the list with its token and re-stamps it,
+because C moves the `Command` itself rather than creating a new one.
 
 Re-entrancy is suppressed per scope: a variable trace pushes its scope onto
 `active_var_scopes` for the duration of the callback, so a callback touching

--- a/docs/design/runtime/trace-implementation.md
+++ b/docs/design/runtime/trace-implementation.md
@@ -118,15 +118,31 @@ not decide which group runs first — only the order within a group.
 The same head-first rule decides **which** registration a `trace remove`
 deletes: C breaks at the first match, so among identical duplicates the newest
 goes. Every removal site therefore searches from the newest end (`rposition`
-over our oldest-first Vecs), as do the teardown paths that collect a
-namespace's unset and command-delete traces before firing them.
+over our oldest-first Vecs), as does the teardown path that collects a
+namespace's unset traces before firing them.
+
+Namespace teardown fires **command**-delete traces one command at a time, in
+the order `TclTeardownNamespace` snapshots `nsPtr->cmdTable` — the retained
+`TCL_STRING_KEYS` bucket order, not registration or lexical order (issue
+#1752). Each token's traces fire while its entry is still in the table, then
+its imports retire depth-first, then the loop moves to the next entry; the
+table is re-snapshotted while it is non-empty, so a command a callback creates
+is torn down in a later pass. A deletion drops exactly the traces the dying
+token carried: a callback that redefines the command registers traces on a new
+token under the same name, and those survive, as C's per-`Command` trace list
+does.
 
 Re-entrancy is suppressed per scope: a variable trace pushes its scope onto
 `active_var_scopes` for the duration of the callback, so a callback touching
-the same variable does not re-fire itself, and command-trace firing is gated on
-`exec_firing`. The interpreter result is preserved across every callback (held
-with an explicit `+1` and restored afterwards), so a trace cannot clobber the
-result of the operation it observed.
+the same variable does not re-fire itself. Command-trace firing is gated the
+way C gates it — **per command**, on the command whose traces are running
+(`CMD_TRACE_ACTIVE`, and `CMD_DYING` for a deletion), not interpreter-wide: a
+callback that deletes a *different* command still fires that command's own
+delete traces, nested inside the first. Execution and step traces keep the
+interpreter-wide gate (`INTERP_TRACE_IN_PROGRESS`), so a callback's own
+dispatches are never step-observed. The interpreter result is preserved across
+every callback (held with an explicit `+1` and restored afterwards), so a trace
+cannot clobber the result of the operation it observed.
 
 A read or write callback that errors reshapes the operation's result
 (`can't read "NAME": …` / `can't set "NAME": …`) and stops further firing —

--- a/runtime/rust/src/cmd_namespace.rs
+++ b/runtime/rust/src/cmd_namespace.rs
@@ -1557,14 +1557,11 @@ mod tests {
         // times the bucket count and re-pushes each chain head-first, which
         // reverses it. Thirteen commands cross the first threshold.
         assert_eq!(
-            teardown_log(
-                "namespace eval N {}
-                 for {set i 0} {$i < 13} {incr i} {
-                     proc ::N::c$i {} {}
-                     trace add command ::N::c$i delete rec
-                 }
-                 namespace delete ::N"
-            ),
+            teardown_log(&format!(
+                "{}
+                 namespace delete ::N",
+                traced_procs("c0 c1 c2 c3 c4 c5 c6 c7 c8 c9 c10 c11 c12")
+            )),
             "c5 c6 c7 c8 c9 c0 c1 c10 c2 c11 c12 c3 c4"
         );
     }

--- a/runtime/rust/src/cmd_namespace.rs
+++ b/runtime/rust/src/cmd_namespace.rs
@@ -1740,6 +1740,50 @@ mod tests {
     }
 
     #[test]
+    fn a_refused_alias_rename_keeps_the_command_tables_growth() {
+        // `TclRenameCommand` creates the destination hash entry *before*
+        // `TclPreventAliasLoop` and deletes it again on a refusal, so the
+        // transient twelfth entry rebuilds the eleven-command table from 4
+        // buckets to 16 and the grown array outlives the rejected rename.
+        let eleven = "namespace eval N {}
+             foreach n {one two three four five six seven eight nine ten eleven} {
+                 proc ::N::$n {} {}
+             }";
+        let trace_and_delete = "
+             foreach n [info commands ::N::*] {trace add command $n delete rec}
+             namespace delete ::N";
+        assert_eq!(
+            teardown_log(&format!("{eleven}{trace_and_delete}")),
+            "six four three eight seven nine five two one eleven ten"
+        );
+        let mut refusal = String::new();
+        let mut alias_survives = String::new();
+        leak_free(|i| {
+            let recorder = b"set log {}
+                 proc rec {old new op} {lappend ::log [namespace tail $old]}";
+            assert_eq!(i.eval_str(recorder), Code::Ok);
+            assert_eq!(i.eval_str(eleven.as_bytes()), Code::Ok);
+            assert_eq!(i.eval_str(b"interp alias {} ::a {} ::N::b"), Code::Ok);
+            assert_eq!(i.eval_str(b"rename ::a ::N::b"), Code::Error);
+            refusal = String::from_utf8_lossy(&i.result_bytes()).into_owned();
+            assert_eq!(i.eval_str(b"llength [info commands ::a]"), Code::Ok);
+            alias_survives = String::from_utf8_lossy(&i.result_bytes()).into_owned();
+            assert_eq!(i.eval_str(trace_and_delete.as_bytes()), Code::Ok);
+            assert_eq!(i.eval_str(b"set ::log"), Code::Ok);
+            assert_eq!(
+                String::from_utf8_lossy(&i.result_bytes()),
+                "three seven one two four eleven eight five nine six ten"
+            );
+            assert_eq!(i.eval_str(b"unset ::log"), Code::Ok);
+        });
+        assert_eq!(
+            refusal,
+            "cannot define or rename alias \"b\": would create a loop"
+        );
+        assert_eq!(alias_survives, "1");
+    }
+
+    #[test]
     fn namespace_delete_removes_subtree() {
         leak_free(|i| {
             i.eval_str(b"namespace eval foo { proc p {} {return P} ; namespace eval bar {} }");

--- a/runtime/rust/src/cmd_namespace.rs
+++ b/runtime/rust/src/cmd_namespace.rs
@@ -1504,6 +1504,244 @@ mod tests {
         }
     }
 
+    /// Run `script` (which fills `::log` through delete-trace callbacks) and
+    /// return the resulting log. Every expectation below is an exact tclsh
+    /// 9.0.4 result, identical on 8.6.16 unless the test says otherwise.
+    fn teardown_log(script: &str) -> String {
+        let mut log = String::new();
+        leak_free(|i| {
+            let recorder = b"set log {}
+                 proc rec {old new op} {lappend ::log [namespace tail $old]}";
+            assert_eq!(i.eval_str(recorder), Code::Ok);
+            assert_eq!(
+                i.eval_str(script.as_bytes()),
+                Code::Ok,
+                "{}",
+                String::from_utf8_lossy(&i.result_bytes())
+            );
+            assert_eq!(i.eval_str(b"set ::log"), Code::Ok);
+            log = String::from_utf8_lossy(&i.result_bytes()).into_owned();
+        });
+        log
+    }
+
+    /// Define `names` as procs in `::N` and trace each one's deletion.
+    fn traced_procs(names: &str) -> String {
+        format!(
+            "namespace eval N {{}}
+             foreach n {{{names}}} {{
+                 proc ::N::$n {{}} {{}}
+                 trace add command ::N::$n delete rec
+             }}"
+        )
+    }
+
+    #[test]
+    fn namespace_teardown_follows_command_table_hash_order() {
+        // TclTeardownNamespace snapshots cmdTable with Tcl_FirstHashEntry, so
+        // the delete traces fire in the retained TCL_STRING_KEYS bucket order,
+        // not the definition or lexical order.
+        assert_eq!(
+            teardown_log(&format!(
+                "{}
+                 namespace delete ::N",
+                traced_procs("one two three four five six seven eight nine ten")
+            )),
+            "six four three eight seven nine five two one ten"
+        );
+    }
+
+    #[test]
+    fn namespace_teardown_hash_order_records_table_growth() {
+        // RebuildTable quadruples the bucket array once entries reach three
+        // times the bucket count and re-pushes each chain head-first, which
+        // reverses it. Thirteen commands cross the first threshold.
+        assert_eq!(
+            teardown_log(
+                "namespace eval N {}
+                 for {set i 0} {$i < 13} {incr i} {
+                     proc ::N::c$i {} {}
+                     trace add command ::N::c$i delete rec
+                 }
+                 namespace delete ::N"
+            ),
+            "c5 c6 c7 c8 c9 c0 c1 c10 c2 c11 c12 c3 c4"
+        );
+    }
+
+    #[test]
+    fn namespace_teardown_hash_order_retains_capacity_across_deletions() {
+        // Tcl_DeleteHashEntry never shrinks the bucket array, so commands
+        // created after a bulk deletion land in the grown table and precede
+        // the survivors.
+        assert_eq!(
+            teardown_log(
+                "namespace eval N {}
+                 foreach n {a0 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11} {proc ::N::$n {} {}}
+                 foreach i {1 2 4 5 6 7 8 9 10 11} {rename ::N::a$i {}}
+                 foreach n {b1 b2 b3} {proc ::N::$n {} {}}
+                 foreach n [info commands ::N::*] {trace add command $n delete rec}
+                 namespace delete ::N"
+            ),
+            "b1 b2 b3 a0 a3"
+        );
+    }
+
+    #[test]
+    fn namespace_teardown_hash_order_moves_a_redefined_command() {
+        // TclCreateObjCommandInNs deletes the existing hash entry and creates
+        // a fresh one, so redefining `one` moves it to its bucket head.
+        assert_eq!(
+            teardown_log(
+                "namespace eval N {}
+                 foreach n {one two three four five six seven eight nine ten} {
+                     proc ::N::$n {} {}
+                 }
+                 proc ::N::one {} {return again}
+                 foreach n [info commands ::N::*] {trace add command $n delete rec}
+                 namespace delete ::N"
+            ),
+            "six four three eight seven one nine five two ten"
+        );
+        // TclRenameCommand creates the destination entry the same way.
+        assert_eq!(
+            teardown_log(
+                "namespace eval N {}
+                 foreach n {one two three four five six seven eight nine ten} {
+                     proc ::N::$n {} {}
+                 }
+                 rename ::N::one ::N::uno
+                 foreach n [info commands ::N::*] {trace add command $n delete rec}
+                 namespace delete ::N"
+            ),
+            "six four three eight seven uno nine five two ten"
+        );
+    }
+
+    #[test]
+    fn namespace_teardown_visits_a_callback_created_command_in_the_next_pass() {
+        // TclTeardownNamespace loops while cmdTable is non-empty, so a command
+        // a delete callback creates is torn down by a second snapshot, after
+        // every entry of the first one.
+        assert_eq!(
+            teardown_log(&format!(
+                "{}
+                 proc mk {{old new op}} {{
+                     lappend ::log [namespace tail $old]
+                     proc ::N::zz {{}} {{}}
+                     trace add command ::N::zz delete rec
+                 }}
+                 trace add command ::N::six delete mk
+                 namespace delete ::N",
+                traced_procs("one two three four five six seven eight nine ten")
+            )),
+            "six six four three eight seven nine five two one ten zz"
+        );
+    }
+
+    #[test]
+    fn namespace_teardown_defers_a_callback_recreated_command_to_the_next_pass() {
+        // A redefinition inside the delete callback unlinks the dying token's
+        // entry itself (Tcl_DeleteCommandFromToken's CMD_DYING branch), so the
+        // replacement is a distinct token the current snapshot no longer names.
+        // tclsh 9.0.4 only: 8.6.16 crashes on this script.
+        assert_eq!(
+            teardown_log(&format!(
+                "{}
+                 proc remake {{old new op}} {{
+                     proc ::N::two {{}} {{}}
+                     trace add command ::N::two delete rec
+                     lappend ::log remade
+                 }}
+                 trace add command ::N::two delete remake
+                 namespace delete ::N",
+                traced_procs("one two three four five six seven eight nine ten")
+            )),
+            "six four three eight seven nine five remade two one ten two"
+        );
+    }
+
+    #[test]
+    fn namespace_teardown_skips_a_command_a_callback_already_deleted() {
+        // The snapshot entry for `one` is gone by the time the loop reaches
+        // it, and Tcl_DeleteCommandFromToken returns early rather than firing
+        // a second time.
+        assert_eq!(
+            teardown_log(&format!(
+                "{}
+                 proc killone {{old new op}} {{rename ::N::one {{}}; lappend ::log killed-one}}
+                 trace add command ::N::six delete killone
+                 namespace delete ::N",
+                traced_procs("one two three four five six seven eight nine ten")
+            )),
+            "one killed-one six four three eight seven nine five two ten"
+        );
+    }
+
+    #[test]
+    fn namespace_teardown_places_imports_at_their_hash_positions() {
+        // An imported redirect occupies an ordinary cmdTable entry, so it is
+        // retired at its own hash position rather than as a separate bulk pass
+        // over the namespace's imports.
+        let expected = "six four three s1 eight seven s2 five two one";
+        assert_eq!(
+            teardown_log(
+                "namespace eval S {proc s1 {} {}; proc s2 {} {}; namespace export s*}
+                 namespace eval N {namespace import ::S::s1 ::S::s2}
+                 foreach n {one two three four five six seven eight} {proc ::N::$n {} {}}
+                 foreach n [info commands ::N::*] {trace add command $n delete rec}
+                 namespace delete ::N"
+            ),
+            expected
+        );
+        // `namespace forget` deletes the entry and the re-import creates a new
+        // one at the same bucket head, so the order is unchanged.
+        assert_eq!(
+            teardown_log(
+                "namespace eval S {proc s1 {} {}; proc s2 {} {}; namespace export s*}
+                 namespace eval N {
+                     namespace import ::S::s1 ::S::s2
+                     namespace forget ::S::s1
+                     namespace import ::S::s1
+                 }
+                 foreach n {one two three four five six seven eight} {proc ::N::$n {} {}}
+                 foreach n [info commands ::N::*] {trace add command $n delete rec}
+                 namespace delete ::N"
+            ),
+            expected
+        );
+    }
+
+    #[test]
+    fn namespace_teardown_retires_each_sources_import_tree_before_the_next_entry() {
+        // Tcl_DeleteCommandFromToken walks the deleted command's ImportRef
+        // list depth-first straight after its own delete trace, so a source's
+        // whole import tree fires before the next cmdTable entry.
+        let mut log = String::new();
+        leak_free(|i| {
+            let script = b"set log {}
+                 namespace eval N {proc one {} {}; proc two {} {}; proc six {} {}
+                                   namespace export *}
+                 namespace eval I {namespace import ::N::one; namespace export *}
+                 namespace eval J {namespace import ::I::one}
+                 foreach c {::N::one ::N::two ::N::six ::I::one ::J::one} {
+                     trace add command $c delete [list apply {{c old new op} {
+                         lappend ::log $c
+                     }} $c]
+                 }
+                 namespace delete ::N
+                 set ::log";
+            assert_eq!(
+                i.eval_str(script),
+                Code::Ok,
+                "{}",
+                String::from_utf8_lossy(&i.result_bytes())
+            );
+            log = String::from_utf8_lossy(&i.result_bytes()).into_owned();
+        });
+        assert_eq!(log, "::N::six ::N::two ::N::one ::I::one ::J::one");
+    }
+
     #[test]
     fn namespace_delete_removes_subtree() {
         leak_free(|i| {

--- a/runtime/rust/src/cmd_trace.rs
+++ b/runtime/rust/src/cmd_trace.rs
@@ -115,6 +115,13 @@ pub mod ops {
 /// One registered command or execution trace (C's `TraceCommandInfo`; both
 /// kinds hang off the same command, distinguished by their op category).
 pub struct CmdTrace {
+    /// This registration's identity, unique for the life of the interpreter.
+    ///
+    /// C frees exactly the trace list the deleted `Command` carried. Our
+    /// registry is keyed by FQN, so a delete callback that redefines the
+    /// command registers *its* traces under the same name; only an id
+    /// distinguishes them from the ones the deletion just fired.
+    pub id: u64,
     /// The command's resolved FQN (the binding the trace is attached to).
     pub name: Vec<u8>,
     /// The user ops this trace fires on (a [`ops`] bitset).
@@ -190,14 +197,20 @@ pub struct TraceTable {
     pub step_active: Vec<StepActive>,
     /// The id the next variable-trace registration takes (see [`VarTrace::id`]).
     pub next_var_trace_id: u64,
+    /// The id the next command-trace registration takes (see [`CmdTrace::id`]).
+    pub next_cmd_trace_id: u64,
     /// Variable cells whose trace callbacks are currently running. Other
     /// variables remain traceable from within a callback.
     pub active_var_scopes: Vec<VarTraceScope>,
     /// Non-zero while a command/execution trace callback is running — C's
-    /// `INTERP_TRACE_IN_PROGRESS`. Suppresses re-entrant command/execution/step
-    /// firing so a callback that renames/invokes the traced command doesn't
-    /// recurse.
+    /// `INTERP_TRACE_IN_PROGRESS`. Suppresses re-entrant execution/step firing
+    /// so a callback that invokes the traced command doesn't recurse.
     pub exec_firing: usize,
+    /// The commands whose `rename`/`delete` traces are currently firing. C
+    /// guards those per `Command` (`CMD_TRACE_ACTIVE`, and `CMD_DYING` for a
+    /// deletion), not interpreter-wide: a callback that deletes a *different*
+    /// command still fires that command's own delete traces, nested.
+    pub firing_cmd_traces: Vec<Vec<u8>>,
     /// The error message a read/write variable-trace callback left, captured so
     /// the variable access can fail with `can't read/set "name": <msg>` (C's
     /// `TclCallVarTraces` propagation). Taken by the access chokepoint.
@@ -419,11 +432,16 @@ fn cmd_trace_add_remove(
     };
     let command = obj_bytes(argv[5]);
     if is_add {
-        interp.traces.borrow_mut().cmd_traces.push(CmdTrace {
+        let mut table = interp.traces.borrow_mut();
+        let id = table.next_cmd_trace_id;
+        table.next_cmd_trace_id += 1;
+        table.cmd_traces.push(CmdTrace {
+            id,
             name: fqn,
             ops: flags,
             command,
         });
+        drop(table);
         interp.invalidate_guard_domain(tcl_runtime_api::guard::GuardDomain::CommandTrace);
     } else {
         // Remove the first trace matching exact ops + command string, where

--- a/runtime/rust/src/cmd_trace.rs
+++ b/runtime/rust/src/cmd_trace.rs
@@ -115,13 +115,16 @@ pub mod ops {
 /// One registered command or execution trace (C's `TraceCommandInfo`; both
 /// kinds hang off the same command, distinguished by their op category).
 pub struct CmdTrace {
-    /// This registration's identity, unique for the life of the interpreter.
+    /// The generation of the command **token** this trace hangs off, or `None`
+    /// when the binding had none (a hidden command).
     ///
-    /// C frees exactly the trace list the deleted `Command` carried. Our
-    /// registry is keyed by FQN, so a delete callback that redefines the
-    /// command registers *its* traces under the same name; only an id
-    /// distinguishes them from the ones the deletion just fired.
-    pub id: u64,
+    /// C keeps the list on the `Command` itself and frees exactly that list
+    /// when the token dies. Our registry is keyed by FQN, so a delete callback
+    /// that binds a replacement at the same name registers on a *different*
+    /// token under the same key; only the generation tells the two lists
+    /// apart. Generations are minted per table in binding order, so a trace on
+    /// a token installed after the dying one always compares greater.
+    pub token: Option<u64>,
     /// The command's resolved FQN (the binding the trace is attached to).
     pub name: Vec<u8>,
     /// The user ops this trace fires on (a [`ops`] bitset).
@@ -197,8 +200,6 @@ pub struct TraceTable {
     pub step_active: Vec<StepActive>,
     /// The id the next variable-trace registration takes (see [`VarTrace::id`]).
     pub next_var_trace_id: u64,
-    /// The id the next command-trace registration takes (see [`CmdTrace::id`]).
-    pub next_cmd_trace_id: u64,
     /// Variable cells whose trace callbacks are currently running. Other
     /// variables remain traceable from within a callback.
     pub active_var_scopes: Vec<VarTraceScope>,
@@ -432,16 +433,15 @@ fn cmd_trace_add_remove(
     };
     let command = obj_bytes(argv[5]);
     if is_add {
-        let mut table = interp.traces.borrow_mut();
-        let id = table.next_cmd_trace_id;
-        table.next_cmd_trace_id += 1;
-        table.cmd_traces.push(CmdTrace {
-            id,
+        // The trace belongs to the token standing at `fqn` now, not to the
+        // name (C hangs it off `cmdPtr->tracePtr`).
+        let token = interp.resolve_cmd_token(&fqn);
+        interp.traces.borrow_mut().cmd_traces.push(CmdTrace {
+            token,
             name: fqn,
             ops: flags,
             command,
         });
-        drop(table);
         interp.invalidate_guard_domain(tcl_runtime_api::guard::GuardDomain::CommandTrace);
     } else {
         // Remove the first trace matching exact ops + command string, where
@@ -1329,6 +1329,105 @@ mod tests {
     /// The commands the same teardown deletes fire their `delete` traces
     /// newest-first too (`CallCommandTraces` walks head→tail). Issue #1440;
     /// tclsh 8.6.16 and 9.0.4 both report `second first`.
+    #[test]
+    fn a_delete_callbacks_own_trace_dies_with_the_dying_token() {
+        // `Tcl_DeleteCommandFromToken` frees the whole `cmdPtr->tracePtr` list
+        // after `CallCommandTraces`. A trace the callback registers on the
+        // command being deleted attaches to that same dying token, so it never
+        // fires — not in this walk (`CallCommandTraces` follows
+        // `active.nextTracePtr`), and not for a later command that takes the
+        // vacated name. Exact tclsh 9.0.4 oracle results (identical on
+        // 8.6.16).
+        let recorders: &[u8] = b"set ::log {}
+             proc inner {old new op} {lappend ::log inner:$old}
+             proc outer {old new op} {lappend ::log outer:$old
+                 trace add command $old delete inner}";
+        // `rename cmd {}`.
+        leak_free(|i| {
+            ok(i, recorders);
+            ok(i, b"proc p {} {}");
+            ok(i, b"trace add command ::p delete outer");
+            ok(i, b"rename ::p {}");
+            assert_eq!(ok(i, b"set ::log"), b"outer:::p");
+            ok(i, b"proc p {} {}");
+            ok(i, b"rename ::p {}");
+            assert_eq!(ok(i, b"set ::log"), b"outer:::p");
+            ok(i, b"unset ::log");
+        });
+        // Redefinition (`TclCreateObjCommandInNs` deletes the old token first).
+        leak_free(|i| {
+            ok(i, recorders);
+            ok(i, b"proc p {} {}");
+            ok(i, b"trace add command ::p delete outer");
+            ok(i, b"proc p {} {}");
+            assert_eq!(ok(i, b"set ::log"), b"outer:::p");
+            ok(i, b"proc p {} {}");
+            ok(i, b"rename ::p {}");
+            assert_eq!(ok(i, b"set ::log"), b"outer:::p");
+            ok(i, b"unset ::log");
+        });
+        // Namespace teardown.
+        leak_free(|i| {
+            ok(i, recorders);
+            ok(i, b"namespace eval N {proc q {} {}}");
+            ok(i, b"trace add command ::N::q delete outer");
+            ok(i, b"namespace delete ::N");
+            assert_eq!(ok(i, b"set ::log"), b"outer:::N::q");
+            ok(i, b"namespace eval N {proc q {} {}}");
+            ok(i, b"namespace delete ::N");
+            assert_eq!(ok(i, b"set ::log"), b"outer:::N::q");
+            ok(i, b"unset ::log");
+        });
+    }
+
+    #[test]
+    fn a_replacements_trace_survives_the_deletion_that_created_it() {
+        // The other half of the same rule: a callback that *binds* a
+        // replacement at the vacated name registers on that new token, whose
+        // own trace list C never touches. Only the dying token's list is
+        // freed. Exact tclsh 9.0.4 oracle results (identical on 8.6.16).
+        leak_free(|i| {
+            ok(i, b"set ::log {}");
+            ok(i, b"proc inner {old new op} {lappend ::log inner:$old}");
+            ok(
+                i,
+                b"proc mk {old new op} {lappend ::log mk:$old
+                      proc ::p {} {}
+                      trace add command ::p delete inner}",
+            );
+            ok(i, b"proc p {} {}");
+            ok(i, b"trace add command ::p delete mk");
+            ok(i, b"rename ::p {}");
+            assert_eq!(ok(i, b"set ::log"), b"mk:::p");
+            assert_eq!(ok(i, b"llength [info commands ::p]"), b"1");
+            ok(i, b"rename ::p {}");
+            assert_eq!(ok(i, b"set ::log"), b"mk:::p inner:::p");
+            assert_eq!(ok(i, b"llength [info commands ::p]"), b"0");
+            ok(i, b"unset ::log");
+        });
+        // A trace the callback adds *before* the replacement still belongs to
+        // the dying token and goes with it; only the one added after survives.
+        leak_free(|i| {
+            ok(i, b"set ::log {}");
+            ok(i, b"proc early {old new op} {lappend ::log early:$old}");
+            ok(i, b"proc late {old new op} {lappend ::log late:$old}");
+            ok(
+                i,
+                b"proc mk {old new op} {lappend ::log mk:$old
+                      trace add command $old delete early
+                      proc ::p {} {}
+                      trace add command ::p delete late}",
+            );
+            ok(i, b"proc p {} {}");
+            ok(i, b"trace add command ::p delete mk");
+            ok(i, b"rename ::p {}");
+            assert_eq!(ok(i, b"set ::log"), b"mk:::p");
+            ok(i, b"rename ::p {}");
+            assert_eq!(ok(i, b"set ::log"), b"mk:::p late:::p");
+            ok(i, b"unset ::log");
+        });
+    }
+
     #[test]
     fn namespace_teardown_fires_command_delete_traces_newest_first() {
         leak_free(|i| {

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -1772,6 +1772,9 @@ impl Interp {
         // it captured here, not whatever the name holds when the callback
         // returns — so the binding is captured alongside the name.
         let bound_before = self.namespaces.borrow().resolve(self.current_ns.get(), old);
+        // The token whose trace list this deletion frees, captured before the
+        // callbacks can bind a replacement at the same name.
+        let dying_token = self.resolve_cmd_token(old);
         let old_fqn = self.resolve_cmd_fqn(old);
         if let Some(of) = &old_fqn {
             if !self.traces.borrow().cmd_traces.is_empty() {
@@ -1867,9 +1870,12 @@ impl Interp {
                         self.oo_command_renamed(&of, Some(&nf));
                     }
                 }
-                // The command is gone; its traces and OO registry entry go too.
+                // The command is gone; the dying token's traces and OO
+                // registry entry go with it. A replacement the delete callback
+                // bound at the same name keeps its own traces (C frees only
+                // `cmdPtr->tracePtr`).
                 RenameOutcome::Deleted => {
-                    self.remove_cmd_traces(&of);
+                    self.remove_cmd_traces_of_token(&of, dying_token);
                     let tokens: Vec<_> = ensemble_token.into_iter().collect();
                     let mut origins = vec![of.clone()];
                     if let Some(removed_fqn) = removed_import_fqn {
@@ -2126,9 +2132,10 @@ impl Interp {
     /// command traces, then drop every command/execution trace on it (the
     /// command — and its trace list — go away). No-op when it has no traces.
     ///
-    /// Only the traces the deletion actually fired are dropped. A callback that
-    /// redefines the command registers traces on the *new* token under the same
-    /// name, and C frees only the list the dying `Command` carried.
+    /// Only the *dying token's* traces are dropped. C frees `cmdPtr->tracePtr`,
+    /// so a trace the callback adds to the command being deleted dies with it,
+    /// while one it registers on a replacement it bound at the same name lives
+    /// on that new token.
     fn on_command_replaced(&mut self, fqn: &[u8]) {
         if self
             .traces
@@ -2139,20 +2146,37 @@ impl Interp {
         {
             return;
         }
-        let token_traces = self.traces.borrow().next_cmd_trace_id;
+        let dying = self.resolve_cmd_token(fqn);
         self.fire_cmd_trace(fqn, b"", crate::cmd_trace::ops::DELETE);
-        self.remove_cmd_traces_before(fqn, token_traces);
+        self.remove_cmd_traces_of_token(fqn, dying);
     }
 
-    /// Drop the traces on `fqn` that were registered before `watermark` — the
-    /// whole list the dying token carried, and nothing a callback registered
-    /// on the replacement while the delete traces ran.
-    fn remove_cmd_traces_before(&mut self, fqn: &[u8], watermark: u64) {
+    /// The generation of the command token `name` resolves to — the identity a
+    /// command trace hangs off.
+    pub(crate) fn resolve_cmd_token(&self, name: &[u8]) -> Option<u64> {
+        self.namespaces
+            .borrow()
+            .resolve_generation(self.current_ns.get(), name)
+    }
+
+    /// Drop the command/execution traces on `fqn` that belonged to the token
+    /// being deleted — C's "free the whole `cmdPtr->tracePtr` list".
+    ///
+    /// Generations are minted in binding order, so a trace registered on a
+    /// replacement the delete callback bound at this same name compares
+    /// greater and survives. An unidentifiable dying token (an unbound or
+    /// hidden name) takes the whole list, as it did before tokens were
+    /// tracked.
+    fn remove_cmd_traces_of_token(&mut self, fqn: &[u8], dying: Option<u64>) {
         let mut traces = self.traces.borrow_mut();
         let old_len = traces.cmd_traces.len();
-        traces
-            .cmd_traces
-            .retain(|t| t.name != fqn || t.id >= watermark);
+        traces.cmd_traces.retain(|t| {
+            t.name != fqn
+                || match (t.token, dying) {
+                    (Some(token), Some(dying)) => token > dying,
+                    _ => false,
+                }
+        });
         let removed = traces.cmd_traces.len() != old_len;
         drop(traces);
         if removed {
@@ -3861,11 +3885,16 @@ impl Interp {
     /// follows a renamed command, as C keeps the trace list on the moving
     /// `Command`).
     fn move_cmd_traces(&mut self, old_fqn: &[u8], new_fqn: &[u8]) {
+        // C moves the `Command` itself, so its trace list travels with the
+        // token. Re-stamp to whatever token now stands at the destination, so
+        // a later deletion there still tells this list from a replacement's.
+        let token = self.resolve_cmd_token(new_fqn);
         let mut traces = self.traces.borrow_mut();
         let mut moved = false;
         for t in traces.cmd_traces.iter_mut() {
             if t.name == old_fqn {
                 t.name = new_fqn.to_vec();
+                t.token = token;
                 moved = true;
             }
         }

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -278,13 +278,6 @@ struct CmdFrame {
 /// entry) — see [`Interp::arg_locs`].
 type ArgLoc = (*mut TclObj, Option<Rc<[u8]>>, u32);
 
-/// One command-trace callback collected during namespace teardown: the
-/// command's FQN and the trace's command prefix. The name doubles as the
-/// grouping key in [`Interp::group_newest_first_per_entity`]. Command traces
-/// have no deprecated spelling, so their op word is always the full `delete`
-/// (C's `TCL_TRACE_OLD_STYLE` is a variable-trace flag only).
-type CmdTeardownCallback = (Vec<u8>, Vec<u8>);
-
 /// One variable-trace callback collected during namespace teardown: the
 /// variable's reported name (including any `(element)`), the trace's command
 /// prefix, and whether it was registered through the deprecated 8.x
@@ -2132,6 +2125,10 @@ impl Interp {
     /// A command at `fqn` is being replaced or deleted: fire its `delete`
     /// command traces, then drop every command/execution trace on it (the
     /// command — and its trace list — go away). No-op when it has no traces.
+    ///
+    /// Only the traces the deletion actually fired are dropped. A callback that
+    /// redefines the command registers traces on the *new* token under the same
+    /// name, and C frees only the list the dying `Command` carried.
     fn on_command_replaced(&mut self, fqn: &[u8]) {
         if self
             .traces
@@ -2142,8 +2139,25 @@ impl Interp {
         {
             return;
         }
+        let token_traces = self.traces.borrow().next_cmd_trace_id;
         self.fire_cmd_trace(fqn, b"", crate::cmd_trace::ops::DELETE);
-        self.remove_cmd_traces(fqn);
+        self.remove_cmd_traces_before(fqn, token_traces);
+    }
+
+    /// Drop the traces on `fqn` that were registered before `watermark` — the
+    /// whole list the dying token carried, and nothing a callback registered
+    /// on the replacement while the delete traces ran.
+    fn remove_cmd_traces_before(&mut self, fqn: &[u8], watermark: u64) {
+        let mut traces = self.traces.borrow_mut();
+        let old_len = traces.cmd_traces.len();
+        traces
+            .cmd_traces
+            .retain(|t| t.name != fqn || t.id >= watermark);
+        let removed = traces.cmd_traces.len() != old_len;
+        drop(traces);
+        if removed {
+            self.invalidate_guard_domain(GuardDomain::CommandTrace);
+        }
     }
 
     /// The reported `line` of the command currently executing at the top of the
@@ -3659,10 +3673,17 @@ impl Interp {
     /// Fire matching command traces (`rename`/`delete`) as `command oldName
     /// newName op` (C's `TraceCommandProc`). `new_fqn` is empty for a delete.
     /// Callback errors are **ignored** (C: "We ignore errors in these traced
-    /// commands"). Re-entrant firing is suppressed (`exec_firing`); the interp
-    /// result is preserved across the callbacks.
+    /// commands"). Re-entrant firing on *this* command is suppressed (C's
+    /// per-`Command` `CMD_TRACE_ACTIVE`/`CMD_DYING`); the interp result is
+    /// preserved across the callbacks.
     fn fire_cmd_trace(&mut self, old_fqn: &[u8], new_fqn: &[u8], op_bit: u8) {
-        if self.traces.borrow().exec_firing > 0 {
+        if self
+            .traces
+            .borrow()
+            .firing_cmd_traces
+            .iter()
+            .any(|firing| firing == old_fqn)
+        {
             return;
         }
         // C prepends each new command trace (`Tcl_TraceCommand`, tclTrace.c
@@ -3690,7 +3711,11 @@ impl Interp {
         let saved = self.result.get();
         unsafe { obj::incr_ref_count(saved) };
 
-        self.traces.borrow_mut().exec_firing += 1;
+        {
+            let mut traces = self.traces.borrow_mut();
+            traces.exec_firing += 1;
+            traces.firing_cmd_traces.push(old_fqn.to_vec());
+        }
         for cmd in cmds {
             // Append `oldName newName op` as properly-quoted list elements.
             let args = crate::list::new_list_obj(&[
@@ -3704,7 +3729,11 @@ impl Interp {
             drop_fresh(args);
             let _ = self.eval_str(&line);
         }
-        self.traces.borrow_mut().exec_firing -= 1;
+        {
+            let mut traces = self.traces.borrow_mut();
+            traces.exec_firing -= 1;
+            traces.firing_cmd_traces.pop();
+        }
 
         unsafe {
             obj::decr_ref_count(self.result.get());
@@ -3965,18 +3994,14 @@ impl Interp {
         // while the token is live, then callbacks run after this exact token is
         // marked dying (C's order; oo-11.8).
         let victims = self.take_ns_unset_traces(ns);
-        // Every command binding directly in this namespace is a true source
-        // deletion. Ensemble commands are additionally tied to their configured
-        // namespace, even when their binding lives elsewhere (for example the
-        // default global `::ns` command).
+        // Ensemble commands are tied to their configured namespace, even when
+        // their binding lives elsewhere (for example the default global `::ns`
+        // command), so they retire before this token is marked dying. Every
+        // other command in the table retires one token at a time below.
         {
             let ids = std::collections::HashSet::from([ns]);
-            let mut deleted_origins: std::collections::HashSet<Vec<u8>> = self
-                .namespaces
-                .borrow()
-                .command_fqns_in_ids(&[ns])
-                .into_iter()
-                .collect();
+            let mut deleted_origins: std::collections::HashSet<Vec<u8>> =
+                std::collections::HashSet::new();
             let mut ensemble_victims = self.namespaces.borrow().ensembles_for(&ids);
             let hidden_tokens: Vec<(Vec<u8>, Rc<crate::ensemble::EnsembleToken>)> = self
                 .hidden
@@ -4005,16 +4030,10 @@ impl Interp {
             }
             self.remove_imports_for_deleted_origins(deleted_origins, &deleted_tokens);
         }
-        // The remaining commands in the namespace tree are deleted too:
-        // collect+remove their command traces (firing the `delete` ones after
-        // the namespace disappears). Namespace-owned ensembles were handled
-        // above because their deletion callback observes the command still
-        // live, even when its binding is outside the subtree.
-        let cmd_victims = self.take_ns_cmd_traces(ns);
         self.namespaces.borrow_mut().begin_namespace_teardown(ns);
         self.namespaces.borrow_mut().clear_namespace_token(ns);
         self.fire_unset_callbacks(victims);
-        self.fire_deleted_cmd_callbacks(cmd_victims);
+        self.tear_down_command_table(ns);
 
         // Tcl snapshots and recursively deletes children only after this
         // token's ordinary command callbacks have completed. A callback may
@@ -4023,6 +4042,51 @@ impl Interp {
         for child in children {
             if self.namespaces.borrow().namespace_is_live(child) {
                 self.delete_namespace_token(child);
+            }
+        }
+    }
+
+    /// Delete one dying namespace's command table the way `TclTeardownNamespace`
+    /// does: snapshot `cmdTable` in `Tcl_FirstHashEntry` order, then delete each
+    /// snapshotted token in turn, repeating while the table is non-empty.
+    ///
+    /// Each token's `delete` traces fire while its entry is still in the table
+    /// (`Tcl_DeleteCommandFromToken` calls `CallCommandTraces` before
+    /// `Tcl_DeleteHashEntry`), and its imports retire depth-first straight
+    /// after — not in a bulk pass over the whole namespace. A callback that
+    /// deletes or redefines a snapshotted entry changes its generation; C's
+    /// `CMD_DYING` early return then leaves the replacement to the next
+    /// snapshot.
+    fn tear_down_command_table(&mut self, ns: NsId) {
+        loop {
+            let snapshot = self.namespaces.borrow().command_hash_order(ns);
+            if snapshot.is_empty() {
+                break;
+            }
+            let mut retired_any = false;
+            for (tail, generation) in snapshot {
+                if self.namespaces.borrow().command_generation(ns, &tail) != Some(generation) {
+                    continue;
+                }
+                let fqn = self.namespaces.borrow().command_fqn_at(ns, &tail);
+                self.on_command_replaced(&fqn);
+                if self.namespaces.borrow().command_generation(ns, &tail) != Some(generation) {
+                    // The callback deleted this token, or redefined the name:
+                    // its own deletion already unlinked the entry, and any
+                    // replacement is a distinct token for the next snapshot.
+                    retired_any = true;
+                    continue;
+                }
+                let ensemble_tokens = match self.namespaces.borrow().command_in(ns, &tail) {
+                    Some(Command::Ensemble(token)) => vec![token],
+                    _ => Vec::new(),
+                };
+                self.namespaces.borrow_mut().remove_in(ns, &tail);
+                self.remove_imports_for_deleted_origins([fqn], &ensemble_tokens);
+                retired_any = true;
+            }
+            if !retired_any {
+                break;
             }
         }
     }
@@ -4116,55 +4180,6 @@ impl Interp {
         }
     }
 
-    /// Remove and return the `(fqn, command)` of every command trace on a command
-    /// directly in `ns`. Recursive namespace teardown calls this once per token,
-    /// so children keep their trace sidecars until their own lifecycle begins.
-    /// Only `delete`-op traces are returned for firing; `rename`-only traces are
-    /// removed silently (a deletion isn't a rename).
-    fn take_ns_cmd_traces(&self, ns: NsId) -> Vec<CmdTeardownCallback> {
-        if self.traces.borrow().cmd_traces.is_empty() {
-            return Vec::new();
-        }
-        // A command trace belongs to this exact table iff its home qualifier is
-        // this namespace's fully-qualified prefix.
-        let namespace_qual: Vec<u8> = {
-            let ns_ref = self.namespaces.borrow();
-            let mut q = ns_ref.qualified_name(ns);
-            if q != b"::" {
-                q.extend_from_slice(b"::");
-            }
-            q
-        };
-        let mut victims = Vec::new();
-        let mut traces = self.traces.borrow_mut();
-        let old_len = traces.cmd_traces.len();
-        traces.cmd_traces.retain(|t| {
-            // The command's home-namespace prefix: everything up to and
-            // including the last `::` (global commands are `::cmd` → `::`).
-            let command_qual: &[u8] = match t.name.windows(2).rposition(|w| w == b"::") {
-                Some(0) => b"::",
-                Some(i) => &t.name[..i + 2],
-                None => b"",
-            };
-            if namespace_qual == command_qual {
-                if (t.ops & crate::cmd_trace::ops::DELETE) != 0 {
-                    victims.push((t.name.clone(), t.command.clone()));
-                }
-                false // drop every trace on a command that is going away
-            } else {
-                true
-            }
-        });
-        let removed = traces.cmd_traces.len() != old_len;
-        drop(traces);
-        if removed {
-            self.invalidate_guard_domain(GuardDomain::CommandTrace);
-        }
-        // Grouped per command, newest-first inside each group — see
-        // [`Self::group_newest_first_per_entity`]. Issue #1440.
-        Self::group_newest_first_per_entity(victims, |victim| victim.0.clone())
-    }
-
     /// The unset-trace callbacks a **cell** contributes when it is destroyed,
     /// newest-first — C walks the `Var`'s prepended trace list head to tail.
     /// Non-destructive: the caller's own sweep drops the traces.
@@ -4194,35 +4209,6 @@ impl Interp {
                 )
             })
             .collect()
-    }
-
-    /// Fire collected command `delete`-trace callbacks as `command oldName {}
-    /// delete` after the namespace has been torn down (errors ignored — a delete
-    /// trace's result is discarded, matching C).
-    fn fire_deleted_cmd_callbacks(&mut self, victims: Vec<CmdTeardownCallback>) {
-        if victims.is_empty() || self.traces.borrow().exec_firing > 0 {
-            return;
-        }
-        let saved = self.result.get();
-        unsafe { obj::incr_ref_count(saved) };
-        self.traces.borrow_mut().exec_firing += 1;
-        for (name, cmd) in victims {
-            let args = crate::list::new_list_obj(&[
-                new_string(&name),
-                new_string(b""),
-                new_string(b"delete"),
-            ]);
-            let mut line = cmd;
-            line.push(b' ');
-            line.extend_from_slice(&obj_bytes(args));
-            drop_fresh(args);
-            let _ = self.eval_str(&line);
-        }
-        self.traces.borrow_mut().exec_firing -= 1;
-        unsafe {
-            obj::decr_ref_count(self.result.get());
-            self.result.set(saved);
-        }
     }
 
     /// Remove and return the `(fullName, command)` of every *unset* variable

--- a/runtime/rust/src/namespace.rs
+++ b/runtime/rust/src/namespace.rs
@@ -69,6 +69,126 @@ pub enum RenameOutcome {
     TargetExists,
 }
 
+/// One namespace's command table: the `BTreeMap` the resolver looks names up
+/// in, plus the retained `TCL_STRING_KEYS` bucket order `TclTeardownNamespace`
+/// snapshots and a per-slot generation.
+///
+/// The order owner is C's `Namespace.cmdTable` itself: its bucket array
+/// quadruples at a 3:1 load factor, never shrinks, and reverses chains on
+/// every rebuild, all of which a namespace's command-delete traces observe.
+/// The generation distinguishes a command a delete callback replaced from the
+/// token the teardown snapshot named, so the replacement waits for the next
+/// pass exactly as C's `CMD_DYING` early return makes it.
+#[derive(Default)]
+struct CommandTable {
+    entries: BTreeMap<Vec<u8>, (u64, Command)>,
+    order: TclStringHashOrder,
+    next_generation: u64,
+}
+
+impl CommandTable {
+    fn get(&self, key: &[u8]) -> Option<&Command> {
+        self.entries.get(key).map(|(_, command)| command)
+    }
+
+    fn contains_key(&self, key: &[u8]) -> bool {
+        self.entries.contains_key(key)
+    }
+
+    fn keys(&self) -> impl Iterator<Item = &Vec<u8>> {
+        self.entries.keys()
+    }
+
+    fn iter(&self) -> impl Iterator<Item = (&Vec<u8>, &Command)> {
+        self.entries
+            .iter()
+            .map(|(key, (_, command))| (key, command))
+    }
+
+    fn values(&self) -> impl Iterator<Item = &Command> {
+        self.entries.values().map(|(_, command)| command)
+    }
+
+    fn values_mut(&mut self) -> impl Iterator<Item = &mut Command> {
+        self.entries.values_mut().map(|(_, command)| command)
+    }
+
+    /// Bind `command` at `key`, returning whatever it displaced. A live key is
+    /// re-created at its bucket head, as C's `TclCreateObjCommandInNs` does
+    /// when it deletes the old hash entry and creates a fresh one.
+    fn insert(&mut self, key: Vec<u8>, command: Command) -> Option<Command> {
+        let generation = self.next_generation;
+        self.next_generation += 1;
+        match self.entries.insert(key.clone(), (generation, command)) {
+            Some((_, displaced)) => {
+                self.order.reinsert(&key);
+                Some(displaced)
+            }
+            None => {
+                self.order.insert(&key);
+                None
+            }
+        }
+    }
+
+    /// Delete `key`'s entry, returning its binding. The bucket array keeps its
+    /// capacity (`Tcl_DeleteHashEntry` never shrinks).
+    fn remove(&mut self, key: &[u8]) -> Option<Command> {
+        let (_, command) = self.entries.remove(key)?;
+        self.order.remove(key);
+        Some(command)
+    }
+
+    /// Take a slot's binding out while leaving its hash entry in place —
+    /// C's alias-loop probe (`TclRenameCommand`) reassigns `cmdPtr->hPtr` and
+    /// undoes the move without ever deleting the source's entry.
+    fn take_slot(&mut self, key: &[u8]) -> Option<(u64, Command)> {
+        self.entries.remove(key)
+    }
+
+    /// Put a slot taken by [`Self::take_slot`] back, creating the hash entry
+    /// when the probe's destination did not already have one.
+    fn restore_slot(&mut self, key: Vec<u8>, slot: (u64, Command)) -> Option<(u64, Command)> {
+        self.order.insert(&key);
+        self.entries.insert(key, slot)
+    }
+
+    /// Create `key`'s hash entry ahead of the binding that fills it — C's
+    /// `TclRenameCommand` calls `Tcl_CreateHashEntry` on the destination
+    /// before it deletes the source's entry.
+    fn reserve_entry(&mut self, key: &[u8]) {
+        self.order.insert(key);
+    }
+
+    /// Delete a hash entry created by [`Self::reserve_entry`] whose value has
+    /// been taken back — the alias-loop probe's refused destination.
+    fn drop_entry(&mut self, key: &[u8]) {
+        self.order.remove(key);
+    }
+
+    /// `Tcl_DeleteHashTable` + `Tcl_InitHashTable`: the table returns to Tcl's
+    /// four static buckets.
+    fn clear(&mut self) {
+        self.entries.clear();
+        self.order.clear();
+    }
+
+    /// The token generation currently bound at `key`.
+    fn generation(&self, key: &[u8]) -> Option<u64> {
+        self.entries.get(key).map(|(generation, _)| *generation)
+    }
+
+    /// The live `(name, generation)` slots in `Tcl_FirstHashEntry` order — the
+    /// snapshot `TclTeardownNamespace` takes before deleting each token.
+    fn hash_order(&self) -> Vec<(Vec<u8>, u64)> {
+        self.order
+            .keys()
+            .into_iter()
+            .filter_map(|key| Some((key.to_vec(), self.generation(key)?)))
+            .collect()
+    }
+}
+
 /// One namespace: its simple name, its command table, child namespaces, the
 /// `namespace path` search list, and `export` patterns.
 struct Namespace {
@@ -78,7 +198,7 @@ struct Namespace {
     children: BTreeMap<Vec<u8>, NsId>,
     /// The child's `TCL_STRING_KEYS` table, including retained resize history.
     child_order: TclStringHashOrder,
-    commands: BTreeMap<Vec<u8>, Command>,
+    commands: CommandTable,
     /// `namespace path` — namespaces searched for unqualified commands (step b).
     path: Vec<NsId>,
     /// `namespace export` patterns — gate what `import` may pull (matched with
@@ -101,7 +221,7 @@ impl Namespace {
             parent,
             children: BTreeMap::new(),
             child_order: TclStringHashOrder::default(),
-            commands: BTreeMap::new(),
+            commands: CommandTable::default(),
             path: Vec::new(),
             exports: Vec::new(),
             vars: VarTable::default(),
@@ -158,6 +278,9 @@ impl Namespaces {
     /// Install one real command binding. Replacement deletes the displaced
     /// command token; the installed ensemble token acquires this binding's FQN.
     fn insert_bound(&mut self, ns: NsId, simple: Vec<u8>, command: Command) {
+        // C redefines a command by deleting the old hash entry and creating a
+        // new one, so the name moves to its bucket head
+        // (`TclCreateObjCommandInNs`).
         if let Some(displaced) = self.arena[ns].commands.remove(&simple) {
             Self::mark_command_deleted(&displaced);
         }
@@ -220,8 +343,10 @@ impl Namespaces {
     /// holding a borrow on the table.
     #[must_use]
     pub fn resolve(&self, current: NsId, name: &[u8]) -> Option<Command> {
-        self.home_of(current, name)
-            .map(|(ns, simple)| self.arena[ns].commands[&simple].clone())
+        self.home_of(current, name).and_then(|(ns, simple)| {
+            // `home_of` reported this exact slot holds a binding.
+            self.arena[ns].commands.get(&simple).cloned()
+        })
     }
 
     /// Rebind an existing command in place at the namespace where it actually
@@ -305,18 +430,23 @@ impl Namespaces {
         let Some((old_ns, old_simple)) = self.home_of(current, old) else {
             return RenameOutcome::NoSuchCommand;
         };
-        // SAFETY of unwrap: `home_of` reported the binding exists.
-        let cmd = self.arena[old_ns].commands.remove(&old_simple).unwrap();
         if new.is_empty() {
+            // SAFETY of unwrap: `home_of` reported the binding exists.
+            let cmd = self.arena[old_ns].commands.remove(&old_simple).unwrap();
             Self::mark_command_deleted(&cmd);
             return RenameOutcome::Deleted;
         }
         let Some((ns, simple)) = self.destination_of(current, new) else {
             // Unreachable for a non-empty, non-separator-terminated name;
-            // put the command back rather than lose it.
-            self.arena[old_ns].commands.insert(old_simple, cmd);
+            // nothing has moved yet, so there is nothing to put back.
             return RenameOutcome::NoSuchCommand;
         };
+        // C's `TclRenameCommand` creates the destination hash entry *before*
+        // deleting the source's, so the transient extra entry can trigger a
+        // rebuild a delete-first order would not.
+        self.arena[ns].commands.reserve_entry(&simple);
+        // SAFETY of unwrap: `home_of` reported the binding exists.
+        let cmd = self.arena[old_ns].commands.remove(&old_simple).unwrap();
         let cmd = Self::rehome_proc(cmd, ns, &self.command_fqn(ns, &simple));
         self.insert_bound(ns, simple, cmd);
         RenameOutcome::Renamed
@@ -445,19 +575,28 @@ impl Namespaces {
         if (dest_ns, dest_simple.as_slice()) == (old_ns, old_simple.as_slice()) {
             return false; // a self-rename moves nothing
         }
-        let Some(moving) = self.unbind_in(old_ns, &old_simple) else {
+        // C creates the destination's hash entry for the probe and deletes it
+        // again on a refusal, and never touches the source's entry at all
+        // (`TclRenameCommand` deletes `oldHPtr` only once the check passes).
+        // The tentative move therefore carries the slot values only.
+        let Some(moving) = self.arena[old_ns].commands.take_slot(&old_simple) else {
             return false;
         };
         let displaced = self.arena[dest_ns]
             .commands
-            .insert(dest_simple.clone(), moving);
+            .restore_slot(dest_simple.clone(), moving);
         let loops = self.alias_chain_loops(dest_ns, &dest_simple);
-        let moved = self.unbind_in(dest_ns, &dest_simple);
-        if let Some(displaced) = displaced {
-            self.arena[dest_ns].commands.insert(dest_simple, displaced);
+        let moved = self.arena[dest_ns].commands.take_slot(&dest_simple);
+        match displaced {
+            Some(displaced) => {
+                self.arena[dest_ns]
+                    .commands
+                    .restore_slot(dest_simple, displaced);
+            }
+            None => self.arena[dest_ns].commands.drop_entry(&dest_simple),
         }
         if let Some(moved) = moved {
-            self.arena[old_ns].commands.insert(old_simple, moved);
+            self.arena[old_ns].commands.restore_slot(old_simple, moved);
         }
         loops
     }
@@ -516,7 +655,7 @@ impl Namespaces {
     pub fn alias_names(&self) -> Vec<Vec<u8>> {
         let mut found: Vec<(NsId, Vec<u8>)> = Vec::new();
         for (id, ns) in self.arena.iter().enumerate() {
-            for (key, cmd) in &ns.commands {
+            for (key, cmd) in ns.commands.iter() {
                 // Both single-interp aliases and cross-interp (child→parent)
                 // aliases are reported by `interp aliases` / `$child aliases`.
                 if matches!(cmd, Command::Alias { .. } | Command::ParentAlias { .. }) {
@@ -830,6 +969,27 @@ impl Namespaces {
             .collect()
     }
 
+    /// `ns`'s live command slots as `(simple name, generation)` in Tcl
+    /// string-hash enumeration order — the snapshot `TclTeardownNamespace`
+    /// takes of `cmdTable` before deleting each token.
+    pub(crate) fn command_hash_order(&self, ns: NsId) -> Vec<(Vec<u8>, u64)> {
+        self.arena[ns].commands.hash_order()
+    }
+
+    /// The token generation currently bound at `(ns, name)`. A teardown
+    /// snapshot compares it before firing: a different generation means a
+    /// delete callback replaced the token, so the replacement belongs to the
+    /// next pass (C's `Tcl_DeleteCommandFromToken` returns early on
+    /// `CMD_DYING`).
+    pub(crate) fn command_generation(&self, ns: NsId, name: &[u8]) -> Option<u64> {
+        self.arena[ns].commands.generation(name)
+    }
+
+    /// The fully-qualified name of the binding at `(ns, name)`.
+    pub(crate) fn command_fqn_at(&self, ns: NsId, name: &[u8]) -> Vec<u8> {
+        self.command_fqn(ns, name)
+    }
+
     /// `ns`'s `namespace unknown` handler, if one is set (an empty/`None` handler
     /// means "use the interpreter default `::unknown`").
     #[must_use]
@@ -858,7 +1018,7 @@ impl Namespaces {
     ) -> Vec<(Vec<u8>, std::rc::Rc<crate::ensemble::EnsembleToken>)> {
         let mut hits = Vec::new();
         for (id, node) in self.arena.iter().enumerate() {
-            for (name, cmd) in &node.commands {
+            for (name, cmd) in node.commands.iter() {
                 if let Command::Ensemble(token) = cmd {
                     if victims.contains(&token.config().ns) {
                         hits.push((self.command_fqn(id, name), std::rc::Rc::clone(token)));
@@ -907,7 +1067,7 @@ impl Namespaces {
     ) -> Vec<(Vec<u8>, std::rc::Rc<crate::interp::ImportToken>)> {
         let mut hits = Vec::new();
         for (id, node) in self.arena.iter().enumerate() {
-            for (name, command) in &node.commands {
+            for (name, command) in node.commands.iter() {
                 let Command::Imported {
                     source,
                     ensemble,
@@ -1065,8 +1225,9 @@ impl Namespaces {
             fqns.extend(
                 self.arena[id]
                     .commands
-                    .keys()
-                    .map(|name| self.command_fqn(id, name)),
+                    .hash_order()
+                    .into_iter()
+                    .map(|(name, _)| self.command_fqn(id, &name)),
             );
         }
         fqns
@@ -1090,16 +1251,13 @@ impl Namespaces {
         }
     }
 
-    /// Clear one dying namespace's own command/variable table while retaining
-    /// its child links and metadata for the recursive delete callbacks still to
-    /// run. The final fixed-point sweep clears the retained metadata and links.
+    /// Clear one dying namespace's own variable table and drop it from every
+    /// `namespace path`, while retaining its child links and metadata for the
+    /// recursive delete callbacks still to run. The command table is emptied
+    /// one token at a time afterwards, in hash order; the final fixed-point
+    /// sweep clears the retained metadata and links.
     pub(crate) fn clear_namespace_token(&mut self, ns: NsId) {
-        let n = &mut self.arena[ns];
-        for command in n.commands.values() {
-            Self::mark_command_deleted(command);
-        }
-        n.commands.clear();
-        n.vars = VarTable::default();
+        self.arena[ns].vars = VarTable::default();
         for node in &mut self.arena {
             node.path.retain(|entry| *entry != ns);
         }

--- a/runtime/rust/src/namespace.rs
+++ b/runtime/rust/src/namespace.rs
@@ -985,6 +985,14 @@ impl Namespaces {
         self.arena[ns].commands.generation(name)
     }
 
+    /// The generation of the command token `name` resolves to from `current`
+    /// — the token identity a command trace is registered against, and the one
+    /// a deletion frees the trace list of.
+    pub(crate) fn resolve_generation(&self, current: NsId, name: &[u8]) -> Option<u64> {
+        let (ns, simple) = self.home_of(current, name)?;
+        self.arena[ns].commands.generation(&simple)
+    }
+
     /// The fully-qualified name of the binding at `(ns, name)`.
     pub(crate) fn command_fqn_at(&self, ns: NsId, name: &[u8]) -> Vec<u8> {
         self.command_fqn(ns, name)

--- a/rust/tcl-cmd-core/src/namespace.rs
+++ b/rust/tcl-cmd-core/src/namespace.rs
@@ -538,10 +538,13 @@ pub fn children<O: ValueOps + Namespaces>(
 
 /// The observable order owner for Tcl's `TCL_STRING_KEYS` hash table.
 ///
-/// Namespace adapters keep one instance per namespace instead of reconstructing
-/// it from the live children: Tcl quadruples the bucket array at a 3:1 load
-/// factor and never shrinks it when entries are deleted, while each resize also
-/// reverses bucket chains. Both facts affect `Tcl_FirstHashEntry` order.
+/// Namespace adapters keep one instance per namespace child table *and* one per
+/// namespace command table instead of reconstructing either from the live
+/// entries: Tcl quadruples the bucket array at a 3:1 load factor and never
+/// shrinks it when entries are deleted, while each resize also reverses bucket
+/// chains. Both facts affect `Tcl_FirstHashEntry` order, which
+/// `TclDeleteNamespaceChildren` and `TclTeardownNamespace` snapshot before
+/// deleting each token.
 #[derive(Clone, Debug)]
 pub struct TclStringHashOrder {
     buckets: Vec<Vec<Vec<u8>>>,
@@ -581,6 +584,27 @@ impl TclStringHashOrder {
             self.rebuild();
         }
         true
+    }
+
+    /// Re-create `key`'s entry at its bucket head, as C's
+    /// `TclCreateObjCommandInNs` does when it redefines an existing command:
+    /// the old hash entry is deleted and a fresh one created, which moves the
+    /// name to the front of its chain.
+    pub fn reinsert(&mut self, key: &[u8]) {
+        self.remove(key);
+        self.insert(key);
+    }
+
+    /// Live entry count (`Tcl_HashTable.numEntries`).
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.entries
+    }
+
+    /// Whether the table holds no live entries.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.entries == 0
     }
 
     /// Delete `key` without shrinking or rebuilding the bucket array.
@@ -740,6 +764,73 @@ mod tests {
     }
 
     #[test]
+    fn tcl_string_hash_order_matches_command_growth_oracles() {
+        // TclTeardownNamespace snapshots cmdTable in Tcl_FirstHashEntry order,
+        // so a namespace's command-delete traces expose every rebuild the
+        // table went through. Exact tclsh 9.0.4 oracle results (identical on
+        // 8.6.16).
+        let order_of = |count: usize, prefix: &str| -> Vec<String> {
+            let mut table = TclStringHashOrder::default();
+            for index in 0..count {
+                assert!(table.insert(format!("{prefix}{index}").as_bytes()));
+            }
+            assert_eq!(table.len(), count);
+            table
+                .keys()
+                .into_iter()
+                .map(|key| String::from_utf8(key.to_vec()).unwrap())
+                .collect()
+        };
+        // 13 entries cross the 12-entry threshold: 4 buckets become 16.
+        assert_eq!(
+            order_of(13, "c"),
+            [
+                "c5", "c6", "c7", "c8", "c9", "c0", "c1", "c10", "c2", "c11", "c12", "c3", "c4",
+            ]
+        );
+        // 49 entries cross the 48-entry threshold too: 16 buckets become 64.
+        let mut expected: Vec<String> = (10..49).map(|index| format!("k{index}")).collect();
+        expected.extend((0..10).map(|index| format!("k{index}")));
+        assert_eq!(order_of(49, "k"), expected);
+    }
+
+    #[test]
+    fn tcl_string_hash_order_reinsert_moves_the_key_to_its_bucket_head() {
+        // Redefining a command deletes its hash entry and creates a new one
+        // (TclCreateObjCommandInNs), so the name moves to the chain head.
+        // Exact tclsh 9.0.4 oracle result for `proc ::N::one` redefined after
+        // the other nine.
+        let names = [
+            "one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten",
+        ];
+        let mut table = TclStringHashOrder::default();
+        for name in names {
+            assert!(table.insert(name.as_bytes()));
+        }
+        table.reinsert(b"one");
+        assert_eq!(table.len(), names.len());
+        let actual: Vec<_> = table
+            .keys()
+            .into_iter()
+            .map(|key| core::str::from_utf8(key).unwrap())
+            .collect();
+        assert_eq!(
+            actual,
+            [
+                "six", "four", "three", "eight", "seven", "one", "nine", "five", "two", "ten",
+            ]
+        );
+        // A plain insert of a live key is a no-op: C finds the entry and never
+        // relocates it.
+        assert!(!table.insert(b"one"));
+        assert_eq!(
+            table.keys().first().copied(),
+            Some(b"six".as_slice()),
+            "insert must not move a live key"
+        );
+    }
+
+    #[test]
     fn tcl_string_hash_order_retains_resize_after_deletion() {
         let mut table = TclStringHashOrder::default();
         for index in 0..12 {
@@ -749,5 +840,22 @@ mod tests {
             assert!(table.remove(format!("a{index}").as_bytes()));
         }
         assert_eq!(table.keys(), [b"a0".as_slice(), b"a3".as_slice()]);
+        assert_eq!(table.len(), 2);
+        // Fresh entries land in the retained 16-bucket array, so they precede
+        // the survivors rather than interleaving with them. Exact tclsh 9.0.4
+        // oracle result for the same sequence of `proc`/`rename` commands.
+        for name in ["b1", "b2", "b3"] {
+            assert!(table.insert(name.as_bytes()));
+        }
+        assert_eq!(
+            table.keys(),
+            [
+                b"b1".as_slice(),
+                b"b2".as_slice(),
+                b"b3".as_slice(),
+                b"a0".as_slice(),
+                b"a3".as_slice(),
+            ]
+        );
     }
 }

--- a/rust/tcl-vm/src/command.rs
+++ b/rust/tcl-vm/src/command.rs
@@ -561,6 +561,10 @@ fn cmd_rename(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
             }
             other => other,
         };
+        // C creates the destination's hash entry before `TclPreventAliasLoop`
+        // and deletes it again on a refusal, so the resize that transient entry
+        // triggers outlives the rejected rename.
+        vm.note_rename_destination(&key);
         let is_alias = matches!(&cmd, Command::Alias(_) | Command::CrossAlias { .. });
         // C's `TclPreventAliasLoop` guards *rename* too: moving an alias onto
         // a name its own target chain resolves back to is refused, with the
@@ -570,6 +574,7 @@ fn cmd_rename(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
         // delete callbacks and trace/deoptimisation state that cannot be
         // rolled back after `register_command` observes an overwrite.
         if is_alias && vm.alias_chain_loops_for_rename(&key, &cmd) {
+            vm.forget_rename_destination(&key);
             let tail = crate::interp::key_holder_and_tail_unrooted(&key).1;
             return err(format!(
                 "cannot define or rename alias \"{tail}\": would create a loop"

--- a/rust/tcl-vm/src/command.rs
+++ b/rust/tcl-vm/src/command.rs
@@ -1179,7 +1179,7 @@ fn cmd_proc(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     // A namespace-qualified proc name requires its namespace to already exist
     // (C's `TclGetNamespaceForQualName` → `nsPtr == NULL`). An unqualified name
     // lands in the current namespace, which always exists (proc-1.2).
-    if name_s.contains("::") && !vm.namespace_accepts_command_definition(&namespace, &reg_name) {
+    if name_s.contains("::") && !vm.namespace_accepts_command_definition(&namespace) {
         return err(format!(
             "can't create procedure \"{name_s}\": unknown namespace"
         ));

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -1200,14 +1200,26 @@ struct VarTrace {
 pub(crate) struct CmdTraceEntry {
     pub(crate) ops: Vec<String>,
     pub(crate) callback: String,
+    /// The generation of the command **token** this entry hangs off, or `None`
+    /// when the binding had none.
+    ///
+    /// C keeps the list on the `Command` itself and frees exactly that list
+    /// when the token dies. The sidecar tables are keyed by command *name*, so
+    /// a delete callback that binds a replacement at the same key registers on
+    /// a different token under that key; only the generation tells the two
+    /// lists apart. Generations are minted in binding order, so a trace on a
+    /// token installed after the dying one compares greater. A hide, expose or
+    /// rename moves the entry with its token, and re-stamps it.
+    token: std::cell::Cell<Option<u64>>,
     firing: std::cell::Cell<bool>,
 }
 
 impl CmdTraceEntry {
-    fn new(ops: Vec<String>, callback: String) -> Self {
+    fn new(ops: Vec<String>, callback: String, token: Option<u64>) -> Self {
         Self {
             ops,
             callback,
+            token: std::cell::Cell::new(token),
             firing: std::cell::Cell::new(false),
         }
     }
@@ -2547,13 +2559,10 @@ impl Vm {
         command: Command,
     ) {
         new_key.clone_into(&mut transaction.new_key);
-        // C's `TclRenameCommand` creates the destination hash entry *before*
-        // deleting the source's, so the transient extra entry can trigger a
-        // rebuild a delete-first order would not. Only the retained order
-        // observes that; the removal/registration order below is unchanged.
+        // The destination hash entry was created by
+        // [`Self::note_rename_destination`] before the alias-loop check, and
         // `register_command` re-inserts the same key, which the order owner
-        // leaves where this call put it.
-        self.note_command_bound(new_key, false);
+        // leaves where that call put it.
         // Keep the successful rename's established source-removal then
         // destination-registration order.  The caller has already completed
         // every rejection path, so this is now allowed to fire destination
@@ -2615,6 +2624,13 @@ impl Vm {
         // ImportRef list. Both the source and every import therefore remain
         // table-visible during this callback.
         self.on_command_removed_for(&key);
+        if self.command_token_identity(&key).as_ref() != Some(&source_token) {
+            // The callback deleted this command, or bound a replacement at the
+            // same name: its own lifecycle already unlinked the dying token
+            // (`Tcl_DeleteCommandFromToken` then finds `cmdPtr->hPtr` NULL), so
+            // whatever holds the name now is a distinct token and stands.
+            return true;
+        }
         self.retire_real_command(&source_token, &command);
         self.take_command_unchecked_key(&transaction.old_key);
         true
@@ -4649,6 +4665,23 @@ impl Vm {
             .insert(tail.as_bytes());
     }
 
+    /// Create a rename destination's hash entry before the alias-loop check,
+    /// as C's `TclRenameCommand` does: `Tcl_CreateHashEntry(&newNsPtr->
+    /// cmdTable, newTail)` runs *before* `TclPreventAliasLoop`, and before the
+    /// source's entry is deleted. The transient extra entry can trigger a
+    /// rebuild a delete-first order would not, and the grown bucket array
+    /// survives even when the check then refuses the rename.
+    pub(crate) fn note_rename_destination(&mut self, key: &str) {
+        self.note_command_bound(key, false);
+    }
+
+    /// Delete a rename destination's hash entry again after the alias-loop
+    /// check refused the move — C's `Tcl_DeleteHashEntry(cmdPtr->hPtr)` on the
+    /// rollback path. The table keeps the capacity the transient entry gave it.
+    pub(crate) fn forget_rename_destination(&mut self, key: &str) {
+        self.note_command_unbound(key);
+    }
+
     /// Insert a command's tail into its holder namespace's retained Tcl
     /// string-hash table. `replacing` marks C's redefinition
     /// (`TclCreateObjCommandInNs` deletes the existing hash entry and creates
@@ -5773,15 +5806,21 @@ impl Vm {
             return err(format!("unknown command \"{name}\""));
         };
         let is_step = is_step_capable(&ops);
+        // The trace belongs to the token standing at this key now, not to the
+        // name (C hangs it off `cmdPtr->tracePtr`).
+        let sidecar = CommandSidecarKey::visible(key);
+        let token = self
+            .command_token_identity(&sidecar)
+            .map(|identity| identity.generation);
         let table = if execution {
             &mut self.exec_traces
         } else {
             &mut self.cmd_traces
         };
         table
-            .entry(CommandSidecarKey::visible(key))
+            .entry(sidecar)
             .or_default()
-            .push(Rc::new(CmdTraceEntry::new(ops, callback)));
+            .push(Rc::new(CmdTraceEntry::new(ops, callback, token)));
         self.invalidate_guard_domain(GuardDomain::CommandTrace);
         // A new enterstep/leavestep-capable trace forces every proc in this
         // interp to (re)compile trace-visible on next call — C's
@@ -5948,11 +5987,13 @@ impl Vm {
         // replacement binding with the same key while this operation is still
         // in flight.  That replacement must not inherit the old handle.
         self.detach_active_sidecars(key);
+        let dying = self
+            .command_token_identity(key)
+            .map(|identity| identity.generation);
         let mut removed_trace = false;
         if !self.cmd_traces.is_empty() {
-            let retired = self.cmd_traces.get(key).cloned().unwrap_or_default();
             self.fire_command_traces_for(key, "", "delete");
-            removed_trace |= self.drop_retired_cmd_traces(key, &retired);
+            removed_trace |= self.drop_retired_cmd_traces(key, dying);
         }
         if !self.exec_traces.is_empty()
             && let Some(removed) = self.exec_traces.remove(key)
@@ -5969,20 +6010,20 @@ impl Vm {
         }
     }
 
-    /// Drop the command traces the dying token carried, leaving behind any a
-    /// delete callback registered on a replacement at the same key. C frees the
-    /// `Command`'s own trace list; our sidecars are keyed by location, so the
-    /// `Rc` is the token-scoped identity.
-    fn drop_retired_cmd_traces(
-        &mut self,
-        key: &CommandSidecarKey,
-        retired: &[Rc<CmdTraceEntry>],
-    ) -> bool {
+    /// Drop the command traces the dying token carried — C's "free the whole
+    /// `cmdPtr->tracePtr` list". A trace the delete callback added to the dying
+    /// command goes with it; one it registered on a replacement it bound at the
+    /// same key has a later generation and survives. An unidentifiable dying
+    /// token takes the whole list.
+    fn drop_retired_cmd_traces(&mut self, key: &CommandSidecarKey, dying: Option<u64>) -> bool {
         let Some(entries) = self.cmd_traces.get_mut(key) else {
             return false;
         };
         let before = entries.len();
-        entries.retain(|entry| !retired.iter().any(|old| Rc::ptr_eq(old, entry)));
+        entries.retain(|entry| match (entry.token.get(), dying) {
+            (Some(token), Some(dying)) => token > dying,
+            _ => false,
+        });
         let removed = entries.len() != before;
         if entries.is_empty() {
             self.cmd_traces.remove(key);
@@ -6020,12 +6061,24 @@ impl Vm {
     /// hide/expose is not a Tcl rename, so no callback is fired.
     fn move_command_traces(&mut self, old_key: &CommandSidecarKey, new_key: CommandSidecarKey) {
         self.relocate_active_sidecars(old_key, &new_key);
+        // The list travels with the token, so re-stamp it to whatever token
+        // now stands at the destination; a later deletion there still tells
+        // this list from a replacement's.
+        let token = self
+            .command_token_identity(&new_key)
+            .map(|identity| identity.generation);
         let mut moved = false;
         if let Some(entries) = self.cmd_traces.remove(old_key) {
+            for entry in &entries {
+                entry.token.set(token);
+            }
             self.cmd_traces.insert(new_key.clone(), entries);
             moved = true;
         }
         if let Some(entries) = self.exec_traces.remove(old_key) {
+            for entry in &entries {
+                entry.token.set(token);
+            }
             self.exec_traces.insert(new_key, entries);
             moved = true;
         }

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -433,6 +433,15 @@ fn canonical_ns_name(name: &str) -> std::borrow::Cow<'_, str> {
     std::borrow::Cow::Owned(join_segments(name))
 }
 
+/// The retained `TCL_STRING_KEYS` tables an interpreter root starts with: the
+/// global holder always has one, empty and at Tcl's four static buckets.
+fn root_hash_order() -> HashMap<String, tcl_cmd_core::namespace::TclStringHashOrder> {
+    HashMap::from([(
+        String::new(),
+        tcl_cmd_core::namespace::TclStringHashOrder::default(),
+    )])
+}
+
 /// [`tcl_syntax::naming::key_holder_and_tail`] for the VM's **unrooted** key
 /// convention: root the key, split by the construction-inverse rule, and
 /// unroot the holder.  Distinct from the written-name colon-run split — an
@@ -778,6 +787,13 @@ pub struct InterpState {
     /// Per-namespace retained `TCL_STRING_KEYS` child-table state. The shared
     /// owner preserves resize and deletion history for `namespace children`.
     ns_child_order: HashMap<String, tcl_cmd_core::namespace::TclStringHashOrder>,
+    /// Per-namespace retained `TCL_STRING_KEYS` command-table state, keyed by
+    /// the holder namespace of each command's canonical key. `commands` is one
+    /// flat map, so the bucket order `TclTeardownNamespace` snapshots lives
+    /// here instead. Builtins are registered in the VM's own bootstrap order
+    /// rather than `Tcl_CreateInterp`'s, so the global holder's order is ours,
+    /// not C's; every per-namespace user table is exact.
+    ns_command_order: HashMap<String, tcl_cmd_core::namespace::TclStringHashOrder>,
     /// Per-namespace command resolution path (`namespace path`): canonical
     /// namespace name (no leading `::`, `""` = global) → the ordered list of
     /// namespaces (canonical) consulted after the current namespace and before
@@ -851,6 +867,11 @@ pub struct InterpState {
     /// doesn't count toward `clippy::struct_excessive_bools` alongside the
     /// interp's genuine bool-valued state (`is_safe`, `debug_frame`, …).
     pub(crate) trace_in_progress: std::cell::Cell<bool>,
+    /// The commands whose `rename`/`delete` traces are currently firing. C
+    /// guards those per `Command` (`CMD_TRACE_ACTIVE`, and `CMD_DYING` for a
+    /// deletion), not interpreter-wide: a callback that deletes a *different*
+    /// command still fires that command's own traces, nested.
+    firing_cmd_traces: Vec<CommandSidecarKey>,
     /// A traced dispatch that deferred its body to a pushed frame parks its
     /// leave context here for `drive_loop` to move onto that frame — set and
     /// drained within one trampoline step.
@@ -1574,10 +1595,8 @@ impl InterpState {
             ns_arena: vec![String::new()],
             ns_intern: HashMap::from([(String::new(), ROOT_NS)]),
             dead_namespaces: HashSet::new(),
-            ns_child_order: HashMap::from([(
-                String::new(),
-                tcl_cmd_core::namespace::TclStringHashOrder::default(),
-            )]),
+            ns_child_order: root_hash_order(),
+            ns_command_order: root_hash_order(),
             ns_paths: HashMap::new(),
             ns_unknowns: HashMap::new(),
             ns_unknown_depth: 0,
@@ -1593,6 +1612,7 @@ impl InterpState {
             exec_step_scopes: Vec::new(),
             trace_deopt_epoch: std::cell::Cell::new(0),
             trace_in_progress: std::cell::Cell::new(false),
+            firing_cmd_traces: Vec::new(),
             pending_exec_leave: None,
             cmd_resolve_cache: std::cell::RefCell::new((0, HashMap::new())),
             cmd_epoch: std::cell::Cell::new(0),
@@ -2394,6 +2414,7 @@ impl Vm {
         // immediately after registering, so clearing here cannot unmark them.
         self.registry_object_roots.remove(name);
         self.commands.insert(name.to_owned(), cmd);
+        self.note_command_bound(name, replacing_command);
         let installed_generation = self.mint_command_generation();
         self.command_generations
             .insert(name.to_owned(), installed_generation);
@@ -2441,6 +2462,7 @@ impl Vm {
         let imported = self.imported_commands.contains_key(name);
         let token = self.command_token_identity(&CommandSidecarKey::visible(name));
         if let Some(command) = self.commands.remove(name) {
+            self.note_command_unbound(name);
             self.command_generations.remove(name);
             if !imported && let Some(token) = token {
                 self.retire_real_command(&token, &command);
@@ -2525,6 +2547,13 @@ impl Vm {
         command: Command,
     ) {
         new_key.clone_into(&mut transaction.new_key);
+        // C's `TclRenameCommand` creates the destination hash entry *before*
+        // deleting the source's, so the transient extra entry can trigger a
+        // rebuild a delete-first order would not. Only the retained order
+        // observes that; the removal/registration order below is unchanged.
+        // `register_command` re-inserts the same key, which the order owner
+        // leaves where this call put it.
+        self.note_command_bound(new_key, false);
         // Keep the successful rename's established source-removal then
         // destination-registration order.  The caller has already completed
         // every rejection path, so this is now allowed to fire destination
@@ -2641,6 +2670,15 @@ impl Vm {
 
         let source_token = self.command_token_identity(key)?;
         self.on_command_removed_for(key);
+        if self.command_token_identity(key).as_ref() != Some(&source_token) {
+            // A delete callback deleted this command or redefined it: that
+            // lifecycle already unlinked the entry and re-pointed the source's
+            // imports (C's `CMD_REDEF_IN_PROGRESS` skips the ImportRef walk,
+            // and `Tcl_DeleteCommandFromToken` finds `cmdPtr->hPtr` already
+            // NULL). Whatever holds the name now is a distinct token, left for
+            // the next teardown snapshot.
+            return Some(command);
+        }
         self.retire_real_command(&source_token, &command);
         match key {
             CommandSidecarKey::Visible(name) => {
@@ -2668,7 +2706,11 @@ impl Vm {
         // the destination; leaving it stranded under the vacated name would
         // gate an unrelated command that later takes that name.
         self.registry_object_roots.remove(key);
-        self.commands.remove(key)
+        let command = self.commands.remove(key);
+        if command.is_some() {
+            self.note_command_unbound(key);
+        }
+        command
     }
 
     /// Remove a command by its exact table key (no name resolution) — the
@@ -3607,6 +3649,7 @@ impl Vm {
             let command_generation = self.command_generations.get(c).copied();
             let builtin_identity = self.builtin_identity_for_key(c);
             if let Some(cmd) = self.commands.remove(c) {
+                self.note_command_unbound(c);
                 self.command_generations.remove(c);
                 self.imported_commands.remove(c);
                 self.builtin_identities.remove(c);
@@ -3744,7 +3787,10 @@ impl Vm {
                 self.in_interp(parent, |vm| {
                     vm.children.remove(&name);
                     vm.bump_cmd_epoch();
-                    vm.commands.remove(name.strip_prefix("::").unwrap_or(&name));
+                    let key = name.strip_prefix("::").unwrap_or(&name).to_owned();
+                    if vm.commands.remove(&key).is_some() {
+                        vm.note_command_unbound(&key);
+                    }
                 });
             }
         }
@@ -4538,17 +4584,17 @@ impl Vm {
         })
     }
 
-    /// A dying namespace rejects new members generally, but Tcl permits a
-    /// command delete callback to replace the still-table-visible command
-    /// token currently being torn down. The replacement remains callable for
-    /// the callback and is swept when namespace teardown resumes.
-    pub(crate) fn namespace_accepts_command_definition(
-        &self,
-        namespace: &str,
-        command_key: &str,
-    ) -> bool {
-        self.namespace_exists(namespace)
-            || (self.namespace_is_dying(namespace) && self.commands.contains_key(command_key))
+    /// Whether a qualified command definition may name `namespace` (C's
+    /// `TclGetNamespaceForQualName` finding a non-`NULL` `nsPtr`). A namespace
+    /// in its synchronous delete window still qualifies: the new command
+    /// remains callable for the callback and is swept when teardown resumes.
+    pub(crate) fn namespace_accepts_command_definition(&self, namespace: &str) -> bool {
+        // `TclTeardownNamespace` unlinks the token from its parent's
+        // `childTable` only *after* the command loop, so through the whole
+        // synchronous delete-callback window `TclGetNamespaceForQualName`
+        // still reaches it: a callback may define a brand-new command there,
+        // which the next teardown snapshot then tears down.
+        self.namespace_exists(namespace) || self.namespace_is_dying(namespace)
     }
 
     /// Register an existing namespace (and its ancestors). The name is
@@ -4601,6 +4647,56 @@ impl Vm {
             .entry(parent)
             .or_default()
             .insert(tail.as_bytes());
+    }
+
+    /// Insert a command's tail into its holder namespace's retained Tcl
+    /// string-hash table. `replacing` marks C's redefinition
+    /// (`TclCreateObjCommandInNs` deletes the existing hash entry and creates
+    /// a new one, so the name moves to its bucket head); a fresh name is a
+    /// plain insert.
+    fn note_command_bound(&mut self, key: &str, replacing: bool) {
+        let (holder, tail) = key_holder_and_tail_unrooted(key);
+        let order = self.ns_command_order.entry(holder).or_default();
+        if replacing {
+            order.reinsert(tail.as_bytes());
+        } else {
+            order.insert(tail.as_bytes());
+        }
+    }
+
+    /// Delete a command's hash entry from its holder's retained table. The
+    /// bucket array keeps its capacity (`Tcl_DeleteHashEntry` never shrinks).
+    fn note_command_unbound(&mut self, key: &str) {
+        let (holder, tail) = key_holder_and_tail_unrooted(key);
+        if let Some(order) = self.ns_command_order.get_mut(&holder) {
+            order.remove(tail.as_bytes());
+        }
+    }
+
+    /// One namespace's live command keys with their token generations, in
+    /// `Tcl_FirstHashEntry` order — the snapshot `TclTeardownNamespace` takes
+    /// of `cmdTable` before deleting each token.
+    fn command_table_hash_order(&self, canonical: &str) -> Vec<(String, u64)> {
+        let prefix = if canonical.is_empty() {
+            String::new()
+        } else {
+            format!("{canonical}::")
+        };
+        self.ns_command_order
+            .get(canonical)
+            .map(|order| {
+                order
+                    .keys()
+                    .into_iter()
+                    .filter_map(|tail| {
+                        let tail = core::str::from_utf8(tail).ok()?;
+                        let key = format!("{prefix}{tail}");
+                        let generation = *self.command_generations.get(&key)?;
+                        Some((key, generation))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
     }
 
     /// Record `namespace export` patterns for the current namespace. C's
@@ -5056,7 +5152,9 @@ impl Vm {
         match live_key {
             CommandSidecarKey::Visible(name) => {
                 self.imported_commands.remove(name);
-                self.commands.remove(name);
+                if self.commands.remove(name).is_some() {
+                    self.note_command_unbound(name);
+                }
                 self.command_generations.remove(name);
                 self.builtin_identities.remove(name);
                 self.registry_object_roots.remove(name);
@@ -5250,33 +5348,39 @@ impl Vm {
             })
     }
 
-    /// Retire the real/imported command identities selected for one namespace's
-    /// command-table teardown. Namespace-owned ensembles live in their own
-    /// ordered list and are drained separately.
-    fn retire_namespace_command_bindings(&mut self, removed_commands: &[String]) {
-        // Every visible real command selected by namespace teardown traverses
-        // the complete source lifecycle here. Delete traces/backrefs/sidecars
-        // therefore retire exactly once and cannot attach to a later command
-        // at the same name.
-        let visible_real_commands: Vec<String> = removed_commands
-            .iter()
-            .filter(|key| !self.imported_commands.contains_key(*key))
-            .cloned()
-            .collect();
-        for key in visible_real_commands {
-            self.retire_command_lifecycle_key(&CommandSidecarKey::visible(key));
+    /// Retire one namespace's snapshotted command tokens in the order
+    /// `TclTeardownNamespace` took them. Namespace-owned ensembles live in
+    /// their own ordered list and are drained separately.
+    ///
+    /// Each entry is addressed by `(key, generation)`: a callback fired by an
+    /// earlier entry may have deleted this one (C's snapshot then holds a
+    /// `CMD_DYING` token and `Tcl_DeleteCommandFromToken` returns early) or
+    /// replaced it with a distinct token the current snapshot does not name.
+    /// Both skip; the next snapshot picks a replacement up.
+    ///
+    /// Returns how many snapshotted tokens were still current when the loop
+    /// reached them, so the caller can stop rather than spin if a pass turns
+    /// out to reach nothing at all.
+    fn retire_namespace_command_bindings(&mut self, snapshot: &[(String, u64)]) -> usize {
+        let mut retired = 0;
+        for (key, generation) in snapshot {
+            if self.command_generations.get(key) != Some(generation) {
+                continue;
+            }
+            retired += 1;
+            // An import merely living inside the deleted namespace is removed
+            // at its own hash position and never marks its shared source token
+            // dead; a real command traverses the complete source lifecycle, so
+            // its delete traces, backrefs and sidecars retire exactly once and
+            // cannot attach to a later command at the same name.
+            let key = CommandSidecarKey::visible(key);
+            if self.imported_commands.contains_key(key.name()) {
+                self.retire_import_binding(&key);
+            } else {
+                self.retire_command_lifecycle_key(&key);
+            }
         }
-
-        // Imported bindings that merely live inside the deleted namespace are
-        // removed separately and never mark their shared source token dead.
-        let imported_victims: Vec<String> = removed_commands
-            .iter()
-            .filter(|key| self.imported_commands.contains_key(*key))
-            .cloned()
-            .collect();
-        for key in imported_victims {
-            self.retire_import_binding(&CommandSidecarKey::visible(key));
-        }
+        retired
     }
 
     /// Drain one namespace's ensemble-token list before that namespace is
@@ -5373,16 +5477,19 @@ impl Vm {
         // table/list traversal without an unordered subtree snapshot.
         loop {
             self.retire_namespace_owned_ensembles(canonical);
-            let frontier: Vec<String> = self
-                .commands
-                .iter()
-                .filter(|(key, _)| key_holder_and_tail_unrooted(key).0 == canonical)
-                .map(|(key, _)| key.clone())
-                .collect();
+            // `Tcl_FirstHashEntry` order, not the flat map's iteration order:
+            // the delete traces of a namespace's commands fire in the retained
+            // bucket order of the table they lived in.
+            let frontier = self.command_table_hash_order(canonical);
             if frontier.is_empty() {
                 break;
             }
-            self.retire_namespace_command_bindings(&frontier);
+            if self.retire_namespace_command_bindings(&frontier) == 0 {
+                // A fresh snapshot always names at least one current token, so
+                // this is unreachable; stop rather than spin if the generation
+                // map ever disagrees with the order owner.
+                break;
+            }
         }
 
         if let Some(global) = self.frames.first_mut() {
@@ -5410,12 +5517,11 @@ impl Vm {
 
         self.ns_exports.remove(canonical);
         self.ns_child_order.remove(canonical);
+        self.ns_command_order.remove(canonical);
         if deleting_root {
             self.ns_intern.insert(String::new(), ROOT_NS);
-            self.ns_child_order.insert(
-                String::new(),
-                tcl_cmd_core::namespace::TclStringHashOrder::default(),
-            );
+            self.ns_child_order = root_hash_order();
+            self.ns_command_order = root_hash_order();
         } else {
             self.ns_intern.remove(canonical);
         }
@@ -5799,14 +5905,16 @@ impl Vm {
     /// Callback errors are ignored (C: "Any errors in these traces are
     /// ignored").
     fn fire_command_traces_for(&mut self, key: &CommandSidecarKey, new_display: &str, op: &str) {
-        // C's `INTERP_TRACE_IN_PROGRESS`: a rename/delete triggered by a
-        // trace callback's own body does not itself fire further traces.
-        if self.cmd_traces.is_empty() || self.trace_in_progress.get() {
+        // C's per-`Command` `CMD_TRACE_ACTIVE`/`CMD_DYING`: a rename/delete of
+        // *this* command from inside its own callback does not fire again. A
+        // different command's traces still do.
+        if self.cmd_traces.is_empty() || self.firing_cmd_traces.contains(key) {
             return;
         }
         let Some(entries) = self.cmd_traces.get(key).cloned() else {
             return;
         };
+        self.firing_cmd_traces.push(key.clone());
         let old_display = format!("::{}", key.name());
         // C prepends each new command trace (`Tcl_TraceCommand`, tclTrace.c
         // 9.0.4:1016-1018) and `CallCommandTraces` walks the list head→tail
@@ -5824,6 +5932,7 @@ impl Vm {
                 );
             }
         }
+        self.firing_cmd_traces.pop();
     }
 
     /// A command at `key` is about to be deleted or overwritten: fire its
@@ -5841,8 +5950,9 @@ impl Vm {
         self.detach_active_sidecars(key);
         let mut removed_trace = false;
         if !self.cmd_traces.is_empty() {
+            let retired = self.cmd_traces.get(key).cloned().unwrap_or_default();
             self.fire_command_traces_for(key, "", "delete");
-            removed_trace |= self.cmd_traces.remove(key).is_some();
+            removed_trace |= self.drop_retired_cmd_traces(key, &retired);
         }
         if !self.exec_traces.is_empty()
             && let Some(removed) = self.exec_traces.remove(key)
@@ -5857,6 +5967,27 @@ impl Vm {
         if removed_trace {
             self.invalidate_guard_domain(GuardDomain::CommandTrace);
         }
+    }
+
+    /// Drop the command traces the dying token carried, leaving behind any a
+    /// delete callback registered on a replacement at the same key. C frees the
+    /// `Command`'s own trace list; our sidecars are keyed by location, so the
+    /// `Rc` is the token-scoped identity.
+    fn drop_retired_cmd_traces(
+        &mut self,
+        key: &CommandSidecarKey,
+        retired: &[Rc<CmdTraceEntry>],
+    ) -> bool {
+        let Some(entries) = self.cmd_traces.get_mut(key) else {
+            return false;
+        };
+        let before = entries.len();
+        entries.retain(|entry| !retired.iter().any(|old| Rc::ptr_eq(old, entry)));
+        let removed = entries.len() != before;
+        if entries.is_empty() {
+            self.cmd_traces.remove(key);
+        }
+        removed
     }
 
     /// A command moved `old_key` → `new_key` (`rename`): fire its `rename`

--- a/rust/tcl-vm/tests/namespace_surface_e2e.rs
+++ b/rust/tcl-vm/tests/namespace_surface_e2e.rs
@@ -809,6 +809,138 @@ fn namespace_teardown_retires_each_sources_import_tree_before_the_next_entry() {
 }
 
 #[test]
+fn a_delete_callbacks_own_trace_dies_with_the_dying_token() {
+    // `Tcl_DeleteCommandFromToken` frees the whole `cmdPtr->tracePtr` list
+    // after `CallCommandTraces`. A trace the callback registers on the command
+    // being deleted attaches to that same dying token, so it never fires — not
+    // in this walk (`CallCommandTraces` follows `active.nextTracePtr`), and not
+    // for a later command that takes the vacated name. Exact Tcl 9.0.4 oracle
+    // results (identical on 8.6.16).
+    let recorders = "set log {}
+             proc inner {old new op} {lappend ::log inner:$old}
+             proc outer {old new op} {lappend ::log outer:$old
+                 trace add command $old delete inner}\n";
+    // `rename cmd {}`.
+    assert_eq!(
+        run(&format!(
+            "{recorders}
+             proc p {{}} {{}}
+             trace add command ::p delete outer
+             rename ::p {{}}
+             set a $log
+             proc p {{}} {{}}
+             rename ::p {{}}
+             list $a $log"
+        )),
+        "outer:::p outer:::p"
+    );
+    // Redefinition (`TclCreateObjCommandInNs` deletes the old token first).
+    assert_eq!(
+        run(&format!(
+            "{recorders}
+             proc p {{}} {{}}
+             trace add command ::p delete outer
+             proc p {{}} {{}}
+             set a $log
+             proc p {{}} {{}}
+             set b $log
+             rename ::p {{}}
+             list $a $b $log"
+        )),
+        "outer:::p outer:::p outer:::p"
+    );
+    // Namespace teardown.
+    assert_eq!(
+        run(&format!(
+            "{recorders}
+             namespace eval N {{proc q {{}} {{}}}}
+             trace add command ::N::q delete outer
+             namespace delete ::N
+             set a $log
+             namespace eval N {{proc q {{}} {{}}}}
+             namespace delete ::N
+             list $a $log"
+        )),
+        "outer:::N::q outer:::N::q"
+    );
+}
+
+#[test]
+fn a_replacements_trace_survives_the_deletion_that_created_it() {
+    // The other half of the same rule: a callback that *binds* a replacement
+    // at the vacated name registers on that new token, whose own trace list C
+    // never touches. Only the dying token's list is freed. Exact Tcl 9.0.4
+    // oracle results (identical on 8.6.16).
+    let recorders = "set log {}
+             proc inner {old new op} {lappend ::log inner:$old}
+             proc mk {old new op} {lappend ::log mk:$old
+                 proc ::p {} {}
+                 trace add command ::p delete inner}\n";
+    assert_eq!(
+        run(&format!(
+            "{recorders}
+             proc p {{}} {{}}
+             trace add command ::p delete mk
+             rename ::p {{}}
+             set a [list $log [llength [info commands ::p]]]
+             rename ::p {{}}
+             list $a $log [llength [info commands ::p]]"
+        )),
+        "{mk:::p 1} {mk:::p inner:::p} 0"
+    );
+    // A trace the callback adds *before* the replacement still belongs to the
+    // dying token and goes with it; only the one added after survives.
+    assert_eq!(
+        run("set log {}
+             proc early {old new op} {lappend ::log early:$old}
+             proc late {old new op} {lappend ::log late:$old}
+             proc mk {old new op} {lappend ::log mk:$old
+                 trace add command $old delete early
+                 proc ::p {} {}
+                 trace add command ::p delete late}
+             proc p {} {}
+             trace add command ::p delete mk
+             rename ::p {}
+             set a $log
+             rename ::p {}
+             list $a $log"),
+        "mk:::p {mk:::p late:::p}"
+    );
+}
+
+#[test]
+fn a_refused_alias_rename_keeps_the_command_tables_growth() {
+    // `TclRenameCommand` creates the destination hash entry *before*
+    // `TclPreventAliasLoop` and deletes it again on a refusal, so the transient
+    // twelfth entry rebuilds the eleven-command table from 4 buckets to 16 and
+    // the grown array outlives the rejected rename. Exact Tcl 9.0.4 oracle
+    // results (identical on 8.6.16).
+    let eleven = "set log {}
+             proc rec {old new op} {lappend ::log [namespace tail $old]}
+             namespace eval N {}
+             foreach n {one two three four five six seven eight nine ten eleven} {
+                 proc ::N::$n {} {}
+             }\n";
+    let trace_and_delete = "foreach n [info commands ::N::*] {trace add command $n delete rec}
+             namespace delete ::N\n";
+    assert_eq!(
+        run(&format!("{eleven}{trace_and_delete} set log")),
+        "six four three eight seven nine five two one eleven ten"
+    );
+    assert_eq!(
+        run(&format!(
+            "{eleven}
+             interp alias {{}} ::a {{}} ::N::b
+             set c [catch {{rename ::a ::N::b}} m]
+             {trace_and_delete}
+             list $c $m [llength [info commands ::a]] $log"
+        )),
+        "1 {cannot define or rename alias \"b\": would create a loop} 1 \
+         {three seven one two four eleven eight five nine six ten}"
+    );
+}
+
+#[test]
 fn deleting_a_namespace_fully_retires_its_visible_ensemble_once() {
     // The ensemble lives in the global command table but is owned by ::N.
     // Namespace teardown fires and removes its delete trace. A later, distinct

--- a/rust/tcl-vm/tests/namespace_surface_e2e.rs
+++ b/rust/tcl-vm/tests/namespace_surface_e2e.rs
@@ -585,6 +585,230 @@ fn child_namespace_teardown_uses_tcl_string_hash_order() {
 }
 
 #[test]
+fn namespace_teardown_uses_command_table_tcl_string_hash_order() {
+    // TclTeardownNamespace snapshots nsPtr->cmdTable with
+    // Tcl_FirstHashEntry/Tcl_NextHashEntry before deleting each token, so the
+    // delete traces fire in the retained TCL_STRING_KEYS bucket order rather
+    // than definition or lexical order. Exact Tcl 9.0.4 oracle result (issue
+    // #1752's own vector).
+    assert_eq!(
+        run("set log {}
+             proc rec {old new op} {lappend ::log [namespace tail $old]}
+             namespace eval N {}
+             foreach n {one two three four five six seven eight nine ten} {
+                 proc ::N::$n {} {}
+                 trace add command ::N::$n delete rec
+             }
+             namespace delete ::N
+             set log"),
+        "six four three eight seven nine five two one ten"
+    );
+}
+
+#[test]
+fn command_table_hash_order_records_table_growth() {
+    // RebuildTable quadruples the bucket array once numEntries reaches three
+    // times numBuckets and re-pushes each chain head-first, reversing it.
+    // Thirteen commands cross the first threshold. Exact Tcl 9.0.4 oracle
+    // result.
+    assert_eq!(
+        run("set log {}
+             proc rec {old new op} {lappend ::log [namespace tail $old]}
+             namespace eval N {}
+             for {set i 0} {$i < 13} {incr i} {
+                 proc ::N::c$i {} {}
+                 trace add command ::N::c$i delete rec
+             }
+             namespace delete ::N
+             set log"),
+        "c5 c6 c7 c8 c9 c0 c1 c10 c2 c11 c12 c3 c4"
+    );
+}
+
+#[test]
+fn command_table_hash_order_retains_capacity_across_deletions() {
+    // Tcl_DeleteHashEntry never shrinks the bucket array, so commands created
+    // after a bulk deletion land in the grown table and precede the survivors.
+    // Exact Tcl 9.0.4 oracle result.
+    assert_eq!(
+        run("set log {}
+             proc rec {old new op} {lappend ::log [namespace tail $old]}
+             namespace eval N {}
+             foreach n {a0 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11} {proc ::N::$n {} {}}
+             foreach i {1 2 4 5 6 7 8 9 10 11} {rename ::N::a$i {}}
+             foreach n {b1 b2 b3} {proc ::N::$n {} {}}
+             foreach n [info commands ::N::*] {trace add command $n delete rec}
+             namespace delete ::N
+             set log"),
+        "b1 b2 b3 a0 a3"
+    );
+}
+
+#[test]
+fn command_table_hash_order_moves_a_redefined_command() {
+    // TclCreateObjCommandInNs deletes the existing hash entry and creates a
+    // fresh one, so redefining `one` moves it to its bucket head. Exact Tcl
+    // 9.0.4 oracle result.
+    assert_eq!(
+        run("set log {}
+             proc rec {old new op} {lappend ::log [namespace tail $old]}
+             namespace eval N {}
+             foreach n {one two three four five six seven eight nine ten} {proc ::N::$n {} {}}
+             proc ::N::one {} {return again}
+             foreach n [info commands ::N::*] {trace add command $n delete rec}
+             namespace delete ::N
+             set log"),
+        "six four three eight seven one nine five two ten"
+    );
+    // TclRenameCommand creates the destination entry the same way, before it
+    // deletes the source's. Exact Tcl 9.0.4 oracle result.
+    assert_eq!(
+        run("set log {}
+             proc rec {old new op} {lappend ::log [namespace tail $old]}
+             namespace eval N {}
+             foreach n {one two three four five six seven eight nine ten} {proc ::N::$n {} {}}
+             rename ::N::one ::N::uno
+             foreach n [info commands ::N::*] {trace add command $n delete rec}
+             namespace delete ::N
+             set log"),
+        "six four three eight seven uno nine five two ten"
+    );
+}
+
+#[test]
+fn namespace_teardown_visits_a_callback_created_command_in_the_next_pass() {
+    // TclTeardownNamespace loops while cmdTable is non-empty, so a command a
+    // delete callback creates is torn down by a second snapshot, after every
+    // entry of the first one. Exact Tcl 9.0.4 oracle result.
+    assert_eq!(
+        run("set log {}
+             proc rec {old new op} {lappend ::log [namespace tail $old]}
+             proc mk {old new op} {
+                 lappend ::log [namespace tail $old]
+                 proc ::N::zz {} {}
+                 trace add command ::N::zz delete rec
+             }
+             namespace eval N {}
+             foreach n {one two three four five six seven eight nine ten} {
+                 proc ::N::$n {} {}
+                 trace add command ::N::$n delete rec
+             }
+             trace add command ::N::six delete mk
+             namespace delete ::N
+             set log"),
+        "six six four three eight seven nine five two one ten zz"
+    );
+}
+
+#[test]
+fn namespace_teardown_defers_a_callback_recreated_command_to_the_next_pass() {
+    // A redefinition inside the delete callback unlinks the dying token's own
+    // entry (Tcl_DeleteCommandFromToken's CMD_DYING branch), so the
+    // replacement is a distinct token the current snapshot no longer names and
+    // the next snapshot picks up. 9.0: exact tclsh 9.0.4 oracle result; 8.6.16
+    // segfaults on this script.
+    assert_eq!(
+        run("set log {}
+             proc rec {old new op} {lappend ::log [namespace tail $old]}
+             proc remake {old new op} {
+                 proc ::N::two {} {}
+                 trace add command ::N::two delete rec
+                 lappend ::log remade
+             }
+             namespace eval N {}
+             foreach n {one two three four five six seven eight nine ten} {
+                 proc ::N::$n {} {}
+                 trace add command ::N::$n delete rec
+             }
+             trace add command ::N::two delete remake
+             namespace delete ::N
+             set log"),
+        "six four three eight seven nine five remade two one ten two"
+    );
+}
+
+#[test]
+fn namespace_teardown_skips_a_command_a_callback_already_deleted() {
+    // CMD_TRACE_ACTIVE is per Command, not interpreter-wide: `one` fires its
+    // own delete trace nested inside six's callback, and the snapshot entry
+    // for it is gone by the time the loop reaches it. Exact Tcl 9.0.4 oracle
+    // result.
+    assert_eq!(
+        run("set log {}
+             proc rec {old new op} {lappend ::log [namespace tail $old]}
+             proc killone {old new op} {rename ::N::one {}; lappend ::log killed-one}
+             namespace eval N {}
+             foreach n {one two three four five six seven eight nine ten} {
+                 proc ::N::$n {} {}
+                 trace add command ::N::$n delete rec
+             }
+             trace add command ::N::six delete killone
+             namespace delete ::N
+             set log"),
+        "one killed-one six four three eight seven nine five two ten"
+    );
+}
+
+#[test]
+fn namespace_teardown_places_imports_at_their_hash_positions() {
+    // An imported redirect occupies an ordinary cmdTable entry, so it retires
+    // at its own hash position rather than in a separate pass over the
+    // namespace's imports. Exact Tcl 9.0.4 oracle result.
+    let imports = "set log {}
+             proc rec {old new op} {lappend ::log [namespace tail $old]}
+             namespace eval S {proc s1 {} {}; proc s2 {} {}; namespace export s*}
+             namespace eval N {namespace import ::S::s1 ::S::s2}
+             foreach n {one two three four five six seven eight} {proc ::N::$n {} {}}
+             foreach n [info commands ::N::*] {trace add command $n delete rec}
+             namespace delete ::N
+             set log";
+    assert_eq!(
+        run(imports),
+        "six four three s1 eight seven s2 five two one"
+    );
+    // `namespace forget` deletes the entry and the re-import creates a new one
+    // at the same bucket head, so the order is unchanged.
+    assert_eq!(
+        run("set log {}
+             proc rec {old new op} {lappend ::log [namespace tail $old]}
+             namespace eval S {proc s1 {} {}; proc s2 {} {}; namespace export s*}
+             namespace eval N {
+                 namespace import ::S::s1 ::S::s2
+                 namespace forget ::S::s1
+                 namespace import ::S::s1
+             }
+             foreach n {one two three four five six seven eight} {proc ::N::$n {} {}}
+             foreach n [info commands ::N::*] {trace add command $n delete rec}
+             namespace delete ::N
+             set log"),
+        "six four three s1 eight seven s2 five two one"
+    );
+}
+
+#[test]
+fn namespace_teardown_retires_each_sources_import_tree_before_the_next_entry() {
+    // Tcl_DeleteCommandFromToken walks the deleted command's ImportRef list
+    // depth-first straight after its own delete trace, so a source's whole
+    // import tree fires before the next cmdTable entry. Exact Tcl 9.0.4 oracle
+    // result.
+    assert_eq!(
+        run("set log {}
+             namespace eval N {proc one {} {}; proc two {} {}; proc six {} {}
+                               namespace export *}
+             namespace eval I {namespace import ::N::one; namespace export *}
+             namespace eval J {namespace import ::I::one}
+             foreach c {::N::one ::N::two ::N::six ::I::one ::J::one} {
+                 trace add command $c delete [list apply {{c old new op} {
+                     lappend ::log $c
+                 }} $c]
+             }
+             namespace delete ::N
+             set log"),
+        "::N::six ::N::two ::N::one ::I::one ::J::one"
+    );
+}
+
+#[test]
 fn deleting_a_namespace_fully_retires_its_visible_ensemble_once() {
     // The ensemble lives in the global command table but is owned by ::N.
     // Namespace teardown fires and removes its delete trace. A later, distinct


### PR DESCRIPTION
## Summary

C's namespace teardown copies `nsPtr->cmdTable` in `Tcl_FirstHashEntry` order before deleting each token, and delete traces make that persistent `TCL_STRING_KEYS` order observable. Neither engine reproduced it. #1749 centralised the same lifecycle for namespace *child* tables and added the ordered ensemble owner, but ordinary per-namespace **command** tables had no hash-order owner.

The issue's ten-proc vector, tclsh 9.0.4 and 8.6.16 → `six four three eight seven nine five two one ten`:

| engine | before | after |
|---|---|---|
| `runtime/rust` | `one two three four five six seven eight nine ten` (registration order) | matches tclsh |
| `rust/tcl-vm` | **random per run** — 5 runs gave 5 different orders, e.g. `eight four ten three nine one five six seven two` | matches tclsh |

### What changed

**`rust/tcl-cmd-core`** — `TclStringHashOrder` already modelled C's string-hash table exactly, including growth without shrink. It gained `reinsert` (C's redefinition deletes the hash entry and creates a new one, so the key moves to the bucket head), `len`, `is_empty`, and unit tests pinning growth-13 / growth-49, delete-reinsert and replace-one. No second order implementation.

**`runtime/rust`** — `Namespace.commands` becomes a `CommandTable` (BTreeMap entries + the shared order owner + a per-entry generation), so all 14 mutation sites are compiler-enforced rather than found by grep. `delete_namespace_token` is now C's per-token loop — fire the trace while the entry is still in the table, then depth-first imports, then the next entry, with stale generations skipping to the next pass — replacing "collect → clear → fire all". This also fixes the runtime firing import traces *before* source traces.

**`rust/tcl-vm`** — `ns_command_order` mirrors the existing `ns_child_order` pattern at the mutation sites that change key membership, and the teardown frontier became `(key, generation)`-aware.

### A command trace belongs to a token, not to a name

Raised as two P2 review findings; both real, both verified against tclsh before changing anything.

A delete callback that runs `trace add command $old delete inner` **without** redefining attaches that registration to the dying token, and C discards it with the token. Measured on 9.0.4 and 8.6.16 (identical) — `inner` must never fire:

| path | tclsh | runtime before | VM before |
|---|---|---|---|
| `rename ::p {}`, recreate, delete | `outer:::p` | ✓ | ✗ `outer:::p inner:::p` |
| redefine `proc p`, redefine again | `outer:::p` | ✗ `outer:::p inner:::p` | ✗ same |
| `namespace delete`, recreate, delete | `outer:::N::q` | ✗ `… inner:::N::q` | ✗ same |

"Was a replacement installed?" is not a sufficient discriminator: a callback that adds a trace **and then** redefines gives `mk:::p late:::p` on tclsh — `early` attached to the dying token and died, `late` attached to the replacement and lived. So each registration now carries the **generation of the token it was made on**, and a deletion frees exactly that token's list; `move_cmd_traces` / `move_command_traces` re-stamp, because C moves the `Command` on rename/hide/expose.

The same rule fixed the mirror-image bug (tclsh: `mk:::p inner:::p`): the runtime dropped every trace on the *name*, so a legitimate replacement lost its own registrations, and the VM was worse — `delete_prepared_renamed_command` unlinked the replacement itself, so a second delete failed with `can't delete "::p": command doesn't exist`.

**Refused renames still grow the table** (VM only; the runtime already did this). C creates the destination hash entry before `TclPreventAliasLoop` and removes it on refusal, and the resize history survives. With 11 commands in `::N` and a rejected `rename ::a ::N::b`, the transient 12th entry rebuilds 4 buckets into 16:

```
control:  six four three eight seven nine five two one eleven ten
rejected: three seven one two four eleven eight five nine six ten
```

### Three further C-parity fixes the loop forced

Restructuring teardown into C's shape exposed three divergences the old collect-then-fire shape hid, in both engines: command-trace re-entry is guarded **per command** (`CMD_TRACE_ACTIVE`/`CMD_DYING`) rather than interpreter-wide (execution/step traces keep `INTERP_TRACE_IN_PROGRESS`); `retire_command_lifecycle_key` re-checks token identity after callbacks; and a namespace in its synchronous delete window accepts a new qualified definition again, since C unlinks from the parent's `childTable` only *after* the command loop.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

```
cargo test -p tcl-cmd-core                          # 100 passed, 0 failed
cargo test -p tcl-vm                                # 1140 passed, 0 failed
cargo test --manifest-path runtime/rust/Cargo.toml  # both tommath states, 0 failed
make rust-check                                     # exit 0
```

`make rust-check` was confirmed green on the base commit first, so the gate result is attributable. Nothing skipped, no test weakened, no new `#[allow]` — `InterpState::fresh` crossing `too_many_lines` was fixed by extracting `root_hash_order()`, not suppressed.

**Both libtommath states were run**, because they are different builds: no-tommath 511 lib tests, tommath 607 lib tests (including `tower_conformance_libtommath`), integration suites green in both. That matters here — CI's `make runtime-rust-test-no-tommath` initially failed this branch because one new test drove its setup with `for`/`incr`, which are `#[cfg(have_tommath)]` (they evaluate expressions); it now uses the `foreach`-based `traced_procs` helper, with insertion order and therefore expected bucket order unchanged.

Twenty-four regressions in total cover growth, deletion, reinsertion, trace-created commands, same-named replacements, token-scoped trace lifetime, and the refused-rename resize. Oracles measured on `tmp/tcl9.0.4/unix/tclsh`, headline vectors confirmed on 8.6.16 and 9.1b0.

## Compiler / diagnostics checklist

- [x] Did this change alter a compiler fact contract? Yes — per-namespace command tables now have a hash-order owner, and command-trace ownership/re-entry semantics changed.
- [x] If yes, I updated the owning design doc — `shared-utility-contracts-rust.md` (contract row + test anchors), plus `command-introspection.md`, `namespace-tree.md` and `trace-implementation.md`.
- [x] If I added or changed a diagnostic or optimisation code, I updated its page under `docs/kcs/codes/` — n/a, none changed.
- [x] If I added a design doc, I linked it from `docs/design/README.md` — n/a, no new design doc.

Closes #1752

## Notes for the reviewer

- **tclsh 8.6.16 segfaults** on the `recreate-two` script (9.0.4 is fine), so that test is pinned 9.0-only.
- **One known-wrong pin is deliberately left alone.** `namespace_surface_e2e.rs` pins `0 0` for the synchronous-delete-window case; real tclsh 9.0.4 and 8.6.16 both give `{} 0`. This change does not make the true behaviour reachable — the cause is `push_ns` silently re-entering a dying namespace, which belongs to #1751. Correcting the pin now would red the suite with no code change behind it, so it is flagged rather than touched.
- **Deliberately out of scope:** the `deferred-with-import` case (lands with #1751) and `info commands` ordering, which is also hash order in C — a separate follow-up.

#1751 is unaffected and lands next; it reuses this per-token teardown loop, run later on a retained token, exactly as C's `Tcl_PopCallFrame` simply calls `Tcl_DeleteNamespace` again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XV29AoTSsaCBgsJuf2EvEK