### PR TITLE
fix(compiler): one owner decides which cell a variable word names (#1772)

### DIFF
--- a/docs/design/compiler/wasm-codegen.md
+++ b/docs/design/compiler/wasm-codegen.md
@@ -211,7 +211,12 @@ unchanged. Statements lower by registry descriptor and dispatch proof:
 Words are evaluated structurally from `WordExpr` only: the `puts` fast path
 that reparsed compatibility text (issue #1772) is gone from every tier, and a
 `[…]` word resolved to `expr` over one braced literal lowers as a native
-expression when the module keeps `expr` bound to its builtin.
+expression when the module keeps `expr` bound to its builtin. The one reading
+a backend still makes of a `$…` spelling — which cell a variable word names,
+and whether `$a(b)` is an element or a scalar spelt `${a(b)}` — has a single
+owner, `native_lowering::cells::variable_word_place`, built on
+`tcl_syntax::naming::split_element_ref`; `cell_place` is its counterpart for a
+statically spelled name word. No tier keeps a copy.
 
 ### Representation and cells
 

--- a/docs/design/compiler/wasm-native-lowering-plan.md
+++ b/docs/design/compiler/wasm-native-lowering-plan.md
@@ -125,7 +125,9 @@ found by this review:
   heuristics appear in `emit_var_get` (`name.contains('(')`) and the
   `AssignConst` gate. These are exactly the "reparse the argument string"
   shortcuts `common-semantic-compiler.md` forbids; the structured `WordExpr`
-  the leaf-invoke planner uses gets this case right.
+  the leaf-invoke planner uses gets this case right. (Closed: P3 retired the
+  fast path, and issue #1772's follow-up routed the remaining name readings
+  through one owner in `native_lowering::cells` — see the lane doc.)
 - **A compiled statement is not an eval-loop boundary.** `tcl_invoke_argv`
   dispatches at `eval_depth == 0`. When the dispatched command is `catch`, its
   body runs through `eval_control_body`, and the eval loop's outermost-eval

--- a/docs/design/contracts/shared-utility-contracts-rust.md
+++ b/docs/design/contracts/shared-utility-contracts-rust.md
@@ -760,20 +760,25 @@ helper without reading the rationale:
   substitution shape — not the stricter `::`-segmented
   `tcl_syntax::naming::is_bare_var_name` that quick fixes use to keep
   `${x}` ↔ `$x` rewrites meaning-preserving. It is `pub(crate)`, and
-  `codegen::values::whole_var_reference` is the **single owner** of the
-  `$name` / `${name}` whole-word extractor built on it: given a word, the
-  exact variable name it refers to, or `None` when the word is not one
-  simple reference. `codegen::wasm::backend` (`emit_word_value`, the
-  `ChannelWrite` argument guard) and `codegen::wasm::leaf_invoke`
-  (`plan_variable`) consume it; each carried a byte-identical private copy
-  until issue #1459.
+  `native_lowering::cells` is the **single owner** of everything built on
+  it: `whole_reference` (given a word, the exact variable name it refers
+  to, or `None` when the word is not one simple reference),
+  `variable_word_place` (which cell that word reads), and `cell_place`
+  (which cell a statically spelled *name* word denotes). The wasm
+  backend's `AssignConst` gate, its leaf-invocation planner
+  (`plan_variable`), and the native lowering all consume those three;
+  each carried a private copy of one or another until issues #1459 and
+  #1772.
   The braced and bare spellings are validated **differently** and must
   stay that way: `${…}` accepts any non-empty name verbatim (braces are
   Tcl's own escape for a name the bare charset cannot express), while a
   bare `$name` must be a whole `is_bare_var_name` run. Routing the braced
   arm through the charset check as well changes behaviour, not just
   duplication — pinned by
-  `whole_var_reference_accepts_any_non_empty_braced_name`.
+  `whole_reference_accepts_any_non_empty_braced_name`.
+  The element split those helpers apply is never hand-rolled either: it
+  is `tcl_syntax::naming::split_element_ref` / `split_array_name_braced`,
+  so a zero-length array name (`set (x) 5`) keeps working.
   The release-aware `${…}` *close* rule is a separate question, owned by
   `tcl_lexer::ranges::braced_var_name_end` and consumed by the decoders
   (`parse_simple_var_ref`, `parse_subst_template`), not here.

--- a/docs/design/lanes/wasm-native-lowering.md
+++ b/docs/design/lanes/wasm-native-lowering.md
@@ -28,9 +28,11 @@ Branch: `claude/wasm-codegen-architecture-5exvpu`.
   installs its functions, and registers `(name, params, table index)`; the
   runtime treats the index as an `extern "C"` function pointer. Falls back to
   the source body when the native entry declines.
-- No emitter reads a compatibility string. `whole_var_reference` and the
-  `name.contains('(')` gates in `codegen/wasm/backend.rs` were retired by P3;
-  word shapes come from `WordExpr` only.
+- No emitter reads a compatibility string for itself. Word shapes come from
+  `WordExpr`; the one reading of a `$…` spelling or a name word left —
+  which cell it denotes — is owned by `native_lowering::cells`
+  (`whole_reference`, `variable_word_place`, `cell_place`) over the
+  `tcl_syntax::naming` split, and every backend consumes it.
 
 ## Site inventory and status
 
@@ -1099,9 +1101,11 @@ harness, and `samples/wasm/budgets.tsv`.
    `value_try_double` (typed reads that never set an error), `expr_eval`,
    `mathop`, `mathfunc` (completion-triple writers). The compat-text gates in
    `backend.rs` — `whole_var_reference`, `is_pure_cmd_subst`,
-   `parse_cmd_parts`, `name.contains('(')` — are gone from every tier, which
-   closed the five analysis-plan ledger rows for issue #1772 in the same
-   commit. `emit_wasm --native` and `Plan::Native` in the harness.
+   `parse_cmd_parts`, `name.contains('(')` — stopped deciding what a *word*
+   is, which closed the five analysis-plan ledger rows for issue #1772 in the
+   same commit; the name readings they left behind were folded into
+   `native_lowering::cells` when #1772 itself closed. `emit_wasm --native` and
+   `Plan::Native` in the harness.
 
 ### Budgets, T0/T1 (`eval_code / expr_bool / invoke_argv / native_i64_f64`)
 

--- a/rust/tcl-compiler/src/codegen/values.rs
+++ b/rust/tcl-compiler/src/codegen/values.rs
@@ -35,39 +35,14 @@ use super::{CodegenCtx, Op, Operand, bytecode_imm};
 /// This is the deliberately *looser* codegen-side contract recorded in
 /// `docs/design/contracts/shared-utility-contracts-rust.md`, distinct from the
 /// stricter `::`-segmented `tcl_syntax::naming::is_bare_var_name` that quick
-/// fixes use. `pub(crate)` so the WASM backend consumes this one rather than
-/// re-deriving the charset (issue #1459).
+/// fixes use. `pub(crate)` so
+/// [`native_lowering::cells`](crate::native_lowering::cells) consumes this one
+/// rather than re-deriving the charset (issue #1459).
 pub(crate) fn is_bare_var_name(name: &str) -> bool {
     !name.is_empty()
         && name
             .bytes()
             .all(|b| b.is_ascii_alphanumeric() || b == b'_' || b == b':')
-}
-
-/// The exact Tcl variable name `word` refers to, when the **whole** word is one
-/// simple variable reference eligible for a direct load — otherwise `None`.
-///
-/// The single owner of the `$name` / `${name}` split for the codegen backends
-/// (issue #1459); `codegen::wasm::backend` and `codegen::wasm::leaf_invoke`
-/// each carried a byte-identical copy.
-///
-/// The two spellings are **not** validated alike, and that asymmetry is the
-/// point: braces are Tcl's own escape for a name the bare charset cannot
-/// express, so `${…}` accepts any non-empty name verbatim, while a bare
-/// `$name` must be a whole [`is_bare_var_name`] run — otherwise the word is
-/// `$name` *followed by literal text* (`$item-suffix`) and loading `item-suffix`
-/// would be wrong. Routing the braced form through the charset check as well
-/// would change behaviour, not just deduplicate.
-///
-/// Note the braced form here is decided by the *last* `}` in the word; the
-/// release-aware `${…}` close rule lives with the decoders in
-/// [`parse_simple_var_ref`] and is issue #1568's territory, not this one.
-pub(crate) fn whole_var_reference(word: &str) -> Option<&str> {
-    if let Some(name) = word.strip_prefix("${").and_then(|s| s.strip_suffix('}')) {
-        return (!name.is_empty()).then_some(name);
-    }
-    let name = word.strip_prefix('$')?;
-    is_bare_var_name(name).then_some(name)
 }
 
 /// Which literal-pool entry point a folded constant takes.
@@ -866,43 +841,6 @@ mod tests {
             parse_simple_var_ref("${x", tcl_dialect::BracedVarStyle::default()),
             None
         );
-    }
-
-    // -- whole_var_reference (issue #1459) --
-
-    /// The braced and bare spellings are validated **differently**, and the
-    /// asymmetry is load-bearing: braces are Tcl's own escape for a name the
-    /// bare charset cannot express. Hoisting the braced arm through
-    /// `is_bare_var_name` — the obvious "deduplication" — would change
-    /// behaviour, so it is pinned here.
-    #[test]
-    fn whole_var_reference_accepts_any_non_empty_braced_name() {
-        assert_eq!(whole_var_reference("${a-b}"), Some("a-b"));
-        assert_eq!(whole_var_reference("${a.b}"), Some("a.b"));
-        assert_eq!(whole_var_reference("${a(b)}"), Some("a(b)"));
-        assert_eq!(whole_var_reference("${x}"), Some("x"));
-        // …but not an empty one.
-        assert_eq!(whole_var_reference("${}"), None);
-    }
-
-    #[test]
-    fn whole_var_reference_charset_checks_only_the_bare_form() {
-        assert_eq!(whole_var_reference("$x"), Some("x"));
-        assert_eq!(whole_var_reference("$::ns::x"), Some("::ns::x"));
-        assert_eq!(whole_var_reference("$x_1"), Some("x_1"));
-        // `$item-suffix` is `$item` followed by literal text, not a whole
-        // reference — so the *word* is not a simple variable load.
-        assert_eq!(whole_var_reference("$item-suffix"), None);
-        assert_eq!(whole_var_reference("$a(b)"), None);
-        assert_eq!(whole_var_reference("$"), None);
-    }
-
-    #[test]
-    fn whole_var_reference_rejects_a_word_that_is_not_a_reference() {
-        assert_eq!(whole_var_reference("x"), None);
-        assert_eq!(whole_var_reference(""), None);
-        assert_eq!(whole_var_reference("[f]"), None);
-        assert_eq!(whole_var_reference("a$b"), None);
     }
 
     // -- the retired `$={name}` marker (issue #1617) --

--- a/rust/tcl-compiler/src/codegen/wasm/backend.rs
+++ b/rust/tcl-compiler/src/codegen/wasm/backend.rs
@@ -58,6 +58,7 @@ use crate::common_aot_plan::semantic_operation_binding_is_trusted;
 use crate::compilation_unit::{CompilationUnit, FunctionUnit};
 use crate::ir::{Module, Procedure, Statement};
 use crate::mixed_region_plan::GuardedSelectionEvidence;
+use crate::native_lowering::cells::{CellPlace, cell_place};
 use crate::native_lowering::{
     FunctionDecline, FunctionReport, LoweringInput, NativeTierReport, lower_function,
 };
@@ -456,23 +457,22 @@ impl WasmEmitter {
         true
     }
 
+    /// A direct procedure's expression reads only its formal parameters
+    /// (`direct_expr_supported`), so every name is a frame slot. Nothing else
+    /// reaches this: `emit_expr_value` runs solely from the `DirectProc`
+    /// `Statement::Return` arm.
     fn emit_var_get(&mut self, name: &str) -> bool {
         let Some(aot) = self.general_imports().aot else {
             return false;
         };
-        if self.mode == FunctionMode::DirectProc {
-            let Some(slot) = self.local_slots.get(name).copied() else {
-                return false;
-            };
-            self.push_i32(i64::from(slot));
-            self.call(aot.local_get);
-        } else {
-            // A direct procedure's expression reads only its formal
-            // parameters (`direct_expr_supported`), so the name is exactly
-            // the cell's name; no compatibility-text spelling is reparsed.
-            self.push_text_pair(name);
-            self.call(aot.var_get);
+        if self.mode != FunctionMode::DirectProc {
+            return false;
         }
+        let Some(slot) = self.local_slots.get(name).copied() else {
+            return false;
+        };
+        self.push_i32(i64::from(slot));
+        self.call(aot.local_get);
         true
     }
 
@@ -1428,9 +1428,13 @@ fn function_facts(
             } = statement
                 && (*name_braced || !crate::naming::is_dynamic_word(name))
                 // `tcl_codegen_var_set` stores under the exact name, so an
-                // unbraced `a(b)` target — an array element, not a scalar whose
-                // name contains parentheses — keeps the source-span fallback.
-                && (*name_braced || !name.contains('('))
+                // array-element target — as opposed to a scalar whose name
+                // merely contains parentheses — keeps the source-span
+                // fallback. `cell_place` owns that reading for every backend.
+                && matches!(
+                    cell_place(name, *name_braced),
+                    Some(CellPlace::Named { .. })
+                )
                 && registry
                     .command_names_for_semantic_operation(SemanticOperationId::StructuredLowering(
                         LoweringHookId::Set,

--- a/rust/tcl-compiler/src/codegen/wasm/leaf_invoke.rs
+++ b/rust/tcl-compiler/src/codegen/wasm/leaf_invoke.rs
@@ -46,7 +46,6 @@
 //! contiguous run of object slots holding its words, so `tcl_invoke_argv`
 //! receives a pointer directly into the frame.
 
-use tcl_lexer::Span;
 use tcl_registry::SemanticOperationId;
 use tcl_runtime_api::codegen_abi::{
     WASM32_COMPLETION_ALIGN, WASM32_COMPLETION_SIZE, WASM32_POINTER_BYTES,
@@ -57,8 +56,8 @@ use crate::backend_registry::{
     SelectionFacts, SelectionInput, SelectionRegion, SelectorAttemptFailure, SelectorDecision,
     SelectorPriority, SelectorRequest,
 };
-use crate::codegen::values::whole_var_reference;
-use crate::ir::{Provenance, SourceSite, WordExpr, WordPart};
+use crate::ir::{SourceSite, WordExpr, WordPart};
+use crate::native_lowering::cells::{CellPlace, VariableWordDecline, variable_word_place};
 use crate::target_contract::{
     LegalisationRequirements, TargetCapabilities, TargetContract, TargetFamily,
 };
@@ -473,61 +472,24 @@ fn plan_part(
     }
 }
 
-/// Plan a variable read, distinguishing `$a(b)` from `${a(b)}`.
+/// Plan a variable read.
 ///
-/// The compatibility spelling normalises both to `${a(b)}`, so the recorded
-/// lexical extent is what tells them apart: a `${…}` reference is exactly two
-/// bytes longer than its name, a `$…` reference exactly one. Only the latter
-/// is an array-element access; `${a(b)}` names a scalar whose name happens to
-/// contain parentheses.
+/// [`variable_word_place`] owns the reading — which cell a `$…` / `${…}` word
+/// names, and how `$a(b)` is told apart from `${a(b)}`; this only maps its
+/// refusal into this planner's vocabulary.
 fn plan_variable(
     spelling: &str,
     source: &SourceSite,
     slot: usize,
 ) -> Result<WasmWordPlan, WasmLeafInvokeDecline> {
-    let name = whole_var_reference(spelling).ok_or(WasmLeafInvokeDecline::DynamicVariableName)?;
-    if !name.contains('(') {
-        return Ok(WasmWordPlan::Scalar {
-            slot,
-            name: name.to_owned(),
-        });
-    }
-    if source.provenance != Provenance::Source {
-        return Err(WasmLeafInvokeDecline::AmbiguousVariableSpelling);
-    }
-    match extent(source.span).checked_sub(name.len()) {
-        // `${name}` — the whole thing is one scalar name.
-        Some(2) => Ok(WasmWordPlan::Scalar {
-            slot,
-            name: name.to_owned(),
-        }),
-        // `$name(key)` — a genuine array element access.
-        Some(1) => {
-            let (base, key) =
-                split_element(name).ok_or(WasmLeafInvokeDecline::AmbiguousVariableSpelling)?;
-            if key.bytes().any(|byte| matches!(byte, b'$' | b'[' | b'\\')) {
-                return Err(WasmLeafInvokeDecline::DynamicVariableName);
-            }
-            Ok(WasmWordPlan::Element {
-                slot,
-                name: base.to_owned(),
-                key: key.to_owned(),
-            })
+    match variable_word_place(spelling, source) {
+        Ok(CellPlace::Named { name }) => Ok(WasmWordPlan::Scalar { slot, name }),
+        Ok(CellPlace::Element { name, key }) => Ok(WasmWordPlan::Element { slot, name, key }),
+        Err(VariableWordDecline::Dynamic) => Err(WasmLeafInvokeDecline::DynamicVariableName),
+        Err(VariableWordDecline::Ambiguous) => {
+            Err(WasmLeafInvokeDecline::AmbiguousVariableSpelling)
         }
-        _ => Err(WasmLeafInvokeDecline::AmbiguousVariableSpelling),
     }
-}
-
-fn extent(span: Span) -> usize {
-    span.end().saturating_sub(span.start()) as usize
-}
-
-/// Split `base(key)` the way the runtime's own array reference split does.
-fn split_element(name: &str) -> Option<(&str, &str)> {
-    let inner = name.strip_suffix(')')?;
-    let open = inner.find('(')?;
-    let (base, key) = inner.split_at(open);
-    (!base.is_empty()).then(|| (base, &key[1..]))
 }
 
 /// The structured words of a `[…]` command substitution.

--- a/rust/tcl-compiler/src/native_lowering/cells.rs
+++ b/rust/tcl-compiler/src/native_lowering/cells.rs
@@ -30,10 +30,21 @@
 //! Shadows are tracked per block. They flow along an edge only when the
 //! successor has exactly that one predecessor and is not a loop header, so a
 //! join or a back edge never sees a shadow from just one of its paths.
+//!
+//! This module is also the **single owner** of "which cell does this statically
+//! spelled name or variable word denote" for every backend — [`cell_place`] for
+//! a name word, [`variable_word_place`] for a `$…` / `${…}` word. Both are
+//! built on the `tcl_syntax::naming` split rules, so no backend re-parses an
+//! argument's compatibility text for itself (issue #1772).
 
 use std::collections::BTreeMap;
 
+use tcl_lexer::Span;
+
 use super::ir::NativeValueId;
+use crate::codegen::values::is_bare_var_name;
+use crate::executable_ir::CellReference;
+use crate::ir::{Provenance, SourceSite};
 
 /// One Tcl variable cell addressed by name.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -69,6 +80,115 @@ impl CellPlace {
             Self::Element { name, key } => format!("{name}({key})"),
         }
     }
+}
+
+/// Why a variable word could not be resolved to a cell statically.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum VariableWordDecline {
+    /// The word is not one whole static reference, or its element key
+    /// substitutes.
+    Dynamic,
+    /// `$a(b)` and `${a(b)}` share a compatibility spelling and the recorded
+    /// lexical extent cannot tell the two apart.
+    Ambiguous,
+}
+
+/// True when `text` carries a substitution a static reading cannot resolve.
+pub(crate) fn has_substitution(text: &str) -> bool {
+    text.bytes().any(|byte| matches!(byte, b'$' | b'[' | b'\\'))
+}
+
+/// The exact Tcl variable name `spelling` refers to, when the **whole** word is
+/// one simple variable reference — otherwise `None`.
+///
+/// The two spellings are **not** validated alike, and that asymmetry is the
+/// point: braces are Tcl's own escape for a name the bare charset cannot
+/// express, so `${…}` accepts any non-empty name verbatim, while a bare
+/// `$name` must be a whole [`is_bare_var_name`] run — otherwise the word is
+/// `$name` *followed by literal text* (`$item-suffix`) and loading
+/// `item-suffix` would be wrong. Routing the braced form through the charset
+/// check as well would change behaviour, not just deduplicate.
+///
+/// Note the braced form here is decided by the *last* `}` in the word, so it
+/// only ever sees a word the caller already knows is one variable reference.
+/// The release-aware `${…}` close rule lives with the decoders in
+/// `codegen::values::parse_simple_var_ref` and is issue #1568's territory.
+pub(crate) fn whole_reference(spelling: &str) -> Option<&str> {
+    if let Some(name) = spelling
+        .strip_prefix("${")
+        .and_then(|rest| rest.strip_suffix('}'))
+    {
+        return (!name.is_empty()).then_some(name);
+    }
+    let name = spelling.strip_prefix('$')?;
+    is_bare_var_name(name).then_some(name)
+}
+
+/// The cell a statically spelled variable **name** denotes, or `None` when the
+/// name is computed at run time.
+///
+/// `braced` is the source token's brace-literal flag: a braced name word
+/// suppresses substitution, so `{a($k)}` names a literal element of `a`.
+pub(crate) fn cell_place(name: &str, braced: bool) -> Option<CellPlace> {
+    match CellReference::from_name(name, braced) {
+        CellReference::Named {
+            name: base,
+            element,
+        } => {
+            if !element {
+                return Some(CellPlace::Named { name: base });
+            }
+            let (_, key) = tcl_syntax::naming::split_array_name_braced(name, braced);
+            let key = key?;
+            if !braced && has_substitution(key) {
+                return None;
+            }
+            Some(CellPlace::Element {
+                name: base,
+                key: key.to_owned(),
+            })
+        }
+        CellReference::Computed => None,
+    }
+}
+
+/// The cell a `$…` / `${…}` variable **word** reads.
+///
+/// The compatibility spelling normalises both `$a(b)` and `${a(b)}` to
+/// `${a(b)}`, so the recorded lexical extent is what tells them apart: a
+/// `${…}` reference is exactly two bytes longer than its name, a `$…` exactly
+/// one. Only the latter is an array-element access; `${a(b)}` names a scalar
+/// whose name happens to contain parentheses.
+pub(crate) fn variable_word_place(
+    spelling: &str,
+    source: &SourceSite,
+) -> Result<CellPlace, VariableWordDecline> {
+    let name = whole_reference(spelling).ok_or(VariableWordDecline::Dynamic)?;
+    let Some((base, key)) = tcl_syntax::naming::split_element_ref(name) else {
+        return Ok(CellPlace::Named {
+            name: name.to_owned(),
+        });
+    };
+    if source.provenance != Provenance::Source {
+        return Err(VariableWordDecline::Ambiguous);
+    }
+    match extent(source.span).checked_sub(name.len()) {
+        // `${name}` — the whole thing is one scalar name.
+        Some(2) => Ok(CellPlace::Named {
+            name: name.to_owned(),
+        }),
+        // `$name(key)` — a genuine array element access.
+        Some(1) if has_substitution(key) => Err(VariableWordDecline::Dynamic),
+        Some(1) => Ok(CellPlace::Element {
+            name: base.to_owned(),
+            key: key.to_owned(),
+        }),
+        _ => Err(VariableWordDecline::Ambiguous),
+    }
+}
+
+fn extent(span: Span) -> usize {
+    span.end().saturating_sub(span.start()) as usize
 }
 
 /// Where a cell lives — the cell-storage lattice element decided for a
@@ -191,6 +311,120 @@ mod tests {
         assert_eq!(state.read(&element), None);
         state.forget_base("a");
         assert!(state.is_empty());
+    }
+
+    /// The braced and bare spellings are validated **differently**, and the
+    /// asymmetry is load-bearing: braces are Tcl's own escape for a name the
+    /// bare charset cannot express. Hoisting the braced arm through
+    /// `is_bare_var_name` — the obvious "deduplication" — would change
+    /// behaviour, so it is pinned here.
+    #[test]
+    fn whole_reference_accepts_any_non_empty_braced_name() {
+        assert_eq!(whole_reference("${a-b}"), Some("a-b"));
+        assert_eq!(whole_reference("${a.b}"), Some("a.b"));
+        assert_eq!(whole_reference("${a(b)}"), Some("a(b)"));
+        assert_eq!(whole_reference("${x}"), Some("x"));
+        // …but not an empty one.
+        assert_eq!(whole_reference("${}"), None);
+    }
+
+    #[test]
+    fn whole_reference_charset_checks_only_the_bare_form() {
+        assert_eq!(whole_reference("$x"), Some("x"));
+        assert_eq!(whole_reference("$::ns::x"), Some("::ns::x"));
+        assert_eq!(whole_reference("$x_1"), Some("x_1"));
+        // `$item-suffix` is `$item` followed by literal text, not a whole
+        // reference — so the *word* is not a simple variable load.
+        assert_eq!(whole_reference("$item-suffix"), None);
+        assert_eq!(whole_reference("$a(b)"), None);
+        assert_eq!(whole_reference("$"), None);
+    }
+
+    #[test]
+    fn whole_reference_rejects_a_word_that_is_not_a_reference() {
+        assert_eq!(whole_reference("x"), None);
+        assert_eq!(whole_reference(""), None);
+        assert_eq!(whole_reference("[f]"), None);
+        assert_eq!(whole_reference("a$b"), None);
+    }
+
+    /// One owner decides the element split, and the lexical extent — not the
+    /// compatibility text — is what separates `$a(b)` from `${a(b)}`.
+    #[test]
+    fn variable_words_tell_element_and_odd_scalar_spellings_apart() {
+        let site = |start: u32, end: u32| SourceSite::source(Span::new(start, end));
+        // `$a(b)`: five source bytes for a four-byte name.
+        assert_eq!(
+            variable_word_place("${a(b)}", &site(0, 5)),
+            Ok(CellPlace::Element {
+                name: "a".to_owned(),
+                key: "b".to_owned(),
+            })
+        );
+        // `${a(b)}`: six, because the braces are part of the word.
+        assert_eq!(
+            variable_word_place("${a(b)}", &site(0, 6)),
+            Ok(CellPlace::Named {
+                name: "a(b)".to_owned(),
+            })
+        );
+        // A name with no element suffix never consults the extent.
+        assert_eq!(
+            variable_word_place("$x", &site(0, 2)),
+            Ok(CellPlace::Named {
+                name: "x".to_owned(),
+            })
+        );
+        // A substituted key is not a static cell: `$a($i)` is six source
+        // bytes for a five-byte name, so the extent reads it as an element.
+        assert_eq!(
+            variable_word_place("${a($i)}", &site(0, 6)),
+            Err(VariableWordDecline::Dynamic)
+        );
+        // Neither is a word that is not one whole reference.
+        assert_eq!(
+            variable_word_place("a$b", &site(0, 3)),
+            Err(VariableWordDecline::Dynamic)
+        );
+        // A rewritten word has no lexical extent to read.
+        assert_eq!(
+            variable_word_place(
+                "${a(b)}",
+                &SourceSite {
+                    span: Span::new(0, 5),
+                    provenance: Provenance::Opaque,
+                }
+            ),
+            Err(VariableWordDecline::Ambiguous)
+        );
+    }
+
+    /// A braced name word is a literal, so `{a(b)}` is the element `a(b)` and
+    /// `{a($k)}` its literal key — while the same text unbraced substitutes.
+    #[test]
+    fn name_words_split_elements_through_the_shared_rule() {
+        assert_eq!(
+            cell_place("a", false),
+            Some(CellPlace::Named {
+                name: "a".to_owned()
+            })
+        );
+        assert_eq!(
+            cell_place("a(b)", false),
+            Some(CellPlace::Element {
+                name: "a".to_owned(),
+                key: "b".to_owned(),
+            })
+        );
+        assert_eq!(
+            cell_place("a($k)", true),
+            Some(CellPlace::Element {
+                name: "a".to_owned(),
+                key: "$k".to_owned(),
+            })
+        );
+        assert_eq!(cell_place("a($k)", false), None);
+        assert_eq!(cell_place("", true), None);
     }
 
     #[test]

--- a/rust/tcl-compiler/src/native_lowering/lower.rs
+++ b/rust/tcl-compiler/src/native_lowering/lower.rs
@@ -38,7 +38,10 @@ use tcl_syntax::expr::ast::render_expr;
 use tcl_syntax::expr::{BinOp, ExprNode, UnaryOp};
 use tcl_syntax::number::{Number, Numbers};
 
-use super::cells::{CellPlace, ShadowState};
+use super::cells::{
+    CellPlace, ShadowState, VariableWordDecline, cell_place, has_substitution, variable_word_place,
+    whole_reference,
+};
 use super::elide::{BarrierDecision, CellDemotion, TraceLedger};
 use super::ir::{
     CmpOp, CompareKind, IfElseResult, IntOp, NativeBlock, NativeBlockId, NativeFunction, NativeOp,
@@ -58,19 +61,15 @@ use crate::dispatch_proof::{
     DispatchEntryAssumption, DispatchProofAnalysis, analyse_dispatch_stability,
 };
 use crate::executable_ir::{
-    CellReference, ExecutableArgvId, ExecutableBlock, ExecutableExpr, ExecutableFunction,
-    ExecutableInstruction, ExecutableTerminator, ExecutableValueId, GenericInvoke,
-    InvocationResolution, LoweredOperation,
+    ExecutableArgvId, ExecutableBlock, ExecutableExpr, ExecutableFunction, ExecutableInstruction,
+    ExecutableTerminator, ExecutableValueId, GenericInvoke, InvocationResolution, LoweredOperation,
 };
 use crate::intervals::Interval;
-use crate::ir::{
-    CommandTokens, Module, NodeId, Provenance, SourceSite, Statement, WordExpr, WordPart,
-};
+use crate::ir::{CommandTokens, Module, NodeId, SourceSite, Statement, WordExpr, WordPart};
 use crate::registry_invocation::{RegistryInvocationResolution, resolve_word_exprs};
 use crate::semantic_optimisation::{SemanticOptimisationConfig, SemanticOptimisationPassId};
 use crate::types::TypeShape;
 use crate::var_escape::types::ProcEscapeSummary;
-use tcl_lexer::Span;
 
 /// Recursion cap for nested command substitution and compound-word parts.
 const MAX_WORD_DEPTH: u32 = 32;
@@ -1058,13 +1057,13 @@ impl<'a> Lowerer<'a> {
     /// bare scalar variable reference.
     fn lower_operand_word(&mut self, text: &str) -> Option<NativeValueId> {
         if text.starts_with('$') {
-            let name = variable_name(text)?;
-            if name.contains('(') {
+            // A retained `$name` word carries no lexical extent here, so the
+            // owner's name reading decides it: an element access is not one
+            // scalar operand.
+            let place = cell_place(whole_reference(text)?, true)?;
+            if matches!(place, CellPlace::Element { .. }) {
                 return None;
             }
-            let place = CellPlace::Named {
-                name: name.to_owned(),
-            };
             let value = self.read_cell(&place);
             return Some(self.as_int_operand(value));
         }
@@ -1826,10 +1825,6 @@ fn hull(a: Interval, b: Interval) -> Interval {
     Interval { lo, hi }
 }
 
-fn has_substitution(text: &str) -> bool {
-    text.bytes().any(|byte| matches!(byte, b'$' | b'[' | b'\\'))
-}
-
 /// The value word of a `set name value` statement's retained tokens.
 fn value_word(tokens: Option<&CommandTokens>) -> Option<&WordExpr> {
     let tokens = tokens?;
@@ -1837,30 +1832,6 @@ fn value_word(tokens: Option<&CommandTokens>) -> Option<&WordExpr> {
         return None;
     }
     tokens.words().get(2)
-}
-
-/// The cell a statically spelled variable name denotes.
-fn cell_place(name: &str, braced: bool) -> Option<CellPlace> {
-    match CellReference::from_name(name, braced) {
-        CellReference::Named {
-            name: base,
-            element,
-        } => {
-            if !element {
-                return Some(CellPlace::Named { name: base });
-            }
-            let (_, key) = tcl_syntax::naming::split_array_name_braced(name, braced);
-            let key = key?;
-            if !braced && has_substitution(key) {
-                return None;
-            }
-            Some(CellPlace::Element {
-                name: base,
-                key: key.to_owned(),
-            })
-        }
-        CellReference::Computed => None,
-    }
 }
 
 /// The cell an expression `$name` / `$arr(key)` reads.
@@ -1881,64 +1852,15 @@ fn expr_variable_place(name: &str) -> Option<CellPlace> {
     }
 }
 
-/// The name a `$…` / `${…}` word spelling refers to.
-fn variable_name(spelling: &str) -> Option<&str> {
-    if let Some(name) = spelling
-        .strip_prefix("${")
-        .and_then(|rest| rest.strip_suffix('}'))
-    {
-        return (!name.is_empty()).then_some(name);
-    }
-    let name = spelling.strip_prefix('$')?;
-    (!name.is_empty()
-        && name
-            .bytes()
-            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'_' || byte == b':'))
-    .then_some(name)
-}
-
-/// The cell a variable word reads, distinguishing `$a(b)` from `${a(b)}` by
-/// the recorded lexical extent exactly as the leaf-invocation planner does.
+/// The cell a variable word reads, in this tier's decline vocabulary.
+///
+/// [`variable_word_place`] is the one owner of the reading; this only names
+/// the refusal.
 fn variable_place(spelling: &str, source: &SourceSite) -> Result<CellPlace, NativeLoweringDecline> {
-    let name = variable_name(spelling).ok_or(NativeLoweringDecline::DynamicVariableName)?;
-    if !name.contains('(') {
-        return Ok(CellPlace::Named {
-            name: name.to_owned(),
-        });
-    }
-    if source.provenance != Provenance::Source {
-        return Err(NativeLoweringDecline::AmbiguousVariableSpelling);
-    }
-    match extent(source.span).checked_sub(name.len()) {
-        Some(2) => Ok(CellPlace::Named {
-            name: name.to_owned(),
-        }),
-        Some(1) => {
-            let inner = name
-                .strip_suffix(')')
-                .ok_or(NativeLoweringDecline::AmbiguousVariableSpelling)?;
-            let open = inner
-                .find('(')
-                .ok_or(NativeLoweringDecline::AmbiguousVariableSpelling)?;
-            let (base, key) = inner.split_at(open);
-            let key = &key[1..];
-            if base.is_empty() {
-                return Err(NativeLoweringDecline::AmbiguousVariableSpelling);
-            }
-            if has_substitution(key) {
-                return Err(NativeLoweringDecline::DynamicVariableName);
-            }
-            Ok(CellPlace::Element {
-                name: base.to_owned(),
-                key: key.to_owned(),
-            })
-        }
-        _ => Err(NativeLoweringDecline::AmbiguousVariableSpelling),
-    }
-}
-
-fn extent(span: Span) -> usize {
-    span.end().saturating_sub(span.start()) as usize
+    variable_word_place(spelling, source).map_err(|decline| match decline {
+        VariableWordDecline::Dynamic => NativeLoweringDecline::DynamicVariableName,
+        VariableWordDecline::Ambiguous => NativeLoweringDecline::AmbiguousVariableSpelling,
+    })
 }
 
 /// The structured words of a `[…]` command substitution, recovered by the

--- a/rust/tcl-compiler/tests/wasm_real_link.rs
+++ b/rust/tcl-compiler/tests/wasm_real_link.rs
@@ -703,6 +703,15 @@ fn compiled_argv_invocations_run_against_the_real_runtime() {
             "set out",
             "fast",
         ),
+        // A braced element *target*: `set {a(b)} 5` writes the element, as
+        // tclsh does, not a scalar literally named `a(b)`. The direct
+        // assignment gate reads that shape through `cell_place`, so this pins
+        // the answer it must keep giving.
+        (
+            "set {cfg(mode)} fast\nlappend out $cfg(mode) [array exists cfg]\n",
+            "set out",
+            "fast 1",
+        ),
         // Runtime dispatch is genuinely runtime dispatch: a renamed command
         // resolves to its new name, which no compile-time binding could know.
         (
@@ -726,6 +735,32 @@ fn compiled_argv_invocations_run_against_the_real_runtime() {
             "program {program:?}, query {query:?}"
         );
     }
+}
+
+/// Issue #1772's exact repro, against the real runtime.
+///
+/// The retired analysis-tier `puts` fast path took a single-argument `puts`
+/// and re-read the argument's *compatibility text* to find a variable name.
+/// For `puts "$p $q"` that text is `${p} ${q}`, whose outer-brace strip yields
+/// the name `p} ${q` — a variable that does not exist, so the runtime wrote
+/// nothing and the following `puts end` was swallowed with it. Nothing else in
+/// the suite shows the symptom the issue reported, because it is a *missing*
+/// line rather than a wrong value: the first `puts` proves the compound word
+/// survives, and `end` proves the statement after it still runs.
+#[test]
+fn analysed_compound_puts_word_reaches_the_runtime_intact() {
+    let Some(runtime) = real_link_runtime() else {
+        return;
+    };
+    assert_eq!(
+        run_real_link_argv(
+            &runtime,
+            "compound-puts",
+            "set p 1\nset q 2\nputs \"$p $q\"\nputs end\n",
+            "set p",
+        ),
+        "1 2\nend\n1",
+    );
 }
 
 /// The compiled path leaks nothing in the real runtime: after repeated runs the


### PR DESCRIPTION
## Summary

#1772 reported that the analysis-tier `puts` fast path re-read an argument's *compatibility text*, so `puts "$p $q"` looked up a variable literally named `p} ${q` and `::top` stopped silently.

**That fast path is already gone.** I verified it rather than assuming: the issue's exact program was added as a linked test and run against the **pre-change tree** (stashing only `rust/tcl-compiler/src`) —

```tcl
set p 1; set q 2
puts "$p $q"
puts end
```

`analysed_compound_puts_word_reaches_the_runtime_intact` expects stdout `1 2` / `end` / `1` against the real linked `tcl_runtime.wasm`, and **passed on the base commit**. `wasm_tiers` was green on base too: all 36 samples — including the four the issue named (`11_while_loop`, `20_lists`, `24_regex`, `41_upvar`) — match the tclsh oracles on the analysis plan, and the stale-entry check confirms `EXPECTED_DIVERGENCES` is down to `73_coroutine` alone.

So what remained is the issue's actual *root cause*: the string-shape heuristics that re-parse an argument's text, which `common-semantic-compiler.md` forbids. Four copies of that reasoning were still live.

### One owner

`native_lowering::cells` now owns it, built on `tcl_syntax::naming::split_element_ref`: `whole_reference`, `variable_word_place`, `cell_place`, `has_substitution`.

Deleted in favour of it:
- `codegen::values::whole_var_reference` — the function whose outer `${…}` strip produced `p} ${q` (its tests moved to the owner);
- a byte-identical private copy of the same logic in `native_lowering/lower.rs` (`variable_name`/`variable_place`/`cell_place`/`extent`), leaving `variable_place` as a five-line decline-mapping adapter;
- `leaf_invoke.rs::plan_variable`'s hand-rolled `split_element` and `extent`;
- the `name.contains('(')` gate in `backend.rs`'s `AssignConst` arm, now `cell_place(...) is Named`;
- the dead `Top` branch of `emit_var_get`, which is DirectProc-only and now says so.

`is_bare_var_name` stays in `values.rs` as the documented looser-charset owner, consumed by `cells`. `expr_variable_place` stays put — it already calls the `tcl_syntax` owner and was never a copy.

Verified afterwards: no `whole_var_reference`, `variable_name`, hand-rolled `strip_suffix(')')` / `find('(')` split, or `contains('(')` gate remains anywhere under `codegen/wasm/` or `native_lowering/`.

This is deliberately **not** the full P3 restructuring of every direct operation onto the `WordExpr` snapshot — that is R10/#1785 and stays separate.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

```
cargo test -p tcl-compiler                                    # 66/66 binaries ok
TCL_REQUIRE_WASM_LINK=1 cargo test -p tcl-compiler \
    --test wasm_tiers --test wasm_real_link                   # 9 + 6 passed, budgets golden unchanged
make rust-check                                               # exit 0
```

`make rust-check` was confirmed green on the base commit first. Nothing skipped or weakened.

## Compiler / diagnostics checklist

- [x] Did this change alter a compiler fact contract? Yes — which cell a variable word names is now decided in one place.
- [x] If yes, I updated the owning design doc — `shared-utility-contracts-rust.md` (divergence entry), `wasm-codegen.md`, `wasm-native-lowering-plan.md` §2.2, and two stale claims in `lanes/wasm-native-lowering.md`.
- [x] If I added or changed a diagnostic or optimisation code, I updated its page under `docs/kcs/codes/` — n/a, none changed.
- [x] If I added a design doc, I linked it from `docs/design/README.md` — n/a, no new design doc.

Closes #1772

## Notes for the reviewer

- **The `AssignConst` admitted set moves slightly**, so "same set" would be inaccurate: `cell_place` *narrows* it (empty and braced-element names now fall back) and *widens* it a little (unbraced non-element names containing `(`, e.g. `a(`, which `var_set` stores correctly as scalars). All movement is toward the runtime's real `var_set` semantics; no test or budget shifted.
- I had drafted a claim that the gate change *fixes* a braced `{a(b)}` assignment target. I tested that on the base commit, found it already behaved correctly, and removed the claim — the case is kept as a plain behavioural pin.
- Environment note for anyone reproducing the link tests: `wasm32-wasip1` was not installed here (only `unknown-unknown` and `wasip2`), so `rustup target add wasm32-wasip1` is needed before a real link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XV29AoTSsaCBgsJuf2EvEK

---
_Generated by [Claude Code](https://claude.ai/code/session_01XV29AoTSsaCBgsJuf2EvEK)_