### PR TITLE
fix(traces): the bytecode VM's trace semantics follow C (#1633)

### DIFF
--- a/docs/design/contracts/variable-trace-dispatch-and-introspection.md
+++ b/docs/design/contracts/variable-trace-dispatch-and-introspection.md
@@ -82,6 +82,22 @@ Where C commits the operation around the trace, the runtime must too:
   *during* teardown and their errors are ignored (#4). The variable is gone
   regardless — a subsequent read must error `no such variable`.
 
+* **The result is the value read back *after* the write traces**, not the
+  value the store was handed: C's `TclPtrSetVarIdx` returns
+  `varPtr->value.objPtr` only while the variable is still a defined scalar and
+  the interp's empty object otherwise, so a callback that rewrites the variable
+  changes what `set`/`append`/`lappend`/`incr` evaluate to, and one that unsets
+  it — or turns it into an array — makes the result empty.
+* **`incr`, and the `lappend` paths that reach `TclPtrGetVarIdx`, fire `read`
+  before `write`**; `append` with values never does (its no-value form is a
+  plain read and does). The `lappend` split is C's, not the command's: the
+  dispatched `Tcl_LappendObjCmd` and the multi-value `INST_LAPPEND_LIST*`
+  opcodes fire `read`, while the single-value in-proc opcodes
+  `INST_LAPPEND_{SCALAR,ARRAY,STK,ARRAY_STK}` omit `TCL_TRACE_READS` and fire
+  `write` only. Such a read treats a trace error as "no current value" — the
+  command still succeeds (`incr` counts from 0, `lappend` discards the old
+  value) and the swallowed error stays visible in `errorInfo`.
+
 **Rule:** never gate the mutation on the trace's success.
 
 ## Re-entrancy and aliasing

--- a/docs/design/contracts/variable-trace-dispatch-and-introspection.md
+++ b/docs/design/contracts/variable-trace-dispatch-and-introspection.md
@@ -109,8 +109,19 @@ Where C commits the operation around the trace, the runtime must too:
   read-trace re-entry through `lappend` is the sharp edge: the canonical-list
   fast path and the trace re-entry must agree on when the value is
   materialised.
-* Removing a variable's traces happens *after* the unset callbacks have fired,
-  so a stale trace cannot re-fire on a later variable that reuses the name.
+* An unset is a three-step: the cell goes, the variable's own trace list comes
+  *out of the table*, and only then do the callbacks fire — from that taken
+  list, which is never put back. So a callback sees the variable already
+  absent, a value it stores survives the unset, and the revived variable
+  carries no traces (not even a write trace that would otherwise have fired on
+  that store). A whole-array trace is not the element's, so an element unset
+  leaves it in place.
+* **A trace a callback removes does not fire in the same pass**, whether it is
+  older and not yet reached or newer and already run; one a callback adds does
+  not fire until the next access. `trace info` reflects both at once. This
+  holds for variable, command and execution traces alike — each firing loop
+  re-reads the live registration rather than trusting a snapshot taken up
+  front.
 * **`trace remove` deletes the newest match.** It removes exactly one
   registration — the first hit walking the list the same way firing does, and
   that head is the newest. When several registrations are identical the choice
@@ -165,6 +176,9 @@ interpreter can't see by name can't be traced.
 | `incr`, and `lappend` on the paths reaching `TclPtrGetVarIdx`, fire `read` first | **Contract** | A trace error there is "no current value", not a failure; the swallowed error stays in `errorInfo`. |
 | `trace info command\|execution NAME` errors for an unknown command | **Contract** | `unknown command "NAME"`, name as written; `trace info variable` stays empty. |
 | Element recovery through a link, and `unset a(k)`'s `name1` | **Contract, release-split** | 9.0+ only — `TclVersion::traces_recover_linked_array_element`. |
+| An unset takes the traces out before firing; a revived variable is trace-less | **Contract** | `UnsetVarStruct` moves the list to a dummy `Var`; whole-array traces stay. |
+| A trace removed mid-firing does not fire; one added waits for the next access | **Contract** | Variable, command and execution traces; `trace info` sees both at once. |
+| A delete trace that re-creates the command leaves the new one standing | **Contract** | C removes the entry only through the dying token's own `hPtr`. |
 | Trace storage layout, callback dispatch internals, refcounts | **Incompatible-by-design** | Object-rep probes never match. |
 
 ## See also

--- a/docs/design/contracts/variable-trace-dispatch-and-introspection.md
+++ b/docs/design/contracts/variable-trace-dispatch-and-introspection.md
@@ -161,6 +161,10 @@ interpreter can't see by name can't be traced.
 | Fire-through-`upvar`/`global` links; re-entrancy terminates | **Contract** | Acts on the target cell. |
 | `info exists/vars/locals`, `trace info` reflect live state | **Contract** | Never compile-time-folded. |
 | `(read trace on "x")` errorInfo frame text | **Contract** | Matches C wording. |
+| A store's result is the value read back after its write traces | **Contract** | `set`/`append`/`lappend`/`incr`/`lset`/`ledit`; empty once the variable is no longer a defined scalar. |
+| `incr`, and `lappend` on the paths reaching `TclPtrGetVarIdx`, fire `read` first | **Contract** | A trace error there is "no current value", not a failure; the swallowed error stays in `errorInfo`. |
+| `trace info command\|execution NAME` errors for an unknown command | **Contract** | `unknown command "NAME"`, name as written; `trace info variable` stays empty. |
+| Element recovery through a link, and `unset a(k)`'s `name1` | **Contract, release-split** | 9.0+ only — `TclVersion::traces_recover_linked_array_element`. |
 | Trace storage layout, callback dispatch internals, refcounts | **Incompatible-by-design** | Object-rep probes never match. |
 
 ## See also

--- a/docs/design/contracts/variable-trace-dispatch-and-introspection.md
+++ b/docs/design/contracts/variable-trace-dispatch-and-introspection.md
@@ -172,12 +172,13 @@ interpreter can't see by name can't be traced.
 | Fire-through-`upvar`/`global` links; re-entrancy terminates | **Contract** | Acts on the target cell. |
 | `info exists/vars/locals`, `trace info` reflect live state | **Contract** | Never compile-time-folded. |
 | `(read trace on "x")` errorInfo frame text | **Contract** | Matches C wording. |
-| A store's result is the value read back after its write traces | **Contract** | `set`/`append`/`lappend`/`incr`/`lset`/`ledit`; empty once the variable is no longer a defined scalar. |
+| A store's result is the value read back after its write traces | **Contract** | `set`/`append`/`lappend`/`incr`/`lset`/`ledit`; empty once the variable is no longer a defined scalar. The **same cell** the store wrote, resolved once — visible at 8.x, where a callback can move what a bare name reaches. |
 | `incr`, and `lappend` on the paths reaching `TclPtrGetVarIdx`, fire `read` first | **Contract** | A trace error there is "no current value", not a failure; the swallowed error stays in `errorInfo`. |
 | `trace info command\|execution NAME` errors for an unknown command | **Contract** | `unknown command "NAME"`, name as written; `trace info variable` stays empty. |
 | Element recovery through a link, and `unset a(k)`'s `name1` | **Contract, release-split** | 9.0+ only — `TclVersion::traces_recover_linked_array_element`. |
 | An unset takes the traces out before firing; a revived variable is trace-less | **Contract** | `UnsetVarStruct` moves the list to a dummy `Var`; whole-array traces stay. |
 | A trace removed mid-firing does not fire; one added waits for the next access | **Contract** | Variable, command and execution traces; `trace info` sees both at once. |
+| A `delete` callback re-creating the command does not cancel the rest of that walk | **Contract** | C walks the dying token's own list; only `trace remove` cancels. An *execution* callback redefining the command does stop its walk. |
 | A delete trace that re-creates the command leaves the new one standing | **Contract** | C removes the entry only through the dying token's own `hPtr`. |
 | Trace storage layout, callback dispatch internals, refcounts | **Incompatible-by-design** | Object-rep probes never match. |
 

--- a/docs/design/runtime/trace-implementation.md
+++ b/docs/design/runtime/trace-implementation.md
@@ -129,6 +129,17 @@ goes. Every removal site therefore searches from the newest end (`rposition`
 over our oldest-first Vecs), as do the teardown paths that collect a
 namespace's unset and command-delete traces before firing them.
 
+Every firing loop walks **live** state rather than a snapshot: it collects the
+registrations' ids up front, in the order above, and re-finds each one in the
+table immediately before running it. That is C's `active.nextTracePtr` /
+`nextPtr` walk, which `Tcl_UntraceVar2` and `Tcl_UntraceCommand` rewrite as
+they unlink a record — so a trace a callback removes does not fire in the same
+pass, while one it adds waits for the next access (C prepends, behind the
+walk). An unset is the exception, and for the same reason: it takes the
+variable's own list out of the table before firing (C moves it to a dummy
+`Var`), so nothing can remove those callbacks any more, and a variable a
+callback revives carries no traces.
+
 Re-entrancy is suppressed per scope: a variable trace pushes its scope onto
 `active_var_scopes` for the duration of the callback, so a callback touching
 the same variable does not re-fire itself, and command-trace firing is gated on

--- a/docs/design/runtime/trace-implementation.md
+++ b/docs/design/runtime/trace-implementation.md
@@ -130,12 +130,30 @@ over our oldest-first Vecs), as do the teardown paths that collect a
 namespace's unset and command-delete traces before firing them.
 
 Every firing loop walks **live** state rather than a snapshot: it collects the
-registrations' ids up front, in the order above, and re-finds each one in the
-table immediately before running it. That is C's `active.nextTracePtr` /
-`nextPtr` walk, which `Tcl_UntraceVar2` and `Tcl_UntraceCommand` rewrite as
-they unlink a record — so a trace a callback removes does not fire in the same
-pass, while one it adds waits for the next access (C prepends, behind the
-walk). An unset is the exception, and for the same reason: it takes the
+registrations' identities up front, in the order above, and re-checks each one
+immediately before running it. That is C's `active.nextTracePtr` / `nextPtr`
+walk, which `Tcl_UntraceVar2` and `Tcl_UntraceCommand` rewrite as they unlink a
+record — so a trace a callback removes does not fire in the same pass, while
+one it adds waits for the next access (C prepends, behind the walk).
+
+*What* the re-check consults differs by kind, because C's walks hold different
+things:
+
+| walk | holds | a callback that redefines the traced command |
+|---|---|---|
+| variable | the cell's list | — |
+| execution (`enter`/`leave`/step) | the list of whatever command the name holds now | stops the rest of the walk |
+| command (`rename`/`delete`) | the dying **token's** own list | does not stop it |
+
+So the execution loops re-read the name-keyed table, while the command loops
+consult a per-registration "untraced" mark that only `trace remove` sets: a
+callback's `proc foo …` takes the table entry over without touching the list
+the walk is following, and the remaining callbacks still run. Once a
+replacement holds the name, a `trace remove` inside a later callback reaches
+*its* list and so cancels nothing. All three shapes are pinned against tclsh
+8.6.16 and 9.0.4.
+
+An unset is the variable-side exception, and for the same reason: it takes the
 variable's own list out of the table before firing (C moves it to a dummy
 `Var`), so nothing can remove those callbacks any more, and a variable a
 callback revives carries no traces.

--- a/docs/design/runtime/trace-implementation.md
+++ b/docs/design/runtime/trace-implementation.md
@@ -110,6 +110,14 @@ list head→tail: the **newest** trace fires first for variable `read`/`write`/
 newest-last, so each firing site iterates reversed; `trace info` also lists
 newest-first, so it iterates reversed too.
 
+From Tcl 9.0 an access whose spelling names no element but whose resolved
+variable *is* one (`upvar #0 a(k) e; set e 5`) recovers the containing array —
+so its traces run as well — and the element's key, reported as `name2`; an
+element unset named by the one-part `a(k)` spelling likewise reports that whole
+spelling as `name1`. 8.4/8.5/8.6 do neither. The release axis is the dialect
+fact `TclVersion::traces_recover_linked_array_element`, which both engines read
+rather than comparing versions beside their trace loops.
+
 For an array-element access the two lists are walked as **groups**: the
 containing array's traces first, then the element's own (`TclCallVarTraces`
 runs its `arrayPtr` loop before its `varPtr` loop). Registration order does

--- a/runtime/rust/src/cmd_trace.rs
+++ b/runtime/rust/src/cmd_trace.rs
@@ -200,6 +200,13 @@ pub struct TraceTable {
     /// The id the next command/execution-trace registration takes (see
     /// [`CmdTrace::id`]).
     pub next_cmd_trace_id: u64,
+    /// Ids `trace remove` has unlinked while a walk was in flight. The
+    /// **delete** walk holds the dying token's list, so a callback that
+    /// re-creates the command under the same name takes the name-keyed table
+    /// entry over without cancelling the remaining callbacks; only an explicit
+    /// untrace does. Recorded only while `exec_firing > 0` and cleared when the
+    /// outermost walk ends, so it never grows unbounded.
+    pub untraced_cmd_trace_ids: Vec<u64>,
     /// Variable cells whose trace callbacks are currently running. Other
     /// variables remain traceable from within a callback.
     pub active_var_scopes: Vec<VarTraceScope>,
@@ -452,7 +459,13 @@ fn cmd_trace_add_remove(
             .iter()
             .rposition(|t| t.name == fqn && t.ops == flags && t.command == command);
         if let Some(i) = pos {
-            interp.traces.borrow_mut().cmd_traces.remove(i);
+            let mut traces = interp.traces.borrow_mut();
+            if traces.exec_firing > 0 {
+                let id = traces.cmd_traces[i].id;
+                traces.untraced_cmd_trace_ids.push(id);
+            }
+            traces.cmd_traces.remove(i);
+            drop(traces);
             interp.invalidate_guard_domain(tcl_runtime_api::guard::GuardDomain::CommandTrace);
         }
     }

--- a/runtime/rust/src/cmd_trace.rs
+++ b/runtime/rust/src/cmd_trace.rs
@@ -115,6 +115,13 @@ pub mod ops {
 /// One registered command or execution trace (C's `TraceCommandInfo`; both
 /// kinds hang off the same command, distinguished by their op category).
 pub struct CmdTrace {
+    /// This registration's identity, unique for the life of the interpreter —
+    /// the command/execution twin of [`VarTrace::id`], and for the same reason:
+    /// C's `CallCommandTraces` and `TclCheckExecutionTraces` walk the live list
+    /// through `nextPtr`, and `Tcl_UntraceCommand` unlinks a record as soon as
+    /// a callback removes it, so a snapshot of callback strings would keep
+    /// firing traces that are already gone. Ids are never reused.
+    pub id: u64,
     /// The command's resolved FQN (the binding the trace is attached to).
     pub name: Vec<u8>,
     /// The user ops this trace fires on (a [`ops`] bitset).
@@ -190,6 +197,9 @@ pub struct TraceTable {
     pub step_active: Vec<StepActive>,
     /// The id the next variable-trace registration takes (see [`VarTrace::id`]).
     pub next_var_trace_id: u64,
+    /// The id the next command/execution-trace registration takes (see
+    /// [`CmdTrace::id`]).
+    pub next_cmd_trace_id: u64,
     /// Variable cells whose trace callbacks are currently running. Other
     /// variables remain traceable from within a callback.
     pub active_var_scopes: Vec<VarTraceScope>,
@@ -419,11 +429,16 @@ fn cmd_trace_add_remove(
     };
     let command = obj_bytes(argv[5]);
     if is_add {
-        interp.traces.borrow_mut().cmd_traces.push(CmdTrace {
+        let mut traces = interp.traces.borrow_mut();
+        traces.next_cmd_trace_id += 1;
+        let id = traces.next_cmd_trace_id;
+        traces.cmd_traces.push(CmdTrace {
+            id,
             name: fqn,
             ops: flags,
             command,
         });
+        drop(traces);
         interp.invalidate_guard_domain(tcl_runtime_api::guard::GuardDomain::CommandTrace);
     } else {
         // Remove the first trace matching exact ops + command string, where

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -3661,16 +3661,19 @@ impl Interp {
         // 9.0.4:1016-1018) and `CallCommandTraces` walks the list head→tail
         // (tclBasic.c:3972-3974), so the newest fires first. Our Vec pushes
         // newest-last. Issue #1440.
-        let ids: Vec<u64> = self
+        // The callbacks are captured up front, not re-read per step: this walk
+        // owns the dying token's list, which a callback's re-creation of the
+        // command detaches from the name. See [`Self::cmd_trace_untraced`].
+        let entries: Vec<(u64, Vec<u8>)> = self
             .traces
             .borrow()
             .cmd_traces
             .iter()
             .rev()
             .filter(|t| t.name == old_fqn && (t.ops & op_bit) != 0)
-            .map(|t| t.id)
+            .map(|t| (t.id, t.command.clone()))
             .collect();
-        if ids.is_empty() {
+        if entries.is_empty() {
             return;
         }
         let op: &[u8] = if op_bit == crate::cmd_trace::ops::RENAME {
@@ -3683,10 +3686,10 @@ impl Interp {
         unsafe { obj::incr_ref_count(saved) };
 
         self.traces.borrow_mut().exec_firing += 1;
-        for id in ids {
-            let Some(cmd) = self.live_cmd_trace(id) else {
+        for (id, cmd) in entries {
+            if self.cmd_trace_untraced(id) {
                 continue;
-            };
+            }
             // Append `oldName newName op` as properly-quoted list elements.
             let args = crate::list::new_list_obj(&[
                 new_string(old_fqn),
@@ -3699,7 +3702,12 @@ impl Interp {
             drop_fresh(args);
             let _ = self.eval_str(&line);
         }
-        self.traces.borrow_mut().exec_firing -= 1;
+        let mut traces = self.traces.borrow_mut();
+        traces.exec_firing -= 1;
+        if traces.exec_firing == 0 {
+            traces.untraced_cmd_trace_ids.clear();
+        }
+        drop(traces);
 
         unsafe {
             obj::decr_ref_count(self.result.get());
@@ -3711,6 +3719,13 @@ impl Interp {
     /// when a callback has since removed it. C walks the trace list through
     /// `nextPtr` and `Tcl_UntraceCommand` unlinks a record at once, so a trace
     /// removed mid-firing never fires in that pass. Issue #1633 row 8.
+    ///
+    /// This is the **execution** rule: `TclCheckExecutionTraces` follows the
+    /// list of whatever command the name now holds, so a callback that
+    /// redefines the traced command stops the rest of the walk — measured on
+    /// tclsh 8.6.16 and 9.0.4, where `proc t {}` inside an `enter` callback
+    /// keeps the older `enter` callback from running. The delete walk answers
+    /// differently; see [`Self::cmd_trace_untraced`].
     fn live_cmd_trace(&self, id: u64) -> Option<Vec<u8>> {
         self.traces
             .borrow()
@@ -3718,6 +3733,17 @@ impl Interp {
             .iter()
             .find(|t| t.id == id)
             .map(|t| t.command.clone())
+    }
+
+    /// Whether `trace remove` has unlinked command trace `id` since this walk
+    /// began. `CallCommandTraces` is handed the dying token's own list
+    /// (`tclBasic.c` 9.0.4:3972-3993), so a callback that re-creates the
+    /// command under the same name takes the name-keyed table entry over while
+    /// the remaining callbacks still run; only an explicit untrace cancels one.
+    /// Measured on tclsh 8.6.16 and 9.0.4: with two `delete` traces whose newer
+    /// callback runs `proc foo …`, **both** fire.
+    fn cmd_trace_untraced(&self, id: u64) -> bool {
+        self.traces.borrow().untraced_cmd_trace_ids.contains(&id)
     }
 
     /// Fire `enter` execution traces on `fqn` (creation order), invoking each as

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -3119,13 +3119,9 @@ impl Interp {
     }
 
     /// Whether this release recovers an array element from the resolved `Var`
-    /// when the access spelling names none.
-    ///
-    /// Tcl 9.0 added it in two places at once: `TclCallVarTraces` fills `part2`
-    /// from the element's hash key (`tclTrace.c` 9.0.4:2560-2565) and
-    /// `UnsetVarStruct` does the same before calling the traces
-    /// (`tclVar.c`:2634-2640). 8.4/8.5/8.6 have neither block. The visible
-    /// consequences, both pinned in `tests/trace_semantics.rs`:
+    /// when the access spelling names none — the release axis itself lives in
+    /// `tcl-dialect`, beside `namespace_var_global_fallback`. The two visible
+    /// consequences are pinned in `tests/trace_semantics.rs`:
     ///
     /// - `upvar #0 a(k) e; set e 5` fires the array's traces *and* the
     ///   element's with `name2 = k` at 9.0; at 8.6 only the element's own, with
@@ -3133,12 +3129,8 @@ impl Interp {
     /// - `unset a(k)` reports `name1 = a(k)` at 9.0 (the recovered `part2`
     ///   stops `TclCallVarTraces` re-splitting the name) and `name1 = a` at
     ///   8.6.
-    ///
-    /// This is a release axis and belongs in `tcl-dialect` beside
-    /// `namespace_var_global_fallback`; it is derived here while that crate is
-    /// outside this lane.
     fn traces_recover_the_linked_element(&self) -> bool {
-        self.runtime_version() >= tcl_dialect::TclVersion::V9_0
+        self.runtime_version().traces_recover_linked_array_element()
     }
 
     /// The unset-trace callbacks a proc frame's locals contribute as the frame

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -3661,16 +3661,16 @@ impl Interp {
         // 9.0.4:1016-1018) and `CallCommandTraces` walks the list head→tail
         // (tclBasic.c:3972-3974), so the newest fires first. Our Vec pushes
         // newest-last. Issue #1440.
-        let cmds: Vec<Vec<u8>> = self
+        let ids: Vec<u64> = self
             .traces
             .borrow()
             .cmd_traces
             .iter()
             .rev()
             .filter(|t| t.name == old_fqn && (t.ops & op_bit) != 0)
-            .map(|t| t.command.clone())
+            .map(|t| t.id)
             .collect();
-        if cmds.is_empty() {
+        if ids.is_empty() {
             return;
         }
         let op: &[u8] = if op_bit == crate::cmd_trace::ops::RENAME {
@@ -3683,7 +3683,10 @@ impl Interp {
         unsafe { obj::incr_ref_count(saved) };
 
         self.traces.borrow_mut().exec_firing += 1;
-        for cmd in cmds {
+        for id in ids {
+            let Some(cmd) = self.live_cmd_trace(id) else {
+                continue;
+            };
             // Append `oldName newName op` as properly-quoted list elements.
             let args = crate::list::new_list_obj(&[
                 new_string(old_fqn),
@@ -3704,6 +3707,19 @@ impl Interp {
         }
     }
 
+    /// The callback prefix of the live command/execution trace `id`, or `None`
+    /// when a callback has since removed it. C walks the trace list through
+    /// `nextPtr` and `Tcl_UntraceCommand` unlinks a record at once, so a trace
+    /// removed mid-firing never fires in that pass. Issue #1633 row 8.
+    fn live_cmd_trace(&self, id: u64) -> Option<Vec<u8>> {
+        self.traces
+            .borrow()
+            .cmd_traces
+            .iter()
+            .find(|t| t.id == id)
+            .map(|t| t.command.clone())
+    }
+
     /// Fire `enter` execution traces on `fqn` (creation order), invoking each as
     /// `<prefix> {cmd args} enter`. Returns `Some(code)` if a callback completed
     /// non-OK — the command is then aborted with that code and the callback's
@@ -3712,23 +3728,26 @@ impl Interp {
         use crate::cmd_trace::ops;
         // C fires `enter` newest-first (the trace list is prepended; the loop
         // walks it head→tail). Our Vec pushes newest-last, so iterate reversed.
-        let cmds: Vec<Vec<u8>> = self
+        let ids: Vec<u64> = self
             .traces
             .borrow()
             .cmd_traces
             .iter()
             .rev()
             .filter(|t| t.name == fqn && (t.ops & ops::ENTER) != 0)
-            .map(|t| t.command.clone())
+            .map(|t| t.id)
             .collect();
-        if cmds.is_empty() {
+        if ids.is_empty() {
             return None;
         }
         let saved = self.result.get();
         unsafe { obj::incr_ref_count(saved) };
         self.traces.borrow_mut().exec_firing += 1;
         let mut abort: Option<Code> = None;
-        for cmd in cmds {
+        for id in ids {
+            let Some(cmd) = self.live_cmd_trace(id) else {
+                continue;
+            };
             let args = crate::list::new_list_obj(&[new_string(cmd_word), new_string(b"enter")]);
             let mut line = cmd;
             line.push(b' ');
@@ -3761,15 +3780,15 @@ impl Interp {
         use crate::cmd_trace::ops;
         // C fires `leave` oldest-first (reverse-scan of the prepended list). Our
         // Vec pushes newest-last, so iterate forward.
-        let cmds: Vec<Vec<u8>> = self
+        let ids: Vec<u64> = self
             .traces
             .borrow()
             .cmd_traces
             .iter()
             .filter(|t| t.name == fqn && (t.ops & ops::LEAVE) != 0)
-            .map(|t| t.command.clone())
+            .map(|t| t.id)
             .collect();
-        if cmds.is_empty() {
+        if ids.is_empty() {
             return code;
         }
         // Save the command's result once; restore it after the callbacks (C's
@@ -3783,7 +3802,10 @@ impl Interp {
 
         self.traces.borrow_mut().exec_firing += 1;
         let mut override_code: Option<Code> = None;
-        for cmd in cmds {
+        for id in ids {
+            let Some(cmd) = self.live_cmd_trace(id) else {
+                continue;
+            };
             let result_bytes = obj_bytes(self.result.get());
             let args = crate::list::new_list_obj(&[
                 new_string(cmd_word),

--- a/runtime/rust/tests/trace_semantics.rs
+++ b/runtime/rust/tests/trace_semantics.rs
@@ -465,6 +465,57 @@ fn a_command_or_execution_trace_removed_during_firing_does_not_fire() {
     );
 }
 
+/// A **delete** walk is handed the dying token's own trace list
+/// (`CallCommandTraces`, `tclBasic.c` 9.0.4:3972-3993), so a callback that
+/// re-creates the command under the same name takes the *name-keyed* entry over
+/// while the rest of that list still fires. Only an explicit `trace remove`
+/// cancels a pending callback, and once a replacement holds the name a
+/// `trace remove` reaches the replacement's empty list and cancels nothing.
+///
+/// tclsh 8.6.16 and 9.0.4 print exactly the transcript below. Deciding liveness
+/// by name-keyed table membership skipped `OLD` and `B1`, because the
+/// callback's `proc` emptied the entry the walk was consulting.
+#[test]
+fn a_delete_callback_recreating_the_command_does_not_cancel_the_walk() {
+    let got = transcript(
+        "set ::log {}\n\
+         proc foo {} { return FOO }\n\
+         proc OLD {o n op} { lappend ::log [list OLD $o $n $op] }\n\
+         proc NEW {o n op} { lappend ::log [list NEW $o $n $op]\n\
+         \x20   proc foo {} { return FOO2 } }\n\
+         trace add command foo delete OLD\n\
+         trace add command foo delete NEW\n\
+         rename foo {}\n\
+         lappend ::log \"call:[foo]\" \"traces:[trace info command foo]\"\n\
+         proc A1 {o n op} { lappend ::log A1 }\n\
+         proc A2 {o n op} { lappend ::log A2\n\
+         \x20   trace remove command a delete A1 }\n\
+         proc a {} {}\n\
+         trace add command a delete A1\n\
+         trace add command a delete A2\n\
+         rename a {}\n\
+         proc B1 {o n op} { lappend ::log B1 }\n\
+         proc B2 {o n op} { lappend ::log B2\n\
+         \x20   proc b {} {}\n\
+         \x20   trace remove command b delete B1 }\n\
+         proc b {} {}\n\
+         trace add command b delete B1\n\
+         trace add command b delete B2\n\
+         rename b {}\n\
+         join $::log \\n",
+    );
+    assert_eq!(
+        got,
+        "NEW ::foo {} delete\n\
+         OLD ::foo {} delete\n\
+         call:FOO2\n\
+         traces:\n\
+         A2\n\
+         B2\n\
+         B1"
+    );
+}
+
 /// A command-delete trace whose callback re-creates the command leaves the
 /// *new* command standing: C deletes the token it captured before the callback
 /// (`CMD_DYING`, its hash entry taken over by the new command), not whatever

--- a/runtime/rust/tests/trace_semantics.rs
+++ b/runtime/rust/tests/trace_semantics.rs
@@ -421,6 +421,50 @@ fn a_trace_removed_during_firing_does_not_fire_in_that_pass() {
     );
 }
 
+/// The command and execution firing loops follow the same rule: a trace an
+/// earlier callback removed does not fire in that pass. C's
+/// `CallCommandTraces` and `TclCheckExecutionTraces` walk the live list through
+/// `nextPtr` and `Tcl_UntraceCommand` unlinks a record at once — for `enter`
+/// and `delete`, which run newest-first, and for `leave`, whose reverse scan
+/// reaches the *oldest* first.
+///
+/// tclsh 8.6.16 and 9.0.4 print exactly the transcript below; these three loops
+/// used to snapshot the callback strings, so `E2`, `D2` and `L1` still fired.
+#[test]
+fn a_command_or_execution_trace_removed_during_firing_does_not_fire() {
+    let got = transcript(
+        "set ::log {}\n\
+         proc target {} { return T }\n\
+         proc E1 args { trace remove execution target enter E2\n\
+         \x20   lappend ::log \"E1: [trace info execution target]\" }\n\
+         proc E2 args { lappend ::log \"E2 fired\" }\n\
+         trace add execution target enter E2\n\
+         trace add execution target enter E1\n\
+         target\n\
+         proc victim {} {}\n\
+         proc D1 args { trace remove command victim delete D2\n\
+         \x20   lappend ::log \"D1: [trace info command victim]\" }\n\
+         proc D2 args { lappend ::log \"D2 fired\" }\n\
+         trace add command victim delete D2\n\
+         trace add command victim delete D1\n\
+         rename victim {}\n\
+         proc lt {} { return L }\n\
+         proc L1 args { lappend ::log \"L1 fired\" }\n\
+         proc L2 args { trace remove execution lt leave L1\n\
+         \x20   lappend ::log \"L2: [trace info execution lt]\" }\n\
+         trace add execution lt leave L2\n\
+         trace add execution lt leave L1\n\
+         lt\n\
+         join $::log \\n",
+    );
+    assert_eq!(
+        got,
+        "E1: {enter E1}\n\
+         D1: {delete D1}\n\
+         L2: {leave L2}"
+    );
+}
+
 /// A command-delete trace whose callback re-creates the command leaves the
 /// *new* command standing: C deletes the token it captured before the callback
 /// (`CMD_DYING`, its hash entry taken over by the new command), not whatever

--- a/rust/tcl-dialect/src/version.rs
+++ b/rust/tcl-dialect/src/version.rs
@@ -376,6 +376,25 @@ impl TclVersion {
         matches!(self, Self::V8_4 | Self::V8_5 | Self::V8_6)
     }
 
+    /// Whether variable traces recover an array element the access spelling
+    /// does not name.
+    ///
+    /// Tcl 9.0 added it in three places at once — `TclVarFindHiddenArray`
+    /// (`tclInt.h` 9.0.4:866), the `part2` recovery in `TclCallVarTraces`
+    /// (`tclTrace.c` 9.0.4:2560-2565) and the same recovery in
+    /// `UnsetVarStruct` (`tclVar.c` 9.0.4:2638-2642); 8.4/8.5/8.6 have none of
+    /// them. Two consequences are visible from script: an alias into an element
+    /// (`upvar #0 a(k) e; set e 5`) fires the containing array's traces too and
+    /// reports `name2 = k`, and `unset a(k)` reports `name1 = a(k)` rather than
+    /// the split-off base. Measured on tclsh 8.4.20, 8.5.19, 8.6.16 (off) and
+    /// 9.0.4, 9.1b0 (on). This belongs to the version-profile vocabulary so
+    /// runtimes do not each encode a release comparison beside their trace
+    /// dispatcher.
+    #[must_use]
+    pub const fn traces_recover_linked_array_element(self) -> bool {
+        matches!(self, Self::V9_0 | Self::V9_1)
+    }
+
     /// The release-defined conversion used when a string is consumed as raw
     /// binary data. See [`ByteStringEncoding`] for the Tcl 8/Tcl 9 split.
     #[must_use]

--- a/rust/tcl-vm/src/cmd_list.rs
+++ b/rust/tcl-vm/src/cmd_list.rs
@@ -89,7 +89,10 @@ fn cmd_lappend(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
         return err_wrong_args("lappend varName ?value ...?");
     };
     let n = name.to_str();
-    let cur = vm.var_get(&n);
+    // The dispatched `lappend` is C's `Tcl_LappendObjCmd`, which fetches
+    // through `TclPtrGetVarIdx` in both its forms (`tclVar.c` 9.0.4:2895 and
+    // :2944), so the read trace fires before the store.
+    let cur = vm.read_for_update(&n);
     if vals.is_empty() {
         // `lappend var` with no values returns the variable's current value
         // *unchanged*: Tcl shimmer-validates it as a list (so a malformed value
@@ -101,8 +104,8 @@ fn cmd_lappend(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
                 Ok(_) => ok(v),
                 Err(c) => c,
             },
-            None => match vm.var_set(&n, Value::empty()) {
-                Ok(()) => ok(Value::empty()),
+            None => match vm.store_var_result(&n, Value::empty()) {
+                Ok(stored) => ok(stored),
                 Err(e) => e,
             },
         };
@@ -114,10 +117,10 @@ fn cmd_lappend(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
         Ok(v) => v,
         Err(e) => return err(e.message()),
     };
-    if let Err(e) = vm.var_set(&n, result.clone()) {
-        return e;
+    match vm.store_var_result(&n, result) {
+        Ok(stored) => ok(stored),
+        Err(e) => e,
     }
-    ok(result)
 }
 
 fn cmd_lassign(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
@@ -187,10 +190,10 @@ fn cmd_ledit(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
         Ok(v) => v,
         Err(e) => return err(e.into_message()),
     };
-    if let Err(e) = vm.var_set(&n, result.clone()) {
-        return e;
+    match vm.store_var_result(&n, result) {
+        Ok(stored) => ok(stored),
+        Err(e) => e,
     }
-    ok(result)
 }
 
 /// `lset listVar ?index ...? newValue` — the runtime form of `lset` (the
@@ -223,10 +226,10 @@ fn cmd_lset(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
         Ok(r) => r,
         Err(c) => return c,
     };
-    if let Err(e) = vm.var_set(&n, new.clone()) {
-        return e;
+    match vm.store_var_result(&n, new) {
+        Ok(stored) => ok(stored),
+        Err(e) => e,
     }
-    ok(new)
 }
 
 /// `lpop listVar ?index ...?` — remove and return an element of the list held

--- a/rust/tcl-vm/src/cmd_string.rs
+++ b/rust/tcl-vm/src/cmd_string.rs
@@ -507,9 +507,14 @@ fn cmd_append(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     };
     let n = name.to_str();
     if vals.is_empty() {
-        // `append x` with no values is a read: return the current value, erroring
-        // if the variable is unset (matching tclsh — the old VM wrongly created an
-        // empty variable here). `var_get` parses `a(k)`.
+        // `append x` with no values is a read: it fires the read trace, whose
+        // error aborts the command exactly as for `set x`, and returns the
+        // current value, erroring if the variable is unset (matching tclsh —
+        // the old VM wrongly created an empty variable here). `var_get` parses
+        // `a(k)`.
+        if let Err(c) = vm.fire_var_traces(&n, "read") {
+            return c;
+        }
         return match vm.var_get(&n) {
             Some(v) => ok(v),
             None => err(format!("can't read \"{n}\": no such variable")),
@@ -520,10 +525,10 @@ fn cmd_append(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     // once. The VM's value model never grows in place, so the core rebuilds.
     let cur = vm.var_get(&n);
     let result = tcl_cmd_core::var::append_bytes(vm, cur, vals);
-    if let Err(e) = vm.var_set(&n, result.clone()) {
-        return e;
+    match vm.store_var_result(&n, result) {
+        Ok(stored) => ok(stored),
+        Err(e) => e,
     }
-    ok(result)
 }
 
 #[cfg(test)]

--- a/rust/tcl-vm/src/cmd_trace.rs
+++ b/rust/tcl-vm/src/cmd_trace.rs
@@ -171,7 +171,7 @@ fn trace_info(vm: &mut Vm, rest: &[Value]) -> Completion<Value> {
     match kind {
         core_trace::TraceKind::Variable => ok(var_trace_entries(vm, &name.to_str())),
         core_trace::TraceKind::Command | core_trace::TraceKind::Execution => {
-            ok(vm.cmd_trace_entries(kind == core_trace::TraceKind::Execution, &name.to_str()))
+            vm.cmd_trace_entries(kind == core_trace::TraceKind::Execution, &name.to_str())
         }
     }
 }

--- a/rust/tcl-vm/src/command.rs
+++ b/rust/tcl-vm/src/command.rs
@@ -275,8 +275,8 @@ fn cmd_set(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
             }
             vm.var_get(&n).map_or_else(|| err(vm.read_miss_msg(&n)), ok)
         }
-        [name, value] => match vm.var_set(&name.to_str(), value.clone()) {
-            Ok(()) => ok(value.clone()),
+        [name, value] => match vm.store_var_result(&name.to_str(), value.clone()) {
+            Ok(stored) => ok(stored),
             Err(e) => e,
         },
         _ => err("wrong # args: should be \"set varName ?newValue?\""),
@@ -1097,17 +1097,18 @@ fn cmd_incr(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
         [name, inc] => (name.to_str(), inc.clone()),
         _ => return err("wrong # args: should be \"incr varName ?increment?\""),
     };
-    // `var_get`/`var_set` parse `base(key)` themselves; an unset variable reads
-    // as `None`, which `int_add` treats as zero.
-    let cur = vm.var_get(&name);
+    // `read_for_update`/`store_var_result` parse `base(key)` themselves; an
+    // unset variable — or one whose read trace errored — reads as `None`, which
+    // `int_add` treats as zero.
+    let cur = vm.read_for_update(&name);
     let sum = match tcl_syntax::value::ValueOps::int_add(vm, cur.as_ref(), &amount) {
         Ok(v) => v,
         Err(e) => return err(e.message()),
     };
-    if let Err(e) = vm.var_set(&name, sum.clone()) {
-        return e;
+    match vm.store_var_result(&name, sum) {
+        Ok(stored) => ok(stored),
+        Err(e) => e,
     }
-    ok(sum)
 }
 
 /// `expr arg ?arg ...?` — concatenate the args and evaluate as an expression.

--- a/rust/tcl-vm/src/exec.rs
+++ b/rust/tcl-vm/src/exec.rs
@@ -1951,10 +1951,13 @@ impl Vm {
         let lits = asm.literals.entries();
         let lvt = asm.lvt.entries();
 
+        // Unwrap a fallible step, unwinding the instruction on an error. The
+        // value form lets a store arm push what the variable reads back.
         macro_rules! try_op {
             ($e:expr) => {
-                if let Err(c) = $e {
-                    return Tick::Return(c);
+                match $e {
+                    Ok(v) => v,
+                    Err(c) => return Tick::Return(c),
                 }
             };
         }
@@ -1968,12 +1971,15 @@ impl Vm {
         // triggering `set x 1`).
         macro_rules! try_cmd {
             ($e:expr) => {
-                if let Err(c) = $e {
-                    let cmd_text = instr.source_cmd_text.clone();
-                    let line = instr.source_line;
-                    let msg = c.result.to_str().to_string();
-                    self.log_command_info(&cmd_text, &msg, line);
-                    return Tick::Return(c);
+                match $e {
+                    Ok(v) => v,
+                    Err(c) => {
+                        let cmd_text = instr.source_cmd_text.clone();
+                        let line = instr.source_line;
+                        let msg = c.result.to_str().to_string();
+                        self.log_command_info(&cmd_text, &msg, line);
+                        return Tick::Return(c);
+                    }
                 }
             };
         }
@@ -2096,8 +2102,8 @@ impl Vm {
             Op::STORE_STK | Op::STORE_SCALAR_STK => {
                 let value = pop(f);
                 let name = pop(f).to_str();
-                try_cmd!(self.set_var(&name, value.clone()));
-                f.stack.push(value);
+                let stored = try_cmd!(self.store_var_result(&name, value));
+                f.stack.push(stored);
             }
             Op::INCR_STK_IMM | Op::INCR_SCALAR_STK_IMM => {
                 let name = pop(f).to_str();
@@ -2128,8 +2134,8 @@ impl Vm {
             Op::STORE_SCALAR1 | Op::STORE_SCALAR4 => {
                 let name = lvt_name(imm0(instr));
                 let value = pop(f);
-                try_op!(self.set_var(&name, value.clone()));
-                f.stack.push(value);
+                let stored = try_op!(self.store_var_result(&name, value));
+                f.stack.push(stored);
             }
             Op::INCR_SCALAR1 => {
                 let name = lvt_name(imm0(instr));
@@ -2226,10 +2232,8 @@ impl Vm {
                 let value = pop(f);
                 let key = pop(f).to_str();
                 let name = pop(f).to_str();
-                if let Err(e) = self.set_array_elem(&name, &key, value.clone()) {
-                    return Tick::Return(e);
-                }
-                f.stack.push(value);
+                let stored = try_op!(self.store_elem_result(&name, &key, value));
+                f.stack.push(stored);
             }
             Op::LOAD_ARRAY1 | Op::LOAD_ARRAY4 => {
                 let name = lvt_name(imm0(instr));
@@ -2248,10 +2252,8 @@ impl Vm {
                 let name = lvt_name(imm0(instr));
                 let value = pop(f);
                 let key = pop(f).to_str();
-                if let Err(e) = self.set_array_elem(&name, &key, value.clone()) {
-                    return Tick::Return(e);
-                }
-                f.stack.push(value);
+                let stored = try_op!(self.store_elem_result(&name, &key, value));
+                f.stack.push(stored);
             }
             Op::ARRAY_EXISTS_IMM => {
                 let name = lvt_name(imm0(instr));
@@ -2399,8 +2401,8 @@ impl Vm {
                     .unwrap_or_default();
                 s.push_str(&v.to_str());
                 let nv = Value::string(s);
-                try_op!(self.set_var(&name, nv.clone()));
-                f.stack.push(nv);
+                let stored = try_op!(self.store_var_result(&name, nv));
+                f.stack.push(stored);
             }
             Op::APPEND_ARRAY1 | Op::APPEND_ARRAY4 => {
                 let name = lvt_name(imm0(instr));
@@ -2412,10 +2414,8 @@ impl Vm {
                     .unwrap_or_default();
                 s.push_str(&v.to_str());
                 let nv = Value::string(s);
-                if let Err(e) = self.set_array_elem(&name, &key, nv.clone()) {
-                    return Tick::Return(e);
-                }
-                f.stack.push(nv);
+                let stored = try_op!(self.store_elem_result(&name, &key, nv));
+                f.stack.push(stored);
             }
             Op::LAPPEND_SCALAR1 | Op::LAPPEND_SCALAR4 => {
                 let name = lvt_name(imm0(instr));
@@ -2429,8 +2429,8 @@ impl Vm {
                 };
                 items.push(v);
                 let nv = Value::list(items);
-                try_op!(self.set_var(&name, nv.clone()));
-                f.stack.push(nv);
+                let stored = try_op!(self.store_var_result(&name, nv));
+                f.stack.push(stored);
             }
             Op::LAPPEND_ARRAY1 | Op::LAPPEND_ARRAY4 => {
                 let name = lvt_name(imm0(instr));
@@ -2445,20 +2445,21 @@ impl Vm {
                 };
                 items.push(v);
                 let nv = Value::list(items);
-                if let Err(e) = self.set_array_elem(&name, &key, nv.clone()) {
-                    return Tick::Return(e);
-                }
-                f.stack.push(nv);
+                let stored = try_op!(self.store_elem_result(&name, &key, nv));
+                f.stack.push(stored);
             }
             Op::LAPPEND_LIST => {
                 // Append each element of the popped list to the scalar var's list.
+                // The `lappendList` opcodes fetch through `TclPtrGetVarIdx`
+                // (`tclExecute.c` 9.0.4:3391), so unlike their single-value
+                // siblings they fire the read trace first.
                 let name = lvt_name(imm0(instr));
                 let add = pop(f);
                 let add_items = match add.as_list() {
                     Ok(l) => l,
                     Err(e) => return Tick::Return(err(e.message)),
                 };
-                let mut items = match self.get_var(&name) {
+                let mut items = match self.read_for_update(&name) {
                     Some(cur) => match cur.as_list() {
                         Ok(l) => (*l).clone(),
                         Err(e) => return Tick::Return(err(e.message)),
@@ -2467,8 +2468,8 @@ impl Vm {
                 };
                 items.extend(add_items.iter().cloned());
                 let nv = Value::list(items);
-                try_op!(self.set_var(&name, nv.clone()));
-                f.stack.push(nv);
+                let stored = try_op!(self.store_var_result(&name, nv));
+                f.stack.push(stored);
             }
 
             // -- append / lappend (stack form, by name) --
@@ -2483,8 +2484,8 @@ impl Vm {
                     .unwrap_or_default();
                 s.push_str(&v.to_str());
                 let nv = Value::string(s);
-                try_cmd!(self.set_var(&name, nv.clone()));
-                f.stack.push(nv);
+                let stored = try_cmd!(self.store_var_result(&name, nv));
+                f.stack.push(stored);
             }
             Op::LAPPEND_STK => {
                 let v = pop(f);
@@ -2498,8 +2499,8 @@ impl Vm {
                 };
                 items.push(v);
                 let nv = Value::list(items);
-                try_cmd!(self.set_var(&name, nv.clone()));
-                f.stack.push(nv);
+                let stored = try_cmd!(self.store_var_result(&name, nv));
+                f.stack.push(stored);
             }
             Op::APPEND_ARRAY_STK => {
                 let v = pop(f);
@@ -2511,10 +2512,8 @@ impl Vm {
                     .unwrap_or_default();
                 s.push_str(&v.to_str());
                 let nv = Value::string(s);
-                if let Err(e) = self.set_array_elem(&name, &key, nv.clone()) {
-                    return Tick::Return(e);
-                }
-                f.stack.push(nv);
+                let stored = try_op!(self.store_elem_result(&name, &key, nv));
+                f.stack.push(stored);
             }
             Op::LAPPEND_ARRAY_STK => {
                 let v = pop(f);
@@ -2529,10 +2528,8 @@ impl Vm {
                 };
                 items.push(v);
                 let nv = Value::list(items);
-                if let Err(e) = self.set_array_elem(&name, &key, nv.clone()) {
-                    return Tick::Return(e);
-                }
-                f.stack.push(nv);
+                let stored = try_op!(self.store_elem_result(&name, &key, nv));
+                f.stack.push(stored);
             }
             // The `lappendList*` family appends *each* element of the popped list
             // (`lappend v {*}$list`); an unparsable list errors before any write.
@@ -2543,7 +2540,7 @@ impl Vm {
                     Ok(l) => l,
                     Err(e) => return Tick::Return(err(e.message)),
                 };
-                let mut items = match self.get_var(&name) {
+                let mut items = match self.read_for_update(&name) {
                     Some(cur) => match cur.as_list() {
                         Ok(l) => (*l).clone(),
                         Err(e) => return Tick::Return(err(e.message)),
@@ -2552,8 +2549,8 @@ impl Vm {
                 };
                 items.extend(add_items.iter().cloned());
                 let nv = Value::list(items);
-                try_cmd!(self.set_var(&name, nv.clone()));
-                f.stack.push(nv);
+                let stored = try_cmd!(self.store_var_result(&name, nv));
+                f.stack.push(stored);
             }
             Op::LAPPEND_LIST_ARRAY => {
                 let name = lvt_name(imm0(instr));
@@ -2563,7 +2560,7 @@ impl Vm {
                     Ok(l) => l,
                     Err(e) => return Tick::Return(err(e.message)),
                 };
-                let mut items = match self.get_array_elem(&name, &key) {
+                let mut items = match self.read_elem_for_update(&name, &key) {
                     Some(cur) => match cur.as_list() {
                         Ok(l) => (*l).clone(),
                         Err(e) => return Tick::Return(err(e.message)),
@@ -2572,10 +2569,8 @@ impl Vm {
                 };
                 items.extend(add_items.iter().cloned());
                 let nv = Value::list(items);
-                if let Err(e) = self.set_array_elem(&name, &key, nv.clone()) {
-                    return Tick::Return(e);
-                }
-                f.stack.push(nv);
+                let stored = try_op!(self.store_elem_result(&name, &key, nv));
+                f.stack.push(stored);
             }
             Op::LAPPEND_LIST_ARRAY_STK => {
                 let add = pop(f);
@@ -2585,7 +2580,7 @@ impl Vm {
                     Ok(l) => l,
                     Err(e) => return Tick::Return(err(e.message)),
                 };
-                let mut items = match self.get_array_elem(&name, &key) {
+                let mut items = match self.read_elem_for_update(&name, &key) {
                     Some(cur) => match cur.as_list() {
                         Ok(l) => (*l).clone(),
                         Err(e) => return Tick::Return(err(e.message)),
@@ -2594,10 +2589,8 @@ impl Vm {
                 };
                 items.extend(add_items.iter().cloned());
                 let nv = Value::list(items);
-                if let Err(e) = self.set_array_elem(&name, &key, nv.clone()) {
-                    return Tick::Return(e);
-                }
-                f.stack.push(nv);
+                let stored = try_op!(self.store_elem_result(&name, &key, nv));
+                f.stack.push(stored);
             }
 
             // -- const (TIP 677) --
@@ -5054,12 +5047,12 @@ impl Vm {
                 "can't incr \"{name}\": variable is a constant"
             )));
         }
-        let cur = self.var_get(name);
+        let cur = self.read_for_update(name);
         let inc = Value::int(amount);
         let next = tcl_syntax::value::ValueOps::int_add(self, cur.as_ref(), &inc)
             .map_err(|e| err(e.message()))?;
-        self.var_set(name, next.clone())?;
-        f.stack.push(next);
+        let stored = self.store_var_result(name, next)?;
+        f.stack.push(stored);
         Ok(())
     }
 }

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -5734,19 +5734,23 @@ impl Vm {
 
     /// The `{ops callback}` pairs registered on command `name` (newest first),
     /// for `trace info command|execution`.
-    pub(crate) fn cmd_trace_entries(&self, execution: bool, name: &str) -> Value {
+    pub(crate) fn cmd_trace_entries(&self, execution: bool, name: &str) -> Completion<Value> {
+        // C resolves the name with `TCL_LEAVE_ERR_MSG` before reporting
+        // (`TraceCommandObjCmd` `tclTrace.c` 9.0.4:661, `TraceExecutionObjCmd`
+        // :454), so introspecting a command that does not exist errors with the
+        // name as written — unlike `trace info variable`, which answers empty.
+        let Some(key) = self.resolve_command_fqn(self.current_ns(), name) else {
+            return err(format!("unknown command \"{name}\""));
+        };
         let table = if execution {
             &self.exec_traces
         } else {
             &self.cmd_traces
         };
-        let Some(list) = self
-            .resolve_command_fqn(self.current_ns(), name)
-            .and_then(|key| table.get(&CommandSidecarKey::visible(key)))
-        else {
-            return Value::empty();
+        let Some(list) = table.get(&CommandSidecarKey::visible(key)) else {
+            return ok(Value::empty());
         };
-        Value::list(
+        ok(Value::list(
             list.iter()
                 .rev()
                 .map(|t| {
@@ -5756,7 +5760,7 @@ impl Vm {
                     ])
                 })
                 .collect(),
-        )
+        ))
     }
 
     /// Run one trace callback with `args` appended (list-quoted), in the
@@ -5965,6 +5969,18 @@ impl Vm {
         name: &str,
         op: &str,
     ) -> Result<(), Completion<Value>> {
+        self.fire_var_traces_reporting(name, op, None)
+    }
+
+    /// [`fire_var_traces`](Self::fire_var_traces) with an explicit `name1` for
+    /// the callbacks. Only the dispatched `unset a(k)` supplies one — see
+    /// [`array_unset_elem_spelled`](Self::array_unset_elem_spelled).
+    fn fire_var_traces_reporting(
+        &mut self,
+        name: &str,
+        op: &str,
+        reported_name1: Option<&str>,
+    ) -> Result<(), Completion<Value>> {
         if self.var_traces.is_empty() {
             return Ok(());
         }
@@ -5985,7 +6001,7 @@ impl Vm {
             return Ok(());
         }
         self.active_traces.insert(active_key.clone());
-        let r = self.fire_var_traces_inner(name, op, &base, &elem);
+        let r = self.fire_var_traces_inner(name, op, reported_name1.unwrap_or(&base), &elem);
         self.active_traces.remove(&active_key);
         r
     }
@@ -5997,7 +6013,7 @@ impl Vm {
         &mut self,
         name: &str,
         op: &str,
-        base: &str,
+        name1: &str,
         elem: &str,
     ) -> Result<(), Completion<Value>> {
         // For an element access C walks the containing array's trace list
@@ -6006,9 +6022,21 @@ impl Vm {
         // `varPtr` loop at :2623) — regardless of which was registered first.
         // Issue #1440.
         let mut keys = Vec::with_capacity(2);
-        if elem_ref(name).is_some() {
+        let mut name2 = elem.to_string();
+        if let Some((base, _)) = elem_ref(name) {
             let (lvl, nm) = self.locate(base);
             keys.push(format!("{lvl}\u{0}{nm}"));
+        } else if self.runtime_version.traces_recover_linked_array_element() {
+            // From Tcl 9.0 an access whose spelling names no element but whose
+            // resolved variable *is* one (`upvar #0 a(k) e; set e 5`) recovers
+            // the containing array — so the array's traces run too — and the
+            // element's key, reported as `name2`. Issue #1633 row 7.
+            let (lvl, nm) = self.locate(name);
+            if let Some((rbase, rkey)) = elem_ref(&nm) {
+                let (blvl, bnm) = self.locate_key_from(rbase, lvl);
+                keys.push(format!("{blvl}\u{0}{bnm}"));
+                name2 = rkey.to_string();
+            }
         }
         keys.push(self.trace_key(name));
         for key in keys {
@@ -6022,8 +6050,8 @@ impl Vm {
                 let script = format!(
                     "{} {} {} {}",
                     tr.command,
-                    tcl_brace(base),
-                    tcl_brace(elem),
+                    tcl_brace(name1),
+                    tcl_brace(&name2),
                     tcl_cmd_core::trace::callback_op_word(op, tr.old_style)
                 );
                 let r = self.eval_source(&script);
@@ -6899,10 +6927,24 @@ impl Vm {
         // Unset traces fire before removal; their errors are ignored.
         let _ = self.fire_var_traces(name, "unset");
         let (lvl, nm) = self.locate(name);
-        let existed = self
-            .frames
-            .get_mut(lvl)
-            .is_some_and(|f| f.locals.remove(&nm).is_some());
+        let existed = if let Some((rbase, rkey)) = elem_ref(&nm) {
+            // The name resolved through a link into an array element
+            // (`upvar #0 a(k) e; unset e`): remove that element, not a cell
+            // spelled `a(k)`, which is what C's resolved `Var` does.
+            let (blvl, bnm) = self.locate_key_from(rbase, lvl);
+            match self
+                .frames
+                .get_mut(blvl)
+                .and_then(|f| f.locals.get_mut(&bnm))
+            {
+                Some(Local::Array(m)) => m.remove(rkey).is_some(),
+                _ => false,
+            }
+        } else {
+            self.frames
+                .get_mut(lvl)
+                .is_some_and(|f| f.locals.remove(&nm).is_some())
+        };
         // A variable's traces are dropped when it is unset.
         if existed {
             let key = self.trace_key(name);
@@ -6926,7 +6968,7 @@ impl Vm {
         complain: bool,
     ) -> Result<(), Completion<Value>> {
         if let Some((array, key)) = elem_ref(name) {
-            self.array_unset_elem(array, key);
+            self.array_unset_elem_spelled(array, key);
             return Ok(());
         }
         // A constant cannot be unset; `-nocomplain` leaves it intact (var-26.12).
@@ -7344,9 +7386,31 @@ impl Vm {
         }
     }
 
+    /// Remove array element `name(key)` through a **two-part** access — C's
+    /// `TclObjUnsetVar2(part1, part2, …)`, which `array unset` and the
+    /// `INST_UNSET_ARRAY*` opcodes use. The traces report `name1 = name`.
     pub(crate) fn array_unset_elem(&mut self, name: &str, key: &str) {
+        self.array_unset_elem_reporting(name, key, None);
+    }
+
+    /// Remove array element `name(key)` named by the **one-part** `a(k)`
+    /// spelling — the dispatched `unset a(k)` and `INST_UNSET_STK`. From Tcl
+    /// 9.0 `UnsetVarStruct` recovers the element's key into `part2`
+    /// (`tclVar.c` 9.0.4:2638-2642), which stops `TclCallVarTraces` splitting
+    /// the spelling, so the callbacks see `name1 = a(k)`; 8.4/8.5/8.6 split it
+    /// and see `name1 = a`. Issue #1633 row 6.
+    pub(crate) fn array_unset_elem_spelled(&mut self, name: &str, key: &str) {
+        if self.runtime_version.traces_recover_linked_array_element() {
+            let spelling = format!("{name}({key})");
+            self.array_unset_elem_reporting(name, key, Some(&spelling));
+        } else {
+            self.array_unset_elem_reporting(name, key, None);
+        }
+    }
+
+    fn array_unset_elem_reporting(&mut self, name: &str, key: &str, reported: Option<&str>) {
         if !self.var_traces.is_empty() {
-            let _ = self.fire_var_traces(&format!("{name}({key})"), "unset");
+            let _ = self.fire_var_traces_reporting(&format!("{name}({key})"), "unset", reported);
         }
         let (lvl, nm) = self.locate(name);
         if let Some(Local::Array(m)) = self.frames.get_mut(lvl).and_then(|f| f.locals.get_mut(&nm))

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -1204,6 +1204,17 @@ pub(crate) struct CmdTraceEntry {
     pub(crate) ops: Vec<String>,
     pub(crate) callback: String,
     firing: std::cell::Cell<bool>,
+    /// Set by [`Vm::remove_cmd_trace`] when it unlinks this registration, so a
+    /// walk already under way skips it — C's `Tcl_UntraceCommand` unlinks from
+    /// the list the walk is following (`tclBasic.c` 9.0.4:4020-4045).
+    ///
+    /// The flag, rather than the entry's presence in `cmd_traces`, is what
+    /// cancels a pending callback: a **delete** walk holds the dying token's
+    /// list, and a callback that re-creates the command under the same name
+    /// takes the *table* entry over without touching that list, so the
+    /// remaining callbacks still run. Table membership cannot tell those two
+    /// apart. Measured on tclsh 8.6.16 and 9.0.4.
+    untraced: std::cell::Cell<bool>,
 }
 
 impl CmdTraceEntry {
@@ -1212,7 +1223,14 @@ impl CmdTraceEntry {
             ops,
             callback,
             firing: std::cell::Cell::new(false),
+            untraced: std::cell::Cell::new(false),
         }
+    }
+
+    /// Whether `trace remove` has unlinked this registration (see
+    /// [`Self::untraced`]).
+    pub(crate) fn untraced(&self) -> bool {
+        self.untraced.get()
     }
 
     /// Whether this entry fires for `op`.
@@ -5749,6 +5767,9 @@ impl Vm {
                 .iter()
                 .rposition(|t| t.ops == ops && t.callback == callback)
             {
+                // Mark before dropping the handle: a firing walk holds its own
+                // `Rc` and consults the flag, not the table.
+                list[index].untraced.set(true);
                 list.remove(index);
                 removed = true;
             }
@@ -5856,16 +5877,14 @@ impl Vm {
             if !entry.ops.iter().any(|o| o == op) {
                 continue;
             }
-            // C's `CallCommandTraces` walks the live list through `nextPtr`
-            // (tclBasic.c 9.0.4:3972-3993) and `Tcl_UntraceCommand` unlinks a
-            // record at once, so a trace an earlier callback removed does not
-            // fire in this pass. Re-check identity against the table, exactly
-            // as the execution-trace loop already does. Issue #1633 row 8.
-            if !self
-                .cmd_traces
-                .get(key)
-                .is_some_and(|live| live.iter().any(|l| Rc::ptr_eq(l, &entry)))
-            {
+            // C's `CallCommandTraces` walks the list hanging off the token it
+            // was handed (tclBasic.c 9.0.4:3972-3993) and `Tcl_UntraceCommand`
+            // unlinks a record at once, so a trace an earlier callback removed
+            // does not fire in this pass (issue #1633 row 8) — but a callback
+            // that re-creates the command under this name only takes the
+            // *table* entry over, leaving the dying token's list to finish
+            // firing. Hence the per-entry flag rather than a table lookup.
+            if entry.untraced() {
                 continue;
             }
             let _ = self.run_cmd_trace_callback(
@@ -7310,14 +7329,62 @@ impl Vm {
         name: &str,
         value: Value,
     ) -> Result<Value, Completion<Value>> {
+        if let Some((base, key)) = elem_ref(name) {
+            let (base, key) = (base.to_owned(), key.to_owned());
+            return self.store_elem_result(&base, &key, value);
+        }
         if self.var_traces.is_empty() {
             // With no traces nothing can have moved the cell: the read-back is
             // the stored value, so skip the second resolution.
-            self.var_set(name, value.clone())?;
+            self.set_var(name, value.clone())?;
             return Ok(value);
         }
-        self.var_set(name, value)?;
-        Ok(self.var_get(name).unwrap_or_else(Value::empty))
+        // Resolve the cell *once*, as C does: `TclObjLookupVarEx` hands
+        // `TclPtrSetVarIdx` a `Var *`, and the read-back is that same `Var`.
+        // Re-running the name lookup would let a write callback steer it
+        // elsewhere — at 8.x a callback that creates `ns::x` beside the `::x`
+        // a bare name had reached through the namespace fallback, or that
+        // unsets the `ns::x` the name did reach, moves the second lookup to a
+        // different variable. Measured on tclsh 8.6.16. Issue #1633 row 1.
+        let cell = self.resolved_cell(name);
+        self.set_var(name, value)?;
+        Ok(self.read_resolved_cell(&cell).unwrap_or_else(Value::empty))
+    }
+
+    /// The frame + key a scalar name resolves to **right now** — C's `Var *`.
+    /// Mirrors the resolution [`write_scalar_raw`](Self::write_scalar_raw) and
+    /// [`write_array_raw`](Self::write_array_raw) perform, so a cell captured
+    /// before a store is exactly the one the store wrote.
+    fn resolved_cell(&self, name: &str) -> (usize, String) {
+        let resolved = self.ns_var_fallback(name);
+        self.locate(resolved.as_deref().unwrap_or(name))
+    }
+
+    /// Read the scalar at an already-resolved [`resolved_cell`](Self::resolved_cell) —
+    /// the tail of [`get_var`](Self::get_var) with the name lookup already done.
+    fn read_resolved_cell(&self, (lvl, nm): &(usize, String)) -> Option<Value> {
+        if let Some((base, key)) = elem_ref(nm) {
+            // The resolved name is itself an element (a link into an array).
+            let (blvl, bnm) = self.locate_key_from(base, *lvl);
+            return match self.frames.get(blvl)?.locals.get(&bnm) {
+                Some(Local::Array(m)) => m.get(key).cloned(),
+                _ => None,
+            };
+        }
+        match self.frames.get(*lvl)?.locals.get(nm) {
+            Some(Local::Scalar(v)) => Some(v.clone()),
+            _ => None,
+        }
+    }
+
+    /// [`read_resolved_cell`](Self::read_resolved_cell) for element `key` of an
+    /// already-resolved array cell — the tail of
+    /// [`get_array_elem`](Self::get_array_elem).
+    fn read_resolved_elem(&self, (lvl, nm): &(usize, String), key: &str) -> Option<Value> {
+        match self.frames.get(*lvl)?.locals.get(nm) {
+            Some(Local::Array(m)) => m.get(key).cloned(),
+            _ => None,
+        }
     }
 
     /// [`store_var_result`](Self::store_var_result) for an already-split
@@ -7333,8 +7400,13 @@ impl Vm {
             self.set_array_elem(name, key, value.clone())?;
             return Ok(value);
         }
+        // The array's own cell is resolved once, for the same reason
+        // [`store_var_result`](Self::store_var_result) explains.
+        let cell = self.resolved_cell(name);
         self.set_array_elem(name, key, value)?;
-        Ok(self.get_array_elem(name, key).unwrap_or_else(Value::empty))
+        Ok(self
+            .read_resolved_elem(&cell, key)
+            .unwrap_or_else(Value::empty))
     }
 
     /// Read `name` for a **read-modify-write** command (`incr`, and the

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -816,6 +816,8 @@ pub struct InterpState {
     /// trace fires regardless of the access path (`upvar` alias, qualified
     /// name, …). Newest trace last; fired newest-first.
     var_traces: HashMap<String, Vec<VarTrace>>,
+    /// Source of [`VarTrace::id`]s; never reused within an interpreter.
+    next_var_trace_id: u64,
     /// `trace add command` registrations (`rename`/`delete` ops), keyed by the
     /// command's table key.  Entries follow the command through `rename` and
     /// are dropped when it is deleted or overwritten (M16.3).
@@ -1160,6 +1162,14 @@ struct CmdArena {
 /// A single registered variable trace.
 #[derive(Clone)]
 struct VarTrace {
+    /// Identity for the firing walk. C walks the live list through
+    /// `active.nextTracePtr` and `Tcl_UntraceVar2` rewrites every active walk
+    /// as it unlinks a record (`tclTrace.c` 9.0.4:2824-2842), so a trace a
+    /// callback removes never fires in that pass. A minted id, never reused,
+    /// survives the `Vec` reshuffling a removal causes where an index would
+    /// not, and identifies one *registration* where a `(ops, command)` pair
+    /// would match its own duplicates. Issue #1633 row 8.
+    id: u64,
     /// Operations this trace fires on (`read`/`write`/`unset`/`array`).
     ops: Vec<String>,
     /// The command prefix invoked as `command name1 name2 op`.
@@ -1170,6 +1180,20 @@ struct VarTrace {
     /// part of the `trace remove`/`trace vdelete` match, exactly as C masks
     /// the flag out there.
     old_style: bool,
+}
+
+/// One group of variable traces a firing walks: the array's or the variable's
+/// own list, still in the table, or a list an unset has already taken out of it.
+enum TraceGroup {
+    Live(String),
+    Taken(Vec<VarTrace>),
+}
+
+/// One step of that walk: a live registration, re-found by id before it runs,
+/// or an already-taken entry, which nothing can remove any more.
+enum Step {
+    Live(u64),
+    Taken(String, bool),
 }
 
 /// One `trace add command|execution` registration: the op set
@@ -1587,6 +1611,7 @@ impl InterpState {
             package_unknown: None,
             package_prefer: initial_package_prefer(),
             var_traces: HashMap::new(),
+            next_var_trace_id: 0,
             cmd_traces: HashMap::new(),
             exec_traces: HashMap::new(),
             active_sidecar_handles: Vec::new(),
@@ -2586,8 +2611,16 @@ impl Vm {
         // ImportRef list. Both the source and every import therefore remain
         // table-visible during this callback.
         self.on_command_removed_for(&key);
+        // C removes the table entry only through the dying `cmdPtr->hPtr`
+        // (`Tcl_DeleteCommandFromToken`, `tclBasic.c` 9.0.4:3865-3873). A
+        // delete callback that re-creates the command under the same name has
+        // taken that entry over, so the new command stands and this deletion
+        // must leave it alone. Issue #1633 row 9.
+        let replaced = self.command_token_identity(&key) != Some(source_token.clone());
         self.retire_real_command(&source_token, &command);
-        self.take_command_unchecked_key(&transaction.old_key);
+        if !replaced {
+            self.take_command_unchecked_key(&transaction.old_key);
+        }
         true
     }
 
@@ -5618,7 +5651,10 @@ impl Vm {
         old_style: bool,
     ) {
         let key = self.trace_key(name);
+        self.next_var_trace_id += 1;
+        let id = self.next_var_trace_id;
         self.var_traces.entry(key).or_default().push(VarTrace {
+            id,
             ops,
             command,
             old_style,
@@ -5817,16 +5853,29 @@ impl Vm {
         // (tclBasic.c:3972-3974), so the newest fires first. Our Vec pushes
         // newest-last. Issue #1440.
         for entry in entries.into_iter().rev() {
-            if entry.ops.iter().any(|o| o == op) {
-                let _ = self.run_cmd_trace_callback(
-                    &entry,
-                    &[
-                        Value::string(old_display.clone()),
-                        Value::string(new_display),
-                        Value::string(op),
-                    ],
-                );
+            if !entry.ops.iter().any(|o| o == op) {
+                continue;
             }
+            // C's `CallCommandTraces` walks the live list through `nextPtr`
+            // (tclBasic.c 9.0.4:3972-3993) and `Tcl_UntraceCommand` unlinks a
+            // record at once, so a trace an earlier callback removed does not
+            // fire in this pass. Re-check identity against the table, exactly
+            // as the execution-trace loop already does. Issue #1633 row 8.
+            if !self
+                .cmd_traces
+                .get(key)
+                .is_some_and(|live| live.iter().any(|l| Rc::ptr_eq(l, &entry)))
+            {
+                continue;
+            }
+            let _ = self.run_cmd_trace_callback(
+                &entry,
+                &[
+                    Value::string(old_display.clone()),
+                    Value::string(new_display),
+                    Value::string(op),
+                ],
+            );
         }
     }
 
@@ -5981,7 +6030,23 @@ impl Vm {
         op: &str,
         reported_name1: Option<&str>,
     ) -> Result<(), Completion<Value>> {
-        if self.var_traces.is_empty() {
+        self.fire_var_traces_taken(name, op, reported_name1, None)
+    }
+
+    /// [`fire_var_traces`](Self::fire_var_traces) walking a trace list that has
+    /// already been taken out of the table for the variable's own group — the
+    /// unset path, where C moves the list to a dummy `Var` before the callbacks
+    /// run (`UnsetVarStruct`, `tclVar.c` 9.0.4:2617-2648). The containing
+    /// array's group, which C leaves on the array's own `Var`, is still walked
+    /// live.
+    fn fire_var_traces_taken(
+        &mut self,
+        name: &str,
+        op: &str,
+        reported_name1: Option<&str>,
+        taken: Option<Vec<VarTrace>>,
+    ) -> Result<(), Completion<Value>> {
+        if self.var_traces.is_empty() && taken.is_none() {
             return Ok(());
         }
         let (base, elem) = elem_ref(name).map_or_else(
@@ -6001,7 +6066,7 @@ impl Vm {
             return Ok(());
         }
         self.active_traces.insert(active_key.clone());
-        let r = self.fire_var_traces_inner(name, op, reported_name1.unwrap_or(&base), &elem);
+        let r = self.fire_var_traces_inner(name, op, reported_name1.unwrap_or(&base), &elem, taken);
         self.active_traces.remove(&active_key);
         r
     }
@@ -6015,17 +6080,18 @@ impl Vm {
         op: &str,
         name1: &str,
         elem: &str,
+        taken: Option<Vec<VarTrace>>,
     ) -> Result<(), Completion<Value>> {
         // For an element access C walks the containing array's trace list
         // first and the element's own list second (`TclCallVarTraces`,
         // tclTrace.c 9.0.4: the `arrayPtr` loop at :2581 precedes the
         // `varPtr` loop at :2623) — regardless of which was registered first.
         // Issue #1440.
-        let mut keys = Vec::with_capacity(2);
+        let mut groups = Vec::with_capacity(2);
         let mut name2 = elem.to_string();
         if let Some((base, _)) = elem_ref(name) {
             let (lvl, nm) = self.locate(base);
-            keys.push(format!("{lvl}\u{0}{nm}"));
+            groups.push(TraceGroup::Live(format!("{lvl}\u{0}{nm}")));
         } else if self.runtime_version.traces_recover_linked_array_element() {
             // From Tcl 9.0 an access whose spelling names no element but whose
             // resolved variable *is* one (`upvar #0 a(k) e; set e 5`) recovers
@@ -6034,25 +6100,54 @@ impl Vm {
             let (lvl, nm) = self.locate(name);
             if let Some((rbase, rkey)) = elem_ref(&nm) {
                 let (blvl, bnm) = self.locate_key_from(rbase, lvl);
-                keys.push(format!("{blvl}\u{0}{bnm}"));
+                groups.push(TraceGroup::Live(format!("{blvl}\u{0}{bnm}")));
                 name2 = rkey.to_string();
             }
         }
-        keys.push(self.trace_key(name));
-        for key in keys {
-            let Some(traces) = self.var_traces.get(&key).cloned() else {
-                continue;
+        groups.push(match taken {
+            Some(list) => TraceGroup::Taken(list),
+            None => TraceGroup::Live(self.trace_key(name)),
+        });
+        for group in groups {
+            // Walk newest-first (the Vec is oldest-last), by identity: a
+            // callback's `trace remove` unlinks its record from the live list
+            // at once, and C's walk then skips it — so the id is re-found in
+            // the table before every callback rather than trusting a snapshot.
+            // A taken list is nobody's to remove any more, so it fires whole.
+            let steps: Vec<Step> = match &group {
+                TraceGroup::Live(key) => self.var_traces.get(key).map_or_else(Vec::new, |list| {
+                    list.iter().rev().map(|t| Step::Live(t.id)).collect()
+                }),
+                TraceGroup::Taken(list) => list
+                    .iter()
+                    .rev()
+                    .filter(|t| t.ops.iter().any(|o| o == op))
+                    .map(|t| Step::Taken(t.command.clone(), t.old_style))
+                    .collect(),
             };
-            for tr in traces.iter().rev() {
-                if !tr.ops.iter().any(|o| o == op) {
+            let live_key = match &group {
+                TraceGroup::Live(key) => key.as_str(),
+                TraceGroup::Taken(_) => "",
+            };
+            for step in steps {
+                let entry = match step {
+                    Step::Live(id) => self
+                        .var_traces
+                        .get(live_key)
+                        .and_then(|list| list.iter().find(|t| t.id == id))
+                        .filter(|t| t.ops.iter().any(|o| o == op))
+                        .map(|t| (t.command.clone(), t.old_style)),
+                    Step::Taken(command, old_style) => Some((command, old_style)),
+                };
+                let Some((command, old_style)) = entry else {
                     continue;
-                }
+                };
                 let script = format!(
                     "{} {} {} {}",
-                    tr.command,
+                    command,
                     tcl_brace(name1),
                     tcl_brace(&name2),
-                    tcl_cmd_core::trace::callback_op_word(op, tr.old_style)
+                    tcl_cmd_core::trace::callback_op_word(op, old_style)
                 );
                 let r = self.eval_source(&script);
                 let failed = match r {
@@ -6923,9 +7018,17 @@ impl Vm {
     }
 
     /// Remove a scalar; returns whether it existed.
+    ///
+    /// C's `UnsetVarStruct` (`tclVar.c` 9.0.4:2560-2745) marks the variable
+    /// undefined and moves its trace list off the cell **before** the unset
+    /// callbacks run, then frees whatever list is left. So a callback sees the
+    /// variable already gone, a value it stores survives the unset, and the
+    /// revived variable carries no traces — not even a write trace that would
+    /// otherwise have fired on that store. The trace key is resolved *before*
+    /// the removal: resolution can depend on the cell still existing (issue
+    /// #1328). Issue #1633 row 10.
     pub fn unset_var(&mut self, name: &str) -> bool {
-        // Unset traces fire before removal; their errors are ignored.
-        let _ = self.fire_var_traces(name, "unset");
+        let key = self.trace_key(name);
         let (lvl, nm) = self.locate(name);
         let existed = if let Some((rbase, rkey)) = elem_ref(&nm) {
             // The name resolved through a link into an array element
@@ -6945,13 +7048,13 @@ impl Vm {
                 .get_mut(lvl)
                 .is_some_and(|f| f.locals.remove(&nm).is_some())
         };
-        // A variable's traces are dropped when it is unset.
-        if existed {
-            let key = self.trace_key(name);
-            if self.var_traces.remove(&key).is_some() {
-                self.invalidate_guard_domain(GuardDomain::VariableTrace);
-            }
+        // A variable's traces go with it, and the taken list is what fires.
+        let taken = self.var_traces.remove(&key);
+        if taken.is_some() {
+            self.invalidate_guard_domain(GuardDomain::VariableTrace);
         }
+        // Unset-trace errors are ignored.
+        let _ = self.fire_var_traces_taken(name, "unset", None, taken);
         existed
     }
 
@@ -7409,13 +7512,23 @@ impl Vm {
     }
 
     fn array_unset_elem_reporting(&mut self, name: &str, key: &str, reported: Option<&str>) {
-        if !self.var_traces.is_empty() {
-            let _ = self.fire_var_traces_reporting(&format!("{name}({key})"), "unset", reported);
-        }
+        let spelling = format!("{name}({key})");
+        // As for a scalar: the element goes, and its own traces come out of the
+        // table, before the callbacks run. The *array's* traces stay — C leaves
+        // them on the array's own `Var` — so they are still live in the walk and
+        // still visible to `trace info`.
+        let trace_key = self.trace_key(&spelling);
         let (lvl, nm) = self.locate(name);
         if let Some(Local::Array(m)) = self.frames.get_mut(lvl).and_then(|f| f.locals.get_mut(&nm))
         {
             m.remove(key);
+        }
+        let taken = self.var_traces.remove(&trace_key);
+        if taken.is_some() {
+            self.invalidate_guard_domain(GuardDomain::VariableTrace);
+        }
+        if !self.var_traces.is_empty() || taken.is_some() {
+            let _ = self.fire_var_traces_taken(&spelling, "unset", reported, taken);
         }
     }
 

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -7148,6 +7148,90 @@ impl Vm {
         self.set_var(name, value)
     }
 
+    /// Store `value` in `name` and return the value the variable **reads back**
+    /// afterwards, which is what `set`/`append`/`lappend`/`incr` evaluate to.
+    /// A write trace that rewrites the variable therefore changes the command's
+    /// result, and one that unsets it — or turns it into an array — makes the
+    /// result empty: C returns `varPtr->value.objPtr` only while the variable
+    /// is still a defined scalar and the interp's empty object otherwise
+    /// (`TclPtrSetVarIdx`, `tclVar.c` 9.0.4:2050-2065; 8.6.16:2006-2012).
+    /// Named after the runtime's `Interp::store_var_result` so both engines'
+    /// read-back owners are greppable together. Issue #1633 row 1.
+    pub(crate) fn store_var_result(
+        &mut self,
+        name: &str,
+        value: Value,
+    ) -> Result<Value, Completion<Value>> {
+        if self.var_traces.is_empty() {
+            // With no traces nothing can have moved the cell: the read-back is
+            // the stored value, so skip the second resolution.
+            self.var_set(name, value.clone())?;
+            return Ok(value);
+        }
+        self.var_set(name, value)?;
+        Ok(self.var_get(name).unwrap_or_else(Value::empty))
+    }
+
+    /// [`store_var_result`](Self::store_var_result) for an already-split
+    /// `name(key)` element, so a key holding parentheses never round-trips
+    /// through an `a(k)` spelling.
+    pub(crate) fn store_elem_result(
+        &mut self,
+        name: &str,
+        key: &str,
+        value: Value,
+    ) -> Result<Value, Completion<Value>> {
+        if self.var_traces.is_empty() {
+            self.set_array_elem(name, key, value.clone())?;
+            return Ok(value);
+        }
+        self.set_array_elem(name, key, value)?;
+        Ok(self.get_array_elem(name, key).unwrap_or_else(Value::empty))
+    }
+
+    /// Read `name` for a **read-modify-write** command (`incr`, and the
+    /// `lappend` paths that reach C's `TclPtrGetVarIdx`): fire the read trace
+    /// and treat an error it raises as "no current value" rather than as a
+    /// failure — `TclPtrIncrObjVarIdx` substitutes 0 for the `NULL` fetch
+    /// (`tclVar.c` 9.0.4:2262-2272) and `Tcl_LappendObjCmd` builds the list
+    /// from the new values alone (:2944-2957, bug 3057639). The swallowed
+    /// error stays logged: tclsh 8.6.16 and 9.0.4 both leave `::errorInfo`
+    /// ending in the `(read trace on "x")` frame while the `incr` succeeds.
+    /// Mirror of the runtime's `Interp::read_for_update`. Issue #1633 rows 3/4.
+    pub(crate) fn read_for_update(&mut self, name: &str) -> Option<Value> {
+        if !self.var_traces.is_empty() && self.fire_var_traces(name, "read").is_err() {
+            self.publish_swallowed_trace_error();
+            return None;
+        }
+        self.var_get(name)
+    }
+
+    /// [`read_for_update`](Self::read_for_update) for an already-split
+    /// `name(key)` element.
+    pub(crate) fn read_elem_for_update(&mut self, name: &str, key: &str) -> Option<Value> {
+        if !self.var_traces.is_empty()
+            && self
+                .fire_var_traces(&format!("{name}({key})"), "read")
+                .is_err()
+        {
+            self.publish_swallowed_trace_error();
+            return None;
+        }
+        self.get_array_elem(name, key)
+    }
+
+    /// Publish the `errorInfo` a read trace left behind when the
+    /// read-modify-write command that fired it swallowed the error. C mirrors
+    /// `iPtr->errorInfo` into the global as each frame is added
+    /// (`TclLogCommandInfo`), so the chain stays visible even though the
+    /// command went on to succeed; the interp's own accumulator is then reset
+    /// so the next error starts a fresh trace.
+    fn publish_swallowed_trace_error(&mut self) {
+        if let Some(info) = self.take_error_info() {
+            self.publish_error_info(&info);
+        }
+    }
+
     // -- arrays (link-aware via `locate`) --
 
     pub(crate) fn get_array_elem(&self, name: &str, key: &str) -> Option<Value> {
@@ -7434,11 +7518,18 @@ impl Vm {
 
     /// Publish `errorInfo` / `errorCode` into the global frame.
     pub(crate) fn publish_error(&mut self, info: &str, code: &Value) {
+        self.publish_error_info(info);
+        if let Some(g) = self.frames.first_mut() {
+            g.locals
+                .insert("errorCode".to_owned(), Local::Scalar(code.clone()));
+        }
+    }
+
+    /// Publish the `errorInfo` global alone, leaving `errorCode` as it is.
+    pub(crate) fn publish_error_info(&mut self, info: &str) {
         if let Some(g) = self.frames.first_mut() {
             g.locals
                 .insert("errorInfo".to_owned(), Local::Scalar(Value::string(info)));
-            g.locals
-                .insert("errorCode".to_owned(), Local::Scalar(code.clone()));
         }
     }
 

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -7028,7 +7028,7 @@ impl Vm {
     /// the removal: resolution can depend on the cell still existing (issue
     /// #1328). Issue #1633 row 10.
     pub fn unset_var(&mut self, name: &str) -> bool {
-        let key = self.trace_key(name);
+        let key = (!self.var_traces.is_empty()).then(|| self.trace_key(name));
         let (lvl, nm) = self.locate(name);
         let existed = if let Some((rbase, rkey)) = elem_ref(&nm) {
             // The name resolved through a link into an array element
@@ -7049,6 +7049,9 @@ impl Vm {
                 .is_some_and(|f| f.locals.remove(&nm).is_some())
         };
         // A variable's traces go with it, and the taken list is what fires.
+        let Some(key) = key else {
+            return existed;
+        };
         let taken = self.var_traces.remove(&key);
         if taken.is_some() {
             self.invalidate_guard_domain(GuardDomain::VariableTrace);
@@ -7512,24 +7515,29 @@ impl Vm {
     }
 
     fn array_unset_elem_reporting(&mut self, name: &str, key: &str, reported: Option<&str>) {
-        let spelling = format!("{name}({key})");
         // As for a scalar: the element goes, and its own traces come out of the
         // table, before the callbacks run. The *array's* traces stay — C leaves
         // them on the array's own `Var` — so they are still live in the walk and
-        // still visible to `trace info`.
-        let trace_key = self.trace_key(&spelling);
+        // still visible to `trace info`. The trace key is resolved while the
+        // element is still present (issue #1328).
+        let traced = (!self.var_traces.is_empty()).then(|| {
+            let spelling = format!("{name}({key})");
+            let trace_key = self.trace_key(&spelling);
+            (spelling, trace_key)
+        });
         let (lvl, nm) = self.locate(name);
         if let Some(Local::Array(m)) = self.frames.get_mut(lvl).and_then(|f| f.locals.get_mut(&nm))
         {
             m.remove(key);
         }
+        let Some((spelling, trace_key)) = traced else {
+            return;
+        };
         let taken = self.var_traces.remove(&trace_key);
         if taken.is_some() {
             self.invalidate_guard_domain(GuardDomain::VariableTrace);
         }
-        if !self.var_traces.is_empty() || taken.is_some() {
-            let _ = self.fire_var_traces_taken(&spelling, "unset", reported, taken);
-        }
+        let _ = self.fire_var_traces_taken(&spelling, "unset", reported, taken);
     }
 
     /// Append one `while executing` / `invoked from within` frame for the

--- a/rust/tcl-vm/tests/command_traces_e2e.rs
+++ b/rust/tcl-vm/tests/command_traces_e2e.rs
@@ -377,6 +377,107 @@ const VECTORS: &[Vector] = &[
                {{enter leave enterstep leavestep} cb}\n\
                {{array read write unset} cb}",
     },
+    // Row 8 (command / execution): the same live-list rule as the variable
+    // half. `CallCommandTraces` walks `nextPtr` (`tclBasic.c` 9.0.4:3972-3993)
+    // and `Tcl_UntraceCommand` unlinks at once, so a trace a callback removes
+    // does not fire in that pass — for `enter` and `delete`, which walk
+    // newest-first, and for `leave`, which C scans in reverse and so reaches
+    // the *oldest* first.
+    //
+    // The `rename` op is deliberately absent. C's `TclRenameCommand` inserts
+    // the *new* hash entry, fires the rename traces while the old entry is
+    // still present, and only then removes it — and the traces hang off the
+    // shared `Command`, so a callback sees one list under either name. This VM
+    // renames first and moves its name-keyed trace list afterwards, so a
+    // callback's `trace info`/`trace remove` finds neither name traced. Fixing
+    // that is a change to when `cmd_rename` publishes the sidecar, not to the
+    // firing walk.
+    Vector {
+        name: "a callback's trace remove is honoured mid-firing for command and execution traces",
+        script: "proc target {} { return T }\n\
+                 proc e1 args { trace remove execution target enter e2\n\
+                 puts \"e1 info: [trace info execution target]\" }\n\
+                 proc e2 args { puts \"e2 fired\" }\n\
+                 trace add execution target enter e2\n\
+                 trace add execution target enter e1\n\
+                 target\n\
+                 puts ---\n\
+                 proc victim {} {}\n\
+                 proc d1 args { trace remove command victim delete d2\n\
+                 puts \"d1 info: [trace info command victim]\" }\n\
+                 proc d2 args { puts \"d2 fired\" }\n\
+                 trace add command victim delete d2\n\
+                 trace add command victim delete d1\n\
+                 rename victim {}\n\
+                 puts ---\n\
+                 proc lt {} { return L }\n\
+                 proc l1 args { puts \"l1 fired\" }\n\
+                 proc l2 args { trace remove execution lt leave l1\n\
+                 puts \"l2 info: [trace info execution lt]\" }\n\
+                 trace add execution lt leave l2\n\
+                 trace add execution lt leave l1\n\
+                 lt\n",
+        want: "e1 info: {enter e1}\n\
+               ---\n\
+               d1 info: {delete d1}\n\
+               ---\n\
+               l2 info: {leave l2}",
+    },
+    // Row 9: `Tcl_DeleteCommandFromToken` marks the command `CMD_DYING`
+    // (`tclBasic.c` 9.0.4:3760), fires the delete traces while its hash entry
+    // still exists (:3793), and removes that entry only through
+    // `cmdPtr->hPtr` if it is still non-NULL (:3865-3873). A callback that
+    // re-creates the command under the same name has taken the entry over, so
+    // the new command stands — trace-less, since the traces went with the old
+    // token. A redefinition still beats the callback's own, `rename` fires no
+    // delete trace, and an `interp alias` replacing a traced proc fires one.
+    Vector {
+        name: "a delete trace that re-creates the command leaves the new one standing",
+        script: "proc foo {} { return foo }\n\
+                 proc delcb {old new op} { puts \"in-trace: [info commands foo]\"\n\
+                 proc foo {} { return foo2 } }\n\
+                 trace add command foo delete delcb\n\
+                 rename foo {}\n\
+                 puts \"exists: [info commands foo]\"\n\
+                 puts [catch {foo} m]\n\
+                 puts $m\n\
+                 puts \"traces: [trace info command foo]\"\n\
+                 puts ---\n\
+                 proc bar {} { return bar1 }\n\
+                 proc delbar {old new op} { proc bar {} { return bar2 } }\n\
+                 trace add command bar delete delbar\n\
+                 proc bar {} { return bar3 }\n\
+                 puts [bar]\n\
+                 puts \"traces: [trace info command bar]\"\n\
+                 puts ---\n\
+                 proc baz {} {}\n\
+                 proc renbaz {old new op} { puts \"ren: $old -> $new ($op)\" }\n\
+                 namespace eval ns {}\n\
+                 trace add command baz delete renbaz\n\
+                 rename baz ns::baz\n\
+                 puts \"baz: [info commands baz] ns::baz: [info commands ::ns::baz]\"\n\
+                 puts ---\n\
+                 proc qux {} { return q }\n\
+                 proc delqux {old new op} { puts \"delqux $op\" }\n\
+                 trace add command qux delete delqux\n\
+                 interp alias {} qux {} puts\n\
+                 qux hi\n\
+                 puts [catch {trace info command qux} m2]\n",
+        want: "in-trace: foo\n\
+               exists: foo\n\
+               0\n\
+               foo2\n\
+               traces: \n\
+               ---\n\
+               bar3\n\
+               traces: \n\
+               ---\n\
+               baz:  ns::baz: ::ns::baz\n\
+               ---\n\
+               delqux delete\n\
+               hi\n\
+               0",
+    },
 ];
 
 /// Former divergence from C (issue #946 fault 3), now fixed: step traces used

--- a/rust/tcl-vm/tests/command_traces_e2e.rs
+++ b/rust/tcl-vm/tests/command_traces_e2e.rs
@@ -423,6 +423,53 @@ const VECTORS: &[Vector] = &[
                ---\n\
                l2 info: {leave l2}",
     },
+    // A **delete** walk is handed the dying token's own trace list
+    // (`CallCommandTraces`, `tclBasic.c` 9.0.4:3972-3993), so a callback that
+    // re-creates the command under the same name takes the *name-keyed* entry
+    // over while the rest of that list still fires. Only an explicit
+    // `trace remove` cancels a pending callback — and once a replacement holds
+    // the name, `trace remove` reaches the replacement's (empty) list instead,
+    // so it cancels nothing. Measured on tclsh 8.6.16 and 9.0.4; the VM used to
+    // decide liveness by table membership, which a re-creation silently
+    // emptied, so every older callback was skipped.
+    Vector {
+        name: "a delete callback that re-creates the command does not cancel the rest of the walk",
+        script: "proc foo {} { return FOO }\n\
+                 proc OLD {old new op} { puts \"OLD $old $new $op\" }\n\
+                 proc NEW {old new op} { puts \"NEW $old $new $op\"\n\
+                 proc foo {} { return FOO2 } }\n\
+                 trace add command foo delete OLD\n\
+                 trace add command foo delete NEW\n\
+                 rename foo {}\n\
+                 puts \"exists:[info commands foo] call:[foo] traces:[trace info command foo]\"\n\
+                 puts ---\n\
+                 proc A1 {o n op} { puts A1 }\n\
+                 proc A2 {o n op} { puts A2\n\
+                 trace remove command a delete A1 }\n\
+                 proc a {} {}\n\
+                 trace add command a delete A1\n\
+                 trace add command a delete A2\n\
+                 rename a {}\n\
+                 puts ---\n\
+                 proc B1 {o n op} { puts B1 }\n\
+                 proc B2 {o n op} { puts B2\n\
+                 proc b {} {}\n\
+                 trace remove command b delete B1 }\n\
+                 proc b {} {}\n\
+                 trace add command b delete B1\n\
+                 trace add command b delete B2\n\
+                 rename b {}\n\
+                 puts \"b-exists:[info commands b] b-traces:[trace info command b]\"\n",
+        want: "NEW ::foo  delete\n\
+               OLD ::foo  delete\n\
+               exists:foo call:FOO2 traces:\n\
+               ---\n\
+               A2\n\
+               ---\n\
+               B2\n\
+               B1\n\
+               b-exists:b b-traces:",
+    },
     // Row 9: `Tcl_DeleteCommandFromToken` marks the command `CMD_DYING`
     // (`tclBasic.c` 9.0.4:3760), fires the delete traces while its hash entry
     // still exists (:3793), and removes that entry only through

--- a/rust/tcl-vm/tests/command_traces_e2e.rs
+++ b/rust/tcl-vm/tests/command_traces_e2e.rs
@@ -128,6 +128,37 @@ struct Vector {
 }
 
 const VECTORS: &[Vector] = &[
+    // `trace info command|execution` resolves the name with `TCL_LEAVE_ERR_MSG`
+    // before reporting (`TraceCommandObjCmd` `tclTrace.c` 9.0.4:661,
+    // `TraceExecutionObjCmd` :454), so a command that does not exist is an
+    // error carrying the name *as written* — unlike `trace info variable`,
+    // which answers the empty list for an untraced or absent variable.
+    // Issue #1633 row 5.
+    Vector {
+        name: "trace info on a nonexistent command errors, as add and remove do",
+        script: "puts [catch {trace info command nosuch} m]|$m\n\
+                 puts [catch {trace info execution nosuch} m]|$m\n\
+                 puts [catch {trace info variable nosuch} m]|$m\n\
+                 puts [catch {trace add command nosuch delete foo} m]|$m\n\
+                 puts [catch {trace remove execution nosuch enter foo} m]|$m\n\
+                 puts [catch {trace remove variable nosuch write foo} m]|$m\n\
+                 puts [catch {trace info command ns::nosuch} m]|$m\n\
+                 puts [catch {trace info command nosuch::nosuch} m]|$m\n\
+                 proc real {} {}\n\
+                 puts [catch {trace info command real} m]|$m\n\
+                 namespace eval nn { proc q {} {} }\n\
+                 puts [catch {trace info command nn::q} m]|$m\n",
+        want: "1|unknown command \"nosuch\"\n\
+               1|unknown command \"nosuch\"\n\
+               0|\n\
+               1|unknown command \"nosuch\"\n\
+               1|unknown command \"nosuch\"\n\
+               0|\n\
+               1|unknown command \"ns::nosuch\"\n\
+               1|unknown command \"nosuch::nosuch\"\n\
+               0|\n\
+               0|",
+    },
     Vector {
         name: "command traces: fully-qualified rename/delete shapes, following the rename",
         script: "proc tracer args { puts \"T:[join $args |]\" }\n\

--- a/rust/tcl-vm/tests/cross_version_command_surface_e2e.rs
+++ b/rust/tcl-vm/tests/cross_version_command_surface_e2e.rs
@@ -1005,14 +1005,19 @@ fn refused_alias_rename_preserves_a_hidden_destination_for_later_releases() {
              namespace eval imported {namespace import ::src::a}\n\
              catch {rename ::src::a lassign} message\n\
              list $message [namespace origin ::imported::a] \\
-                  [llength [trace info command lassign]] \\
-                  [llength [trace info execution lassign]] [info exists ::events]\n",
+                  [catch {trace info command lassign}] \\
+                  [catch {trace info execution lassign}] [info exists ::events]\n",
         )
         .expect("8.4 setup compiles");
     assert!(setup.code.is_ok());
+    // `lassign` is unavailable at 8.4, so introspecting its traces errors
+    // rather than answering an empty list — C resolves the name with
+    // `TCL_LEAVE_ERR_MSG` first (`TraceCommandObjCmd`, `tclTrace.c`
+    // 9.0.4:661), measured on tclsh 8.4.20 through 9.0.4. The point of the
+    // pair is unchanged: no registration is reachable here, and none fired.
     assert_eq!(
         setup.result.to_str().as_ref(),
-        "{cannot define or rename alias \"lassign\": would create a loop} ::src::a 0 0 0"
+        "{cannot define or rename alias \"lassign\": would create a loop} ::src::a 1 1 0"
     );
 
     vm.set_dialect_profile(

--- a/rust/tcl-vm/tests/cross_version_vars_e2e.rs
+++ b/rust/tcl-vm/tests/cross_version_vars_e2e.rs
@@ -310,6 +310,39 @@ const VECTORS: &[Vector] = &[
         want_8x: "trace:g:write\nX",
         want_90: "foo",
     },
+    // A store returns the variable read back *after* its write traces
+    // (`TclPtrSetVarIdx`, issue #1633 row 1) — and C reads back the very `Var`
+    // it wrote, not the name a second time. Only 8.x can tell the two apart,
+    // because only 8.x lets a callback change which cell a bare name reaches:
+    // here the write lands on `::x` through the fallback, and the callback
+    // creates `::n::x` beside it. Re-resolving would answer `NSVAL`.
+    Vector {
+        name: "a write callback creating the namespace cell cannot move the read-back",
+        script: "proc mk {n1 n2 op} { set ::n::x NSVAL }\n\
+                 set ::x GLOBAL\n\
+                 namespace eval n {}\n\
+                 trace add variable ::x write mk\n\
+                 namespace eval n { puts [set x V] }\n\
+                 puts [set ::x]:[info exists ::n::x]\n",
+        want_8x: "V\nV:1",
+        want_90: "V\nGLOBAL:1",
+    },
+    // The mirror image: the name reaches `::m::y` and the callback unsets it,
+    // so the read-back finds the cell gone and the store is empty at both
+    // releases. Re-resolving would fall back to `::y` at 8.x and answer
+    // `GLOBAL2`.
+    Vector {
+        name: "a write callback unsetting the cell leaves the store empty, with no fallback",
+        script: "proc rm {n1 n2 op} { unset ::m::y }\n\
+                 set ::y GLOBAL2\n\
+                 namespace eval m {}\n\
+                 set ::m::y NSVAL2\n\
+                 trace add variable ::m::y write rm\n\
+                 namespace eval m { puts <[set y V]> }\n\
+                 puts [info exists ::m::y]:[set ::y]\n",
+        want_8x: "<>\n0:GLOBAL2",
+        want_90: "<>\n0:GLOBAL2",
+    },
 ];
 
 #[test]

--- a/rust/tcl-vm/tests/element_recovery_traces_e2e.rs
+++ b/rust/tcl-vm/tests/element_recovery_traces_e2e.rs
@@ -1,0 +1,275 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Cross-version vectors for the array element a trace access does not name
+//! (issue #1633 rows 6 and 7).
+//!
+//! Tcl 9.0 added the recovery in three places at once —
+//! `TclVarFindHiddenArray` (`tclInt.h` 9.0.4:866), the `part2` refill in
+//! `TclCallVarTraces` (`tclTrace.c` 9.0.4:2560-2565) and the same refill in
+//! `UnsetVarStruct` (`tclVar.c` 9.0.4:2638-2642). 8.4/8.5/8.6 carry none of
+//! them, so the identical script reports different callback arguments per
+//! release:
+//!
+//! * `upvar #0 a(k) e; set e 5` fires the *array's* traces as well as the
+//!   element's and reports `name2 = k` at 9.x; at 8.x only the element's own
+//!   fire, with an empty `name2`.
+//! * An element unset named by the **one-part** `a(k)` spelling, so `part2`
+//!   starts empty, reports `name1 = a(k)` at 9.x and `name1 = a` at 8.x. A
+//!   *two-part* element unset (`array unset a k`, the `INST_UNSET_ARRAY*`
+//!   opcodes) supplies `part2` itself and reports `name1 = a` at every release.
+//!
+//! The sheet spells the one-part unset dynamically (`set nm a; unset
+//! ${nm}(k)`) because C's answer for the *literal* `unset a(k)` depends on
+//! whether the enclosing script was byte-compiled: `TclCompileUnsetCmd` emits
+//! the two-part `INST_UNSET_ARRAY_STK` (so `name1 = a`), while an uncompiled
+//! evaluation reaches `Tcl_UnsetObjCmd` and the one-part form. Measured both
+//! ways on 9.0.4 — a script file given to `tclsh` reports `a(k)`, the same
+//! text piped to its stdin reports `a`. A dynamic name is never compiled to
+//! the two-part opcode, so it pins the recovery itself rather than the
+//! compiler's choice.
+//!
+//! The axis is a `tcl-dialect` fact, `TclVersion::
+//! traces_recover_linked_array_element`, so both engines read one truth table.
+//! Measured on tclsh 8.4.20, 8.5.19, 8.6.16, 9.0.4 and 9.1b0.
+
+use std::cell::RefCell;
+use std::io::Write as _;
+use std::rc::Rc;
+
+use tcl_compiler::cfg_builder::build_cfg_codegen;
+use tcl_compiler::codegen::codegen_module;
+use tcl_dialect::{DialectProfile, TclVersion};
+use tcl_vm::{CompileError, CompileService, Vm};
+
+struct CompilerSvc;
+
+impl CompileService for CompilerSvc {
+    type Module = tcl_bytecode::ModuleAsm;
+
+    fn compile(&self, src: &str) -> Result<tcl_bytecode::ModuleAsm, CompileError> {
+        self.compile_for_profile(
+            src,
+            tcl_registry::model::ingress::resolve_environment(TclVersion::V9_0.dialect_name())
+                .analyser_profile(),
+        )
+    }
+
+    fn compile_for_profile(
+        &self,
+        src: &str,
+        profile: &'static DialectProfile,
+    ) -> Result<tcl_bytecode::ModuleAsm, CompileError> {
+        let registry = tcl_registry::model::ingress::static_context_for_profile(profile).commands();
+        let config = tcl_lexer::LexerConfig::from_grammar(profile.grammar);
+        let ir = tcl_compiler::lowering::lower_to_ir_for_bytecode_with_dialect(
+            src,
+            registry,
+            config,
+            Some(profile),
+        );
+        let cfg = build_cfg_codegen(&ir, false);
+        Ok(codegen_module(&cfg, &ir, registry))
+    }
+}
+
+#[derive(Clone, Default)]
+struct Capture(Rc<RefCell<Vec<u8>>>);
+
+impl std::io::Write for Capture {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.borrow_mut().extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+fn vm_output(src: &str, version: TclVersion) -> String {
+    let profile = tcl_registry::model::ingress::resolve_environment(version.dialect_name())
+        .analyser_profile();
+    let asm = CompilerSvc
+        .compile_for_profile(src, profile)
+        .expect("test script compiles for its selected profile");
+    let capture = Capture::default();
+    let mut vm = Vm::with_output(Box::new(capture.clone()));
+    vm.set_compiler(Box::new(CompilerSvc));
+    vm.set_runtime_version(version);
+    let _ = vm.run_module(&asm);
+    String::from_utf8_lossy(&capture.0.borrow())
+        .trim()
+        .to_owned()
+}
+
+fn tclsh_output(bin_env: &str, names: &[&str], src: &str) -> Option<String> {
+    let mut candidates = std::env::var(bin_env).ok().into_iter().collect::<Vec<_>>();
+    candidates.extend(names.iter().map(ToString::to_string));
+    for name in candidates {
+        let Ok(mut child) = std::process::Command::new(name)
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+        else {
+            continue;
+        };
+        child
+            .stdin
+            .as_mut()
+            .expect("stdin")
+            .write_all(src.as_bytes())
+            .expect("write Tcl script");
+        let output = child.wait_with_output().expect("run Tcl script");
+        if output.status.success() {
+            return Some(String::from_utf8_lossy(&output.stdout).trim().to_owned());
+        }
+    }
+    None
+}
+
+/// Proc callbacks, not `apply`: 8.4 has neither `apply` nor `lassign`.
+const SCRIPT: &str = "\
+proc A {n1 n2 op} { puts \"A n1=<$n1> n2=<$n2> op=$op\" }\n\
+proc E {n1 n2 op} { puts \"E n1=<$n1> n2=<$n2> op=$op\" }\n\
+array set a {k v}\n\
+trace add variable a write A\n\
+trace add variable a(k) write E\n\
+upvar #0 a(k) e\n\
+set e 5\n\
+trace add variable a unset A\n\
+trace add variable a(k) unset E\n\
+set nm a\n\
+unset ${nm}(k)\n\
+array set b {k v}\n\
+trace add variable b(k) unset E\n\
+upvar #0 b(k) f\n\
+unset f\n\
+puts \"b(k) exists after alias unset: [info exists b(k)]\"\n\
+array set g {k v}\n\
+trace add variable g unset A\n\
+trace add variable g(k) unset E\n\
+array unset g k\n\
+array set d {k v}\n\
+trace add variable d write A\n\
+trace add variable d(k) write E\n\
+set d(k) 2\n";
+
+const EXPECT_8X: &str = "\
+E n1=<e> n2=<> op=write\n\
+A n1=<a> n2=<k> op=unset\n\
+E n1=<a> n2=<k> op=unset\n\
+E n1=<f> n2=<> op=unset\n\
+b(k) exists after alias unset: 0\n\
+A n1=<g> n2=<k> op=unset\n\
+E n1=<g> n2=<k> op=unset\n\
+A n1=<d> n2=<k> op=write\n\
+E n1=<d> n2=<k> op=write";
+
+const EXPECT_9X: &str = "\
+A n1=<e> n2=<k> op=write\n\
+E n1=<e> n2=<k> op=write\n\
+A n1=<a(k)> n2=<k> op=unset\n\
+E n1=<a(k)> n2=<k> op=unset\n\
+E n1=<f> n2=<k> op=unset\n\
+b(k) exists after alias unset: 0\n\
+A n1=<g> n2=<k> op=unset\n\
+E n1=<g> n2=<k> op=unset\n\
+A n1=<d> n2=<k> op=write\n\
+E n1=<d> n2=<k> op=write";
+
+struct Vector {
+    version: TclVersion,
+    expected: &'static str,
+    env: &'static str,
+    tclsh: &'static [&'static str],
+}
+
+const VECTORS: &[Vector] = &[
+    Vector {
+        version: TclVersion::V8_4,
+        expected: EXPECT_8X,
+        env: "TCL_LSP_TCLSH84",
+        tclsh: &["tclsh8.4"],
+    },
+    Vector {
+        version: TclVersion::V8_5,
+        expected: EXPECT_8X,
+        env: "TCL_LSP_TCLSH85",
+        tclsh: &["tclsh8.5"],
+    },
+    Vector {
+        version: TclVersion::V8_6,
+        expected: EXPECT_8X,
+        env: "TCL_LSP_TCLSH86",
+        tclsh: &["tclsh8.6"],
+    },
+    Vector {
+        version: TclVersion::V9_0,
+        expected: EXPECT_9X,
+        env: "TCL_LSP_TCLSH90",
+        tclsh: &["tclsh9.0"],
+    },
+    Vector {
+        version: TclVersion::V9_1,
+        expected: EXPECT_9X,
+        env: "TCL_LSP_TCLSH91",
+        tclsh: &["tclsh9.1"],
+    },
+];
+
+#[test]
+fn element_recovery_follows_the_selected_release() {
+    for vector in VECTORS {
+        assert_eq!(
+            vm_output(SCRIPT, vector.version),
+            vector.expected,
+            "{:?}",
+            vector.version
+        );
+    }
+}
+
+#[test]
+fn vectors_match_real_tclsh_when_available() {
+    let mut ran = 0;
+    for vector in VECTORS {
+        if let Some(actual) = tclsh_output(vector.env, vector.tclsh, SCRIPT) {
+            assert_eq!(actual, vector.expected, "{:?}", vector.version);
+            ran += 1;
+        }
+    }
+    if ran == 0 {
+        eprintln!("skipping: no versioned tclsh binaries found");
+    }
+}
+
+/// The release axis is a dialect fact, so a profile edit moves both engines.
+#[test]
+fn the_dialect_owns_the_release_boundary() {
+    for version in [TclVersion::V8_4, TclVersion::V8_5, TclVersion::V8_6] {
+        assert!(
+            !version.traces_recover_linked_array_element(),
+            "{version:?}"
+        );
+    }
+    for version in [TclVersion::V9_0, TclVersion::V9_1] {
+        assert!(version.traces_recover_linked_array_element(), "{version:?}");
+    }
+}

--- a/rust/tcl-vm/tests/variable_trace_semantics_e2e.rs
+++ b/rust/tcl-vm/tests/variable_trace_semantics_e2e.rs
@@ -374,6 +374,147 @@ const VECTORS: &[Vector] = &[
                lappend: code=0 msg=z y=z\n\
                lappend0: code=0 msg= z2=",
     },
+    // Row 8 (variable): the firing walk consults the live trace list, not a
+    // snapshot. C's `TclCallVarTraces` follows `active.nextTracePtr`
+    // (`tclTrace.c` 9.0.4:2583, :2622) and `Tcl_UntraceVar2` unlinks a record
+    // at once, rewriting every active walk (:2824-2842); `TraceVarEx` prepends,
+    // so an addition sits behind the walk. A trace a callback removes therefore
+    // does not fire in that pass — whether it is older and not yet reached, or
+    // newer and already run — one it adds does not fire until the next access,
+    // and `trace info` reflects both immediately.
+    Vector {
+        name: "a callback's trace remove and trace add are honoured mid-firing",
+        script: "proc t1 {n1 n2 op} { trace remove variable ::t write t1\n\
+                 puts \"t1 info: [trace info variable ::t]\" }\n\
+                 proc t2 {n1 n2 op} { trace add variable ::t write t3\n\
+                 puts \"t2 info: [trace info variable ::t]\" }\n\
+                 proc t3 {n1 n2 op} { puts \"t3 fired\" }\n\
+                 proc t4 {n1 n2 op} { puts \"t4 fired\" }\n\
+                 set t 0\n\
+                 trace add variable t write t4\n\
+                 trace add variable t write t2\n\
+                 trace add variable t write t1\n\
+                 set t 1\n\
+                 puts \"after: [trace info variable ::t]\"\n\
+                 set t 2\n\
+                 puts ---\n\
+                 proc u1 {n1 n2 op} { trace remove variable ::u write u2\n\
+                 puts \"u1 info: [trace info variable ::u]\" }\n\
+                 proc u2 {n1 n2 op} { puts \"u2 fired\" }\n\
+                 set u 0\n\
+                 trace add variable u write u2\n\
+                 trace add variable u write u1\n\
+                 set u 1\n\
+                 puts ---\n\
+                 proc v1 {n1 n2 op} { puts \"v1 fired\" }\n\
+                 proc v2 {n1 n2 op} { trace remove variable ::v write v1\n\
+                 puts \"v2 info: [trace info variable ::v]\" }\n\
+                 set v 0\n\
+                 trace add variable v write v2\n\
+                 trace add variable v write v1\n\
+                 set v 1\n\
+                 puts ---\n\
+                 proc w1 {n1 n2 op} { trace remove variable ::w write w1\n\
+                 trace add variable ::w write w1\n\
+                 puts \"w1 info: [trace info variable ::w]\" }\n\
+                 set w 0\n\
+                 trace add variable w write w1\n\
+                 set w 1\n",
+        want: "t1 info: {write t2} {write t4}\n\
+               t2 info: {write t3} {write t2} {write t4}\n\
+               t4 fired\n\
+               after: {write t3} {write t2} {write t4}\n\
+               t3 fired\n\
+               t2 info: {write t3} {write t3} {write t2} {write t4}\n\
+               t4 fired\n\
+               ---\n\
+               u1 info: {write u1}\n\
+               ---\n\
+               v1 fired\n\
+               v2 info: {write v2}\n\
+               ---\n\
+               w1 info: {write w1}",
+    },
+    // Row 10: `UnsetVarStruct` (`tclVar.c` 9.0.4:2560-2745) marks the variable
+    // undefined and moves its trace list aside *before* the callbacks run, then
+    // frees whatever list is left. So a callback sees the variable already
+    // gone, a value it stores survives the unset, and the revived variable
+    // carries no traces — not even the write trace that would otherwise have
+    // fired on that store. Whole-array traces are not the element's, so an
+    // element unset leaves them in place.
+    //
+    // Row 8's unset variant rides along: an unset callback that removes another
+    // unset trace finds nothing to remove (the list is already out of the
+    // table, C's Bug 3062331), and the taken list still fires it.
+    Vector {
+        name: "an unset takes the traces out before firing, so a revive survives trace-less",
+        script: "proc rev {n1 n2 op} { puts \"in-trace exists=[info exists ::a]\"\n\
+                 set ::a revived }\n\
+                 set a orig\n\
+                 trace add variable a unset rev\n\
+                 unset a\n\
+                 puts \"exists=[info exists a] val=<$a> traces=<[trace info variable a]>\"\n\
+                 puts ---\n\
+                 proc reve {n1 n2 op} { set ::b(k) revived }\n\
+                 array set b {k v}\n\
+                 trace add variable b(k) unset reve\n\
+                 unset b(k)\n\
+                 puts \"b exists=[info exists b(k)] val=<$b(k)> traces=<[trace info variable b(k)]>\"\n\
+                 puts ---\n\
+                 proc reva {n1 n2 op} { set ::c(k) revived }\n\
+                 array set c {k v}\n\
+                 trace add variable c unset reva\n\
+                 unset c(k)\n\
+                 puts \"c exists=[info exists c(k)] val=<$c(k)> traces on c=<[trace info variable c]>\"\n\
+                 puts ---\n\
+                 proc revw {n1 n2 op} { set ::d(j) revived }\n\
+                 array set d {k v}\n\
+                 trace add variable d unset revw\n\
+                 unset d\n\
+                 puts \"d exists=[info exists d(j)] val=<$d(j)> isarray=[array exists d] traces=<[trace info variable d]>\"\n\
+                 puts ---\n\
+                 proc revz {n1 n2 op} { set ::z revived }\n\
+                 proc wz {n1 n2 op} { puts \"write fired\" }\n\
+                 set z orig\n\
+                 trace add variable z unset revz\n\
+                 trace add variable z write wz\n\
+                 unset z\n\
+                 puts \"z=<$z> traces=<[trace info variable z]>\"\n\
+                 puts ---\n\
+                 proc revu {n1 n2 op} { set ::y revived\n\
+                 puts \"y=$::y\"\n\
+                 unset ::y\n\
+                 puts \"exists=[info exists ::y]\" }\n\
+                 set y orig\n\
+                 trace add variable y unset revu\n\
+                 unset y\n\
+                 puts \"after exists=[info exists y]\"\n\
+                 puts ---\n\
+                 proc z1 {n1 n2 op} { trace remove variable ::zz unset z2\n\
+                 puts \"z1 info: <[trace info variable ::zz]>\" }\n\
+                 proc z2 {n1 n2 op} { puts \"z2 fired\" }\n\
+                 set zz 0\n\
+                 trace add variable zz unset z2\n\
+                 trace add variable zz unset z1\n\
+                 unset zz\n",
+        want: "in-trace exists=0\n\
+               exists=1 val=<revived> traces=<>\n\
+               ---\n\
+               b exists=1 val=<revived> traces=<>\n\
+               ---\n\
+               c exists=1 val=<revived> traces on c=<{unset reva}>\n\
+               ---\n\
+               d exists=1 val=<revived> isarray=1 traces=<>\n\
+               ---\n\
+               z=<revived> traces=<>\n\
+               ---\n\
+               y=revived\n\
+               exists=0\n\
+               after exists=0\n\
+               ---\n\
+               z1 info: <>\n\
+               z2 fired",
+    },
 ];
 
 #[test]

--- a/rust/tcl-vm/tests/variable_trace_semantics_e2e.rs
+++ b/rust/tcl-vm/tests/variable_trace_semantics_e2e.rs
@@ -1,0 +1,404 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Variable-trace semantics on the read-modify-write commands (issue #1633
+//! rows 1, 3 and 4).
+//!
+//! Two C facts drive every vector here:
+//!
+//! * `TclPtrSetVarIdx` returns the variable read back **after** the write
+//!   traces have run (`tclVar.c` 9.0.4:2050-2065), not the value the store
+//!   was handed — so a callback that rewrites, unsets, or arrays the
+//!   variable changes what `set`/`append`/`lappend`/`incr` evaluate to.
+//! * `incr`, and the `lappend` paths that reach `TclPtrGetVarIdx`, fire the
+//!   variable's `read` trace before the store. `incr` always does
+//!   (`TclPtrIncrObjVarIdx` :2262-2272); `lappend` does only through
+//!   `Tcl_LappendObjCmd` (:2895, :2944) and `INST_LAPPEND_LIST*`
+//!   (`tclExecute.c:3391`) — the single-value in-proc opcodes
+//!   `INST_LAPPEND_{SCALAR,ARRAY,STK,ARRAY_STK}` omit `TCL_TRACE_READS`
+//!   (`tclExecute.c:3110-3121`) and fire `write` only. `append` never fires
+//!   `read`.
+//!
+//! Every vector's stdout is compared against the bytecode VM **and** — when
+//! installed — real `tclsh8.6` / `tclsh9.0`; the two releases produce
+//! identical bytes for all of it (measured on 8.6.16 and 9.0.4).
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use tcl_compiler::cfg_builder::build_cfg_codegen;
+use tcl_compiler::codegen::codegen_module;
+use tcl_compiler::lowering::{lower_to_ir, lower_to_ir_traced};
+use tcl_registry::CommandRegistry;
+use tcl_vm::{CompileError, CompileService, Vm};
+
+struct CompilerSvc {
+    registry: CommandRegistry,
+}
+
+impl CompileService for CompilerSvc {
+    type Module = tcl_bytecode::ModuleAsm;
+
+    fn compile(&self, src: &str) -> Result<tcl_bytecode::ModuleAsm, CompileError> {
+        if let Some(msg) = tcl_compiler::lowering::first_fatal_parse_error(src) {
+            return Err(CompileError(msg));
+        }
+        let ir = lower_to_ir(src, &self.registry);
+        let cfg = build_cfg_codegen(&ir, false);
+        Ok(codegen_module(&cfg, &ir, &self.registry))
+    }
+
+    fn compile_traced(&self, src: &str) -> Result<tcl_bytecode::ModuleAsm, CompileError> {
+        if let Some(msg) = tcl_compiler::lowering::first_fatal_parse_error(src) {
+            return Err(CompileError(msg));
+        }
+        let ir = lower_to_ir_traced(src, &self.registry);
+        let cfg = build_cfg_codegen(&ir, false);
+        Ok(codegen_module(&cfg, &ir, &self.registry))
+    }
+}
+
+#[derive(Clone, Default)]
+struct Capture(Rc<RefCell<Vec<u8>>>);
+
+impl std::io::Write for Capture {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.borrow_mut().extend_from_slice(buf);
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Run `src` in the VM; the script's `puts` output is returned.
+fn vm_output(src: &str) -> String {
+    let registry = CommandRegistry::build_default();
+    let ir = lower_to_ir(src, &registry);
+    let cfg = build_cfg_codegen(&ir, false);
+    let asm = codegen_module(&cfg, &ir, &registry);
+
+    let cap = Capture::default();
+    let mut vm = Vm::with_output(Box::new(cap.clone()));
+    vm.set_compiler(Box::new(CompilerSvc {
+        registry: CommandRegistry::build_default(),
+    }));
+    let _ = vm.run_module(&asm);
+    String::from_utf8_lossy(&cap.0.borrow()).trim().to_string()
+}
+
+/// Run `src` under a real tclsh, or `None` when that binary isn't available.
+fn tclsh_output(bin_env: &str, names: &[&str], src: &str) -> Option<String> {
+    use std::io::Write as _;
+    let mut candidates: Vec<String> = Vec::new();
+    if let Ok(explicit) = std::env::var(bin_env) {
+        candidates.push(explicit);
+    }
+    candidates.extend(names.iter().map(ToString::to_string));
+    for name in candidates {
+        let Ok(mut child) = std::process::Command::new(&name)
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+        else {
+            continue;
+        };
+        child
+            .stdin
+            .as_mut()
+            .expect("stdin")
+            .write_all(src.as_bytes())
+            .expect("write");
+        let out = child.wait_with_output().expect("run");
+        if out.status.success() {
+            return Some(String::from_utf8_lossy(&out.stdout).trim().to_string());
+        }
+    }
+    None
+}
+
+struct Vector {
+    name: &'static str,
+    script: &'static str,
+    want: &'static str,
+}
+
+const VECTORS: &[Vector] = &[
+    // Row 1: `TclPtrSetVarIdx`'s tail returns the variable's value *after* the
+    // write traces, and the empty string when the variable no longer holds a
+    // scalar — the callback unset it, or turned it into an array.
+    Vector {
+        name: "a write trace that rewrites or removes the variable decides what the store returns",
+        script: "proc mangle {n1 n2 op} { set ::x mangled }\n\
+                 trace add variable x write mangle\n\
+                 puts <[set x orig]>\n\
+                 proc vanish {n1 n2 op} { unset ::y }\n\
+                 trace add variable y write vanish\n\
+                 puts <[set y orig]>|[info exists y]\n\
+                 proc mangle2 {n1 n2 op} { set ::z mangled }\n\
+                 trace add variable z write mangle2\n\
+                 puts <[incr z]>\n\
+                 set w 5\n\
+                 proc vanish2 {n1 n2 op} { unset ::w }\n\
+                 trace add variable w write vanish2\n\
+                 puts <[incr w 3]>|\n\
+                 proc toarray {n1 n2 op} { unset ::c; set ::c(e) 1 }\n\
+                 set c 1\n\
+                 trace add variable c write toarray\n\
+                 puts <[set c orig]>|[array exists c]\n",
+        want: "<mangled>\n<>|0\n<mangled>\n<>|\n<>|1",
+    },
+    // Row 1 again, one line per store arm the VM carries: scalar and element,
+    // stack-named and slot-named, `set`/`append`/`lappend`/`incr`, at the top
+    // level and inside a proc.
+    Vector {
+        name: "every store path returns the value read back after the write traces",
+        script: "proc mang {n1 n2 op} { upvar 1 $n1 v; set v mangled }\n\
+                 proc mange {n1 n2 op} { upvar 1 $n1 arr; set arr($n2) mangled }\n\
+                 set a orig\n\
+                 trace add variable a write mang\n\
+                 puts \"append-top: <[append a x]>|$a\"\n\
+                 set b orig\n\
+                 trace add variable b write mang\n\
+                 puts \"lappend-top: <[lappend b x]>|$b\"\n\
+                 array set c {k orig}\n\
+                 trace add variable c(k) write mange\n\
+                 puts \"set-elem: <[set c(k) new]>|$c(k)\"\n\
+                 array set d {k orig}\n\
+                 trace add variable d(k) write mange\n\
+                 puts \"append-elem: <[append d(k) x]>|$d(k)\"\n\
+                 array set e {k orig}\n\
+                 trace add variable e(k) write mange\n\
+                 puts \"lappend-elem: <[lappend e(k) x]>|$e(k)\"\n\
+                 proc p {} {\n\
+                 set l orig\n\
+                 trace add variable l write mang\n\
+                 puts \"set-local: <[set l new]>|$l\"\n\
+                 set m orig\n\
+                 trace add variable m write mang\n\
+                 puts \"append-local: <[append m x]>|$m\"\n\
+                 set n orig\n\
+                 trace add variable n write mang\n\
+                 puts \"lappend-local: <[lappend n x]>|$n\"\n\
+                 set o 1\n\
+                 trace add variable o write bump\n\
+                 puts \"incr-local: <[incr o]>|$o\"\n\
+                 array set q {k orig}\n\
+                 trace add variable q(k) write mange\n\
+                 puts \"set-elem-local: <[set q(k) new]>|$q(k)\"\n\
+                 puts \"lappend-elem-local: <[lappend q(k) z]>|$q(k)\"\n\
+                 set r orig\n\
+                 trace add variable r write mang\n\
+                 puts \"lappend2-local: <[lappend r a b]>|$r\"\n\
+                 }\n\
+                 proc bump {n1 n2 op} { upvar 1 $n1 v; set v 100 }\n\
+                 p\n\
+                 set s orig\n\
+                 trace add variable s write mang\n\
+                 set nm s\n\
+                 puts \"set-stk: <[set $nm new]>|$s\"\n",
+        want: "append-top: <mangled>|mangled\n\
+               lappend-top: <mangled>|mangled\n\
+               set-elem: <mangled>|mangled\n\
+               append-elem: <mangled>|mangled\n\
+               lappend-elem: <mangled>|mangled\n\
+               set-local: <mangled>|mangled\n\
+               append-local: <mangled>|mangled\n\
+               lappend-local: <mangled>|mangled\n\
+               incr-local: <100>|100\n\
+               set-elem-local: <mangled>|mangled\n\
+               lappend-elem-local: <mangled>|mangled\n\
+               lappend2-local: <mangled>|mangled\n\
+               set-stk: <mangled>|mangled",
+    },
+    // Row 3: `incr` reads through `TclPtrGetVarIdx`, so the read trace fires
+    // first — on a compiled slot, on a stack name, on an array element, and on
+    // a variable the `incr` itself creates. `append` never fires `read`.
+    Vector {
+        name: "incr fires read before write; append and plain set fire write only",
+        script: "proc R {n1 n2 op} { lappend ::log $op }\n\
+                 proc RE {n1 n2 op} { lappend ::log $op:$n1,$n2 }\n\
+                 set x 1\n\
+                 trace add variable x {read write} R\n\
+                 set ::log {}\n\
+                 incr x\n\
+                 puts \"incr: $::log\"\n\
+                 set ::log {}\n\
+                 incr x 5\n\
+                 puts \"incr5: $::log\"\n\
+                 set ::log {}\n\
+                 append x a\n\
+                 puts \"append: $::log\"\n\
+                 set ::log {}\n\
+                 set x 3\n\
+                 puts \"set: $::log\"\n\
+                 trace add variable nx {read write} R\n\
+                 set ::log {}\n\
+                 incr nx\n\
+                 puts \"incr-new: $::log nx=$nx\"\n\
+                 array set a {k 1}\n\
+                 trace add variable a(k) {read write} RE\n\
+                 set ::log {}\n\
+                 incr a(k)\n\
+                 puts \"incr-elem: $::log\"\n\
+                 proc p1 {} {\n\
+                 set l 1\n\
+                 trace add variable l {read write} R\n\
+                 set ::log {}\n\
+                 incr l\n\
+                 puts \"incr-local: $::log\"\n\
+                 set ::log {}\n\
+                 incr l 2\n\
+                 puts \"incr-local2: $::log\"\n\
+                 }\n\
+                 p1\n",
+        want: "incr: read write\n\
+               incr5: read write\n\
+               append: write\n\
+               set: write\n\
+               incr-new: read write nx=1\n\
+               incr-elem: read:a,k write:a,k\n\
+               incr-local: read write\n\
+               incr-local2: read write",
+    },
+    // Row 4: `lappend` fires `read` only where C reaches `TclPtrGetVarIdx` —
+    // the dispatched `Tcl_LappendObjCmd` (everything outside a proc body, and
+    // the no-value form) and the multi-value `INST_LAPPEND_LIST*` opcodes
+    // (`tclExecute.c:3391`). C's single-value in-proc opcodes
+    // `INST_LAPPEND_{SCALAR,ARRAY,STK,ARRAY_STK}` omit `TCL_TRACE_READS`
+    // (`tclExecute.c:3110-3121`) and fire `write` only, and so do this VM's.
+    //
+    // Residual, deliberately absent from this sheet: an in-proc *single-value*
+    // `lappend l z` / `lappend arr(k) z` still reaches this VM's dispatched
+    // `lappend` rather than its write-only `LAPPEND_SCALAR`/`LAPPEND_ARRAY`
+    // arms, so it fires `read write` where C fires `write`. The cause is not
+    // the trace code: `cmd_proc` looks the pre-compiled body up under the
+    // *unqualified* `reg_name` while the compiler keys module procedures by
+    // `::name`, so a global proc always misses and its body is recompiled as a
+    // top-level script — losing every `is_proc` specialisation. Fixing that
+    // lookup makes these two spellings correct with no change here.
+    Vector {
+        name: "lappend fires read on the dispatched and multi-value paths only",
+        script: "proc R {n1 n2 op} { lappend ::log $op }\n\
+                 set x a\n\
+                 trace add variable x {read write} R\n\
+                 set ::log {}\n\
+                 lappend x z\n\
+                 puts \"top-1: $::log\"\n\
+                 set ::log {}\n\
+                 lappend x\n\
+                 puts \"top-0: $::log\"\n\
+                 set ::log {}\n\
+                 lappend x a b\n\
+                 puts \"top-2: $::log\"\n\
+                 set g a\n\
+                 trace add variable g {read write} R\n\
+                 set ::log {}\n\
+                 eval {lappend g z}\n\
+                 puts \"top-eval: $::log\"\n\
+                 set ::log {}\n\
+                 if 1 {lappend g z}\n\
+                 puts \"top-if: $::log\"\n\
+                 proc p {} {\n\
+                 set l a\n\
+                 trace add variable l {read write} R\n\
+                 set ::log {}\n\
+                 lappend l a b\n\
+                 puts \"proc-local2: $::log\"\n\
+                 set ::log {}\n\
+                 lappend l\n\
+                 puts \"proc-local0: $::log\"\n\
+                 set ::log {}\n\
+                 eval {lappend l z}\n\
+                 puts \"proc-eval: $::log\"\n\
+                 array set arr {k a}\n\
+                 trace add variable arr(k) {read write} R\n\
+                 set ::log {}\n\
+                 lappend arr(k) a b\n\
+                 puts \"proc-elem2: $::log\"\n\
+                 }\n\
+                 p\n",
+        want: "top-1: read write\n\
+               top-0: read\n\
+               top-2: read write\n\
+               top-eval: read write\n\
+               top-if: read write\n\
+               proc-local2: read write\n\
+               proc-local0: read\n\
+               proc-eval: read write\n\
+               proc-elem2: read write",
+    },
+    // Rows 3 + 4: the read a read-modify-write command performs treats a
+    // trace error as "no current value" rather than as a failure — `incr`
+    // counts from 0, `lappend` discards the old value — and the swallowed
+    // error stays logged in `::errorInfo` with its `(read trace on "x")`
+    // frame and no `invoked from within` for the surviving command.
+    Vector {
+        name: "an erroring read trace leaves incr and lappend succeeding, error logged",
+        script: "proc boom {n1 n2 op} { error bang }\n\
+                 set x 1\n\
+                 trace add variable x read boom\n\
+                 set c [catch {incr x} m]\n\
+                 set ei $::errorInfo\n\
+                 trace remove variable x read boom\n\
+                 puts \"incr: code=$c msg=$m x=$x\"\n\
+                 puts \"ei-tail: [lrange [split $ei \\n] end-1 end]\"\n\
+                 set y old\n\
+                 trace add variable y read boom\n\
+                 set c2 [catch {lappend y z} m2]\n\
+                 trace remove variable y read boom\n\
+                 puts \"lappend: code=$c2 msg=$m2 y=$y\"\n\
+                 set z2 old\n\
+                 trace add variable z2 read boom\n\
+                 set c3 [catch {lappend z2} m3]\n\
+                 trace remove variable z2 read boom\n\
+                 puts \"lappend0: code=$c3 msg=$m3 z2=$z2\"\n",
+        want: "incr: code=0 msg=1 x=1\n\
+               ei-tail: {\"boom x {} read\"} {    (read trace on \"x\")}\n\
+               lappend: code=0 msg=z y=z\n\
+               lappend0: code=0 msg= z2=",
+    },
+];
+
+#[test]
+fn vm_matches_the_pinned_trace_vectors() {
+    for v in VECTORS {
+        assert_eq!(vm_output(v.script), v.want, "{}", v.name);
+    }
+}
+
+/// The table itself is pinned to C Tcl (8.6.16 and 9.0.4 agree on every line).
+#[test]
+fn vectors_match_real_tclsh() {
+    let mut ran = 0;
+    for v in VECTORS {
+        for (env, names) in [
+            ("TCL_LSP_TCLSH86", &["tclsh8.6"][..]),
+            ("TCL_LSP_TCLSH90", &["tclsh9.0"][..]),
+        ] {
+            if let Some(got) = tclsh_output(env, names, v.script) {
+                assert_eq!(got, v.want, "[{env}] {}", v.name);
+                ran += 1;
+            }
+        }
+    }
+    if ran == 0 {
+        eprintln!("skipping: neither tclsh8.6 nor tclsh9.0 found");
+    }
+}


### PR DESCRIPTION
## Summary

#1633 listed ten trace divergences found by an adversarial sweep. #1795's `r5-trace-semantics` lane had since fixed every `runtime/rust` row, so this PR is **almost entirely `rust/tcl-vm`** — rows 1, 3, 4, 5, 6, 7, 8, 9, 10 — plus row 8's command/execution half in *both* engines and the release axis moved into `tcl-dialect` so both engines share it. Row 2 was verified already correct in both.

| row | engine | outcome |
|---|---|---|
| 1 read-back after write traces | tclvm | `store_var_result`/`store_elem_result` — every dispatched command (`set`/`append`/`lappend`/`incr`/`lset`/`ledit`) and all 20 `STORE_*`/`APPEND_*`/`LAPPEND_*` arms |
| 2 `(write trace on "x")` frame | — | verified already correct |
| 3 `incr` fires `read` | tclvm | `read_for_update` in `cmd_incr` + `incr_var` |
| 4 `lappend` fires `read` | tclvm | fixed on the paths C fires it; single-value opcode arms stay write-only |
| 5 `trace info command\|execution nosuch` | tclvm | `cmd_trace_entries` returns a `Completion` and errors |
| 6/7 element recovery + release axis | dialect + tclvm | new `TclVersion::traces_recover_linked_array_element`; the runtime's predicate becomes a delegation |
| 8 variable | tclvm | `VarTrace::id`, live re-find per callback |
| 8 command/execution | tclvm + runtime | VM `Rc::ptr_eq` liveness; runtime `CmdTrace::id` in all three loops |
| 9 delete trace re-creates | tclvm | C's `hPtr != NULL` token-identity rule |
| 10 unset revives | tclvm | cell removed, traces taken out, *then* fire |

Also fixed in passing: `unset` through an element alias removed nothing, and `append x` with no values fires `read` (a plain read) where the VM fired nothing.

### Three corrections to the issue's own table

Measured on 8.4.20 / 8.5.19 / 8.6.16 / 9.0.4 / 9.1b0:

- **Row 6 is not a release difference — it is a delivery artefact.** The issue records `unset a(k)` reporting `name1 = a(k)` "at 9.0 only". In fact the *same script text* gives `name1=<a(k)>` from a file and `name1=<a>` on stdin, on the same shell, because `TclCompileUnsetCmd` emits the two-part opcode only when the script is compiled. A test pinning `a(k)` would pin the compiler, not the trace. The sheet uses a dynamic spelling instead.
- **Row 10's "in-trace exists=1" is wrong.** C marks the variable undefined *before* firing, so the callback measures `exists=0`.
- **Row 4's residual is broader than the issue's "`lappend ::g z` in a proc"** — see the filed residual below.

### Measured bytes (8.6.16 / 9.0.4 identical unless noted)

- Row 1: `<mangled>` / `<>|0` / `<mangled>` / `<>|` / `<>|1` — VM was `<orig> <orig>|0 <1> <8> <orig>|1`
- Row 3: `incr: read write`, `incr-elem: read:a,k write:a,k` — VM was `write` everywhere
- Row 5: `1 unknown command "nosuch"` (also verified on 8.4.20 / 8.5.19) — VM returned empty
- Rows 6/7: 8.4–8.6 `E n1=<e> n2=<> op=write`, `A n1=<a> n2=<k> op=unset`; 9.0/9.1 `A n1=<e> n2=<k>`, `E n1=<e> n2=<k>`, `A n1=<a(k)> n2=<k>` — VM gave the 8.x shape at every release
- Row 8: `u1 info: {write u1}` with no `u2 fired`; `e1 info: {enter e1}`, `d1 info: {delete d1}`, `l2 info: {leave l2}` — both engines printed the extra `u2 fired` / `E2 fired` / `D2 fired` / `L1 fired`
- Row 9: `in-trace: foo / exists: foo / 0 / foo2 / traces:` — VM gave `exists: / 1 / invalid command name "foo"`
- Row 10: `in-trace exists=0`, then `exists=1 val=<revived> traces=<>` — VM revived nothing

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

```
cd /home/user/wt-traces && source scripts/dev/agent-build-env.sh
cargo test -p tcl-vm                                # 56 test binaries, 0 failures (both wasm tests included)
cargo test --manifest-path runtime/rust/Cargo.toml  # 0 failures
make rust-check                                     # exit 0
```

`make rust-check` was confirmed green on the base commit first, so the gate result is attributable. Nothing skipped. Row 8's runtime half is proven by a test that fails without the `CmdTrace::id` change.

Two earlier wasm-test failures during this work were **disk exhaustion**, not the change — the box's quota is shared with three other worktrees' target dirs and filled twice; both passed once space was available.

**One test changed — please review.** `refused_alias_rename_preserves_a_hidden_destination_for_later_releases` pinned `[llength [trace info command lassign]]` → `0` at the 8.4 profile, which **no tclsh gives** — all four releases error there. Its probe is now `[catch …]` → `1`, same subject, correct oracle.

## Compiler / diagnostics checklist

- [x] Did this change alter a compiler fact contract? Yes — variable-trace firing, the value a store returns, and the array-element release axis.
- [x] If yes, I updated the owning design doc — the trace docs under `docs/design/runtime/`, and the release axis now lives in `tcl-dialect` as `TclVersion::traces_recover_linked_array_element` rather than an ad-hoc version check.
- [x] If I added or changed a diagnostic or optimisation code, I updated its page under `docs/kcs/codes/` — n/a, none changed.
- [x] If I added a design doc, I linked it from `docs/design/README.md` — n/a, no new design doc.

Closes #1633

## Residuals filed, not fixed here

- `cmd_proc` looks the pre-compiled body up **unqualified** while the compiler keys `::name`, so every global proc recompiles as a top-level script and loses `is_proc`. That is why an in-proc single-value `lappend` still fires `read write`. Out of scope, and worth its own issue — it is a performance bug as much as a semantic one.
- `cmd_rename` publishes the trace sidecar *after* the rename, so a rename callback sees neither name traced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XV29AoTSsaCBgsJuf2EvEK

---
_Generated by [Claude Code](https://claude.ai/code/session_01XV29AoTSsaCBgsJuf2EvEK)_