### PR TITLE
fix(runtime): the $child shorthand reaches the same interp owners as the long form (#1412)

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -264,19 +264,20 @@ proof, and the entry contract that together gate stable-call CSE (`O105`).
   in `cmd_proc.rs` / `interp.rs`).
 - [runtime/rename-alias.md](runtime/rename-alias.md) — layout + flow
   for `rename` and single-interp `interp alias`, layered on top of the
-  namespace tree.  Covers `CMD_ALIAS` flag, `AliasRec`, dispatch
-  trampoline, and the compiled-proc name-slot preservation
-  caveat.
+  namespace tree.  Covers the `Command` enum (no flags word, no
+  type-punned payload), the dispatch trampoline, the
+  `TclPreventAliasLoop` gate, the occupied-destination refusal, and
+  proc re-homing across a cross-namespace rename.
 - [runtime/command-introspection.md](runtime/command-introspection.md)
-  — interpreter-wide hidden-commands table, `interp hide` / `expose`
-  semantics, the `OFF_EXPORT_NAME_BUCKET` sidecar that unblocks
-  compiled-proc rename, and the `info commands` / `info procs` /
-  `namespace which -command` walkers.
+  — interpreter-wide hidden-commands table, `interp hide` / `expose` /
+  `invokehidden` semantics and C's observable check order, and the
+  `info commands` / `info procs` / `namespace which -command`
+  walkers.
 - [runtime/child-interp.md](runtime/child-interp.md) — child-
   interpreter primitives (`interp create` / `eval` / `exists` /
-  `slaves` / `delete`), the `Interp` struct + per-interp hidden
-  table, the `enter` / `leave` swap pair for nested eval, and the
-  compiler's conservative proc-index flush on `interp create` /
+  `slaves` / `delete`), the `Interp` handle + per-interp hidden
+  table, `with_child` as the re-entrancy guard for nested eval, and
+  the compiler's conservative proc-index flush on `interp create` /
   `eval` / `delete`.
 - [runtime/memory-management.md](runtime/memory-management.md) —
   TclObj refcount discipline, `OBJ_STR_CAP` ownership, the

--- a/docs/design/contracts/command-binding-and-aliasing.md
+++ b/docs/design/contracts/command-binding-and-aliasing.md
@@ -69,9 +69,26 @@ trace, or sourced-file boundary.
 ### rename
 `rename old new` moves the Command between namespace command tables;
 `rename old ""` deletes and must splice the command out of every importer's
-redirect list and deactivate those redirects. Self-rename is a no-op.
-Built-ins are protected (`return`, `error`) and refused verbatim
-(`can't rename "X": …`). Renaming a command does **not** chase existing
+redirect list and deactivate those redirects.
+
+Self-rename is **not** a no-op: `TclRenameCommand` checks the destination's
+hash table before it removes the source, so `rename foo foo` finds the source
+itself occupying the slot and is refused like any other occupied destination —
+`can't rename to "foo": command already exists`, errorcode `TCL OPERATION
+RENAME TARGET_EXISTS`.
+
+There is **no protected-command list**. `rename return myreturn` and `rename
+error myerror` both succeed on tclsh 8.6.16 and 9.0.4, and the runtime allows
+them (pinned by `cmd_alias.rs::tests::rename_builtin_return_is_allowed`).
+What `rename` refuses is about the move, not the source: an occupied
+destination (above), a rename that would close an alias cycle (`cannot define
+or rename alias "X": would create a loop`), and a builtin the emulated release
+does not carry. A missing source is `can't rename "X": command doesn't exist`,
+or `can't delete "X": command doesn't exist` when the destination is empty —
+the verb follows the requested operation. All three carry C's errorcodes
+(`TCL LOOKUP COMMAND X` on a miss).
+
+Renaming a command does **not** chase existing
 `interp alias` targets — an alias stores the target *name*, so after a rename
 the stored name simply stops resolving (matches C).
 
@@ -186,7 +203,7 @@ redefinition.
 | Behaviour | Class | Notes |
 |---|---|---|
 | Unqualified resolution order: current ns → path → global → unknown | **Contract** | Path makes bare `+` resolve via `::tcl::mathop`. |
-| `rename` move/delete, importer splice, built-in protection | **Contract** | `can't rename "X": …` verbatim. |
+| `rename` move/delete, importer splice, occupied-destination refusal | **Contract** | `can't rename "X": …` / `can't delete "X": …` / `can't rename to "X": command already exists` verbatim. No protected-builtin list — `rename return myreturn` succeeds. |
 | `interp alias` frozen prefix, by-name target re-resolve, no rename-follow | **Contract** | Lazily sees target deletion only. |
 | `import` transparent unwrap; snapshot-at-import; `forget`/source-rename splice | **Contract** | Imports unwrapped, aliases not. |
 | Ensemble subcommand prefix-match, `-map`/`-unknown`/`-subcommands` | **Contract** | `dict for`→`::tcl::dict::for` rewrite. |

--- a/docs/design/runtime/backend-constraints.md
+++ b/docs/design/runtime/backend-constraints.md
@@ -59,11 +59,19 @@ The second half is a tcltest overlay: a Tcl script that reads the
 introspection facts, registers backend constraints, and feeds
 `tcltest::configure -skip` the test-id globs the current backend cannot run.
 
-**The hook is wired in both harnesses; no overlay script is checked in.**
-Setting `TCL_BACKEND_CONSTRAINTS` to a path sources that file at the right
-moment, but the repository ships no such file, and no backend constraint names
-are registered anywhere in the tree. Until an overlay exists, every backend
-runs the full suite and reports capability gaps as failures rather than skips.
+**The overlay is checked in at `tests/external/backend_constraints.tcl`**, and
+`TCL_BACKEND_CONSTRAINTS` points a harness at it (or at a replacement). It
+registers seven constraint names — `rustBackend`, `bytecodeRuntime`,
+`treewalkRuntime`, `wasmBackend`, `notWasm`, `wasiPreview1`, `ebpfBackend` —
+and is safe to source under C tclsh, because every fact it reads defaults when
+the key is absent.
+
+The tcltest sweep passes it by default: `rust/xtask/src/tcltest_sweep.rs`
+names it in the `BACKEND_CONSTRAINTS` const, sets the env var for every VM
+run, and *refuses to sweep at all* without it
+(`missing default backend constraint overlay …`). The two example harnesses do
+not default it — set `TCL_BACKEND_CONSTRAINTS` yourself for a manual
+`run_test` or `run_script --init`.
 
 Where each harness sources it:
 
@@ -78,26 +86,50 @@ Where each harness sources it:
 
 ```sh
 # tcl-vm bytecode VM, evaluated as the WASI backend
-TCL_BACKEND_CONSTRAINTS=<overlay.tcl> \
+TCL_BACKEND_CONSTRAINTS=tests/external/backend_constraints.tcl \
 TCL_WASI_SPEC=preview1 \
-  cargo run -p tcl-vm --release --example run_test -- tmp/tcl9.0.3/tests/socket.test
+  cargo run -p tcl-vm --release --example run_test -- tmp/tcl9.0.4/tests/socket.test
 
 # runtime/rust tree-walk runtime, evaluated as eBPF
-TCL_BACKEND_CONSTRAINTS=<overlay.tcl> \
+TCL_BACKEND_CONSTRAINTS=tests/external/backend_constraints.tcl \
 TCL_EBPF_SPEC=1.4 \
-  cargo run --release --example run_script -- --init tmp/tcl9.0.3/tests/clock.test
+  cargo run --release --example run_script -- --init tmp/tcl9.0.4/tests/clock.test
 ```
 
 A native run (no `TCL_*_SPEC`) has nothing to skip and runs the full suite.
 
-### What an overlay has to do
+### What the overlay does
 
-1. Read the introspection facts, defaulting to `native` when absent, so it is
-   safe under C tclsh or an older build.
-2. Register the backend constraints the exclusion rows name.
-3. Feed `tcltest::configure -skip` from a data-driven exclusion table ordered
-   by capability area, each row carrying the *reason* — the audit trail for why
-   a test is not run.
+1. Reads `::tcl_platform(runtime)` (defaulting to `c`) and `(wasm)` / `(wasi)`
+   / `(ebpf)` (defaulting to empty), so the file is safe under C tclsh.
+   `runtime/rust` publishes `runtime = "treewalk"` and `tcl-vm` publishes
+   `"bytecode"`; `tcl-platform` owns the schema.
+2. Registers the seven constraint names:
+
+   | Name | True when |
+   |---|---|
+   | `rustBackend` | `runtime` is `bytecode`, `treewalk`, or `ebpf` |
+   | `bytecodeRuntime` | `runtime eq "bytecode"` |
+   | `treewalkRuntime` | `runtime eq "treewalk"` |
+   | `wasmBackend` / `notWasm` | `wasm ne ""` / `wasm eq ""` |
+   | `wasiPreview1` | `wasi` is `preview1` or `0.1` |
+   | `ebpfBackend` | `ebpf ne ""` |
+
+3. Appends to any existing `::tcltest::configure -skip`, one row per backend
+   boundary: `platform-1.1` (the Rust runtimes add introspection keys, so C's
+   exact-key assertion is inapplicable); `socket-*` when there is no `socket`
+   command; `exec-*` when there is no `exec`, or under WASI or eBPF;
+   `thread-* async-*` when `tcl_platform(threaded)` is absent or false;
+   `fCmd-* fileSystem-*` under eBPF.
+
+The authoring rule is in the file's own header and is **gated**: an overlay may
+exclude only platform identity, unavailable host capabilities, and C-only
+internal-representation probes. Semantic stems (`set-*`, `expr-*`, `proc-*`,
+`namespace-*`, `dict-*`) are forbidden.
+`tcltest_sweep.rs::tests::overlay_only_skips_explicit_backend_cases` pins every
+`lappend exclusions` pattern against `ALLOWED_BACKEND_SKIP_PATTERNS` and fails
+on a semantic stem, so an overlay edit must update that list in the same
+change.
 
 ## Relationship to the tier ladder
 

--- a/docs/design/runtime/child-interp.md
+++ b/docs/design/runtime/child-interp.md
@@ -8,11 +8,13 @@ table, children registry — plus `interp create` / `eval` / `exists` /
 [`rename-alias.md`](rename-alias.md), and
 [`command-introspection.md`](command-introspection.md).
 
-Reference Tcl 9 sources: `tmp/tcl9.0.3/generic/tclInterp.c`
-(`ChildCreate`, `ChildEval`, `InterpObjCmd` dispatch,
-`OPT_{CREATE,EVAL,EXISTS,SLAVES,DELETE}` branches) and
-`tmp/tcl9.0.3/generic/tclBasic.c` (`Tcl_CreateInterp` /
-`DeleteInterp`).
+Reference Tcl 9 sources: `tmp/tcl9.0.4/generic/tclInterp.c`
+(`NRInterpCmd` dispatch and its `options[]` / `optionsNoSlaves[]`
+tables, `NRChildCmd` and its own shorter `options[]`, `ChildCreate`,
+`ChildEval`, `ChildHide`, `ChildExpose`, `ChildInvokeHidden`) and
+`tmp/tcl9.0.4/generic/tclBasic.c` (`Tcl_CreateInterp` / `DeleteInterp`,
+and `Tcl_HideCommand` / `Tcl_ExposeCommand`, which are here rather than
+in `tclInterp.c`).
 
 ## 1. Scope
 
@@ -35,6 +37,8 @@ In:
 - `interp recursionlimit path ?newlimit?`, `interp limit path
   limitType ?-option value …?`, `interp bgerror path ?cmdPrefix?`,
   and `interp debug path ?-frame ?bool??`.
+- `interp target path alias` — the interpreter path an alias
+  resolves its target in ([`rename-alias.md`](rename-alias.md) §4.3).
 - Child-as-command dispatch: `<child> eval script` resolves
   through `Command::ChildInterp` and routes into the child.
 - Per-interp `InterpState` carrying the namespace tree, frame
@@ -43,28 +47,38 @@ In:
   covered in [`rename-alias.md`](rename-alias.md) §4.5.
 - Conservative compiler-side command-binding distrust when registry-declared
   interpreter or command-table transitions cannot be bounded.
-- tclsh-style error wording for the ensemble: `bad option "X": must be
-  alias, aliases, bgerror, cancel, children, create, debug,
-  delete, eval, exists, expose, hide, hidden, issafe,
-  invokehidden, limit, marktrusted, recursionlimit, share,
-  target, or transfer`; `bad option "-X": must be -safe or --`
-  for `interp create`.
+- tclsh-style error wording, from two separate lists — as in C, where
+  `NRInterpCmd` and `NRChildCmd` carry their own `options[]`.  For the
+  ensemble: `bad option "X": must be alias, aliases, bgerror,
+  children, create, debug, delete, eval, exists, expose, hide,
+  hidden, issafe, invokehidden, limit, marktrusted,
+  recursionlimit, or target`.  For the `$child` shorthand, C's
+  shorter list verbatim: `bad option "X": must be alias, aliases,
+  bgerror, debug, eval, expose, hide, hidden, issafe,
+  invokehidden, limit, marktrusted, or recursionlimit` — no
+  `children`, `create`, `delete` or `exists`, which are only ever
+  spelled `interp <op> path`.  `bad option "-X": must be -safe or
+  --` for `interp create`.
+
+  The ensemble list is a deliberate **subset** of tclsh's: it drops
+  `cancel`, `share` and `transfer` because this runtime does not
+  implement them, on the view that advertising a subcommand that then
+  fails with the wrong error is the worse lie (issue #1412 item 3).
+  8.6's `slaves` is likewise never advertised, matching 9.0.4's
+  `optionsNoSlaves[]` output; the spelling still dispatches.
 
 Known gaps:
 
-- `interp target`, `interp share`, `interp transfer`, and
-  `interp cancel` are not implemented.  They appear in the
-  `bad option` list (which is the verbatim tclsh wording) but have
-  no dispatch arm, so invoking one reports `bad option` naming a
-  subcommand the same message lists as valid.
+- `interp share`, `interp transfer` and `interp cancel` are not
+  implemented, and — unlike `interp target`, which is — are not
+  advertised either.  `share` / `transfer` need a channel table shared
+  between interpreters; `cancel` needs a cancellation flag the eval
+  loop polls (C's `Tcl_CancelEval`).  Neither is in this runtime.
 - The Safe Base (`safe.tcl`) is not present.  `-safe` does the
   `Tcl_MakeSafe` half of the job (§6); what is missing is the Tcl-level
   access-path virtualisation that re-aliases `source` / `load` / `file`
   / `glob` onto token-mapped parent commands, so a safe child cannot
   load packages the way a real safe interpreter can.
-- `$child <sub>` for a subcommand with no arm reports
-  `interp subcommand "X" is not supported in this runtime` rather than
-  the tclsh `bad option` list that the `interp <sub>` path emits.
 - Querying a child alias (`interp alias childPath name`) reports
   `querying a child alias is not yet supported`.
 - Cross-interp aliases only run child→parent.  A non-empty *target*
@@ -168,20 +182,58 @@ The hidden table is a field of `InterpState`, so `hide` / `expose` /
 `hidden` / `invokehidden` naturally address whichever interpreter the
 path resolved to — there is no interpreter argument to thread through.
 
-- `hide_command(name)` resolves `name` at the global namespace, removes
-  the binding, and moves the `Command` into `hidden`.
-- `expose_command(name)` is the inverse: remove from `hidden`,
-  re-`register` in the command table.
+- `hide_command(name, hidden_name) -> CommandVisibilityOutcome`
+  resolves `name` at the global namespace and moves the `Command` into
+  `hidden` under `hidden_name`.
+- `expose_command(hidden_name, name) -> CommandVisibilityOutcome` is
+  the inverse: take `hidden_name` out of `hidden` and `register` it in
+  the command table as `name`.
+- `finish_command_visibility(op, source, destination, outcome)` is the
+  one seam that turns either outcome into Tcl's public diagnostic, so
+  the ensemble form and the `$child` shorthand cannot drift apart in
+  message or `-errorcode`.
 - `invoke_hidden(name, argv)` clones the handle out of `hidden` and
   `invoke`s it, or raises `invalid hidden command name "X"`.
 - `hidden_names()` lists the table (a `BTreeMap`, so the listing is
   sorted and deterministic).
 
-Two structural restrictions are enforced at the command layer, matching
-C: the hidden-command token may not carry namespace qualifiers
-(`cannot use namespace qualifiers in hidden command token (rename)`),
-and only global-namespace commands may be hidden
-(`can only hide global namespace commands (use rename then hide)`).
+Neither move is a silent no-op; each failure is a real Tcl error with
+C's message and errorcode:
+
+| Failure | Message | `-errorcode` |
+|---|---|---|
+| hide, token carries `::` | `cannot use namespace qualifiers in hidden command token (rename)` | `TCL VALUE HIDDENTOKEN` |
+| hide, source does not resolve | `unknown command "X"` | `TCL LOOKUP COMMAND X` |
+| hide, source is not global | `can only hide global namespace commands (use rename then hide)` | `TCL HIDE NON_GLOBAL` |
+| hide, token already hidden | `hidden command named "X" already exists` | `TCL HIDE ALREADY_HIDDEN` |
+| expose, destination contains `::` | `cannot expose to a namespace (use expose to toplevel, then rename)` | `TCL EXPOSE NON_GLOBAL` |
+| expose, token not hidden | `unknown hidden command "X"` | `TCL LOOKUP HIDDENTOKEN X` |
+| expose, destination occupied | `exposed command "X" already exists` | `TCL EXPOSE COMMAND_EXISTS` |
+
+The order of those checks is C's and is observable, because more than
+one can apply at once.  `Tcl_HideCommand` checks the token's qualifiers,
+*then* resolves the source, *then* rejects a non-global source, *then*
+refuses an occupied token; `Tcl_ExposeCommand` checks the destination
+for `::` first, *then* looks the token up, *then* refuses an occupied
+destination.  Two consequences worth stating: expose has **no**
+token-qualifier check at all, so `interp expose kid ::tok plain` is
+`unknown hidden command "::tok"`, not a token error; and expose's
+destination test is a raw "contains `::`", so a *leading* `::` fails it
+too (`interp expose kid tok ::plain`).  Hide's source test is the
+opposite — a leading `::` (or any run of colons) is fine, since the
+lookup is global-anchored anyway.
+
+`interp invokehidden` and `$child invokehidden` take `-global`,
+`-namespace ns` and `--` before the command word, and evaluate the
+hidden command with the interpreter's current namespace switched for
+the duration of that one call (`set_current_ns`, saved and restored).
+`-namespace`'s namespace is resolved from the **global** namespace
+whatever the caller's current one is, and created if unknown — C's
+`TCL_GLOBAL_ONLY | TCL_CREATE_NS_IF_UNKNOWN` — so `-namespace bar` from
+inside `::foo` names `::bar`.  Passing both `-global` and `-namespace`
+is legal and the **last one wins**; C has no mutual-exclusion error
+here.  An unrecognised flag is a hard `bad option "-x": must be
+-global, -namespace, or --`.
 
 The permission checks are on the **executing** interpreter, not the
 target: a safe interpreter may not hide, expose, or invoke hidden
@@ -332,7 +384,8 @@ through the `catch` fallback.
 | Piece | Where |
 |---|---|
 | `InterpState`'s child fields, `with_child` / `with_child_path`, `create_child` / `delete_child` / `eval_in_child`, `make_safe`, the hidden-table ops, `dispatch_child`, `dispatch_parent_alias` | `runtime/rust/src/interp.rs` |
-| The `interp` ensemble's argument handling — `interp_create`, `interp_delete`, `interp_alias`, `interp_aliases`, `interp_hidectl`, `interp_invokehidden`, `interp_limit`, `interp_marktrusted`, `interp_debug`, `interp_path`, `not_found_path` | `runtime/rust/src/cmd_alias.rs` |
+| The `interp` ensemble's argument handling — `interp_create`, `interp_delete`, `interp_alias`, `interp_aliases`, `interp_hidectl`, `interp_invokehidden`, `interp_limit`, `interp_marktrusted`, `interp_debug`, `interp_target`, `interp_path`, `not_found_path` | `runtime/rust/src/cmd_alias.rs` |
+| `alias_target_path` (backing `interp target`) | `runtime/rust/src/interp.rs` |
 | `Command::ChildInterp` / `Command::ParentAlias` | `runtime/rust/src/interp.rs` |
 | Per-interp namespace arena (`Namespaces`) | `runtime/rust/src/namespace.rs` |
 | Compiler-side command-binding proof (`scan_module_command_mutations`, `trusts`, `trusts_proc_binding`) | `rust/tcl-compiler/src/command_binding.rs` |
@@ -348,8 +401,8 @@ architectures:
   as the re-entrancy guard and child→parent aliases (§6). `interp
   create`/`eval`/`delete`/`exists`/`children`/`issafe`/`marktrusted`/`hide`/
   `expose`/`hidden`/`invokehidden`/`recursionlimit`/`limit`/`bgerror`/`debug`
-  are implemented; the Safe Base and `interp target`/`share`/`transfer`/
-  `cancel` are the gaps listed in §1.
+  are implemented, as is `interp target`; the Safe Base and `interp
+  share`/`transfer`/`cancel` are the gaps listed in §1.
 
 - **`tcl-vm`** (bytecode VM) is an engine (`Vm`) driving a tree of
   interpreters in one arena: each interpreter's state (`InterpState`) lives

--- a/docs/design/runtime/command-introspection.md
+++ b/docs/design/runtime/command-introspection.md
@@ -15,10 +15,12 @@ rename/alias layer ([`rename-alias.md`](rename-alias.md)):
   for interpreted procs.
 - ``info level`` / ``info script``.
 
-Reference Tcl 9 sources: ``tmp/tcl9.0.3/generic/tclInterp.c``
-(``HiddenObjCmd``, ``ExposeObjCmd``, ``Tcl_HideCommand``),
-``tmp/tcl9.0.3/generic/tclNamesp.c`` (``Tcl_NamespaceWhichObjCmd``,
-``Tcl_GetCommandFullName``), and ``tmp/tcl9.0.3/generic/tclCmdIL.c``
+Reference Tcl 9 sources: ``tmp/tcl9.0.4/generic/tclBasic.c``
+(``Tcl_HideCommand`` ``:2270``, ``Tcl_ExposeCommand`` ``:2439`` — both
+live here, not in ``tclInterp.c``, which holds only the ``ChildHide`` /
+``ChildExpose`` / ``ChildInvokeHidden`` argument wrappers),
+``tmp/tcl9.0.4/generic/tclNamesp.c`` (``Tcl_NamespaceWhichObjCmd``,
+``Tcl_GetCommandFullName``), and ``tmp/tcl9.0.4/generic/tclCmdIL.c``
 (``InfoCommandsCmd``, ``InfoProcsCmd``, ``InfoDefaultCmd``).
 
 ## 1. Scope
@@ -66,25 +68,41 @@ the hidden table, and command resolution never probes it.
 The per-interpreter placement, and the path-addressing that follows
 from it, are described in [`child-interp.md`](child-interp.md) §5.
 
-The internal API is four methods on `Interp`:
+The internal API is five methods on `Interp`:
 
 | Method | Purpose |
 |---|---|
-| ``hide_command(name) -> bool`` | Move a command from the table into `hidden`; false if it did not resolve. |
-| ``expose_command(name) -> bool`` | The inverse; false if it was not hidden. |
+| ``hide_command(name, hidden_name) -> CommandVisibilityOutcome`` | Move `name` out of the command table into `hidden` under `hidden_name`. |
+| ``expose_command(hidden_name, name) -> CommandVisibilityOutcome`` | The inverse: `hidden_name` leaves `hidden` and is registered as `name`. |
+| ``finish_command_visibility(op, source, destination, outcome)`` | Turn either outcome into Tcl's message + ``-errorcode``. |
 | ``invoke_hidden(name, argv) -> Code`` | Dispatch a hidden command. |
 | ``hidden_names() -> Vec<Vec<u8>>`` | The sorted listing. |
+
+Neither move reports a bare success flag: `CommandVisibilityOutcome` is
+`Moved` / `Missing` / `NonGlobal` / `Collision`, and
+`finish_command_visibility` is the single seam that words each one, so
+the `interp hide|expose path …` form and the `$child hide|expose …`
+shorthand cannot drift apart.
 
 ### 2.2 `interp hide` semantics
 
 `cmd_alias.rs`'s `interp_hidectl` drives both directions. Before the
 move it enforces the structural rules and the permission check:
 
-| Condition | Message |
-|---|---|
-| the executing interp is safe | `permission denied: safe interpreter cannot hide commands` |
-| the hidden token contains `::` | `cannot use namespace qualifiers in hidden command token (rename)` |
-| the source command is not in the global namespace | `can only hide global namespace commands (use rename then hide)` |
+| Condition | Message | `-errorcode` |
+|---|---|---|
+| the executing interp is safe | `permission denied: safe interpreter cannot hide commands` | — |
+| the hidden token contains `::` | `cannot use namespace qualifiers in hidden command token (rename)` | `TCL VALUE HIDDENTOKEN` |
+| the source command does not resolve | `unknown command "X"` | `TCL LOOKUP COMMAND X` |
+| the source command is not in the global namespace | `can only hide global namespace commands (use rename then hide)` | `TCL HIDE NON_GLOBAL` |
+| the token is already hidden | `hidden command named "X" already exists` | `TCL HIDE ALREADY_HIDDEN` |
+
+Those rows are in C's order, and the order is observable when more than
+one applies: `Tcl_HideCommand` tests the token's qualifiers, then
+resolves the source, then rejects a non-global source, then refuses an
+occupied token. So `interp hide kid ns::nosuch tok` is `unknown command
+"ns::nosuch"` (not the non-global error), and `interp hide kid nosuch
+takentok` is `unknown command "nosuch"` (not the collision error).
 
 The move itself is `hide_command`: resolve the name at the global
 namespace, delete the binding, and insert the `Command` handle into
@@ -100,18 +118,31 @@ does not resolve still reports the interpreter-path error.
 
 ### 2.3 `interp expose` semantics
 
-The inverse, with the mirrored checks:
+The inverse — but *not* a mirror image, because C's checks differ:
 
-| Condition | Message |
-|---|---|
-| the executing interp is safe | `permission denied: safe interpreter cannot expose commands` |
-| the hidden name contains `::` | `cannot use namespace qualifiers in hidden command token (rename)` |
-| the destination is not in the global namespace | `cannot expose to a namespace (use expose to toplevel, then rename)` |
+| Condition | Message | `-errorcode` |
+|---|---|---|
+| the executing interp is safe | `permission denied: safe interpreter cannot expose commands` | — |
+| the destination name contains `::` | `cannot expose to a namespace (use expose to toplevel, then rename)` | `TCL EXPOSE NON_GLOBAL` |
+| the token is not hidden | `unknown hidden command "X"` | `TCL LOOKUP HIDDENTOKEN X` |
+| the destination is already bound | `exposed command "X" already exists` | `TCL EXPOSE COMMAND_EXISTS` |
+
+Again the order is C's and is observable. Two asymmetries against §2.2
+are worth stating because they look like bugs and are not:
+
+- `Tcl_ExposeCommand` has **no** token-qualifier check. A qualified
+  *token* is simply a token that is not in the hidden table, so
+  `interp expose kid ::tok plain` is `unknown hidden command "::tok"`.
+- Its destination test is a raw "contains `::`", so a **leading** `::`
+  fails it too: `interp expose kid tok ::plain` is
+  `cannot expose to a namespace …`. Hide's source test is the opposite —
+  a leading `::`, or any run of colons, is fine there, because that
+  lookup is global-anchored anyway.
 
 `expose_command` removes the entry from `hidden` and re-`register`s it
 in the command table under the exposed name. Exposing a command that is
-not hidden is a silent no-op, and — unlike C — an occupied destination
-is not refused; the `register` overwrites it.
+not hidden raises, and an occupied destination is refused rather than
+overwritten.
 
 ### 2.4 `interp hidden`
 
@@ -130,13 +161,28 @@ raises ``invalid hidden command name "X"``; a safe executing
 interpreter is refused with ``not allowed to invoke hidden commands
 from safe interpreter``.
 
-**The option flags are skipped, not honoured.** The parser walks past
-`-global`, `-namespace ns`, and any other leading `-…` word purely to
-find the command word, so the hidden command always runs in the target
-interpreter's current context. C's `-namespace ns` evaluation context
-and its
-``cannot use -global option and -namespace option together`` rejection
-are not implemented.
+The option flags are honoured. `-global` and `-namespace ns` set the
+addressed interpreter's current namespace for the duration of that one
+call (saved and restored around it), `--` ends the option list, and any
+other leading `-…` word is a hard ``bad option "-x": must be -global,
+-namespace, or --`` rather than a silent skip. `-namespace`'s namespace
+is resolved from the **global** namespace whatever the caller's current
+one is, and is created if unknown — C's ``TCL_GLOBAL_ONLY |
+TCL_CREATE_NS_IF_UNKNOWN`` (tclsh-pinned: `-namespace bar` from inside
+`::foo` still names `::bar`).
+
+Two clarifications, both measured on 8.6.16 and 9.0.4:
+
+- **There is no `cannot use -global option and -namespace option
+  together` error.** Earlier revisions of this document, and issue
+  #1412's own item 5, asserted C rejects the pair; it does not, on
+  either release. `-global` is simply spelled `-namespace ::`
+  internally, so the **last** option given wins:
+  `-global -namespace foo` lands in `::foo`, and
+  `-namespace foo -global` lands in `::`.
+- Option matching here is exact, where C's `Tcl_GetIndexFromObj`
+  accepts unambiguous abbreviations (`-g`, `-n`). That gap is part of
+  the wider option-prefix sweep (#1607), not of this surface.
 
 ## 3. `info commands` / `info procs`
 
@@ -331,23 +377,26 @@ namespace-path resolver, not the introspection surface described here.
 
 ### 8.3 Divergences in the hidden-command surface
 
-Three behaviours differ from C Tcl and are stated here rather than in
-the sections above so they are findable as a set:
+One behavioural gap remains, and it is shared with the rest of the
+`interp` ensemble rather than special to this surface: option words are
+matched **exactly**, where C accepts any unambiguous abbreviation
+(`interp invokehidden {} -g …`, `interp hid …`) and answers the empty
+option word with `ambiguous option ""`. Converting the ensemble's
+hand-spelled option lists to the shared prefix matcher is issue #1607;
+until it lands, only the full spellings are accepted.
 
-- Hiding a non-existent command, exposing a non-hidden one, or
-  addressing a child path that does not resolve is a silent no-op
-  instead of an error.
-- `interp expose` does not refuse an occupied destination; it
-  overwrites the binding.
-- `interp invokehidden`'s `-global` / `-namespace ns` flags are parsed
-  and discarded rather than establishing an evaluation context.
+The three divergences this section used to list — silent hide/expose
+misses, an overwriting `expose` destination, and `invokehidden` flags
+parsed and discarded — are fixed, on both the `interp <op> path` form
+and the `$child <op>` shorthand. §2.2, §2.3 and §2.5 describe what the
+runtime now does.
 
 ## 9. Implementation map
 
 | Piece | Where |
 |---|---|
 | The `hidden` table and `hide_command` / `expose_command` / `invoke_hidden` / `hidden_names` | `runtime/rust/src/interp.rs` |
-| `interp hide` / `expose` / `hidden` / `invokehidden` argument handling and permission checks | `runtime/rust/src/cmd_alias.rs` |
+| `interp hide` / `expose` / `hidden` / `invokehidden` / `target` argument handling and permission checks, and the `hidectl_in` / `invokehidden_in` owners the `$child` shorthand shares | `runtime/rust/src/cmd_alias.rs` |
 | The `info` ensemble's adapters | `runtime/rust/src/cmd_info.rs` |
 | The listing / `info level` / `info body` / `args` / `default` cores | `rust/tcl-cmd-core/src/info.rs` |
 | `namespace which` / `current` and the ensemble's prefix resolution | `runtime/rust/src/cmd_namespace.rs` |

--- a/docs/design/runtime/rename-alias.md
+++ b/docs/design/runtime/rename-alias.md
@@ -3,8 +3,9 @@
 The Tcl 9 semantics for ``rename`` and ``interp alias`` in the WASM runtime
 (`runtime/rust`), built on the namespace tree from
 [`namespace-tree.md`](namespace-tree.md).  Source of truth for the C semantics
-is ``tmp/tcl9.0.3/generic/tclBasic.c`` (``TclRenameCommand``) and
-``tmp/tcl9.0.3/generic/tclInterp.c`` (``AliasCreate`` / ``AliasDelete``).
+is ``tmp/tcl9.0.4/generic/tclBasic.c`` (``TclRenameCommand``, ``:3152``)
+and ``tmp/tcl9.0.4/generic/tclInterp.c`` (``AliasCreate`` /
+``AliasDelete`` / ``OPT_TARGET``, ``:1121``).
 
 The command-layer *contract* this implements — and its compiler-side
 consequences — is
@@ -26,6 +27,8 @@ In:
   child, which installs a child→parent alias (§4.5).
 - ``interp aliases ?path?`` — every alias command's name in the
   addressed interpreter.
+- ``interp target path alias`` — the interpreter path to the
+  interpreter an alias resolves its target in (§4.3).
 - Alias dispatch trampoline wired into the one command-dispatch
   switch so aliases are transparent to callers.  Resolution is by
   *stored target name* on each dispatch, anchored at the global
@@ -35,6 +38,16 @@ In:
 - C's ``TclPreventAliasLoop`` gate on both alias creation and
   ``rename``: an alias that would close a cycle is refused with
   ``cannot define or rename alias "X": would create a loop`` (§4.6).
+
+Out, deliberately: ``interp cancel``, ``interp share`` and ``interp
+transfer`` are neither implemented nor *advertised*.  They need
+infrastructure this runtime has none of — a cancellation flag the eval
+loop polls (C's ``Tcl_CancelEval``) and a channel table shared between
+interpreters — so the ``bad option`` list names only what actually
+dispatches, rather than repeating tclsh's full list and naming three
+subcommands that would then fail with the wrong error (issue #1412
+item 3).  That is a knowing divergence from tclsh's advertised list;
+see [`child-interp.md`](child-interp.md) §1.
 
 Covered by sibling documents:
 
@@ -89,8 +102,10 @@ Two consequences differ from a flags-and-payload layout:
 |-----------------------------------|-----------------------------------------------------------------------------------------------|
 | ``rename old new``                | Move the `Command` out of the namespace where ``old`` *resolves* and insert it under ``new`` (relative to the current namespace, absolute when ``::``-led). |
 | ``rename old ""``                 | Delete ``old``: drop the table entry, tear down a suspended coroutine of that name, remove the command's traces. |
-| ``rename foo foo``                | No-op — remove then reinsert under the same key.                                              |
-| ``rename nosuch x``               | ``can't rename "nosuch": command doesn't exist``.                                              |
+| ``rename foo foo``                | Refused — ``can't rename to "foo": command already exists`` (`TCL OPERATION RENAME TARGET_EXISTS`); the source still occupies the slot when the destination is checked, so a self-rename is *not* a no-op. |
+| ``rename a b`` with ``b`` bound   | Refused with the same message and errorcode; **both** commands survive intact.                |
+| ``rename nosuch x``               | ``can't rename "nosuch": command doesn't exist`` (`TCL LOOKUP COMMAND nosuch`).                |
+| ``rename nosuch ""``              | ``can't delete "nosuch": command doesn't exist`` (`TCL LOOKUP COMMAND nosuch`) — the verb follows the requested operation, not the failure. |
 
 Any command may be renamed, builtins included: C Tcl has no protected
 list at this layer, and `rename ::return ::myreturn` succeeds on real
@@ -113,10 +128,20 @@ The command table is a `BTreeMap<Vec<u8>, Command>` per namespace, so
 removal is a real removal; there are no tombstones and no probe chains
 to preserve.
 
+Occupancy of the destination is decided one layer above the table
+operation, in `Interp::rename_command`, via
+`Namespaces::destination_occupant_fqn` — and *before* any command trace
+fires, matching C, which checks ``newNsPtr->cmdTable`` before it touches
+the source (``tclBasic.c:3213``).  `Namespaces::rename` itself stays the
+unconditional table op and refuses nothing; occupancy protection is the
+caller's job.  One destination that looks occupied but is not: a
+release-gated TclOO root, which `Interp::is_gate_hidden_object_root`
+reads as free because the emulated release does not carry it.
+
 ### 3.3 What follows the command
 
 `Interp::rename_command` is the layer above the table operation, and it
-carries four things across the move:
+carries five things across the move:
 
 - **Command traces** fire *before* the mutation (C's `TclRenameCommand`
   semantics — the command still exists under its old name during the
@@ -135,6 +160,13 @@ carries four things across the move:
   first, so the suspended worker is torn down rather than orphaned.
 - **TclOO objects.**  When the OO registry is non-empty, a renamed or
   deleted object command updates (or is removed from) it.
+- **Proc home.**  A cross-namespace rename re-homes the proc:
+  `Namespaces::rehome_proc` builds a fresh `Rc<ProcDef>` with the
+  destination's namespace and FQN, so ``namespace current`` inside the
+  body reports the *destination* (C assigns ``cmdPtr->nsPtr =
+  newNsPtr``, ``tclBasic.c:3239``).  Frames already on the stack keep the
+  snapshot they captured, so a rename during an active call does not
+  re-home that call.
 
 A delete-trace callback may itself delete the command — by deleting the
 object's namespace, say.  C captured the command token before the
@@ -142,14 +174,24 @@ callback, so the deletion still succeeds; the runtime reproduces that by
 treating "existed at entry, gone now, ``new`` empty" as a normal delete
 rather than reporting ``command doesn't exist``.
 
-### 3.4 No protected-command list
+### 3.4 No protected-command list, three refusals
 
 `Namespaces::rename` is the pure table operation and refuses nothing.
-The `rename` builtin above it refuses nothing either.  This is the
-tclsh-pinned behaviour described in §3.1: renaming a builtin, including
-``return`` and ``error``, succeeds.  C's ``TclProtectedCommandsList``
-is not mirrored — the pin is the observed tclsh result, not the C data
+There is no protected-command list above it either: renaming a builtin,
+including ``return`` and ``error``, succeeds, which is the tclsh-pinned
+behaviour described in §3.1.  C's ``TclProtectedCommandsList`` is not
+mirrored — the pin is the observed tclsh result, not the C data
 structure.
+
+What the `rename` builtin *does* refuse is not about the source command
+but about the move itself, and there are exactly three cases:
+
+- an **occupied destination** — ``can't rename to "X": command already
+  exists`` (§3.1), self-rename included;
+- a **rename that would close an alias cycle** — ``cannot define or
+  rename alias "X": would create a loop`` (§4.6);
+- a **release-gated builtin**, which the emulated release does not
+  carry and so cannot be moved (#1462 / #1463).
 
 ### 3.5 Invalidation
 
@@ -218,6 +260,7 @@ is live too and is documented in [`child-interp.md`](child-interp.md).
 | ``interp alias {} new``                        | Result is the ``target ?arg…?`` list; ``alias "new" not found`` if it is not an alias |
 | ``interp alias {} new {}``                     | Delete the binding; empty result                  |
 | ``interp aliases ?path?``                      | Tcl list of every alias name in the addressed interp |
+| ``interp target path alias``                   | The interp path (from this interp) to the interpreter ``alias`` resolves its target in: ``{}`` for a same-interp alias, ``path`` minus its last element for a child→parent one.  ``alias "X" in path "P" not found`` (`TCL LOOKUP ALIAS X`) when the addressed interp has no such alias |
 
 ### 4.4 Performance
 
@@ -340,7 +383,13 @@ Two layers:
    interpreter; `interp.rs`'s `mod tests` plants a cycle straight into
    the command table to prove the dispatch bound catches what the gate
    cannot see.
-2. **Upstream `.test` coverage** (``rename.test``, the single-interp subset of
+2. **Oracle-pinned integration tests** —
+   `runtime/rust/tests/rename_interp_semantics.rs` runs whole `rename` /
+   `interp` sheets through a live `Interp` and asserts the exact bytes a
+   pinned `tclsh` produced, message and ``-errorcode`` together.  Each
+   test quotes the sheet it pins, so a reader can paste it into a real
+   tclsh and re-derive the expectation.
+3. **Upstream `.test` coverage** (``rename.test``, the single-interp subset of
    ``interp.test``) runs through the tcltest harness; where it sits on the
    capability ladder is [`tcl-test-tiers.md`](tcl-test-tiers.md), and the
    per-stem numbers are [`rust-vm-tier-parity.md`](rust-vm-tier-parity.md).
@@ -360,12 +409,22 @@ comparable `Command` enum (`Alias(Rc<Vec<Value>>)` and a `CrossAlias`
 carrying an `InterpId`), and runs the same ``TclPreventAliasLoop`` gate
 on alias creation and rename (§4.6), walking its alias graph across the
 whole interpreter tree by `InterpId` because its aliases really can span
-interpreters.  It still goes further on one point C Tcl also covers and
-this runtime does not: it refuses a rename onto an existing name
-(``can't rename to "X": command already exists``), where this runtime's
-`rename` overwrites the destination instead — so
-``proc b …; interp alias {} a {} b; rename a b`` is refused here by the
-alias-loop gate rather than by the destination check, with the same
-surviving table state but a different message.  The VM also re-homes a
-renamed proc — the `ProcDef`'s namespace and name follow the move, so
-``namespace current`` inside the body reports the destination.
+interpreters.  On the two points this document used to record as
+VM-only, the engines now agree: both refuse a rename onto an occupied
+destination (``can't rename to "X": command already exists``) and both
+re-home a renamed proc, so ``namespace current`` inside the body reports
+the destination.
+
+The divergences that remain are the VM's, and belong to `rust/tcl-vm`
+rather than here:
+
+- its ``interp`` option list advertises ``cancel`` and ``target`` with
+  no arm behind either, and accepts ``share`` / ``transfer`` as silent
+  no-ops (this runtime implements ``target`` and advertises neither of
+  the other three — §1);
+- its ``$child`` option list advertises ``transfer``, which C's child
+  command object does not, and omits ``debug``, which it does;
+- its ``interp invokehidden`` has no ``-global`` at all and skips
+  ``-namespace ns`` and any unknown flag silently, instead of switching
+  evaluation context and refusing
+  ([`command-introspection.md`](command-introspection.md) §2.5).

--- a/docs/kcs/kcs-howto-run-tcltest-bundles.md
+++ b/docs/kcs/kcs-howto-run-tcltest-bundles.md
@@ -46,6 +46,11 @@ a hang); `TCL_BACKEND_CONSTRAINTS=<overlay.tcl>` sources a skip overlay before
 the file so tests the backend cannot support are skipped. The tree-walk runtime
 analogue is `runtime/rust`'s `run_script --init`.
 
+The whole sweep sets `TCL_BACKEND_CONSTRAINTS=tests/external/backend_constraints.tcl`
+for you (and refuses to start without that file). A manual `run_test` or
+`run_script --init` does **not** — set it yourself, or the run reports
+capability gaps as failures rather than skips.
+
 Run the same file through the C oracle to compare:
 
 ```

--- a/runtime/rust/src/cmd_alias.rs
+++ b/runtime/rust/src/cmd_alias.rs
@@ -34,7 +34,7 @@
 //! See `list.rs` for the module-level `not_unsafe_ptr_arg_deref` rationale.
 #![allow(clippy::not_unsafe_ptr_arg_deref)]
 
-use crate::interp::{obj_bytes, Code, CommandVisibilityOp, Interp};
+use crate::interp::{drop_fresh, obj_bytes, Code, CommandVisibilityOp, Interp};
 use crate::list;
 use crate::namespace::RenameOutcome;
 use crate::obj::{self, TclObj};
@@ -75,7 +75,8 @@ fn rename(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             let mut m = verb.to_vec();
             m.extend_from_slice(&old);
             m.extend_from_slice(b"\": command doesn't exist");
-            interp.set_error(&m)
+            let code = crate::interp::error_code_list(&[b"TCL", b"LOOKUP", b"COMMAND", &old]);
+            interp.error_with_code(&m, &code)
         }
         // C names the refused alias by the simple command name it would have
         // been bound under (`Tcl_GetCommandName`), not by the written path.
@@ -178,6 +179,9 @@ fn interp_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         b"hidden" => {
             // `interp hidden ?path?` — hidden command names in the interp
             // addressed by the (possibly nested) path.
+            if argv.len() > 3 {
+                return interp.wrong_args(b"interp hidden ?path?");
+            }
             let path = argv.get(2).map(|&a| interp_path(a)).unwrap_or_default();
             let names = interp
                 .with_child_path(&path, |c| c.hidden_names())
@@ -192,6 +196,9 @@ fn interp_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         b"issafe" => {
             // `interp issafe ?path?` — the current interp (no path) or a child
             // addressed by a (possibly nested) path.
+            if argv.len() > 3 {
+                return interp.wrong_args(b"interp issafe ?path?");
+            }
             let path = argv.get(2).map(|&a| interp_path(a)).unwrap_or_default();
             let safe = interp
                 .with_child_path(&path, |c| c.is_safe())
@@ -369,9 +376,9 @@ fn not_found_path(interp: &mut Interp, path: &[Vec<u8>]) -> Code {
     let joined = crate::list::new_list_obj(&elems);
     let rendered = obj_bytes(joined);
     for e in elems {
-        crate::interp::drop_fresh(e);
+        drop_fresh(e);
     }
-    crate::interp::drop_fresh(joined);
+    drop_fresh(joined);
     let mut m = b"could not find interpreter \"".to_vec();
     m.extend_from_slice(&rendered);
     m.push(b'"');
@@ -449,15 +456,62 @@ fn interp_debug(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     }
 }
 
-/// Whether `name` resolves in the global namespace — it carries no namespace
-/// qualifiers beyond an optional leading `::`.
-fn is_global_command(name: &[u8]) -> bool {
-    let body = name.strip_prefix(b"::".as_slice()).unwrap_or(name);
-    !body.windows(2).any(|w| w == b"::")
+/// The shared owner of `interp hide|expose path cmdName ?other?` and the
+/// `$child hide|expose cmdName ?other?` shorthand — C's `ChildHide` /
+/// `ChildExpose`, which `NRInterpCmd` and `NRChildCmd` both call rather than
+/// each re-deriving the argument rules.
+///
+/// `words` is `[cmdName ?hiddenCmdName?]`, already arity-checked by the caller
+/// (the two entry points word their `wrong # args` differently, and only they
+/// know the noun). `cmd` is the source — the visible command when hiding, the
+/// hidden token when exposing — and `token` the destination, defaulting to
+/// `cmd` in the one-word form.
+///
+/// Only the destination test lives here; the rest of C's order is inside
+/// [`Interp::hide_command`] / [`Interp::expose_command`], where the lookups
+/// happen. The two directions are **not** mirror images:
+///
+/// - hiding refuses a qualified *token* — `Tcl_HideCommand` runs
+///   `strstr(hiddenCmdToken, "::")` first (`tclBasic.c:2314`) — but accepts a
+///   qualified-looking source, because that lookup is global-anchored anyway;
+/// - exposing refuses a *destination* containing `::` anywhere, a leading one
+///   included, because C tests it with the same raw `strstr`
+///   (`Tcl_ExposeCommand`, `:2469`) — and has no token check at all, so a
+///   qualified token is simply a token that is not in the hidden table.
+pub(crate) fn hidectl_in(
+    interp: &mut Interp,
+    path: &[Vec<u8>],
+    op: CommandVisibilityOp,
+    words: &[*mut TclObj],
+) -> Code {
+    let cmd = obj_bytes(words[0]);
+    let token = words.get(1).map_or_else(|| cmd.clone(), |&w| obj_bytes(w));
+    if tcl_syntax::naming::is_qualified(&token) {
+        return match op {
+            CommandVisibilityOp::Hide => interp.error_with_code(
+                b"cannot use namespace qualifiers in hidden command token (rename)",
+                b"TCL VALUE HIDDENTOKEN",
+            ),
+            CommandVisibilityOp::Expose => interp.error_with_code(
+                b"cannot expose to a namespace (use expose to toplevel, then rename)",
+                b"TCL EXPOSE NON_GLOBAL",
+            ),
+        };
+    }
+    let moved = interp.with_child_path(path, |c| match op {
+        CommandVisibilityOp::Hide => c.hide_command(&cmd, &token),
+        CommandVisibilityOp::Expose => c.expose_command(&cmd, &token),
+    });
+    let Some(moved) = moved else {
+        return not_found_path(interp, path);
+    };
+    interp.finish_command_visibility(op, &cmd, &token, moved)
 }
 
 /// `interp hide|expose path cmdName` — move a command into/out of the hidden
-/// table of the named (or current, when path is `{}`) interpreter.
+/// table of the named (or current, when path is `{}`) interpreter. The
+/// argument rules are [`hidectl_in`]'s; this arm owns only the arity message
+/// and the executing-interp permission check.
 fn interp_hidectl(interp: &mut Interp, argv: &[*mut TclObj], op: CommandVisibilityOp) -> Code {
     // `interp hide   path cmdName     ?hiddenCmdName?`
     // `interp expose path hiddenName  ?cmdName?`
@@ -483,52 +537,7 @@ fn interp_hidectl(interp: &mut Interp, argv: &[*mut TclObj], op: CommandVisibili
             }
         });
     }
-    let path = interp_path(argv[2]);
-    let cmd = obj_bytes(argv[3]);
-    let token = if argv.len() == 5 {
-        obj_bytes(argv[4])
-    } else {
-        cmd.clone()
-    };
-    // The hidden-command token may never carry namespace qualifiers, and only
-    // global-namespace commands can be hidden / exposed-from.
-    match op {
-        CommandVisibilityOp::Hide => {
-            if token.windows(2).any(|w| w == b"::") {
-                return interp.set_error(
-                    b"cannot use namespace qualifiers in hidden command token (rename)",
-                );
-            }
-            if !is_global_command(&cmd) {
-                return interp
-                    .set_error(b"can only hide global namespace commands (use rename then hide)");
-            }
-        }
-        CommandVisibilityOp::Expose => {
-            if cmd.windows(2).any(|w| w == b"::") {
-                return interp.set_error(
-                    b"cannot use namespace qualifiers in hidden command token (rename)",
-                );
-            }
-            if !is_global_command(&token) {
-                return interp.set_error(
-                    b"cannot expose to a namespace (use expose to toplevel, then rename)",
-                );
-            }
-        }
-    }
-    // Tcl's `Tcl_HideCommand` reports a missing source as `unknown command`;
-    // retaining the old silent no-op swallowed typos in security-sensitive
-    // command-surface setup. Exposure remains a separate operation with its
-    // existing hidden-command error behaviour.
-    let moved = interp.with_child_path(&path, |c| match op {
-        CommandVisibilityOp::Hide => c.hide_command(&cmd, &token),
-        CommandVisibilityOp::Expose => c.expose_command(&cmd, &token),
-    });
-    let Some(moved) = moved else {
-        return not_found_path(interp, &path);
-    };
-    interp.finish_command_visibility(op, &cmd, &token, moved)
+    hidectl_in(interp, &interp_path(argv[2]), op, &argv[3..])
 }
 
 /// `interp invokehidden path ?-namespace ns? ?-global? ?--? cmdName ?arg
@@ -554,11 +563,32 @@ fn interp_invokehidden(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     if argv.len() < 4 {
         return interp.wrong_args(USAGE);
     }
-    let path = interp_path(argv[2]);
+    invokehidden_in(interp, &interp_path(argv[2]), &argv[3..], USAGE)
+}
+
+/// The shared owner of `interp invokehidden path …` and the `$child
+/// invokehidden …` shorthand — C's `ChildInvokeHidden`, reached from both
+/// `NRInterpCmd` and `NRChildCmd`.
+///
+/// `words` is everything after the path: the option words, the command word,
+/// and its arguments. `usage` is the caller's own `wrong # args` text, which is
+/// all that differs between the two entry points (`interp invokehidden path …`
+/// versus `<child> invokehidden …`).
+///
+/// The safe-interpreter check runs **after** option parsing, as C does: the
+/// options are read by the ensemble dispatcher and only then is
+/// `ChildInvokeHidden` entered, so `interp invokehidden {} -bogus …` from a
+/// safe interpreter reports the bad option rather than the permission denial.
+pub(crate) fn invokehidden_in(
+    interp: &mut Interp,
+    path: &[Vec<u8>],
+    words: &[*mut TclObj],
+    usage: &[u8],
+) -> Code {
     let mut ns_name: Option<Vec<u8>> = None;
-    let mut i = 3;
-    while i < argv.len() {
-        let opt = obj_bytes(argv[i]);
+    let mut i = 0;
+    while i < words.len() {
+        let opt = obj_bytes(words[i]);
         if opt.first() != Some(&b'-') {
             break;
         }
@@ -569,12 +599,12 @@ fn interp_invokehidden(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             }
             b"-namespace" => {
                 i += 1;
-                if i == argv.len() {
+                if i == words.len() {
                     // C: "there must be more arguments" — stop scanning
                     // options and fall through to the arg-count check below.
                     break;
                 }
-                ns_name = Some(obj_bytes(argv[i]));
+                ns_name = Some(obj_bytes(words[i]));
                 i += 1;
             }
             b"--" => {
@@ -589,22 +619,22 @@ fn interp_invokehidden(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             }
         }
     }
-    if i >= argv.len() {
-        return interp.wrong_args(USAGE);
+    if i >= words.len() {
+        return interp.wrong_args(usage);
     }
     if interp.is_safe() {
         return interp.set_error(b"not allowed to invoke hidden commands from safe interpreter");
     }
-    let cmd = obj_bytes(argv[i]);
+    let cmd = obj_bytes(words[i]);
     // Build the hidden command's argv (cmd + remaining args).
-    let mut hidden_argv: Vec<*mut TclObj> = Vec::with_capacity(argv.len() - i);
-    for &a in &argv[i..] {
+    let mut hidden_argv: Vec<*mut TclObj> = Vec::with_capacity(words.len() - i);
+    for &a in &words[i..] {
         unsafe { obj::incr_ref_count(a) };
         hidden_argv.push(a);
     }
     // Run in the addressed interp (the current one for an empty path), in the
     // requested namespace context if any, copying its result back up the path.
-    let code = match interp.with_child_path(&path, |c| {
+    let code = match interp.with_child_path(path, |c| {
         let saved_ns = c.current_ns();
         if let Some(name) = &ns_name {
             let target = c.ensure_global_namespace(name);
@@ -618,7 +648,7 @@ fn interp_invokehidden(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             interp.set_result_bytes(&res);
             code
         }
-        None => not_found_path(interp, &path),
+        None => not_found_path(interp, path),
     };
     for a in hidden_argv {
         unsafe { obj::decr_ref_count(a) };
@@ -788,16 +818,6 @@ fn set_alias_list(interp: &mut Interp, target: &[u8], prefix: &[Vec<u8>]) {
     interp.set_result(list::new_list_obj(&elems));
     for e in elems {
         drop_fresh(e);
-    }
-}
-
-/// Free a freshly created (`rc 0`) object once `new_list_obj` has taken its own
-/// reference.
-fn drop_fresh(obj: *mut TclObj) {
-    // SAFETY: `obj` is a live rc-0 object; retain-then-release frees it cleanly.
-    unsafe {
-        obj::incr_ref_count(obj);
-        obj::decr_ref_count(obj);
     }
 }
 
@@ -992,11 +1012,21 @@ mod tests {
             );
             assert_eq!(i.eval_str(b"interp hidden {}"), Code::Ok);
             assert_eq!(i.result_bytes(), b"visible");
+            // Hiding again once the source has moved into the hidden table is a
+            // *lookup* miss, not a token collision: `Tcl_HideCommand` resolves
+            // the source before it consults the hidden table, and the source is
+            // no longer there to resolve (tclsh 8.6.16 / 9.0.4-pinned). Reaching
+            // the collision needs a live source *and* a taken token, so the
+            // command has to be re-created first.
+            assert_eq!(i.eval_str(b"interp hide {} visible"), Code::Error);
+            assert_eq!(i.result_bytes(), b"unknown command \"visible\"");
+            assert_eq!(i.eval_str(b"proc visible {} {return shadow}"), Code::Ok);
             assert_eq!(i.eval_str(b"interp hide {} visible"), Code::Error);
             assert_eq!(
                 i.result_bytes(),
                 b"hidden command named \"visible\" already exists"
             );
+            assert_eq!(i.eval_str(b"rename visible {}"), Code::Ok);
             assert_eq!(i.eval_str(b"interp invokehidden {} visible"), Code::Ok);
             assert_eq!(i.result_bytes(), b"visible");
             assert_eq!(i.eval_str(b"interp expose {} visible"), Code::Ok);
@@ -1048,6 +1078,47 @@ mod tests {
             );
             assert_eq!(i.eval_str(b"interp hide {} lassign"), Code::Error);
             assert_eq!(i.result_bytes(), b"unknown command \"lassign\"");
+        });
+    }
+
+    /// The `$child` shorthand now routes through `hidectl_in` /
+    /// `invokehidden_in`, and the latter moved the manual
+    /// `incr_ref_count`/`decr_ref_count` bracketing around the hidden argv out
+    /// of two call sites into one. The counter harness is the guard on that
+    /// move: a dropped `+1` or a missing `-1` shows up here and nowhere else.
+    #[test]
+    fn child_shorthand_visibility_ops_are_leak_free() {
+        leak_free(|i| {
+            assert_eq!(i.eval_str(b"set c [interp create]"), Code::Ok);
+            assert_eq!(i.eval_str(b"$c eval {proc lst {} {return L}}"), Code::Ok);
+            assert_eq!(i.eval_str(b"$c hide lst mylst"), Code::Ok);
+            assert_eq!(i.eval_str(b"$c hidden"), Code::Ok);
+            assert_eq!(i.result_bytes(), b"mylst");
+            assert_eq!(i.eval_str(b"$c invokehidden mylst"), Code::Ok);
+            assert_eq!(i.result_bytes(), b"L");
+            assert_eq!(i.eval_str(b"$c expose mylst lst2"), Code::Ok);
+            assert_eq!(i.eval_str(b"$c hide set"), Code::Ok);
+            assert_eq!(i.eval_str(b"$c invokehidden -global set g 1"), Code::Ok);
+            assert_eq!(i.result_bytes(), b"1");
+            assert_eq!(
+                i.eval_str(b"$c invokehidden -namespace foo set q 2"),
+                Code::Ok
+            );
+            assert_eq!(i.result_bytes(), b"2");
+            assert_eq!(
+                i.eval_str(b"catch {$c invokehidden -bogus set x 1} m; set m"),
+                Code::Ok
+            );
+            assert_eq!(
+                i.result_bytes(),
+                b"bad option \"-bogus\": must be -global, -namespace, or --"
+            );
+            assert_eq!(i.eval_str(b"catch {$c hide ::foo::bar} m; set m"), Code::Ok);
+            assert_eq!(
+                i.result_bytes(),
+                b"cannot use namespace qualifiers in hidden command token (rename)"
+            );
+            assert_eq!(i.eval_str(b"interp delete $c"), Code::Ok);
         });
     }
 

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -6802,8 +6802,11 @@ impl Interp {
         }
     }
 
-    /// `interp hide name`: move command `name` out of the command table into the
-    /// hidden table. Returns whether it existed.
+    /// `interp hide name`: move command `name` out of the command table into
+    /// the hidden table under `hidden_name`. `Missing` when `name` does not
+    /// resolve, `Collision` when `hidden_name` is already hidden, `Moved` on
+    /// success — never a bare success flag, because the caller has to word
+    /// three different diagnostics.
     pub(crate) fn hide_command(
         &mut self,
         name: &[u8],

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -6502,12 +6502,26 @@ impl Interp {
     }
 
     /// The `wrong # args: should be "<child><tail>"` message for the `$child
-    /// <sub>` shorthand. C's `NRChildCmd` names the child command itself in
-    /// every one of its arity errors, never the `interp` ensemble, so the noun
-    /// has to come from `name` rather than a literal.
-    fn child_wrong_args(&mut self, name: &[u8], tail: &[u8]) -> Code {
+    /// <sub>` shorthand. C's `NRChildCmd` builds every one of its arity errors
+    /// with `Tcl_WrongNumArgs(interp, 1, objv, …)`, so the noun is **`objv[0]`
+    /// — the word this call was written with**, never the `interp` ensemble and
+    /// never the child's table key.
+    ///
+    /// The two spellings diverge whenever the command is not reached under the
+    /// name it was created with: after `interp create kid; rename kid foo`,
+    /// `foo hidden extra` reports `"foo hidden"`, and the qualified `::foo
+    /// hidden extra` reports `"::foo hidden"` (tclsh 8.6.16 / 9.0.4-pinned).
+    /// Only the child *lookup* keeps using the table key.
+    ///
+    /// One spelling this does not yet recover: reached through an `interp
+    /// alias`, C reports the *alias*' name, because `AliasObjCmd` installs an
+    /// ensemble rewrite (`TclInitRewriteEnsemble`, tclInterp.c) that
+    /// `Tcl_WrongNumArgs` reads back. This runtime's alias trampoline records no
+    /// such rewrite, so `bar hidden extra` reports the target's name rather than
+    /// `bar` — a separate gap in alias dispatch, not in this seam.
+    fn child_wrong_args(&mut self, argv: &[*mut TclObj], tail: &[u8]) -> Code {
         let mut message = b"wrong # args: should be \"".to_vec();
-        message.extend_from_slice(name);
+        message.extend_from_slice(&invoked_word(argv));
         message.extend_from_slice(tail);
         message.push(b'"');
         self.error(&message)
@@ -6524,19 +6538,19 @@ impl Interp {
     /// differ between the two entry points.
     fn dispatch_child(&mut self, name: &[u8], argv: &[*mut TclObj]) -> Code {
         if argv.len() < 2 {
-            return self.child_wrong_args(name, b" cmd ?arg ...?");
+            return self.child_wrong_args(argv, b" cmd ?arg ...?");
         }
         match obj_bytes(argv[1]).as_slice() {
             b"eval" => {
                 if argv.len() < 3 {
-                    return self.child_wrong_args(name, b" eval arg ?arg ...?");
+                    return self.child_wrong_args(argv, b" eval arg ?arg ...?");
                 }
                 let script = join_words(&argv[2..]);
                 self.eval_in_child(name, &script)
             }
             b"issafe" => {
                 if argv.len() != 2 {
-                    return self.child_wrong_args(name, b" issafe");
+                    return self.child_wrong_args(argv, b" issafe");
                 }
                 let safe = self.with_child(name, |c| c.is_safe()).unwrap_or(false);
                 self.set_result_bytes(if safe { b"1" } else { b"0" });
@@ -6561,7 +6575,7 @@ impl Interp {
                 };
                 if argv.len() != 3 && argv.len() != 4 {
                     return self.child_wrong_args(
-                        name,
+                        argv,
                         if hide {
                             b" hide cmdName ?hiddenCmdName?"
                         } else {
@@ -6581,7 +6595,7 @@ impl Interp {
                 crate::cmd_alias::hidectl_in(self, &[name.to_vec()], op, &argv[2..])
             }
             b"invokehidden" => {
-                let mut usage = name.to_vec();
+                let mut usage = invoked_word(argv);
                 usage.extend_from_slice(
                     b" invokehidden ?-namespace ns? ?-global? ?--? cmd ?arg ..?",
                 );
@@ -6589,7 +6603,7 @@ impl Interp {
             }
             b"hidden" => {
                 if argv.len() != 2 {
-                    return self.child_wrong_args(name, b" hidden");
+                    return self.child_wrong_args(argv, b" hidden");
                 }
                 let names = self
                     .with_child(name, |c| c.hidden_names())
@@ -6601,7 +6615,7 @@ impl Interp {
             }
             b"aliases" => {
                 if argv.len() != 2 {
-                    return self.child_wrong_args(name, b" aliases");
+                    return self.child_wrong_args(argv, b" aliases");
                 }
                 let names = self
                     .with_child(name, |c| c.alias_names())
@@ -6625,7 +6639,7 @@ impl Interp {
             // `$child recursionlimit ?newlimit?` — the path-less child form.
             b"recursionlimit" => {
                 if argv.len() > 3 {
-                    return self.child_wrong_args(name, b" recursionlimit ?newlimit?");
+                    return self.child_wrong_args(argv, b" recursionlimit ?newlimit?");
                 }
                 let newlimit = argv.get(2).map(|&a| obj_bytes(a));
                 match self.with_child(name, |c| c.recursion_limit_apply(newlimit.as_deref())) {
@@ -6641,7 +6655,7 @@ impl Interp {
             // handler.
             b"bgerror" => {
                 if argv.len() > 3 {
-                    return self.child_wrong_args(name, b" bgerror ?cmdPrefix?");
+                    return self.child_wrong_args(argv, b" bgerror ?cmdPrefix?");
                 }
                 let prefix = argv.get(2).copied();
                 match self.with_child(name, |c| c.bgerror_apply(prefix)) {
@@ -6666,7 +6680,7 @@ impl Interp {
             // `$child debug ?-frame ?bool??` — the per-interp frame-debug switch.
             b"debug" => {
                 if argv.len() > 4 {
-                    return self.child_wrong_args(name, b" debug ?-frame ?bool??");
+                    return self.child_wrong_args(argv, b" debug ?-frame ?bool??");
                 }
                 let opts: Vec<*mut TclObj> = argv[2..].to_vec();
                 match self.with_child(name, |c| c.debug_apply(&opts)) {
@@ -6682,7 +6696,7 @@ impl Interp {
             // child's commands/time limit.
             b"limit" => {
                 if argv.len() < 3 {
-                    return self.child_wrong_args(name, b" limit limitType ?-option value ...?");
+                    return self.child_wrong_args(argv, b" limit limitType ?-option value ...?");
                 }
                 let ltype = obj_bytes(argv[2]);
                 let opts: Vec<*mut TclObj> = argv[3..].to_vec();
@@ -8642,6 +8656,16 @@ fn proc_usage(called: &[u8], params: &[Param], quote_name: bool) -> Vec<u8> {
     }
     m.push(b'"');
     m
+}
+
+/// The word a call was written with — `argv[0]`, C's `objv[0]`.
+///
+/// This is what `Tcl_WrongNumArgs` prints, and it is deliberately *not* the
+/// name a command is filed under: the two differ after a `rename`, under a
+/// qualified spelling, and through an alias. Empty for an argv with no words,
+/// which no dispatch path produces.
+fn invoked_word(argv: &[*mut TclObj]) -> Vec<u8> {
+    argv.first().map_or_else(Vec::new, |&word| obj_bytes(word))
 }
 
 /// Discard a freshly created (`rc 0`) object that is not going to be stored

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -504,10 +504,18 @@ impl CoroContext {
 #[derive(Default)]
 pub struct ImportToken;
 
+/// Why a hidden-table move did or did not happen. The variants are in C's
+/// own check order, which is observable when more than one applies —
+/// `finish_command_visibility` is the only thing that words them.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum CommandVisibilityOutcome {
     Moved,
+    /// The source did not resolve (hide) or is not in the hidden table
+    /// (expose).
     Missing,
+    /// The source resolved outside the global namespace (hide only).
+    NonGlobal,
+    /// The destination is already taken.
     Collision,
 }
 
@@ -6493,18 +6501,43 @@ impl Interp {
             .resolve_fqn(self.current_ns.get(), name)
     }
 
+    /// The `wrong # args: should be "<child><tail>"` message for the `$child
+    /// <sub>` shorthand. C's `NRChildCmd` names the child command itself in
+    /// every one of its arity errors, never the `interp` ensemble, so the noun
+    /// has to come from `name` rather than a literal.
+    fn child_wrong_args(&mut self, name: &[u8], tail: &[u8]) -> Code {
+        let mut message = b"wrong # args: should be \"".to_vec();
+        message.extend_from_slice(name);
+        message.extend_from_slice(tail);
+        message.push(b'"');
+        self.error(&message)
+    }
+
     /// Dispatch a child-interpreter command (`$child subcommand ?arg ...?`): the
     /// child is addressable like the `interp` ensemble restricted to it.
+    ///
+    /// The `hide` / `expose` / `invokehidden` arms hand off to
+    /// [`crate::cmd_alias::hidectl_in`] / [`crate::cmd_alias::invokehidden_in`],
+    /// the same owners `interp hide|expose|invokehidden path …` calls — C's
+    /// `NRChildCmd` and `NRInterpCmd` share `ChildHide` / `ChildExpose` /
+    /// `ChildInvokeHidden` the same way. Only the arity check and its noun
+    /// differ between the two entry points.
     fn dispatch_child(&mut self, name: &[u8], argv: &[*mut TclObj]) -> Code {
         if argv.len() < 2 {
-            return self.error(b"wrong # args: should be \"interp cmd ?arg ...?\"");
+            return self.child_wrong_args(name, b" cmd ?arg ...?");
         }
         match obj_bytes(argv[1]).as_slice() {
             b"eval" => {
+                if argv.len() < 3 {
+                    return self.child_wrong_args(name, b" eval arg ?arg ...?");
+                }
                 let script = join_words(&argv[2..]);
                 self.eval_in_child(name, &script)
             }
             b"issafe" => {
+                if argv.len() != 2 {
+                    return self.child_wrong_args(name, b" issafe");
+                }
                 let safe = self.with_child(name, |c| c.is_safe()).unwrap_or(false);
                 self.set_result_bytes(if safe { b"1" } else { b"0" });
                 Code::Ok
@@ -6514,13 +6547,28 @@ impl Interp {
                 self.set_result_bytes(b"");
                 Code::Ok
             }
-            b"hide" | b"expose" if argv.len() == 3 => {
+            // Both forms are `$child hide|expose name ?other?`. The one-word
+            // form spells source and destination the same, which is what makes
+            // C's asymmetric checks visible here: `kid hide ::foo::bar` is a
+            // qualified *token* and `kid expose ::foo::bar` a qualified
+            // *destination*, so the two report different errors.
+            b"hide" | b"expose" => {
                 let hide = obj_bytes(argv[1]) == b"hide";
                 let op = if hide {
                     CommandVisibilityOp::Hide
                 } else {
                     CommandVisibilityOp::Expose
                 };
+                if argv.len() != 3 && argv.len() != 4 {
+                    return self.child_wrong_args(
+                        name,
+                        if hide {
+                            b" hide cmdName ?hiddenCmdName?"
+                        } else {
+                            b" expose hiddenCmdName ?cmdName?"
+                        },
+                    );
+                }
                 // A safe interpreter may not touch any hidden-command table
                 // (checked on the executing interp).
                 if self.is_safe() {
@@ -6530,40 +6578,19 @@ impl Interp {
                         b"permission denied: safe interpreter cannot expose commands"
                     });
                 }
-                let cmd = obj_bytes(argv[2]);
-                let outcome = self
-                    .with_child(name, |c| match op {
-                        CommandVisibilityOp::Hide => c.hide_command(&cmd, &cmd),
-                        CommandVisibilityOp::Expose => c.expose_command(&cmd, &cmd),
-                    })
-                    .unwrap_or(CommandVisibilityOutcome::Missing);
-                self.finish_command_visibility(op, &cmd, &cmd, outcome)
+                crate::cmd_alias::hidectl_in(self, &[name.to_vec()], op, &argv[2..])
             }
-            b"invokehidden" if argv.len() >= 3 => {
-                if self.is_safe() {
-                    return self
-                        .error(b"not allowed to invoke hidden commands from safe interpreter");
-                }
-                let cmd = obj_bytes(argv[2]);
-                let hidden_argv: Vec<*mut TclObj> = argv[2..].to_vec();
-                for &a in &hidden_argv {
-                    unsafe { obj::incr_ref_count(a) };
-                }
-                let out = self.with_child(name, |c| {
-                    (c.invoke_hidden(&cmd, &hidden_argv), c.result_bytes())
-                });
-                for &a in &hidden_argv {
-                    unsafe { obj::decr_ref_count(a) };
-                }
-                match out {
-                    Some((code, res)) => {
-                        self.set_result_bytes(&res);
-                        code
-                    }
-                    None => self.error(b"could not find interpreter"),
-                }
+            b"invokehidden" => {
+                let mut usage = name.to_vec();
+                usage.extend_from_slice(
+                    b" invokehidden ?-namespace ns? ?-global? ?--? cmd ?arg ..?",
+                );
+                crate::cmd_alias::invokehidden_in(self, &[name.to_vec()], &argv[2..], &usage)
             }
             b"hidden" => {
+                if argv.len() != 2 {
+                    return self.child_wrong_args(name, b" hidden");
+                }
                 let names = self
                     .with_child(name, |c| c.hidden_names())
                     .unwrap_or_default();
@@ -6573,6 +6600,9 @@ impl Interp {
                 Code::Ok
             }
             b"aliases" => {
+                if argv.len() != 2 {
+                    return self.child_wrong_args(name, b" aliases");
+                }
                 let names = self
                     .with_child(name, |c| c.alias_names())
                     .unwrap_or_default();
@@ -6595,10 +6625,7 @@ impl Interp {
             // `$child recursionlimit ?newlimit?` — the path-less child form.
             b"recursionlimit" => {
                 if argv.len() > 3 {
-                    let mut m = b"wrong # args: should be \"".to_vec();
-                    m.extend_from_slice(name);
-                    m.extend_from_slice(b" recursionlimit ?newlimit?\"");
-                    return self.error(&m);
+                    return self.child_wrong_args(name, b" recursionlimit ?newlimit?");
                 }
                 let newlimit = argv.get(2).map(|&a| obj_bytes(a));
                 match self.with_child(name, |c| c.recursion_limit_apply(newlimit.as_deref())) {
@@ -6613,11 +6640,8 @@ impl Interp {
             // `$child bgerror ?cmdPrefix?` — get/set the child's background-error
             // handler.
             b"bgerror" => {
-                if argv.len() < 2 || argv.len() > 3 {
-                    let mut m = b"wrong # args: should be \"".to_vec();
-                    m.extend_from_slice(name);
-                    m.extend_from_slice(b" bgerror ?cmdPrefix?\"");
-                    return self.error(&m);
+                if argv.len() > 3 {
+                    return self.child_wrong_args(name, b" bgerror ?cmdPrefix?");
                 }
                 let prefix = argv.get(2).copied();
                 match self.with_child(name, |c| c.bgerror_apply(prefix)) {
@@ -6641,11 +6665,10 @@ impl Interp {
             }
             // `$child debug ?-frame ?bool??` — the per-interp frame-debug switch.
             b"debug" => {
-                let opts: Vec<*mut TclObj> = argv[2..].to_vec();
                 if argv.len() > 4 {
-                    return self
-                        .error(b"wrong # args: should be \"interp debug path ?-frame ?bool??\"");
+                    return self.child_wrong_args(name, b" debug ?-frame ?bool??");
                 }
+                let opts: Vec<*mut TclObj> = argv[2..].to_vec();
                 match self.with_child(name, |c| c.debug_apply(&opts)) {
                     Some(Ok(o)) => {
                         self.set_result(o);
@@ -6659,10 +6682,7 @@ impl Interp {
             // child's commands/time limit.
             b"limit" => {
                 if argv.len() < 3 {
-                    let mut m = b"wrong # args: should be \"".to_vec();
-                    m.extend_from_slice(name);
-                    m.extend_from_slice(b" limit limitType ?-option value ...?\"");
-                    return self.error(&m);
+                    return self.child_wrong_args(name, b" limit limitType ?-option value ...?");
                 }
                 let ltype = obj_bytes(argv[2]);
                 let opts: Vec<*mut TclObj> = argv[3..].to_vec();
@@ -6804,23 +6824,37 @@ impl Interp {
 
     /// `interp hide name`: move command `name` out of the command table into
     /// the hidden table under `hidden_name`. `Missing` when `name` does not
-    /// resolve, `Collision` when `hidden_name` is already hidden, `Moved` on
-    /// success — never a bare success flag, because the caller has to word
-    /// three different diagnostics.
+    /// resolve, `NonGlobal` when it resolves outside the global namespace,
+    /// `Collision` when `hidden_name` is already hidden, `Moved` on success —
+    /// never a bare success flag, because the caller has to word four
+    /// different diagnostics, and C's order between them is observable.
     pub(crate) fn hide_command(
         &mut self,
         name: &[u8],
         hidden_name: &[u8],
     ) -> CommandVisibilityOutcome {
-        if self.hidden.borrow().contains_key(hidden_name) {
-            return CommandVisibilityOutcome::Collision;
-        }
         // Gated: a builtin the emulated release does not carry is not there to
         // be hidden, so `interp hide` cannot park it in the hidden table where
         // `interp invokehidden` would reach it past the surface check.
         let resolved = self.resolve_dispatchable(GLOBAL, name);
         match resolved {
             Some(cmd) => {
+                // C's order, and it is observable: `Tcl_HideCommand` resolves
+                // the source before it rejects a non-global one, and rejects a
+                // non-global one before it refuses an occupied token
+                // (tclBasic.c:2325, :2339, :2365). `interp hide kid nosuch
+                // taken` is therefore `unknown command "nosuch"`, not the
+                // collision.
+                //
+                // The global test goes through the shared namespace owner, so a
+                // run of colons collapses the way `TclGetNamespaceForQualName`
+                // collapses it: `::::foo` names the global `foo` (tclsh-pinned).
+                if !tcl_cmd_core::namespace::qualifiers(name).is_empty() {
+                    return CommandVisibilityOutcome::NonGlobal;
+                }
+                if self.hidden.borrow().contains_key(hidden_name) {
+                    return CommandVisibilityOutcome::Collision;
+                }
                 self.invalidate_interpreter_policy();
                 let old_fqn = self.namespaces.borrow().resolve_fqn(GLOBAL, name);
                 self.namespaces.borrow_mut().take(GLOBAL, name);
@@ -6851,6 +6885,13 @@ impl Interp {
         hidden_name: &[u8],
         name: &[u8],
     ) -> CommandVisibilityOutcome {
+        // C's order: `Tcl_ExposeCommand` looks the token up (tclBasic.c:2486)
+        // before it examines the destination (:2525), so `interp expose kid
+        // nosuchtok taken` is `unknown hidden command "nosuchtok"`, not the
+        // collision.
+        if !self.hidden.borrow().contains_key(hidden_name) {
+            return CommandVisibilityOutcome::Missing;
+        }
         if self.namespaces.borrow().resolve_fqn(GLOBAL, name).is_some() {
             return CommandVisibilityOutcome::Collision;
         }
@@ -6917,6 +6958,18 @@ impl Interp {
                     error_code_list(&[b"TCL", b"LOOKUP", b"HIDDENTOKEN", source]),
                 )
             }
+            (CommandVisibilityOp::Hide, CommandVisibilityOutcome::NonGlobal) => (
+                b"can only hide global namespace commands (use rename then hide)".to_vec(),
+                b"TCL HIDE NON_GLOBAL".to_vec(),
+            ),
+            // C keeps this branch behind its own "theoretically impossible"
+            // comment (tclBasic.c:2500): only `Tcl_HideCommand` fills the
+            // hidden table, and it already refused a non-global source, so
+            // `expose_command` never reports it either.
+            (CommandVisibilityOp::Expose, CommandVisibilityOutcome::NonGlobal) => (
+                b"trying to expose a non-global command namespace command".to_vec(),
+                b"NONE".to_vec(),
+            ),
             (CommandVisibilityOp::Hide, CommandVisibilityOutcome::Collision) => {
                 let mut message = b"hidden command named \"".to_vec();
                 message.extend_from_slice(destination);

--- a/runtime/rust/tests/rename_interp_semantics.rs
+++ b/runtime/rust/tests/rename_interp_semantics.rs
@@ -684,3 +684,79 @@ fn rename_miss_carries_the_lookup_errorcode() {
             .as_slice()
     );
 }
+
+/// The `$child` arity errors name the word the *call* used, not the child's
+/// table key. C builds every one of them with `Tcl_WrongNumArgs(interp, 1,
+/// objv, …)`, so the noun is `objv[0]`; the runtime was passing the name
+/// stored in `Command::ChildInterp`, which stops matching as soon as the
+/// command is reached under any other spelling.
+///
+/// A test that only ever calls the child `kid` cannot tell the two apart —
+/// which is exactly how this survived the first pass — so this one renames the
+/// child first, and checks the qualified spelling too. Every arm that takes an
+/// arity check is covered, including `recursionlimit` / `bgerror` / `limit`,
+/// which carried the same defect before the shorthand work.
+///
+/// tclsh9.0.4 (and 8.6.16):
+///   interp create kid
+///   rename kid foo
+///   set out {}
+///   foreach script {{foo} {foo eval} {foo issafe extra} {foo hidden extra}
+///                   {foo aliases extra} {foo hide} {foo expose a b c}
+///                   {foo invokehidden} {foo recursionlimit a b} {foo bgerror a b}
+///                   {foo debug a b c} {foo limit} {::foo hidden extra}} {
+///       catch $script m; lappend out $m
+///   }
+///   lappend out [foo eval {set x renamed-child-still-works}]
+///   => {wrong # args: should be "foo cmd ?arg ...?"} … {wrong # args: should be
+///      "::foo hidden"} renamed-child-still-works
+#[test]
+fn child_arity_errors_name_the_word_the_call_used() {
+    let mut interp = Interp::new();
+    assert_eq!(
+        interp.eval_str(
+            b"interp create kid
+              rename kid foo
+              set out {}
+              foreach script {
+                  {foo}
+                  {foo eval}
+                  {foo issafe extra}
+                  {foo hidden extra}
+                  {foo aliases extra}
+                  {foo hide}
+                  {foo expose a b c}
+                  {foo invokehidden}
+                  {foo recursionlimit a b}
+                  {foo bgerror a b}
+                  {foo debug a b c}
+                  {foo limit}
+                  {::foo hidden extra}
+              } {
+                  catch $script m
+                  lappend out $m
+              }
+              lappend out [foo eval {set x renamed-child-still-works}]
+              set out"
+        ),
+        Code::Ok
+    );
+    assert_eq!(
+        interp.result_bytes(),
+        b"{wrong # args: should be \"foo cmd ?arg ...?\"} \
+          {wrong # args: should be \"foo eval arg ?arg ...?\"} \
+          {wrong # args: should be \"foo issafe\"} \
+          {wrong # args: should be \"foo hidden\"} \
+          {wrong # args: should be \"foo aliases\"} \
+          {wrong # args: should be \"foo hide cmdName ?hiddenCmdName?\"} \
+          {wrong # args: should be \"foo expose hiddenCmdName ?cmdName?\"} \
+          {wrong # args: should be \"foo invokehidden ?-namespace ns? ?-global? \
+          ?--? cmd ?arg ..?\"} \
+          {wrong # args: should be \"foo recursionlimit ?newlimit?\"} \
+          {wrong # args: should be \"foo bgerror ?cmdPrefix?\"} \
+          {wrong # args: should be \"foo debug ?-frame ?bool??\"} \
+          {wrong # args: should be \"foo limit limitType ?-option value ...?\"} \
+          {wrong # args: should be \"::foo hidden\"} renamed-child-still-works"
+            .as_slice()
+    );
+}

--- a/runtime/rust/tests/rename_interp_semantics.rs
+++ b/runtime/rust/tests/rename_interp_semantics.rs
@@ -318,3 +318,369 @@ fn a_delete_trace_recreating_an_identical_alias_keeps_the_new_binding() {
     assert_eq!(interp.eval_str(b"foo"), Code::Ok);
     assert_eq!(interp.result_bytes(), b"R".as_slice());
 }
+
+/// R1: `$child hide|expose` takes the same one- *or* two-word form the
+/// ensemble does. The arm used to guard on `argv.len() == 3`, so the two-word
+/// spelling fell through to the `bad option` fallthrough and reported
+/// `bad option "hide"` — an option the same message lists as valid.
+///
+/// tclsh9.0.4 (and 8.6.16):
+///   interp create kid
+///   kid eval {proc lst {} {}}
+///   kid hide lst mylst
+///   kid hidden                     ;# => mylst
+///   kid expose mylst lst2
+///   kid eval {info commands lst2}  ;# => lst2
+#[test]
+fn child_hide_and_expose_accept_the_two_word_form() {
+    let mut interp = Interp::new();
+    assert_eq!(interp.eval_str(b"interp create kid"), Code::Ok);
+    assert_eq!(interp.eval_str(b"kid eval {proc lst {} {}}"), Code::Ok);
+    assert_eq!(interp.eval_str(b"kid hide lst mylst"), Code::Ok);
+    assert_eq!(interp.eval_str(b"kid hidden"), Code::Ok);
+    assert_eq!(interp.result_bytes(), b"mylst".as_slice());
+    assert_eq!(interp.eval_str(b"kid expose mylst lst2"), Code::Ok);
+    assert_eq!(interp.eval_str(b"kid eval {info commands lst2}"), Code::Ok);
+    assert_eq!(interp.result_bytes(), b"lst2".as_slice());
+}
+
+/// R1, the arity errors: C's `NRChildCmd` names the *child command* in its
+/// `wrong # args` text, never the `interp` ensemble.
+///
+/// tclsh9.0.4 (and 8.6.16):
+///   interp create kid
+///   set out {}
+///   foreach script {{kid hide} {kid hide set tok extra}
+///                   {kid expose} {kid expose a b c}} {
+///       catch $script m o; lappend out $m [dict get $o -errorcode]
+///   }
+///   set out
+///   => {wrong # args: should be "kid hide cmdName ?hiddenCmdName?"} {TCL WRONGARGS} …
+#[test]
+fn child_hide_and_expose_arity_errors_name_the_child() {
+    let mut interp = Interp::new();
+    assert_eq!(
+        interp.eval_str(
+            b"interp create kid
+              set out {}
+              foreach script {
+                  {kid hide}
+                  {kid hide set tok extra}
+                  {kid expose}
+                  {kid expose a b c}
+              } {
+                  catch $script m o
+                  lappend out $m [dict get $o -errorcode]
+              }
+              set out"
+        ),
+        Code::Ok
+    );
+    assert_eq!(
+        interp.result_bytes(),
+        b"{wrong # args: should be \"kid hide cmdName ?hiddenCmdName?\"} \
+          {TCL WRONGARGS} \
+          {wrong # args: should be \"kid hide cmdName ?hiddenCmdName?\"} \
+          {TCL WRONGARGS} \
+          {wrong # args: should be \"kid expose hiddenCmdName ?cmdName?\"} \
+          {TCL WRONGARGS} \
+          {wrong # args: should be \"kid expose hiddenCmdName ?cmdName?\"} \
+          {TCL WRONGARGS}"
+            .as_slice()
+    );
+}
+
+/// R2: the shorthand goes through the same structural checks as the ensemble
+/// form. It used to call `hide_command(&cmd, &cmd)` directly, so
+/// `kid hide ::foo::bar` silently filed a namespaced command under the token
+/// `::foo::bar` — a token C has never allowed. The last element re-reads the
+/// command to prove the refusal left it in place.
+///
+/// The two directions are asymmetric because C's are: the one-word form spells
+/// source and destination alike, so the same word is a *token* when hiding and
+/// a *destination* when exposing, and the two report different errors.
+///
+/// tclsh9.0.4 (and 8.6.16):
+///   interp create kid
+///   kid eval {namespace eval foo {proc bar {} {}}; namespace eval ns {}}
+///   set out {}
+///   foreach script {{kid hide ::foo::bar} {kid hide ::set} {kid hide set ::tok}
+///                   {kid expose set ns::y} {kid expose ::set}} {
+///       catch $script m o; lappend out $m [dict get $o -errorcode]
+///   }
+///   lappend out [kid eval {info commands ::foo::bar}]
+#[test]
+fn child_hide_and_expose_enforce_the_structural_checks() {
+    let mut interp = Interp::new();
+    assert_eq!(
+        interp.eval_str(
+            b"interp create kid
+              kid eval {namespace eval foo {proc bar {} {}}; namespace eval ns {}}
+              set out {}
+              foreach script {
+                  {kid hide ::foo::bar}
+                  {kid hide ::set}
+                  {kid hide set ::tok}
+                  {kid expose set ns::y}
+                  {kid expose ::set}
+              } {
+                  catch $script m o
+                  lappend out $m [dict get $o -errorcode]
+              }
+              lappend out [kid eval {info commands ::foo::bar}]
+              set out"
+        ),
+        Code::Ok
+    );
+    assert_eq!(
+        interp.result_bytes(),
+        b"{cannot use namespace qualifiers in hidden command token (rename)} \
+          {TCL VALUE HIDDENTOKEN} \
+          {cannot use namespace qualifiers in hidden command token (rename)} \
+          {TCL VALUE HIDDENTOKEN} \
+          {cannot use namespace qualifiers in hidden command token (rename)} \
+          {TCL VALUE HIDDENTOKEN} \
+          {cannot expose to a namespace (use expose to toplevel, then rename)} \
+          {TCL EXPOSE NON_GLOBAL} \
+          {cannot expose to a namespace (use expose to toplevel, then rename)} \
+          {TCL EXPOSE NON_GLOBAL} ::foo::bar"
+            .as_slice()
+    );
+}
+
+/// R2b / R2c: `Tcl_ExposeCommand`'s check order is observable when more than
+/// one check applies. It tests the *destination* for `::` first, then looks the
+/// token up, then refuses an occupied destination — and it has **no**
+/// token-qualifier check at all, so a qualified token is simply a token that is
+/// not in the hidden table. Its destination test is a raw `strstr`, so a
+/// leading `::` fails it too.
+///
+/// tclsh9.0.4 (and 8.6.16):
+///   interp create kid; interp hide kid list tok
+///   set out {}
+///   foreach script {{interp expose kid ::tok plain} {interp expose kid tok ::plain}
+///                   {interp expose kid nosuchtok set}} {
+///       catch $script m o; lappend out $m [dict get $o -errorcode]
+///   }
+///   => {unknown hidden command "::tok"} {TCL LOOKUP HIDDENTOKEN ::tok} …
+#[test]
+fn expose_check_order_matches_c() {
+    let mut interp = Interp::new();
+    assert_eq!(
+        interp.eval_str(
+            b"interp create kid
+              interp hide kid list tok
+              set out {}
+              foreach script {
+                  {interp expose kid ::tok plain}
+                  {interp expose kid tok ::plain}
+                  {interp expose kid nosuchtok set}
+              } {
+                  catch $script m o
+                  lappend out $m [dict get $o -errorcode]
+              }
+              set out"
+        ),
+        Code::Ok
+    );
+    assert_eq!(
+        interp.result_bytes(),
+        b"{unknown hidden command \"::tok\"} {TCL LOOKUP HIDDENTOKEN ::tok} \
+          {cannot expose to a namespace (use expose to toplevel, then rename)} \
+          {TCL EXPOSE NON_GLOBAL} \
+          {unknown hidden command \"nosuchtok\"} \
+          {TCL LOOKUP HIDDENTOKEN nosuchtok}"
+            .as_slice()
+    );
+}
+
+/// R2d / R2e: `Tcl_HideCommand`'s order is the mirror question — token
+/// qualifiers, *then* resolve the source, *then* reject a non-global source,
+/// *then* refuse an occupied token. The runtime used to test non-global before
+/// existence and occupancy before both, so a missing source could be reported
+/// as either of the other two.
+///
+/// tclsh9.0.4 (and 8.6.16):
+///   interp create kid
+///   kid eval {namespace eval ns {proc x {} {}}}
+///   interp hide kid list existingtok
+///   set out {}
+///   foreach script {{interp hide kid ns::nosuch tok} {interp hide kid nosuch existingtok}
+///                   {interp hide kid ns::x tok} {interp hide kid set existingtok}} {
+///       catch $script m o; lappend out $m [dict get $o -errorcode]
+///   }
+///   => {unknown command "ns::nosuch"} {TCL LOOKUP COMMAND ns::nosuch} …
+#[test]
+fn hide_check_order_matches_c() {
+    let mut interp = Interp::new();
+    assert_eq!(
+        interp.eval_str(
+            b"interp create kid
+              kid eval {namespace eval ns {proc x {} {}}}
+              interp hide kid list existingtok
+              set out {}
+              foreach script {
+                  {interp hide kid ns::nosuch tok}
+                  {interp hide kid nosuch existingtok}
+                  {interp hide kid ns::x tok}
+                  {interp hide kid set existingtok}
+              } {
+                  catch $script m o
+                  lappend out $m [dict get $o -errorcode]
+              }
+              set out"
+        ),
+        Code::Ok
+    );
+    assert_eq!(
+        interp.result_bytes(),
+        b"{unknown command \"ns::nosuch\"} {TCL LOOKUP COMMAND ns::nosuch} \
+          {unknown command \"nosuch\"} {TCL LOOKUP COMMAND nosuch} \
+          {can only hide global namespace commands (use rename then hide)} \
+          {TCL HIDE NON_GLOBAL} \
+          {hidden command named \"existingtok\" already exists} \
+          {TCL HIDE ALREADY_HIDDEN}"
+            .as_slice()
+    );
+}
+
+/// R3: `$child invokehidden` parses its options. The arm used to take
+/// `argv[2]` as the command word unconditionally, so `-global` was looked up as
+/// a hidden command name. `-global` and `-namespace ns` both switch the child's
+/// evaluation context for the one call; passing both is legal and the **last**
+/// one wins (there is no mutual-exclusion error in C — see
+/// `invokehidden_rejects_unknown_options_and_namespace_is_global_anchored`).
+///
+/// tclsh9.0.4 (and 8.6.16):
+///   interp create kid; interp hide kid set
+///   set out {}
+///   lappend out [kid invokehidden -global set g 9] [kid eval {info exists ::g}]
+///   lappend out [kid invokehidden -namespace foo set q 1] [kid eval {info exists ::foo::q}]
+///   lappend out [kid invokehidden -global -namespace foo set r 2] \
+///               [kid eval {list [info exists ::r] [info exists ::foo::r]}]
+///   lappend out [kid invokehidden -- set w 4]
+///   foreach script {{kid invokehidden -bogus set x 1} {kid invokehidden}
+///                   {kid invokehidden -namespace}} { catch $script m; lappend out $m }
+///   => 9 1 1 1 2 {0 1} 4 {bad option "-bogus": must be -global, -namespace, or --} …
+#[test]
+fn child_invokehidden_honours_global_and_namespace_and_rejects_bad_options() {
+    let mut interp = Interp::new();
+    assert_eq!(
+        interp.eval_str(
+            b"interp create kid
+              interp hide kid set
+              set out {}
+              lappend out [kid invokehidden -global set g 9] [kid eval {info exists ::g}]
+              lappend out [kid invokehidden -namespace foo set q 1] \
+                          [kid eval {info exists ::foo::q}]
+              lappend out [kid invokehidden -global -namespace foo set r 2] \
+                          [kid eval {list [info exists ::r] [info exists ::foo::r]}]
+              lappend out [kid invokehidden -- set w 4]
+              foreach script {
+                  {kid invokehidden -bogus set x 1}
+                  {kid invokehidden}
+                  {kid invokehidden -namespace}
+              } {
+                  catch $script m
+                  lappend out $m
+              }
+              set out"
+        ),
+        Code::Ok
+    );
+    assert_eq!(
+        interp.result_bytes(),
+        b"9 1 1 1 2 {0 1} 4 \
+          {bad option \"-bogus\": must be -global, -namespace, or --} \
+          {wrong # args: should be \"kid invokehidden ?-namespace ns? ?-global? \
+          ?--? cmd ?arg ..?\"} \
+          {wrong # args: should be \"kid invokehidden ?-namespace ns? ?-global? \
+          ?--? cmd ?arg ..?\"}"
+            .as_slice()
+    );
+}
+
+/// R4: every arity message names the right noun, and the lenient arms count
+/// their words. `kid` alone said `"interp cmd ?arg ...?"`; `kid eval` with no
+/// script evaluated the empty string; `kid hidden extra` and its peers accepted
+/// the surplus word silently.
+///
+/// tclsh9.0.4 (and 8.6.16):
+///   interp create kid
+///   set out {}
+///   foreach script {{kid} {kid eval} {kid hidden extra} {kid aliases extra}
+///                   {kid issafe extra} {interp hidden kid extra}
+///                   {interp issafe kid extra}} {
+///       catch $script m o; lappend out $m [dict get $o -errorcode]
+///   }
+///   => {wrong # args: should be "kid cmd ?arg ...?"} {TCL WRONGARGS} …
+#[test]
+fn child_and_interp_arity_errors_use_the_right_noun() {
+    let mut interp = Interp::new();
+    assert_eq!(
+        interp.eval_str(
+            b"interp create kid
+              set out {}
+              foreach script {
+                  {kid}
+                  {kid eval}
+                  {kid hidden extra}
+                  {kid aliases extra}
+                  {kid issafe extra}
+                  {interp hidden kid extra}
+                  {interp issafe kid extra}
+              } {
+                  catch $script m o
+                  lappend out $m [dict get $o -errorcode]
+              }
+              set out"
+        ),
+        Code::Ok
+    );
+    assert_eq!(
+        interp.result_bytes(),
+        b"{wrong # args: should be \"kid cmd ?arg ...?\"} {TCL WRONGARGS} \
+          {wrong # args: should be \"kid eval arg ?arg ...?\"} {TCL WRONGARGS} \
+          {wrong # args: should be \"kid hidden\"} {TCL WRONGARGS} \
+          {wrong # args: should be \"kid aliases\"} {TCL WRONGARGS} \
+          {wrong # args: should be \"kid issafe\"} {TCL WRONGARGS} \
+          {wrong # args: should be \"interp hidden ?path?\"} {TCL WRONGARGS} \
+          {wrong # args: should be \"interp issafe ?path?\"} {TCL WRONGARGS}"
+            .as_slice()
+    );
+}
+
+/// R6: a `rename` miss carries C's structured error code. The message was
+/// already right (item 4); only the `-errorcode` was `NONE`, because the miss
+/// went through `Interp::error` rather than `error_with_code`.
+///
+/// tclsh9.0.4 (and 8.6.16):
+///   set out {}
+///   foreach script {{rename nosuch {}} {rename nosuch x}} {
+///       catch $script m o; lappend out $m [dict get $o -errorcode]
+///   }
+///   => {can't delete "nosuch": command doesn't exist} {TCL LOOKUP COMMAND nosuch}
+///      {can't rename "nosuch": command doesn't exist} {TCL LOOKUP COMMAND nosuch}
+#[test]
+fn rename_miss_carries_the_lookup_errorcode() {
+    let mut interp = Interp::new();
+    assert_eq!(
+        interp.eval_str(
+            b"set out {}
+              foreach script {{rename nosuch {}} {rename nosuch x}} {
+                  catch $script m o
+                  lappend out $m [dict get $o -errorcode]
+              }
+              set out"
+        ),
+        Code::Ok
+    );
+    assert_eq!(
+        interp.result_bytes(),
+        b"{can't delete \"nosuch\": command doesn't exist} \
+          {TCL LOOKUP COMMAND nosuch} \
+          {can't rename \"nosuch\": command doesn't exist} \
+          {TCL LOOKUP COMMAND nosuch}"
+            .as_slice()
+    );
+}


### PR DESCRIPTION
## Summary

All seven code defects in #1412, the three contradicting doc comments, and the missing `tests/external/backend_constraints.tcl` overlay already landed on `rust` (#1795 lane `r6a-rename-interp`, and `d993e19`). The issue stayed open, and the docs still described the runtime as it *was*.

So this PR does three things: corrects the docs (that half carries `Closes #1412`), fixes six residuals the oracle exposed on the `$child` shorthand path — the same defect classes as the issue, on the path #1795 did not cover — and corrects a contract page whose statements are false.

### Why the shorthand diverged

`interp hide kid …` and `kid hide …` had separate implementations. C routes both through `ChildHide` / `ChildInvokeHidden`, so the fix extracts `hidectl_in` / `invokehidden_in` as `pub(crate)` owners in `cmd_alias.rs`, called from `interp_hidectl`/`interp_invokehidden` **and** `dispatch_child`.

Measured on tclsh 8.6.16 and 9.0.4 (identical throughout), before → after:

| # | case | before | after (matches C) |
|---|---|---|---|
| R1 | `kid hide lst mylst` | `bad option "hide"` | succeeds |
| R1 | `kid hide` | `bad option "hide"` | `wrong # args: should be "kid hide cmdName ?hiddenCmdName?"` |
| R2 | `kid hide ::foo::bar` | **silently hid it** | `cannot use namespace qualifiers in hidden command token (rename)` `[TCL VALUE HIDDENTOKEN]`, command intact |
| R2b | `interp expose kid ::tok plain` | `cannot use namespace qualifiers…` | `unknown hidden command "::tok"` `[TCL LOOKUP HIDDENTOKEN ::tok]` |
| R2c | `interp expose kid tok ::plain` | `unknown hidden command "tok"` | `cannot expose to a namespace…` `[TCL EXPOSE NON_GLOBAL]` |
| R2d | `interp hide kid ns::nosuch tok` | `can only hide global namespace commands…` | `unknown command "ns::nosuch"` |
| R2e | `interp hide kid nosuch existingtok` | `hidden command named "existingtok" already exists` | `unknown command "nosuch"` |
| R3 | `kid invokehidden -global set g 9` | `invalid hidden command name "-global"` | `9`, `::g` set |
| R4 | `kid` | `…"interp cmd ?arg ...?"` | `…"kid cmd ?arg ...?"` |
| R4 | `kid eval`, `kid hidden extra`, `kid aliases extra`, `kid issafe extra`, `interp hidden kid extra`, `interp issafe kid extra` | **silently accepted** | correct `wrong # args` |
| R6 | `rename nosuch x` | errorcode `NONE` | `TCL LOOKUP COMMAND nosuch` |

R2b–R2e are all one rule: C resolves before it checks for a collision. R2d/R2e needed Missing-before-Collision in `hide_command`, and — not in the plan — symmetrically in `expose_command` (`interp expose kid nosuchtok set` → `unknown hidden command "nosuchtok"`).

Also fixed on the way: `is_global_command`'s hand-rolled `::` strip mishandled colon runs, so `interp hide kid ::::list tok` was refused where tclsh accepts it. That check now goes through the shared owner `tcl_cmd_core::namespace::qualifiers`, matching the VM and the shared-owner invariant rather than re-deriving the rule.

### Two claims in the issue and the contract are false

**The issue's item 5** says C rejects `-global` with `-namespace` (`cannot use -global option and -namespace option together`). **No such error exists on either release.** `-global` is `-namespace ::` internally and the *last option wins*: `-global -namespace foo` → `::foo::r`, `-namespace foo -global` → `::s`. The docs now state the measured behaviour and retract the claim explicitly.

**`command-binding-and-aliasing.md`** claimed self-rename is a no-op and that built-ins are protected. Both false: `rename pp pp` → `can't rename to "pp": command already exists` `[TCL OPERATION RENAME TARGET_EXISTS]`, and `rename return myreturn` / `rename error myerror` both succeed. There is no protected list, and `command_binding.rs` encodes none, so nothing downstream depended on it. That correction is commit `85eeaf9`, kept separate so it can be dropped in review.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

```
cargo test --manifest-path runtime/rust/Cargo.toml
cargo test -p tcl-vm
make rust-check
```

All green, from a **cold rebuild** — the box hit ENOSPC mid-session, so the worktree's `target/` was deleted and everything re-run from scratch (an earlier `check-source-data` failure was the disk, not the change). `make rust-check` exit 0.

The **no-tommath** build was run too (`touch build.rs`, 500 lib tests): all 9 new tests pass there, and no new test script uses `if`/`while`/`for`/`incr`/`expr`, which are `#[cfg(have_tommath)]`. Both plan mutations caught their intended tests.

The full error sheet now diffs clean against tclsh 9.0.4 except three errorcodes deliberately left alone: the two `bad option` sites (`TCL LOOKUP INDEX option X`), which #1607 supplies, and `invalid hidden command name` (`TCL LOOKUP HIDDENTOKEN`), pre-existing and out of scope.

**One existing test was corrected — please review.** `rename_and_hide_error_shapes_and_lifecycle` hid `visible`, then hid it again expecting `hidden command named "visible" already exists`. Both oracles answer `unknown command "visible"` there: the source has already moved into the hidden table, so the resolve fails first. It only passed because the runtime checked the hidden table first — the very ordering bug R2d/R2e fix. The test now pins the oracle answer **and** re-creates the command to reach the genuine collision, so it covers strictly more than before.

## Compiler / diagnostics checklist

- [x] Did this change alter a compiler fact contract? Yes — `rename`/`hide`/`expose` error ordering and codes, and the `$child` dispatch surface.
- [x] If yes, I updated the owning design doc — 5 docs under `docs/design/runtime/` plus `command-binding-and-aliasing.md`.
- [x] If I added or changed a diagnostic or optimisation code, I updated its page under `docs/kcs/codes/` — one KCS note updated.
- [x] If I added a design doc, I linked it from `docs/design/README.md` — n/a, no new design doc.

Closes #1412

## Notes for the reviewer

- **#1607's surface is untouched**: the advertised option-list text is byte-identical to `192142d` in both files, no prefix or abbreviation matching was added, and `invokehidden_in`'s option loop moved verbatim.
- **Found, deliberately not fixed** (worth a follow-up): `kid delete` dispatches where C answers `bad option "delete"`; `kid marktrusted x` and `kid alias x` remain lenient; `invalid hidden command name` and the safe-interpreter denials carry `NONE` where C sets `TCL LOOKUP HIDDENTOKEN` / `TCL OPERATION INTERP UNSAFE`.
- The docs commit describes the branch's end state, so `cc6e35b` alone is briefly ahead of the code. Fine as one PR — but if the docs half is split out, the `$child` sentences in `child-interp.md` §5 and `command-introspection.md` §2.2/§2.3/§8.3 need `b6ad8a8` with them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XV29AoTSsaCBgsJuf2EvEK

---
_Generated by [Claude Code](https://claude.ai/code/session_01XV29AoTSsaCBgsJuf2EvEK)_