### PR TITLE
refactor(registry): retire five traits nothing reads, derive two of them

### DIFF
--- a/docs/design/compiler/command-registry.md
+++ b/docs/design/compiler/command-registry.md
@@ -203,7 +203,7 @@ So the vocabulary follows three rules:
 |---------|----------------|
 | `HAS_SWITCH_BODY` | `case_list`; derived as `CommandSpec::has_switch_body` |
 | `HAS_DESTRUCTIVE_OPS` | `SubCommand::destructive`; derived as `CommandSpec::has_destructive_ops` |
-| `HAS_INTERP_EVAL` | `taint_interp_eval_subcommands`, which is consumed and disagreed with the flag in both directions (`send` had the flag without the list; Tk's `console` the list without the flag); `send` carries `EVALUATES_CODE` on its own |
+| `HAS_INTERP_EVAL` | `taint_interp_eval_subcommands`, which is consumed and disagreed with the flag in both directions; `send` carries `EVALUATES_CODE` on its own |
 | `CONFIGURES_CHANNEL` | the `FileIo` side effect with `reads` and `writes` that both carriers, `chan` and `fconfigure`, already declare |
 | `STRING_LIST_CONFUSION` | nothing — an authoring hint about `append`, not a behavioural fact |
 
@@ -216,16 +216,17 @@ not.
 
 `HAS_LOOP_BODY` is the trait the first rule would have retired and did not:
 nothing else in the model says a body may run more than once
-(`NEVER_INLINE_BODY` marks a different set — `dict for`, `dict map` and
-`timerate` are loops without it). It was given the consumer it should have
-had instead. Whether a command is a loop is `CommandRegistry::is_loop_command`,
-and the W240/W241/W242 termination checks read the condition, body, init and
-step positions off its declared argument roles (the `Expr` word, the `Body`
-words around it), so a pack shipping its own loop construct is analysed
-under whatever name it has; a loop with no boolean condition (`foreach`,
-`lmap`) has no termination shape to check. The literal `while` / `for`
-positions survive only as the registry-less fallback, the same shape
-`is_loop_exit_command` already documents.
+(`NEVER_INLINE_BODY` marks a different set — `timerate` and `array for` are
+loops without it, and `switch` has it without being one). It was given the
+consumer it should have had instead. Whether a command is a loop is
+`CommandRegistry::is_loop_command`, and the W240/W241/W242 termination
+checks read the condition, body, init and step positions off its declared
+argument roles (the `Expr` word, the `Body` words around it), so a pack
+shipping its own loop construct is analysed under whatever name it has; a
+loop with no boolean condition (`foreach`, `lmap`) has no termination shape
+to check. The literal `while` / `for` positions survive only as the
+registry-less fallback, the same shape `is_loop_exit_command` already
+documents.
 
 #### Purity and optimisation
 

--- a/docs/design/compiler/command-registry.md
+++ b/docs/design/compiler/command-registry.md
@@ -161,7 +161,7 @@ covers the compiler-facing ones.
 | Trait bit | Purpose |
 |-----------|---------|
 | `CREATES_DYNAMIC_BARRIER` | Lowered to `IRBarrier` -- blocks optimisations across this call |
-| `HAS_LOOP_BODY` | Command has a loop body (affects dead-code analysis) |
+| `HAS_LOOP_BODY` | A body argument may run more than once.  The registry's one answer to "is this a loop?" (`CommandRegistry::is_loop_command`); the W240/W241/W242 termination checks read the loop's shape off its argument roles, so no loop is named in the analyser.  See [Retiring a trait](#retiring-a-trait) |
 | `NEVER_INLINE_BODY` | Body arguments must not be inlined by the optimiser |
 | `LOOP_LIST_HEADER` | CFG header carries list-expression args evaluated once before the loop body (foreach, lmap) |
 | `CONTROL_FLOW` | Command is a control-flow statement (break, continue, return) |
@@ -172,6 +172,60 @@ covers the compiler-facing ones.
 
 Traits compose across levels: a `SubCommand` carries its own `traits`, and
 consumers read the union of the command's and the resolved subcommand's bits.
+
+##### Retiring a trait
+
+A trait is a fact a consumer branches on. One that nothing reads is not
+harmless: where a descriptor already carries the fact, the flag is a second
+statement of it, and the two drift with no consumer to notice.
+`HAS_SWITCH_BODY` said strictly less than `case_list` — six `expect*`
+commands declared the clause list without ever carrying the flag.
+`HAS_DESTRUCTIVE_OPS` disagreed with `SubCommand::destructive` in both
+directions — `registry` carried it with no destructive subcommand, while
+`after`, `array`, `dict`, `oo::object` and `timer` had one without it.
+
+So the vocabulary follows three rules:
+
+- **A trait must have a behavioural consumer.** A row in the snapshot's
+  `TRAIT_FLAGS` serialisation table is not one.
+- **A fact a descriptor already carries is derived, not flagged.** The
+  query reads the descriptor a consumer needs anyway, so it cannot disagree
+  with it.
+- **A retired spelling stays in `RETIRED_TRAITS`** (`traits.rs`), paired
+  with a sentence naming what carries the fact now. Packs name traits as
+  strings, so a `.tclspec` written against an older registry still says
+  `traits HAS_SWITCH_BODY`; the loader consults the table before reporting
+  an unknown trait, and the author is told where the behaviour moved. The
+  word is still dropped — the replacement is a descriptor the pack already
+  writes. A test forbids a retired name from being declared again.
+
+| Retired | Carried now by |
+|---------|----------------|
+| `HAS_SWITCH_BODY` | `case_list`; derived as `CommandSpec::has_switch_body` |
+| `HAS_DESTRUCTIVE_OPS` | `SubCommand::destructive`; derived as `CommandSpec::has_destructive_ops` |
+| `HAS_INTERP_EVAL` | `taint_interp_eval_subcommands`, which is consumed and disagreed with the flag in both directions (`send` had the flag without the list; Tk's `console` the list without the flag); `send` carries `EVALUATES_CODE` on its own |
+| `CONFIGURES_CHANNEL` | the `FileIo` side effect with `reads` and `writes` that both carriers, `chan` and `fconfigure`, already declare |
+| `STRING_LIST_CONFUSION` | nothing — an authoring hint about `append`, not a behavioural fact |
+
+One fact was deliberately let go. `registry` models its operations as
+`ArgValue`s rather than a subcommand table, because Tcl accepts any unique
+abbreviation and the table would misreport `registry se`; so
+`has_destructive_ops` answers false for it. Its persistent write is carried
+by its `FileIo` side effect, which is read. The command-level boolean was
+not.
+
+`HAS_LOOP_BODY` is the trait the first rule would have retired and did not:
+nothing else in the model says a body may run more than once
+(`NEVER_INLINE_BODY` marks a different set — `dict for`, `dict map` and
+`timerate` are loops without it). It was given the consumer it should have
+had instead. Whether a command is a loop is `CommandRegistry::is_loop_command`,
+and the W240/W241/W242 termination checks read the condition, body, init and
+step positions off its declared argument roles (the `Expr` word, the `Body`
+words around it), so a pack shipping its own loop construct is analysed
+under whatever name it has; a loop with no boolean condition (`foreach`,
+`lmap`) has no termination shape to check. The literal `while` / `for`
+positions survive only as the registry-less fallback, the same shape
+`is_loop_exit_command` already documents.
 
 #### Purity and optimisation
 
@@ -1644,6 +1698,11 @@ is what that looks like from the outside.
 - Prefer a new `CommandSpec` field or a typed hook ID over teaching a
   consumer a command name; the registry is the source of truth, and a
   consumer that matches on a name is the thing this design exists to avoid.
+- To add a trait: first check that no descriptor already carries the fact
+  — if one does, add a derived query on `CommandSpec` instead — and that a
+  consumer will branch on it.  To retire one, move its spelling to
+  `RETIRED_TRAITS` with a sentence naming the replacement, and never
+  declare a retired name again.  See [Retiring a trait](#retiring-a-trait).
 
 ## The reference manual
 

--- a/docs/design/spec-dsl-examples/switch.tclspec
+++ b/docs/design/spec-dsl-examples/switch.tclspec
@@ -13,7 +13,7 @@ command switch {
     # not through a whole-command dialect gate.
     dialects {all-tcl f5-irules}
     traits {NOT_PROC_FACTORY BYTE_COMPILED CONTROL_FLOW LANGUAGE_KEYWORD
-            NEVER_INLINE_BODY HAS_SWITCH_BODY}
+            NEVER_INLINE_BODY}
 
     # `string pattern body ?pattern body ...?` (an odd count from 3) — OR the
     # single-braced-body shorthand `string {pattern body ...}` (exactly 2).

--- a/docs/design/spec-packs.md
+++ b/docs/design/spec-packs.md
@@ -479,11 +479,10 @@ let packs survive releases without rebuilds:
   that `CommandSpec::has_switch_body` is the derived answer, rather than
   that the word is unknown. The rest of the `traits` list and the command
   still load, and the word itself does nothing — the replacement is a
-  descriptor the pack already writes, so there is no shim to carry. The
-  table is `RETIRED_TRAITS` in `rust/tcl-registry/src/traits.rs`; when a
-  trait is retired at all is
-  [command-registry.md](compiler/command-registry.md#retiring-a-trait)'s
-  rule.
+  descriptor the pack already writes, so there is no compatibility shim.
+  The table is `RETIRED_TRAITS` in `rust/tcl-registry/src/traits.rs`; the
+  rule for retiring a trait is in
+  [command-registry.md](compiler/command-registry.md#retiring-a-trait).
 - **Except where dropping the word would strengthen the answer.** Since
   `SpecTcl` 2.0 (redesign §6.1, review B13) an unknown word in a pack
   declaring a vocabulary this build postdates is classified by its

--- a/docs/design/spec-packs.md
+++ b/docs/design/spec-packs.md
@@ -473,6 +473,17 @@ let packs survive releases without rebuilds:
 - Unknown property words, trait names, role names, or hook names are
   dropped with a logged notice; the rest of the spec loads. New server +
   old pack always works; old server + new pack degrades gracefully.
+- A trait name the registry has since retired is dropped the same way,
+  but the notice names what carries the fact now: a pack saying
+  `traits HAS_SWITCH_BODY` is told that a `case_list` block carries it and
+  that `CommandSpec::has_switch_body` is the derived answer, rather than
+  that the word is unknown. The rest of the `traits` list and the command
+  still load, and the word itself does nothing — the replacement is a
+  descriptor the pack already writes, so there is no shim to carry. The
+  table is `RETIRED_TRAITS` in `rust/tcl-registry/src/traits.rs`; when a
+  trait is retired at all is
+  [command-registry.md](compiler/command-registry.md#retiring-a-trait)'s
+  rule.
 - **Except where dropping the word would strengthen the answer.** Since
   `SpecTcl` 2.0 (redesign §6.1, review B13) an unknown word in a pack
   declaring a vocabulary this build postdates is classified by its

--- a/docs/references/command-spec/fields.md
+++ b/docs/references/command-spec/fields.md
@@ -1396,11 +1396,6 @@ The registry's behavioural vocabulary — one flag per fact a consumer might nee
 | `PERFORMS_SUBSTITUTION` | performs Tcl substitution |
 | `OPENS_CHANNEL` | opens an I/O channel |
 | `SOURCES_FILE` | sources another file |
-| `HAS_SWITCH_BODY` | takes a switch-style clause list |
-| `STRING_LIST_CONFUSION` | at risk of string/list confusion |
-| `CONFIGURES_CHANNEL` | configures a channel |
-| `HAS_INTERP_EVAL` | evaluates code in another interpreter |
-| `HAS_DESTRUCTIVE_OPS` | has irreversible operations |
 | `IS_EVENT_HANDLER` | an iRules event handler |
 | `UNNORMALISED_HTTP_GETTER` | returns unnormalised HTTP data |
 | `REQUIRES_HTTP_CONTEXT` | requires an uncommitted HTTP transaction |

--- a/rust/tcl-compiler/src/analyser/bounds_checks.rs
+++ b/rust/tcl-compiler/src/analyser/bounds_checks.rs
@@ -62,10 +62,93 @@ fn is_loop_exit_command(name: &str, registry: Option<&tcl_registry::CommandRegis
         .is_some_and(|spec| spec.traits.contains(tcl_registry::Traits::TERMINATES_BLOCK))
 }
 
+/// Which argument of a conditional-loop invocation is which: the boolean
+/// condition, the loop body, and — for a C-style loop — the init and step
+/// scripts.  Indices exclude the command name.
+struct LoopShape {
+    init: Option<usize>,
+    cond: usize,
+    step: Option<usize>,
+    body: usize,
+}
+
+/// The loop shape of `name`, or `None` when it is not a conditional loop.
+///
+/// Whether a command *is* a loop is the registry's answer
+/// ([`tcl_registry::CommandRegistry::is_loop_command`], reading
+/// `HAS_LOOP_BODY`), and the shape is read off its declared argument roles:
+/// the `Expr` word is the condition, the last `Body` word after it is the loop
+/// body, and a `Body` on either side of the condition is the C-style init and
+/// step.  A pack-declared loop therefore reaches W240 / W241 / W242 with no
+/// command name written here.
+///
+/// The literal `while` / `for` positions survive only as the registry-less
+/// fallback, the same shape [`is_loop_exit_command`] documents: an analyse
+/// with no registry still checks the two core loops.
+fn loop_shape(name: &str, registry: Option<&tcl_registry::CommandRegistry>) -> Option<LoopShape> {
+    let Some(registry) = registry else {
+        return core_loop_shape(name);
+    };
+    let Some(spec) = registry.get(name) else {
+        return core_loop_shape(name);
+    };
+    registry
+        .is_loop_command(name)
+        .then(|| conditional_loop_shape(spec))
+        .flatten()
+}
+
+/// The `while` / `for` argument positions, for an analyse with no registry to
+/// ask.
+fn core_loop_shape(name: &str) -> Option<LoopShape> {
+    match name {
+        "while" => Some(LoopShape {
+            init: None,
+            cond: 0,
+            step: None,
+            body: 1,
+        }),
+        "for" => Some(LoopShape {
+            init: Some(0),
+            cond: 1,
+            step: Some(2),
+            body: 3,
+        }),
+        _ => None,
+    }
+}
+
+/// Read a loop's condition / body / init / step positions off its argument
+/// roles, or `None` when it has no single boolean-condition word — `foreach`
+/// and `lmap` iterate a list rather than testing a condition, so nothing here
+/// applies to them.
+fn conditional_loop_shape(spec: &tcl_registry::spec::CommandSpec) -> Option<LoopShape> {
+    let mut cond = None;
+    let mut bodies: Vec<usize> = Vec::new();
+    for &(index, role) in spec.arg_roles {
+        match role {
+            tcl_registry::arg_role::ArgRole::Expr if cond.is_some() => return None,
+            tcl_registry::arg_role::ArgRole::Expr => cond = Some(usize::from(index)),
+            tcl_registry::arg_role::ArgRole::Body => bodies.push(usize::from(index)),
+            _ => {}
+        }
+    }
+    let cond = cond?;
+    bodies.sort_unstable();
+    let body = bodies.iter().copied().rfind(|&i| i > cond)?;
+    Some(LoopShape {
+        init: bodies.iter().copied().find(|&i| i < cond),
+        cond,
+        step: bodies.iter().copied().find(|&i| i > cond && i < body),
+        body,
+    })
+}
+
 /// W240 (constant-false condition → dead body) / W241 (constant-true
-/// condition whose body never leaves the loop → provably infinite) for
-/// `while` / `for`.  The loop-exit set is registry-driven — see
-/// [`is_loop_exit_command`].  `args` / `arg_tokens` exclude the command name.
+/// condition whose body never leaves the loop → provably infinite) for every
+/// registry-declared conditional loop — see [`loop_shape`].  The loop-exit set
+/// is registry-driven too — see [`is_loop_exit_command`].  `args` /
+/// `arg_tokens` exclude the command name.
 pub(crate) fn loop_termination_diagnostics(
     cmd_name: &str,
     args: &[String],
@@ -74,20 +157,21 @@ pub(crate) fn loop_termination_diagnostics(
     lexer_config: tcl_lexer::LexerConfig,
     grammar: &tcl_dialect::LexerGrammar,
 ) -> Vec<Diagnostic> {
-    // (init, cond, step, body, cond_tok) — init/step empty for `while`.
-    let (init_text, cond_text, step_text, body_text, cond_tok) = match cmd_name {
-        "while" if args.len() >= 2 && arg_tokens.len() >= 2 => {
-            ("", args[0].as_str(), "", args[1].as_str(), &arg_tokens[0])
-        }
-        "for" if args.len() >= 4 && arg_tokens.len() >= 4 => (
-            args[0].as_str(),
-            args[1].as_str(),
-            args[2].as_str(),
-            args[3].as_str(),
-            &arg_tokens[1],
-        ),
-        _ => return Vec::new(),
+    let Some(shape) = loop_shape(cmd_name, registry) else {
+        return Vec::new();
     };
+    // An under-applied call is an arity diagnostic, not a termination one.
+    if args.len() <= shape.body || arg_tokens.len() <= shape.body {
+        return Vec::new();
+    }
+    let word = |index: Option<usize>| index.map_or("", |i| args[i].as_str());
+    let (init_text, cond_text, step_text, body_text, cond_tok) = (
+        word(shape.init),
+        args[shape.cond].as_str(),
+        word(shape.step),
+        args[shape.body].as_str(),
+        &arg_tokens[shape.cond],
+    );
 
     match condition_constant(cond_text) {
         Some(false) => {
@@ -113,8 +197,10 @@ pub(crate) fn loop_termination_diagnostics(
         None => {}
     }
 
-    // `for {init} {cond} {step} body` provably-infinite counter shape.
-    if cmd_name == "for"
+    // `for {init} {cond} {step} body` provably-infinite counter shape — only a
+    // loop that declares both an init and a step script has a counter to walk.
+    if shape.init.is_some()
+        && shape.step.is_some()
         && let Some(reason) = for_is_provably_infinite(
             init_text,
             cond_text,
@@ -1211,6 +1297,63 @@ mod tests {
         assert_eq!(codes("while 1 {incr n}\n"), vec!["W241"]);
         // `continue` is NOT an exit — it keeps looping — so W241 still fires.
         assert_eq!(codes("while 1 {continue}\n"), vec!["W241"]);
+    }
+
+    /// A registry whose loop vocabulary is not Tcl's: `spin` loops, `peek`
+    /// has the identical argument shape and does not.
+    fn registry_with_a_declared_loop() -> tcl_registry::CommandRegistry {
+        use tcl_registry::arg_role::ArgRole;
+        use tcl_registry::spec::CommandSpec;
+
+        const ROLES: &[(u8, ArgRole)] = &[(0, ArgRole::Expr), (1, ArgRole::Body)];
+        let mut registry = tcl_registry::CommandRegistry::build_default();
+        registry.insert(CommandSpec {
+            name: "spin",
+            traits: tcl_registry::Traits::CONTROL_FLOW
+                .union(tcl_registry::Traits::HAS_BOOLEAN_COND)
+                .union(tcl_registry::Traits::HAS_LOOP_BODY),
+            arity: tcl_registry::arity::Arity::exact(2),
+            arg_roles: ROLES,
+            ..CommandSpec::DEFAULT
+        });
+        registry.insert(CommandSpec {
+            name: "peek",
+            traits: tcl_registry::Traits::HAS_BOOLEAN_COND,
+            arity: tcl_registry::arity::Arity::exact(2),
+            arg_roles: ROLES,
+            ..CommandSpec::DEFAULT
+        });
+        registry
+    }
+
+    fn loop_codes(src: &str, registry: &tcl_registry::CommandRegistry) -> Vec<DiagCode> {
+        let command = sole_command(src, config()).expect("one command");
+        let name = command.texts.first().expect("a command word").clone();
+        super::loop_termination_diagnostics(
+            &name,
+            command.args(),
+            command.arg_tokens(),
+            Some(registry),
+            config(),
+            &tcl_dialect::LexerGrammar::default(),
+        )
+        .iter()
+        .map(|d| d.code)
+        .collect()
+    }
+
+    #[test]
+    fn a_declared_loop_is_analysed_under_whatever_name_it_has() {
+        // The loop question is the registry's: a command carrying
+        // HAS_LOOP_BODY reaches W240 / W241 with no name written here, which
+        // is what lets a spec pack ship its own loop construct.
+        let registry = registry_with_a_declared_loop();
+        assert_eq!(loop_codes("spin 0 {puts hi}", &registry), [DiagCode::W240]);
+        assert_eq!(loop_codes("spin 1 {puts hi}", &registry), [DiagCode::W241]);
+        assert!(loop_codes("spin 1 {break}", &registry).is_empty());
+        // The control that makes the trait load-bearing: the same argument
+        // shape without it runs its body once and is not a loop.
+        assert!(loop_codes("peek 1 {puts hi}", &registry).is_empty());
     }
 
     #[test]

--- a/rust/tcl-registry/examples/dump_specs.rs
+++ b/rust/tcl-registry/examples/dump_specs.rs
@@ -103,14 +103,6 @@ const BOOL_TRAITS: &[(&str, Traits)] = &[
     ("performs_substitution", Traits::PERFORMS_SUBSTITUTION),
     ("opens_channel", Traits::OPENS_CHANNEL),
     ("sources_file", Traits::SOURCES_FILE),
-    ("has_switch_body", Traits::HAS_SWITCH_BODY),
-    (
-        "has_string_list_confusion_risk",
-        Traits::STRING_LIST_CONFUSION,
-    ),
-    ("configures_channel", Traits::CONFIGURES_CHANNEL),
-    ("has_interp_eval", Traits::HAS_INTERP_EVAL),
-    ("has_destructive_ops", Traits::HAS_DESTRUCTIVE_OPS),
     ("is_irules_event_handler", Traits::IS_EVENT_HANDLER),
     (
         "is_unnormalized_http_getter",

--- a/rust/tcl-registry/src/command_snapshot.rs
+++ b/rust/tcl-registry/src/command_snapshot.rs
@@ -53,7 +53,6 @@ const EMPTY_LIST_DIGEST: &str =
 /// these boolean fields into the [`Traits`] bitflags.
 const TRAIT_FLAGS: &[(&str, Traits)] = &[
     ("byte_compiled", Traits::BYTE_COMPILED),
-    ("configures_channel", Traits::CONFIGURES_CHANNEL),
     (
         "configures_instance_options",
         Traits::CONFIGURES_INSTANCE_OPTIONS,
@@ -68,14 +67,7 @@ const TRAIT_FLAGS: &[(&str, Traits)] = &[
     ("evaluates_code", Traits::EVALUATES_CODE),
     ("frameless_runtime", Traits::FRAMELESS_RUNTIME),
     ("has_boolean_condition", Traits::HAS_BOOLEAN_COND),
-    ("has_destructive_ops", Traits::HAS_DESTRUCTIVE_OPS),
-    ("has_interp_eval", Traits::HAS_INTERP_EVAL),
     ("has_loop_body", Traits::HAS_LOOP_BODY),
-    (
-        "has_string_list_confusion_risk",
-        Traits::STRING_LIST_CONFUSION,
-    ),
-    ("has_switch_body", Traits::HAS_SWITCH_BODY),
     ("taints_var_writes", Traits::TAINTS_VAR_WRITES),
     ("taint_source_zero_args", Traits::TAINT_SOURCE_ZERO_ARGS),
     ("irules_top_level_only", Traits::IRULES_TOP_LEVEL_ONLY),

--- a/rust/tcl-registry/src/commands/tcl/append_.rs
+++ b/rust/tcl-registry/src/commands/tcl/append_.rs
@@ -35,7 +35,6 @@ pub fn spec() -> CommandSpec {
         traits: Traits::FRAMELESS_RUNTIME
             | Traits::BYTE_COMPILED
             | Traits::READS_BEFORE_WRITE
-            | Traits::STRING_LIST_CONFUSION
             | Traits::FIRST_ARG_VARNAME,
         arity: Arity::at_least(1),
         // S110: string-concatenates onto the target variable, coercing a

--- a/rust/tcl-registry/src/commands/tcl/case_.rs
+++ b/rust/tcl-registry/src/commands/tcl/case_.rs
@@ -112,8 +112,7 @@ pub fn spec() -> CommandSpec {
         traits: Traits::NOT_PROC_FACTORY
             | Traits::CONTROL_FLOW
             | Traits::LANGUAGE_KEYWORD
-            | Traits::NEVER_INLINE_BODY
-            | Traits::HAS_SWITCH_BODY,
+            | Traits::NEVER_INLINE_BODY,
         // Floor of 2: `case string {patList body ...}`, the shortest legal
         // call (tclsh 8.6.14 rejects a bare `case x` with "wrong # args").
         // No upper bound and no parity rule, because the optional `in` word

--- a/rust/tcl-registry/src/commands/tcl/chan_.rs
+++ b/rust/tcl-registry/src/commands/tcl/chan_.rs
@@ -873,7 +873,7 @@ const CMD_OPTIONS: &[OptionSpec] = &[
 pub fn spec() -> CommandSpec {
     CommandSpec {
         name: "chan",
-        traits: Traits::BYTE_COMPILED | Traits::CONFIGURES_CHANNEL | Traits::HAS_DESTRUCTIVE_OPS,
+        traits: Traits::BYTE_COMPILED,
         // `chan` is a Tcl 8.5+ ensemble: no chan.n manual page and no `chan`
         // entry in the 8.4 command index (confirmed: the 8.4 URL 404s and the
         // 8.4 command index lists only the pre-ensemble standalone commands it

--- a/rust/tcl-registry/src/commands/tcl/fconfigure_.rs
+++ b/rust/tcl-registry/src/commands/tcl/fconfigure_.rs
@@ -281,7 +281,7 @@ pub fn spec() -> CommandSpec {
     CommandSpec {
         name: "fconfigure",
         surface: Some(SpecSurface::ALL_TCL),
-        traits: Traits::BYTE_COMPILED | Traits::CONFIGURES_CHANNEL | Traits::SAFE_INTERP_HIDDEN,
+        traits: Traits::BYTE_COMPILED | Traits::SAFE_INTERP_HIDDEN,
         arity: Arity::at_least(1),
         arg_roles: &[(0, ArgRole::Channel)],
         return_type: Some(TclType::String),

--- a/rust/tcl-registry/src/commands/tcl/file_.rs
+++ b/rust/tcl-registry/src/commands/tcl/file_.rs
@@ -658,10 +658,7 @@ pub fn spec() -> CommandSpec {
     CommandSpec {
         name: "file",
         surface: Some(SpecSurface::ALL_TCL),
-        traits: Traits::BYTE_COMPILED
-            | Traits::HAS_DESTRUCTIVE_OPS
-            | Traits::RETURNS_PATH
-            | Traits::SAFE_INTERP_HIDDEN,
+        traits: Traits::BYTE_COMPILED | Traits::RETURNS_PATH | Traits::SAFE_INTERP_HIDDEN,
         arity: Arity::at_least(1),
         subcommands: SUBCOMMANDS,
         side_effects: &[SideEffect {

--- a/rust/tcl-registry/src/commands/tcl/interp.rs
+++ b/rust/tcl-registry/src/commands/tcl/interp.rs
@@ -922,8 +922,6 @@ pub fn spec() -> CommandSpec {
         surface: Some(SpecSurface::ALL_TCL),
         traits: Traits::NOT_PROC_FACTORY
             | Traits::BYTE_COMPILED
-            | Traits::HAS_INTERP_EVAL
-            | Traits::HAS_DESTRUCTIVE_OPS
             | Traits::LANGUAGE_KEYWORD
             | Traits::DYNAMIC_EVAL_BODY
             // `interp alias` / `hide` / `expose` / `invokehidden` all take

--- a/rust/tcl-registry/src/commands/tcl/namespace_.rs
+++ b/rust/tcl-registry/src/commands/tcl/namespace_.rs
@@ -1209,7 +1209,6 @@ pub fn spec() -> CommandSpec {
             | Traits::BYTE_COMPILED
             | Traits::LANGUAGE_KEYWORD
             | Traits::NEVER_INLINE_BODY
-            | Traits::HAS_DESTRUCTIVE_OPS
             | Traits::DYNAMIC_EVAL_BODY,
         arity: Arity::at_least(1),
         subcommands: SUBCOMMANDS,

--- a/rust/tcl-registry/src/commands/tcl/registry_.rs
+++ b/rust/tcl-registry/src/commands/tcl/registry_.rs
@@ -104,7 +104,6 @@ pub fn spec() -> CommandSpec {
     CommandSpec {
         name: "registry",
         surface: Some(SpecSurface::ALL_TCL),
-        traits: Traits::HAS_DESTRUCTIVE_OPS,
         arity: Arity::new(2, 5),
         return_type: Some(TclType::String),
         side_effects: &[SideEffect {

--- a/rust/tcl-registry/src/commands/tcl/switch_.rs
+++ b/rust/tcl-registry/src/commands/tcl/switch_.rs
@@ -204,8 +204,7 @@ pub fn spec() -> CommandSpec {
             | Traits::BYTE_COMPILED
             | Traits::CONTROL_FLOW
             | Traits::LANGUAGE_KEYWORD
-            | Traits::NEVER_INLINE_BODY
-            | Traits::HAS_SWITCH_BODY,
+            | Traits::NEVER_INLINE_BODY,
         // `string pattern body ?pattern body ...?` (an odd count from 3)
         // — OR the single-braced-body shorthand, `string {pattern body
         // ...}` (exactly 2) — confirmed against tclsh 8.6.14: `switch $s

--- a/rust/tcl-registry/src/commands/tk/send.rs
+++ b/rust/tcl-registry/src/commands/tk/send.rs
@@ -129,7 +129,6 @@ pub fn spec() -> CommandSpec {
         script_timing_resolver: Some(send_script_timing),
         traits: Traits::EVALUATES_CODE
             | Traits::SCRIPT_CONCATENATES_ARGS
-            | Traits::HAS_INTERP_EVAL
             | Traits::TAINT_SINK
             | Traits::CREATES_DYNAMIC_BARRIER
             | Traits::DYNAMIC_EVAL_BODY,

--- a/rust/tcl-registry/src/registry.rs
+++ b/rust/tcl-registry/src/registry.rs
@@ -4727,8 +4727,10 @@ impl CommandRegistry {
     /// The single answer for a consumer that needs "is this a loop?" without
     /// naming `while` / `for` / `foreach`, so a pack-declared loop command
     /// joins loop analysis with no consumer edit. Nothing else in the model
-    /// says it: `NEVER_INLINE_BODY` marks a different, non-coextensive set
-    /// (`dict for`, `dict map` and `timerate` are loops without it).
+    /// says it: `NEVER_INLINE_BODY` marks a different, non-coextensive set —
+    /// `timerate` and `array for` are loops without it, and consumers read the
+    /// command's bits unioned with the resolved subcommand's, so `dict for`
+    /// carries it from `dict` itself.
     #[must_use]
     pub fn is_loop_command(&self, name: &str) -> bool {
         self.get(name)

--- a/rust/tcl-registry/src/registry.rs
+++ b/rust/tcl-registry/src/registry.rs
@@ -4721,6 +4721,20 @@ impl CommandRegistry {
             .is_some_and(|t| t == crate::types::TclType::List)
     }
 
+    /// Whether `name` runs one of its body arguments more than once —
+    /// [`Traits::HAS_LOOP_BODY`].
+    ///
+    /// The single answer for a consumer that needs "is this a loop?" without
+    /// naming `while` / `for` / `foreach`, so a pack-declared loop command
+    /// joins loop analysis with no consumer edit. Nothing else in the model
+    /// says it: `NEVER_INLINE_BODY` marks a different, non-coextensive set
+    /// (`dict for`, `dict map` and `timerate` are loops without it).
+    #[must_use]
+    pub fn is_loop_command(&self, name: &str) -> bool {
+        self.get(name)
+            .is_some_and(|spec| spec.traits.contains(Traits::HAS_LOOP_BODY))
+    }
+
     /// `{command: BytePayloadSpec}` for every registered `<proto>::payload`
     /// byte-array command — the getter is a binary source and `<cmd> replace`
     /// a byte sink for the S110 byte-array-corruption check.

--- a/rust/tcl-registry/src/spec.rs
+++ b/rust/tcl-registry/src/spec.rs
@@ -2728,6 +2728,31 @@ impl CommandSpec {
             .find(|s| s.name == canonical && avail(s))
     }
 
+    /// Whether this command takes a `{pattern body …}` clause list as its
+    /// final braced word.
+    ///
+    /// Derived from [`Self::case_list`], which describes the clause shape a
+    /// consumer actually needs. This replaces the retired `HAS_SWITCH_BODY`
+    /// flag, which said strictly less than the descriptor and disagreed with
+    /// it: Expect's `expect*` commands declared the clause list without ever
+    /// carrying the flag.
+    #[must_use]
+    pub fn has_switch_body(&self) -> bool {
+        self.case_list.is_some()
+    }
+
+    /// Whether any of this command's subcommands performs an irreversible
+    /// operation.
+    ///
+    /// Derived from [`SubCommand::destructive`], the per-subcommand truth a
+    /// consumer needs in order to say *which* operation is irreversible. This
+    /// replaces the retired `HAS_DESTRUCTIVE_OPS` flag, a second command-level
+    /// answer that disagreed with the subcommands in both directions.
+    #[must_use]
+    pub fn has_destructive_ops(&self) -> bool {
+        self.subcommands.iter().any(|sub| sub.destructive)
+    }
+
     /// Return static arg role for a given index, if declared.
     #[must_use]
     pub fn arg_role_at(&self, index: u8) -> Option<ArgRole> {

--- a/rust/tcl-registry/src/traits.rs
+++ b/rust/tcl-registry/src/traits.rs
@@ -374,16 +374,6 @@ declare_traits! {
     OpensChannel => OPENS_CHANNEL, Security, "opens an I/O channel";
     /// Sources a file (`source`).
     SourcesFile => SOURCES_FILE, Security, "sources another file";
-    /// Has a switch body (`switch`).
-    HasSwitchBody => HAS_SWITCH_BODY, ControlFlow, "takes a switch-style clause list";
-    /// String/list confusion risk (`append`).
-    StringListConfusion => STRING_LIST_CONFUSION, Runtime, "at risk of string/list confusion";
-    /// Configures a channel (`fconfigure`, `chan configure`).
-    ConfiguresChannel => CONFIGURES_CHANNEL, Security, "configures a channel";
-    /// Has `interp eval` subcommand.
-    HasInterpEval => HAS_INTERP_EVAL, DynamicAnalysis, "evaluates code in another interpreter";
-    /// Has destructive operations (`file delete`, `namespace delete`).
-    HasDestructiveOps => HAS_DESTRUCTIVE_OPS, Security, "has irreversible operations";
     /// iRules event handler (`when`).
     IsEventHandler => IS_EVENT_HANDLER, Irules, "an iRules event handler";
     /// Returns unnormalised HTTP path/URI/query.
@@ -567,8 +557,7 @@ declare_traits! {
     /// var-escape slot resolver treats a frame reached this way as
     /// hash-backed. Single source of truth for the former
     /// `DYNAMIC_EVAL_COMMANDS` allow-list. (Distinct from
-    /// `HAS_INTERP_EVAL` / `CREATES_DYNAMIC_BARRIER`, which only some
-    /// of these carry.)
+    /// `CREATES_DYNAMIC_BARRIER`, which only some of these carry.)
     DynamicEvalBody => DYNAMIC_EVAL_BODY, ControlFlow, "its body is evaluated dynamically";
 
     /// (Subcommand) introspects program state by variable *name* —
@@ -1243,11 +1232,6 @@ declare_trait_examples! {
     PerformsSubstitution => flow!("set channel stdin\nset template {[read $channel]}\nset value [subst $template]\nputs $value"; (2, "subst"); (1, "{[read $channel]}", "contains substitutions as data"), (2, "subst $template", "performs those substitutions at runtime"), (3, "$value", "carries their result"));
     OpensChannel => flow!("set path [gets stdin]\nset channel [open $path r]\nputs [read $channel]"; (1, "open"); (0, "[gets stdin]", "supplies an untrusted path"), (1, "open $path r", "opens an external resource"), (2, "read $channel", "observes data from the channel"));
     SourcesFile => flow!("set path ./plugin.tcl\nsource $path\nplugin::run"; (1, "source"); (0, "./plugin.tcl", "selects another source file"), (1, "source $path", "evaluates that file in this interpreter"), (2, "plugin::run", "uses a command the file defined"));
-    HasSwitchBody => flow!("set mode [gets stdin]\nswitch -- $mode { safe {puts ok} default {puts rejected} }"; (1, "switch"); (0, "[gets stdin]", "supplies the selector"), (1, "switch", "selects one clause body"), (1, "default {puts rejected}", "handles unmatched input"));
-    StringListConfusion => flow!("set values [list alpha beta]\nappend values \" {gamma\"\nset status [catch {llength $values} message]\nputs [list $status $message]"; (1, "append"); (0, "[list alpha beta]", "starts as a canonical list"), (1, "append values", "performs a string operation on it"), (2, "llength $values", "later reinterprets the changed string as a list"), (3, "$status $message", "observes the malformed-list error"));
-    ConfiguresChannel => flow!("set channel [open data.bin w+]\nfconfigure $channel -translation binary\nputs -nonewline $channel hello\nseek $channel 0\nset bytes [read $channel]"; (1, "fconfigure"); (0, "open data.bin w+", "creates the channel"), (1, "fconfigure $channel", "changes its I/O semantics"), (4, "read $channel", "uses the configured translation"));
-    HasInterpEval => flow!("set child [interp create -safe]\ninterp eval $child {set value 42}\ninterp eval $child {puts $value}"; (1, "interp"); (0, "[interp create -safe]", "creates another interpreter"), (1, "interp eval", "evaluates code in that interpreter"), (2, "$value", "observes its separate state"));
-    HasDestructiveOps => flow!("set path ./cache.tmp\nclose [open $path w]\nfile delete -- $path\nfile exists $path"; (2, "file"); (0, "./cache.tmp", "identifies existing state"), (2, "file delete", "irreversibly removes it"), (3, "file exists $path", "now reports false"));
     IsEventHandler => flow!("when HTTP_REQUEST {\n    set uri [HTTP::uri]\n    log local0. $uri\n}"; (0, "when"); (0, "when HTTP_REQUEST", "registers the deferred event handler"), (1, "HTTP::uri", "reads request data when the event fires"), (2, "$uri", "flows to the handler output"));
     UnnormalisedHttpGetter => flow!("when HTTP_REQUEST {\n    set path [HTTP::path]\n    HTTP::respond 200 content $path\n}"; (1, "HTTP::path"); (1, "HTTP::path", "returns attacker-controlled, unnormalised path data"), (2, "$path", "reaches an output without protection and reports taint"));
     RequiresHttpContext => flow!("when HTTP_REQUEST {\n    HTTP::respond 200\n    HTTP::header value Host\n}"; (2, "HTTP::header"); (1, "HTTP::respond 200", "commits the HTTP response"), (2, "HTTP::header", "requires the now-unavailable HTTP transaction and is diagnosed"));
@@ -1360,6 +1344,41 @@ const _: () = assert!(
     "more traits than a u128 bitset can hold — widen `Traits` to [u64; N] via a custom bit type"
 );
 
+/// Trait spellings that were declared once and have since been retired, each
+/// paired with a sentence naming what carries the fact now.
+///
+/// A `.tclspec` pack names traits as strings, so a pack written against an
+/// older registry still says `traits HAS_SWITCH_BODY` long after the flag is
+/// gone. The loader consults this table before reporting an unknown trait, so
+/// its author is told where the behaviour moved rather than only that the word
+/// means nothing. The row is still dropped — the replacement is derived from a
+/// descriptor the pack already writes, not from the retired word.
+///
+/// A name here must never become a live [`Trait::name`] again; the
+/// `no_retired_trait_is_declared_again` test is that gate.
+pub const RETIRED_TRAITS: &[(&str, &str)] = &[
+    (
+        "HAS_SWITCH_BODY",
+        "a `case_list` block now carries this; the derived answer is `CommandSpec::has_switch_body`",
+    ),
+    (
+        "HAS_DESTRUCTIVE_OPS",
+        "`destructive` on the individual subcommand now carries this; the derived answer is `CommandSpec::has_destructive_ops`",
+    ),
+    (
+        "HAS_INTERP_EVAL",
+        "`taint_interp_eval_subcommands` names the subcommands that evaluate in another interpreter, and `EVALUATES_CODE` marks a command that evaluates its argument as code",
+    ),
+    (
+        "CONFIGURES_CHANNEL",
+        "a `SideEffect` on the `FileIo` target with `reads` and `writes` set now carries this",
+    ),
+    (
+        "STRING_LIST_CONFUSION",
+        "retired with no replacement: it was an authoring hint about `append`, not a behavioural fact about the command",
+    ),
+];
+
 /// Clause/block words that behave as [`Traits::LANGUAGE_KEYWORD`] tokens but
 /// have no standalone `CommandSpec` — they are never independently invocable
 /// (`else` only means anything as an `if` clause), so they cannot carry a
@@ -1391,3 +1410,22 @@ pub const CLAUSE_KEYWORDS_WITHOUT_COMMAND_SPEC: &[&str] =
 /// argument aliasing — rewriting a literal `then` to `$alias` would break
 /// `if`'s clause parsing) must keep literal.
 pub const CLAUSE_NOISE_KEYWORDS: &[&str] = &["then"];
+
+#[cfg(test)]
+mod tests {
+    use super::{RETIRED_TRAITS, Trait};
+
+    /// The gate that stops a retired trait coming back. Reviving a spelling
+    /// would leave the loader telling a pack author the flag moved while the
+    /// registry accepted it, and would silently re-adopt whichever meaning the
+    /// new declaration happened to give it.
+    #[test]
+    fn no_retired_trait_is_declared_again() {
+        for (name, _) in RETIRED_TRAITS {
+            assert!(
+                Trait::from_name(name).is_none(),
+                "`{name}` is listed as retired but `declare_traits!` declares it again"
+            );
+        }
+    }
+}

--- a/rust/tcl-registry/tests/registry_sweep.rs
+++ b/rust/tcl-registry/tests/registry_sweep.rs
@@ -157,11 +157,6 @@ const ALL_TRAITS: &[Traits] = &[
     Traits::PERFORMS_SUBSTITUTION,
     Traits::OPENS_CHANNEL,
     Traits::SOURCES_FILE,
-    Traits::HAS_SWITCH_BODY,
-    Traits::STRING_LIST_CONFUSION,
-    Traits::CONFIGURES_CHANNEL,
-    Traits::HAS_INTERP_EVAL,
-    Traits::HAS_DESTRUCTIVE_OPS,
     Traits::IS_EVENT_HANDLER,
     Traits::UNNORMALISED_HTTP_GETTER,
     Traits::RETURNS_PATH,
@@ -1294,12 +1289,22 @@ fn family_control_flow_shapes() {
             "{c} HAS_LOOP_BODY"
         );
     }
+    // The two derived answers that replaced retired command-level flags. Both
+    // read a descriptor a consumer needs anyway, so neither can disagree with
+    // it the way the flags did — `expect` declared a clause list without ever
+    // carrying `HAS_SWITCH_BODY`, and `array` had a destructive subcommand
+    // without `HAS_DESTRUCTIVE_OPS`.
+    assert!(reg.get("switch").unwrap().has_switch_body());
+    assert!(!reg.get("if").unwrap().has_switch_body());
     assert!(
-        reg.get("switch")
-            .unwrap()
-            .traits
-            .contains(Traits::HAS_SWITCH_BODY)
+        reg.get("file").unwrap().has_destructive_ops(),
+        "`file delete` is irreversible"
     );
+    assert!(
+        reg.get("array").unwrap().has_destructive_ops(),
+        "`array unset` is irreversible, and the retired flag missed it"
+    );
+    assert!(!reg.get("string").unwrap().has_destructive_ops());
     // tclsh: `switch --` terminator is real — `switch -- abc {abc {...}}` runs.
     // The registry models the terminator via resolve_option_terminator.
     let term = reg.resolve_option_terminator(

--- a/rust/tcl-spectcl/src/loader.rs
+++ b/rust/tcl-spectcl/src/loader.rs
@@ -2128,10 +2128,27 @@ fn parse_traits(text: &str, line: u32, log: &mut Log) -> Traits {
     for name in list_words(text) {
         match catalogue::trait_bit(&name) {
             Some(bit) => traits |= bit,
-            None => log.say(line, format!("unknown trait `{name}` dropped")),
+            None => log.say(line, unaccepted_trait_notice(&name)),
         }
     }
     traits
+}
+
+/// The notice for a trait word the registry will not accept.
+///
+/// A retired spelling names what carries the fact now: a pack written against
+/// an older registry is still out there saying `traits HAS_SWITCH_BODY`, and
+/// its author needs the replacement, not the news that a word the registry
+/// once documented is meaningless. The word is dropped either way — the
+/// replacement is a descriptor the pack writes for itself.
+fn unaccepted_trait_notice(name: &str) -> String {
+    match tcl_registry::traits::RETIRED_TRAITS
+        .iter()
+        .find(|(retired, _)| *retired == name)
+    {
+        Some((_, replacement)) => format!("retired trait `{name}` dropped: {replacement}"),
+        None => format!("unknown trait `{name}` dropped"),
+    }
 }
 
 fn parse_taint(text: &str, line: u32, log: &mut Log) -> tcl_registry::taint::TaintColour {

--- a/rust/tcl-spectcl/tests/golden/foreach.snap
+++ b/rust/tcl-spectcl/tests/golden/foreach.snap
@@ -12,4 +12,4 @@ registrations 1
 notices 1
 notice command foreach 44 presentation names a lowering hook: this changes how the compiler translates the command, not just what the editor knows about it
 commands 1
-command foreach line 10 overrides false degraded false spec 4ed49f1387133cd4 hooks 11d82c6adf139993 grammar 715ea0deb6f6f5f9
+command foreach line 10 overrides false degraded false spec 3c8e1c3a51e856d8 hooks 11d82c6adf139993 grammar 715ea0deb6f6f5f9

--- a/rust/tcl-spectcl/tests/golden/if.snap
+++ b/rust/tcl-spectcl/tests/golden/if.snap
@@ -12,4 +12,4 @@ registrations 1
 notices 1
 notice command if 39 presentation names a lowering hook: this changes how the compiler translates the command, not just what the editor knows about it
 commands 1
-command if line 10 overrides false degraded false spec dae3095f335c9e6f hooks 47ad4b1a6bacb531 grammar 586dd5a294898ebe
+command if line 10 overrides false degraded false spec fe32fe7e8631a812 hooks 47ad4b1a6bacb531 grammar 586dd5a294898ebe

--- a/rust/tcl-spectcl/tests/golden/irules-http-header.snap
+++ b/rust/tcl-spectcl/tests/golden/irules-http-header.snap
@@ -11,4 +11,4 @@ dialects []
 registrations 1
 notices 0
 commands 1
-command HTTP::header line 9 overrides false degraded false spec 439d279fd3f085b1 hooks 831154110e30ac6a grammar 715ea0deb6f6f5f9
+command HTTP::header line 9 overrides false degraded false spec eebdabccc01c4d02 hooks 831154110e30ac6a grammar 715ea0deb6f6f5f9

--- a/rust/tcl-spectcl/tests/golden/lsort.snap
+++ b/rust/tcl-spectcl/tests/golden/lsort.snap
@@ -11,4 +11,4 @@ dialects []
 registrations 1
 notices 0
 commands 1
-command lsort line 9 overrides false degraded false spec 911416683c3af40c hooks 831154110e30ac6a grammar 715ea0deb6f6f5f9
+command lsort line 9 overrides false degraded false spec 81a1dc2a709789ba hooks 831154110e30ac6a grammar 715ea0deb6f6f5f9

--- a/rust/tcl-spectcl/tests/golden/oo-class.snap
+++ b/rust/tcl-spectcl/tests/golden/oo-class.snap
@@ -32,4 +32,4 @@ notice command oo::class / subcommand createWithNamespace 162 presentation `stat
 notice command oo::class / subcommand createWithNamespace 163 presentation `state_transitions` row `covers` is not yet loadable; dropped
 notice command oo::class / subcommand createWithNamespace 164 presentation `state_transitions` row `commit` is not yet loadable; dropped
 commands 1
-command oo::class line 29 overrides false degraded false spec 498f0db02aeb7415 hooks c568c098585ed341 grammar 715ea0deb6f6f5f9
+command oo::class line 29 overrides false degraded false spec 3bb0d24d12fd6d73 hooks c568c098585ed341 grammar 715ea0deb6f6f5f9

--- a/rust/tcl-spectcl/tests/golden/return.snap
+++ b/rust/tcl-spectcl/tests/golden/return.snap
@@ -12,4 +12,4 @@ registrations 2
 notices 1
 notice command return 73 presentation names a lowering hook: this changes how the compiler translates the command, not just what the editor knows about it
 commands 1
-command return line 35 overrides false degraded false spec e8a6b4bbabb841d1 hooks c736f86e54c816fb grammar 715ea0deb6f6f5f9
+command return line 35 overrides false degraded false spec a82450e157441a5a hooks c736f86e54c816fb grammar 715ea0deb6f6f5f9

--- a/rust/tcl-spectcl/tests/golden/snit-type.snap
+++ b/rust/tcl-spectcl/tests/golden/snit-type.snap
@@ -11,4 +11,4 @@ dialects []
 registrations 1
 notices 0
 commands 1
-command snit::type line 36 overrides false degraded false spec 187969c0ddfacda0 hooks 831154110e30ac6a grammar 715ea0deb6f6f5f9
+command snit::type line 36 overrides false degraded false spec bdea1345064ef307 hooks 831154110e30ac6a grammar 715ea0deb6f6f5f9

--- a/rust/tcl-spectcl/tests/golden/string.snap
+++ b/rust/tcl-spectcl/tests/golden/string.snap
@@ -11,4 +11,4 @@ dialects []
 registrations 2
 notices 0
 commands 1
-command string line 44 overrides false degraded false spec 75702e665a076ffa hooks c9b906d3883689e3 grammar 715ea0deb6f6f5f9
+command string line 44 overrides false degraded false spec 68753704ca44f28f hooks c9b906d3883689e3 grammar 715ea0deb6f6f5f9

--- a/rust/tcl-spectcl/tests/golden/switch.snap
+++ b/rust/tcl-spectcl/tests/golden/switch.snap
@@ -12,4 +12,4 @@ registrations 1
 notices 1
 notice command switch 48 presentation names a lowering hook: this changes how the compiler translates the command, not just what the editor knows about it
 commands 1
-command switch line 10 overrides false degraded false spec c848940fc52c38ff hooks 18a4376560a3f79b grammar 715ea0deb6f6f5f9
+command switch line 10 overrides false degraded false spec 1e8299fd79b2d7f0 hooks 18a4376560a3f79b grammar 715ea0deb6f6f5f9

--- a/rust/tcl-spectcl/tests/golden/upvar.snap
+++ b/rust/tcl-spectcl/tests/golden/upvar.snap
@@ -19,4 +19,4 @@ notice command upvar 61 presentation `state_transitions` row `covers` is not yet
 notice command upvar 62 presentation `state_transitions` row `covers` is not yet loadable; dropped
 notice command upvar 65 presentation `state_transitions` row `commit` is not yet loadable; dropped
 commands 1
-command upvar line 16 overrides false degraded false spec 069eec64872b821e hooks 831154110e30ac6a grammar 715ea0deb6f6f5f9
+command upvar line 16 overrides false degraded false spec e09b64bd087244aa hooks 831154110e30ac6a grammar 715ea0deb6f6f5f9

--- a/rust/tcl-spectcl/tests/pack_torture.rs
+++ b/rust/tcl-spectcl/tests/pack_torture.rs
@@ -667,6 +667,35 @@ fn unknown_words_at_every_level_are_dropped_with_a_notice() {
     );
 }
 
+/// A retired trait spelling is still dropped, but the notice names what
+/// carries the fact now — a pack written against an older registry gets a
+/// migration instruction rather than "unknown word".
+#[test]
+fn a_retired_trait_name_is_dropped_with_its_replacement_named() {
+    let pack = evaluate_pack(
+        "speclib demo 1.1 {\n\
+        \x20 command demo::pick {\n\
+        \x20   arity 2\n\
+        \x20   traits {CONTROL_FLOW HAS_SWITCH_BODY}\n\
+        \x20 }\n\
+        }\n",
+    );
+
+    let cmd = pack
+        .command("demo::pick")
+        .expect("a retired trait must not take the command down");
+    assert!(
+        cmd.spec.traits.contains(tcl_registry::Traits::CONTROL_FLOW),
+        "the live sibling trait must still apply"
+    );
+    let notices = notice_text_for(&pack);
+    assert!(
+        notices.contains("retired trait `HAS_SWITCH_BODY` dropped")
+            && notices.contains("CommandSpec::has_switch_body"),
+        "the notice must name the replacement: {notices}"
+    );
+}
+
 /// A `-dialect` naming no profile keeps the extension row without routing, and
 /// a bogus `dialects` word does not take the command down.
 #[test]


### PR DESCRIPTION
## Summary

An audit of all 96 behavioural traits found **six with no behavioural consumer anywhere in `rust/`** — their only non-spec, non-test appearance was the `TRAIT_FLAGS` serialisation table in `command_snapshot.rs`, which never branches on them. Five are retired; the sixth is kept and finally wired up.

Two of them were a second source of truth that **disagreed with the first**:

| Retired | Was wrong how | Carried now by |
|---|---|---|
| `HAS_SWITCH_BODY` | said strictly less than `case_list` — six `expect*` commands declared the clause list without ever carrying the flag | `case_list`; derived as `CommandSpec::has_switch_body` |
| `HAS_DESTRUCTIVE_OPS` | disagreed with `SubCommand::destructive` **in both directions**: `registry` carried it with no destructive subcommand, while `after`, `array`, `dict`, `oo::object` and `timer` had one without it | `SubCommand::destructive`; derived as `CommandSpec::has_destructive_ops` |
| `HAS_INTERP_EVAL` | disagreed with `taint_interp_eval_subcommands` (which *is* consumed) in both directions | that list; `send` carries `EVALUATES_CODE` on its own |
| `CONFIGURES_CHANNEL` | — | the `FileIo` side effect with `reads` and `writes` that `chan` and `fconfigure` already declare |
| `STRING_LIST_CONFUSION` | — | nothing: an authoring hint about `append`, not a behavioural fact |

**One fact was deliberately let go.** `registry` models its operations as `ArgValue`s rather than a subcommand table, on purpose — Tcl accepts any unique abbreviation and a table would misreport `registry se` — so `has_destructive_ops` answers false for it. Its persistent write is carried by its `FileIo` side effect, which is read; the command-level boolean was not.

### `HAS_LOOP_BODY` is kept, and given the consumer it should have had

Nothing else in the model says a body may run more than once. Meanwhile `bounds_checks.rs` matched `"while"` and `cmd_name == "for"` by name — exactly what the registry rule exists to prevent.

Whether a command is a loop is now `CommandRegistry::is_loop_command`, and the W240/W241/W242 termination checks read the condition, body, init and step positions off the command's **declared argument roles** (the `Expr` word, the `Body` words around it). A pack shipping its own loop construct is analysed under whatever name it has; a new test proves a `spin`-named loop reaches W240/W241 while a command with the identical argument shape and no `HAS_LOOP_BODY` does not. The literal `while`/`for` positions survive only as the registry-less fallback — the shape `is_loop_exit_command` already documents.

### Retired names do not become a dead end

A `.tclspec` written against an older registry still says `traits HAS_SWITCH_BODY`. `RETIRED_TRAITS` pairs each retired spelling with a sentence naming what carries the fact now, and the loader consults it before reporting an unknown trait, so the author is told where the behaviour moved. The row is **still dropped** — the replacement is derived from a descriptor the pack already writes, not from the retired word. A test forbids a retired name from ever being declared again.

Part of #1712's "disposition for every authored trait" — this PR covers the six with no consumer. The purity overlap (`PURE`, `PURE_EVALUATION`, `SubCommand::pure`, `CSE_CANDIDATE`, `ResultStability`, `const_fold` — five mechanisms with nothing enforcing agreement) is **not** in this PR; see the note below.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

```
cargo fmt --all
cargo clippy --workspace --all-targets      # 0 warnings
cargo test -p tcl-registry
cargo test -p tcl-spectcl
cargo test -p tcl-spec-studio
cargo test -p tcl-compiler
make codegen                                # regenerated artefacts committed
make xtask-check                            # all drift gates pass
cargo xtask kcs-index-links                 # KCS docs checks passed
```

## Compiler / diagnostics checklist

- [x] Did this change alter a compiler fact contract? — **Yes.** Five trait bits are gone from the vocabulary, two facts became derived queries, and W240/W241/W242 now decide "is this a loop" from the registry rather than from two command names. No diagnostic's meaning or severity changed; the set of commands that reach them can only grow, and only for a command that declares `HAS_LOOP_BODY`.
- [x] If yes, I updated the owning design doc — `docs/design/compiler/command-registry.md` gains "Retiring a trait" (the three rules, the retired/carried-by table, the `registry` case, and why `HAS_LOOP_BODY` was kept); `docs/design/spec-packs.md`'s compatibility policy gains the retired-name notice.
- [x] If I added or changed a diagnostic or optimisation code — none added or changed.
- [x] If I added a design doc, I linked it — no new doc; `cargo xtask kcs-index-links` passes.

## Not in this PR, and why

#1712 asks for `Traits::PURE` to be removed and purity derived from the effect footprint. I don't believe that is sound yet: an empty `side_effects` today means *unknown*, not *verified absent*, so deriving purity from it would silently widen what the optimiser may do. The per-domain completeness model (`Unknown` / `Partial` / `Complete`) that would make it safe is the larger half of that issue. The precondition worth doing first is one central purity query with a gate against raw reads — that is a separate change, not this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AWimhq6f4xQHmdN8Gr6CY2

---
_Generated by [Claude Code](https://claude.ai/code/session_01AWimhq6f4xQHmdN8Gr6CY2)_