### PR TITLE
feat(lsp): a .tclspec document gets the treatment its own dialect asks for

### DIFF
--- a/rust/tcl-lsp-core/src/code_actions.rs
+++ b/rust/tcl-lsp-core/src/code_actions.rs
@@ -1947,14 +1947,18 @@ pub fn spec_pack_quick_fixes(
         let Some((line_text, word_start)) = word_site(source, d.range.start_line, word) else {
             continue;
         };
-        let head = line_text.split_whitespace().next().unwrap_or_default();
         let offset = line_index.line_start(d.range.start_line)
             + u32::try_from(word_start).unwrap_or(u32::MAX);
+        let config = tcl_lexer::LexerConfig::for_file_grammar(dialect.grammar);
+        let Some(head) = statement_head_at(source, offset, config) else {
+            continue;
+        };
+        let head = head.as_str();
         let grammar = crate::oo_body::definition_grammar_at(
             source,
             offset,
             registry,
-            tcl_lexer::LexerConfig::for_file_grammar(dialect.grammar),
+            config,
             Some(dialect.surface_query()),
         );
         let candidates: Vec<&str> = if head == word {
@@ -2012,6 +2016,69 @@ fn quoted_word(message: &str) -> Option<&str> {
     let rest = message.split_once('`')?.1;
     let (word, _) = rest.split_once('`')?;
     (!word.is_empty() && !word.contains(char::is_whitespace)).then_some(word)
+}
+
+/// The keyword of the statement `offset` falls inside.
+///
+/// A statement is not a line: Tcl ends one at `;` as readily as at a newline,
+/// so on `arity 1; arty 2` the line's first word names the *neighbouring* row
+/// and every candidate set derived from it is the wrong one. The segmenter is
+/// what knows where a row begins, and the descent into braced words is what
+/// brings a nested row — every row of a pack is nested at least twice — within
+/// its reach.
+///
+/// `None` when no statement covers the offset (a word inside a comment, a
+/// nest deeper than the walk follows), which costs an action rather than
+/// offering one computed against the wrong row.
+fn statement_head_at(source: &str, offset: u32, config: tcl_lexer::LexerConfig) -> Option<String> {
+    fn walk(
+        source: &str,
+        slice: &str,
+        base: u32,
+        offset: u32,
+        depth: u32,
+        config: tcl_lexer::LexerConfig,
+    ) -> Option<String> {
+        // The same bound every other walk over a nested body carries.
+        if depth > 32 {
+            return None;
+        }
+        for cmd in tcl_compiler::segmenter::segment_commands_with_offset_and_config(
+            slice,
+            base,
+            config.at_depth(depth),
+        ) {
+            if offset < cmd.span.start() || offset >= cmd.span.end() {
+                continue;
+            }
+            // A braced word holding the offset is a script of its own, and the
+            // row the notice points at is one of *its* statements.
+            for tok in cmd.argv.iter().skip(1) {
+                if tok.kind != tcl_lexer::TokenType::Str {
+                    continue;
+                }
+                let inner_start = tok
+                    .span
+                    .start()
+                    .saturating_add(u32::from(tok.content_offset));
+                let inner_end = tok
+                    .span
+                    .end()
+                    .min(u32::try_from(source.len()).unwrap_or(u32::MAX));
+                if inner_start > inner_end || offset < inner_start || offset >= inner_end {
+                    continue;
+                }
+                let Some(inner) = source.get(inner_start as usize..inner_end as usize) else {
+                    continue;
+                };
+                return walk(source, inner, inner_start, offset, depth + 1, config);
+            }
+            return Some(cmd.name().to_owned());
+        }
+        None
+    }
+
+    walk(source, source, 0, offset, 0, config)
 }
 
 /// `line`'s text and the byte offset of `word` within it, when the word really
@@ -3539,6 +3606,45 @@ mod tests {
                 start_character: 0,
                 end_line: 2,
                 end_character: 23,
+            },
+        }];
+        let actions = spec_pack_quick_fixes(src, crate::profile_for_dialect("spectcl"), &diags);
+        assert_eq!(actions.len(), 1, "{actions:?}");
+        assert_eq!(actions[0].edits[0].new_text, "-role");
+    }
+
+    /// Two rows on one line: `;` ends a statement, so the row a word sits on
+    /// is the segmenter's answer and not the line's first word — which here
+    /// names the *neighbour* and would offer nothing at all.
+    #[test]
+    fn a_row_sharing_its_line_is_corrected_against_its_own_head() {
+        let src = "speclib mylib 1 {\n    command mylib::x {\n        arity 1; arty 2\n    }\n}\n";
+        let diags = vec![ContextDiagnostic {
+            code: SPEC_PACK_DIAGNOSTIC_CODE.to_owned(),
+            message: "mylib::x: unknown property `arty` dropped".to_owned(),
+            range: LspRange {
+                start_line: 2,
+                start_character: 0,
+                end_line: 2,
+                end_character: 23,
+            },
+        }];
+        let actions = spec_pack_quick_fixes(src, crate::profile_for_dialect("spectcl"), &diags);
+        assert_eq!(actions.len(), 1, "{actions:?}");
+        assert_eq!(actions[0].edits[0].new_text, "arity");
+        assert_eq!(actions[0].edits[0].range.start_character, 17);
+
+        // …and the flag case, whose option table comes from the head of the
+        // row the flag was written on (`arg`), not the line's (`arity`).
+        let src = "speclib mylib 1 {\n    command mylib::x {\n        arity 1; arg 0 -rle Body\n    }\n}\n";
+        let diags = vec![ContextDiagnostic {
+            code: SPEC_PACK_DIAGNOSTIC_CODE.to_owned(),
+            message: "unknown flag `-rle` on `arg` dropped".to_owned(),
+            range: LspRange {
+                start_line: 2,
+                start_character: 0,
+                end_line: 2,
+                end_character: 32,
             },
         }];
         let actions = spec_pack_quick_fixes(src, crate::profile_for_dialect("spectcl"), &diags);

--- a/rust/tcl-lsp-core/src/code_actions.rs
+++ b/rust/tcl-lsp-core/src/code_actions.rs
@@ -53,6 +53,11 @@
 //!   it never fires on a comment, a string, an argument word, or a
 //!   definition's name (issue #1191).
 //!
+//! * Spec-pack did-you-mean actions ([`spec_pack_quick_fixes`]) — the
+//!   `SpecTcl` loader drops a word it does not know and says so; the
+//!   vocabulary it was measured against is closed, so the notice is a typo
+//!   with one computable correction.
+//!
 //! Limitations:
 //!
 //! * [`package_require_actions`] derives its catalogue from
@@ -1883,6 +1888,160 @@ const REGEX_QUOTE_PROC: &str =
 /// carriage-return characters to empty, not the two-character sequences.
 const CRLF_STRIP_MAP: &str = "string map {\"\\n\" \"\" \"\\r\" \"\"}";
 
+/// The diagnostic code every `SpecTcl` pack-load notice carries.
+///
+/// One code for the family rather than one per notice kind: the notices are
+/// *degradations* the loader chose to report, not a diagnostic catalogue with
+/// per-code documentation and quick fixes behind it. A user who does not want
+/// them silences the family.
+///
+/// It lives here rather than beside the publisher so the code the notices go
+/// out under and the code the quick-fix below reads back are one string.
+pub const SPEC_PACK_DIAGNOSTIC_CODE: &str = "SPECTCL";
+
+/// How many candidates a did-you-mean rewrite offers.
+///
+/// One, not a menu: a pack-load notice names one word, and three near-equal
+/// candidates out of a closed vocabulary is a worse answer than none — at that
+/// point the author wants the vocabulary, which completion already offers on
+/// the same line, not a ranking of guesses.
+const SPEC_PACK_SUGGESTIONS: usize = 1;
+
+/// Did-you-mean quick-fixes for a spec pack's load notices.
+///
+/// A `SpecTcl` vocabulary is **closed**: a property word is a member of the
+/// grammar in force where it was written, and a flag is an entry in the option
+/// table of the row it was written on. So a notice naming a word the loader
+/// dropped is a typo with a computable correction, and the fix is the one edit
+/// that turns the pack the author meant to write into the pack that loads.
+///
+/// The notice says *which* word (it quotes it); the source says *what kind* of
+/// word it is, from its position in the row — which is why nothing here reads
+/// the notice's prose beyond the quoted word itself. A word the source does
+/// not confirm at the position the notice points to, or one with no candidate
+/// inside the edit-distance budget, yields no action rather than a guess.
+///
+/// Only the two positionally-determined kinds are offered — a row's own
+/// keyword and a flag on a row — because those are the two whose candidate
+/// vocabulary is a fact of this registry. A misspelled trait, dialect or taint
+/// colour is a *value* inside a row whose vocabulary the pack loader owns, and
+/// no consumer here can enumerate it.
+#[must_use]
+pub fn spec_pack_quick_fixes(
+    source: &str,
+    dialect: &'static tcl_dialect::DialectProfile,
+    diags: &[ContextDiagnostic],
+) -> Vec<CodeAction> {
+    let registry = crate::registry_for_dialect_profile(dialect);
+    // A dialect with no document grammar has no pack vocabulary to correct
+    // against; every notice below is by construction on a declaration file.
+    if registry.document_grammar().is_none() {
+        return Vec::new();
+    }
+    let line_index = LineIndex::new(source);
+    let mut out = Vec::new();
+    for d in diags.iter().filter(|d| d.code == SPEC_PACK_DIAGNOSTIC_CODE) {
+        let Some(word) = quoted_word(&d.message) else {
+            continue;
+        };
+        let Some((line_text, word_start)) = word_site(source, d.range.start_line, word) else {
+            continue;
+        };
+        let head = line_text.split_whitespace().next().unwrap_or_default();
+        let offset = line_index.line_start(d.range.start_line)
+            + u32::try_from(word_start).unwrap_or(u32::MAX);
+        let grammar = crate::oo_body::definition_grammar_at(
+            source,
+            offset,
+            registry,
+            tcl_lexer::LexerConfig::for_file_grammar(dialect.grammar),
+            Some(dialect.surface_query()),
+        );
+        let candidates: Vec<&str> = if head == word {
+            // The row's own keyword: the member vocabulary of the grammar this
+            // row sits in, which is exactly what completion offers here.
+            grammar.map(|g| g.members.iter().map(|m| m.keyword).collect())
+        } else if word.starts_with('-') {
+            // A flag on a row: the option table of the row's own spec.
+            registry
+                .get(head)
+                .map(|spec| spec.options.iter().map(|opt| opt.name).collect())
+        } else {
+            None
+        }
+        .unwrap_or_default();
+        let Some(&suggestion) = tcl_compiler::text::suggest_similar(
+            word,
+            candidates,
+            SPEC_PACK_SUGGESTIONS,
+            tcl_compiler::text::scaled_max_distance(word),
+        )
+        .first() else {
+            continue;
+        };
+        let start = char_col_to_utf16_local(line_text, line_text[..word_start].chars().count());
+        let end = char_col_to_utf16_local(
+            line_text,
+            line_text[..word_start + word.len()].chars().count(),
+        );
+        out.push(CodeAction::new(
+            format!("Change `{word}` to `{suggestion}`"),
+            vec![crate::rename::TextEdit {
+                range: LspRange {
+                    start_line: d.range.start_line,
+                    start_character: start,
+                    end_line: d.range.start_line,
+                    end_character: end,
+                },
+                new_text: suggestion.to_owned(),
+            }],
+            ActionKind::QuickFix,
+            None,
+        ));
+    }
+    out
+}
+
+/// The first `` `word` `` a notice quotes.
+///
+/// Every "unknown X dropped" notice quotes the word it dropped, and that
+/// quoting is the notice's only machine-readable part — the word is not
+/// recoverable from the whole-line range alone, which is all the diagnostic
+/// otherwise carries.
+fn quoted_word(message: &str) -> Option<&str> {
+    let rest = message.split_once('`')?.1;
+    let (word, _) = rest.split_once('`')?;
+    (!word.is_empty() && !word.contains(char::is_whitespace)).then_some(word)
+}
+
+/// `line`'s text and the byte offset of `word` within it, when the word really
+/// is a whole word there.
+///
+/// The confirmation matters: a notice quotes a word the *loader* read, and the
+/// buffer may have moved on since the pack was loaded. An edit that no longer
+/// matches the text yields no action instead of rewriting whatever now sits at
+/// that offset.
+fn word_site<'a>(source: &'a str, line: u32, word: &str) -> Option<(&'a str, usize)> {
+    let line_text = source.split('\n').nth(line as usize)?;
+    let mut from = 0;
+    while let Some(rel) = line_text[from..].find(word) {
+        let at = from + rel;
+        let before_ok = line_text[..at]
+            .chars()
+            .next_back()
+            .is_none_or(|c| c.is_whitespace() || c == '{');
+        let after_ok = line_text[at + word.len()..]
+            .chars()
+            .next()
+            .is_none_or(|c| c.is_whitespace() || c == '}');
+        if before_ok && after_ok {
+            return Some((line_text, at));
+        }
+        from = at + word.len();
+    }
+    None
+}
+
 /// Quick-fixes for context-supplied diagnostics (iRules taint encode-wrap +
 /// double-encode removal).
 #[must_use]
@@ -3301,5 +3460,134 @@ mod tests {
             .expect("data_group_definition payload");
         assert!(def.contains("ltm data-group internal"), "{def:?}");
         assert!(def.contains("type string"), "{def:?}");
+    }
+
+    /// A pack-load notice about a dropped property becomes the one edit that
+    /// spells the property the way the grammar in force does.
+    #[test]
+    fn a_dropped_property_offers_the_nearest_real_word() {
+        let src = "speclib mylib 1 {\n    command mylib::x {\n        arty 1\n    }\n}\n";
+        let diags = vec![ContextDiagnostic {
+            code: SPEC_PACK_DIAGNOSTIC_CODE.to_owned(),
+            message: "mylib::x: unknown property `arty` dropped".to_owned(),
+            range: LspRange {
+                start_line: 2,
+                start_character: 0,
+                end_line: 2,
+                end_character: 14,
+            },
+        }];
+        let actions = spec_pack_quick_fixes(src, crate::profile_for_dialect("spectcl"), &diags);
+        assert_eq!(actions.len(), 1, "{actions:?}");
+        assert_eq!(actions[0].title, "Change `arty` to `arity`");
+        assert_eq!(actions[0].edits.len(), 1);
+        assert_eq!(actions[0].edits[0].new_text, "arity");
+        assert_eq!(actions[0].edits[0].range.start_line, 2);
+        assert_eq!(actions[0].edits[0].range.start_character, 8);
+        assert_eq!(actions[0].edits[0].range.end_character, 12);
+    }
+
+    /// The candidate set is the grammar *in force*, not the pack's whole
+    /// vocabulary: `summary` is a `hover` word, so a typo of it inside a
+    /// `command` body must not resolve to it.
+    #[test]
+    fn the_candidate_vocabulary_is_the_grammar_in_force() {
+        let src = "speclib mylib 1 {\n    command mylib::x {\n        hover {\n            sumary {x}\n        }\n    }\n}\n";
+        let diags = vec![ContextDiagnostic {
+            code: SPEC_PACK_DIAGNOSTIC_CODE.to_owned(),
+            message: "unknown property `sumary` dropped".to_owned(),
+            range: LspRange {
+                start_line: 3,
+                start_character: 0,
+                end_line: 3,
+                end_character: 22,
+            },
+        }];
+        let actions = spec_pack_quick_fixes(src, crate::profile_for_dialect("spectcl"), &diags);
+        assert_eq!(actions.len(), 1, "{actions:?}");
+        assert_eq!(actions[0].edits[0].new_text, "summary");
+
+        // The same misspelling one level out has no `summary` to reach.
+        let outer = "speclib mylib 1 {\n    command mylib::x {\n        sumary {x}\n    }\n}\n";
+        let outer_diags = vec![ContextDiagnostic {
+            code: SPEC_PACK_DIAGNOSTIC_CODE.to_owned(),
+            message: "unknown property `sumary` dropped".to_owned(),
+            range: LspRange {
+                start_line: 2,
+                start_character: 0,
+                end_line: 2,
+                end_character: 18,
+            },
+        }];
+        assert!(
+            !spec_pack_quick_fixes(outer, crate::profile_for_dialect("spectcl"), &outer_diags)
+                .iter()
+                .any(|a| a.edits[0].new_text == "summary")
+        );
+    }
+
+    /// A dropped flag is corrected against the option table of the row it was
+    /// written on, which the registry owns.
+    #[test]
+    fn a_dropped_flag_offers_the_nearest_option() {
+        let src = "speclib mylib 1 {\n    command mylib::x {\n        arg 0 -rle Body\n    }\n}\n";
+        let diags = vec![ContextDiagnostic {
+            code: SPEC_PACK_DIAGNOSTIC_CODE.to_owned(),
+            message: "unknown flag `-rle` on `arg` dropped".to_owned(),
+            range: LspRange {
+                start_line: 2,
+                start_character: 0,
+                end_line: 2,
+                end_character: 23,
+            },
+        }];
+        let actions = spec_pack_quick_fixes(src, crate::profile_for_dialect("spectcl"), &diags);
+        assert_eq!(actions.len(), 1, "{actions:?}");
+        assert_eq!(actions[0].edits[0].new_text, "-role");
+    }
+
+    /// A word the buffer no longer carries — the notice is from the last load,
+    /// the author has since retyped the line — yields no edit at all.
+    #[test]
+    fn a_notice_the_buffer_has_moved_past_offers_nothing() {
+        let src = "speclib mylib 1 {\n    command mylib::x {\n        arity 1\n    }\n}\n";
+        let diags = vec![ContextDiagnostic {
+            code: SPEC_PACK_DIAGNOSTIC_CODE.to_owned(),
+            message: "unknown property `arty` dropped".to_owned(),
+            range: LspRange {
+                start_line: 2,
+                start_character: 0,
+                end_line: 2,
+                end_character: 15,
+            },
+        }];
+        assert!(
+            spec_pack_quick_fixes(src, crate::profile_for_dialect("spectcl"), &diags).is_empty()
+        );
+    }
+
+    /// Only a pack file: the same-shaped diagnostic on an ordinary Tcl
+    /// document has no closed vocabulary behind it.
+    #[test]
+    fn an_ordinary_tcl_document_gets_no_pack_quick_fix() {
+        let src = "proc arty {} {}\n";
+        let diags = vec![ContextDiagnostic {
+            code: SPEC_PACK_DIAGNOSTIC_CODE.to_owned(),
+            message: "unknown property `arty` dropped".to_owned(),
+            range: LspRange {
+                start_line: 0,
+                start_character: 0,
+                end_line: 0,
+                end_character: 15,
+            },
+        }];
+        assert!(
+            spec_pack_quick_fixes(
+                src,
+                tcl_registry::model::ingress::resolve_environment("tcl").analyser_profile(),
+                &diags,
+            )
+            .is_empty()
+        );
     }
 }

--- a/rust/tcl-lsp-core/src/declaration_outline.rs
+++ b/rust/tcl-lsp-core/src/declaration_outline.rs
@@ -19,8 +19,11 @@
 //! The outline of a **declaration document**.
 //!
 //! A declaration document is one whose dialect states facts rather than
-//! running a script — today that is the `sslictcl` environment, whose
-//! defining property is that nothing in a `.sslictcl` file is ever evaluated.
+//! running a script — the `sslictcl` and `spectcl` environments, whose
+//! defining property is that nothing in such a file is ever evaluated. The
+//! registry says which those are: a dialect declaring a
+//! [`CommandRegistry::document_grammar`] has declared its document root a
+//! closed member vocabulary.
 //! Its *blocks* are its structure: each block statement is a declared entity,
 //! so it is an outline entry, and a nested block is a child of the one that
 //! contains it. A script document's outline comes from the analyser's scope
@@ -38,6 +41,7 @@
 //! token walk read, and which answers for every definition body rather than
 //! only a declaration document's.
 //!
+//! [`CommandRegistry::document_grammar`]: tcl_registry::CommandRegistry::document_grammar
 //! [`DefinitionBodyGrammar`]: tcl_registry::definer::DefinitionBodyGrammar
 //! [`ArgRole::Name`]: tcl_registry::arg_role::ArgRole::Name
 //! [`ArgRole::Body`]: tcl_registry::arg_role::ArgRole::Body
@@ -83,15 +87,24 @@ impl BlockDeclaration {
 
 /// Whether documents of `dialect` are declarations rather than scripts.
 ///
-/// The same resolved-authoring-surface question
-/// [`crate::sslictcl_diagnostics::applies_to`] asks, and deliberately the
-/// same answer: the property both surfaces here depend on — that the document
-/// is never evaluated — is precisely what makes the `SslicTcl` loader the
-/// authority over it. When a second such environment appears, both read the
-/// widened predicate rather than growing a list of dialects apiece.
+/// The registry answers it, and the answer is one field: a dialect whose
+/// command surface declares a [`CommandRegistry::document_grammar`] has said
+/// that the *root* of its documents is a closed member vocabulary rather than
+/// an open command position — which is exactly what "this file states facts"
+/// means. `SslicTcl` and `SpecTcl` both declare one; plain Tcl, iRules, and
+/// every EDA shell declare none, so their outline stays the analyser's scope
+/// tree.
+///
+/// Deliberately *not* a package test: keying on a surface name would have to
+/// grow a name per authoring dialect, and the fact the outline actually needs
+/// is already modelled.
+///
+/// [`CommandRegistry::document_grammar`]: tcl_registry::CommandRegistry::document_grammar
 #[must_use]
 pub fn is_declaration_document(dialect: &DialectProfile) -> bool {
-    crate::sslictcl_diagnostics::applies_to(dialect)
+    crate::registry_for_dialect_profile(dialect)
+        .document_grammar()
+        .is_some()
 }
 
 /// Every block declaration in `source`, in source order, nested.
@@ -251,6 +264,41 @@ mod tests {
                 .map(BlockDeclaration::label)
                 .collect::<Vec<_>>(),
             vec!["check modern", "grade"],
+        );
+    }
+
+    /// A `.tclspec` pack is a declaration document on the same registry
+    /// footing as a `.sslictcl` one: `SpecTcl` declares a document grammar
+    /// too, so the pack's blocks are its outline with nothing dialect-specific
+    /// in this module.
+    #[test]
+    fn a_spec_pack_outlines_as_its_own_declaration_blocks() {
+        const PACK: &str = "speclib mylib 1 {\n\
+                            \x20   command mylib::x {\n\
+                            \x20       arity 1\n\
+                            \x20       hover {\n\
+                            \x20           summary {Do a thing.}\n\
+                            \x20       }\n\
+                            \x20   }\n\
+                            }\n";
+        let outline = declarations(PACK, profile_for_dialect("spectcl"));
+        let labels: Vec<String> = outline.iter().map(BlockDeclaration::label).collect();
+        assert_eq!(labels, vec!["speclib mylib"]);
+        assert_eq!(
+            outline[0]
+                .children
+                .iter()
+                .map(BlockDeclaration::label)
+                .collect::<Vec<_>>(),
+            vec!["command mylib::x"],
+        );
+        assert_eq!(
+            outline[0].children[0]
+                .children
+                .iter()
+                .map(BlockDeclaration::label)
+                .collect::<Vec<_>>(),
+            vec!["hover"],
         );
     }
 

--- a/rust/tcl-lsp-core/src/document_links.rs
+++ b/rust/tcl-lsp-core/src/document_links.rs
@@ -63,10 +63,12 @@
 //!   sub-arg is a simple bareword / quoted string; the joined
 //!   path resolves against `workspace_root` like any other
 //!   relative arg.
+//! * A spec pack's `include NAME` row — see [`pack_include_links`].
 
 use tcl_compiler::auto_path_eval::carries_substitution;
 use tcl_compiler::segmenter::segment_commands_with_offset_and_config;
 use tcl_lexer::{LineIndex, Token, TokenType};
+use tcl_registry::definer::DefinerFamily;
 
 /// One link in a document — target URI plus the source range.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -187,6 +189,13 @@ pub fn document_links_in_context(
         script_path,
         ctx.imported_constants.unwrap_or(&no_imports),
     );
+    links.extend(pack_include_links(
+        source,
+        dialect,
+        &line_index,
+        workspace_root,
+        home,
+    ));
 
     for seg in segment_commands_with_offset_and_config(
         source,
@@ -283,6 +292,84 @@ pub fn document_links_in_context(
         });
     }
 
+    links
+}
+
+/// Every `include NAME` row of a spec pack, as a link to the sibling file it
+/// names.
+///
+/// A pack's `include` row is the one statement in the `SpecTcl` vocabulary
+/// that names another file: `include NAME` resolves against the including
+/// pack's **own directory** and nothing else (`IncludeContext::for_file`), so
+/// the `workspace_root` the server already passes — the document's enclosing
+/// directory — is exactly the anchor the loader uses, and no path arithmetic
+/// of this provider's own is involved.
+///
+/// The gate is the registry, not the dialect's name: a document whose command
+/// surface declares a [`DefinerFamily::SpecTcl`] document grammar *is* a pack,
+/// however it reached that surface (the `.tclspec` extension, an editor
+/// language id, a `# tcl-dialect:` pin). An ordinary Tcl script that happens to
+/// call a proc of its own named `include` has no such grammar and gets no link.
+///
+/// Only the pack scope is scanned, because that is the only scope a file
+/// include is legal in — the loader drops one written anywhere else — and only
+/// the two-word file form: `include from SOURCE into TARGET { … }` composes a
+/// command surface out of packs already loaded and resolves no file at all.
+fn pack_include_links(
+    source: &str,
+    dialect: &'static tcl_dialect::DialectProfile,
+    line_index: &LineIndex,
+    workspace_root: Option<&str>,
+    home: Option<&str>,
+) -> Vec<DocumentLink> {
+    if crate::registry_for_dialect_profile(dialect)
+        .document_grammar()
+        .is_none_or(|grammar| grammar.family != DefinerFamily::SpecTcl)
+    {
+        return Vec::new();
+    }
+    let config = tcl_lexer::LexerConfig::for_file_grammar(dialect.grammar);
+    let mut links = Vec::new();
+    for pack in segment_commands_with_offset_and_config(source, 0, config) {
+        // `speclib NAME VERSION { … }` — the pack body is the fourth word, and
+        // the document grammar admits no other statement at the root.
+        if pack.texts.first().is_none_or(|head| head != "speclib") {
+            continue;
+        }
+        let Some(body) = pack.argv.get(3) else {
+            continue;
+        };
+        let body_start = body.span.start() + u32::from(body.content_offset);
+        let Some(body_text) = source
+            .get(body_start as usize..)
+            .and_then(|rest| rest.get(..body.span.end().saturating_sub(body_start) as usize))
+        else {
+            continue;
+        };
+        for row in segment_commands_with_offset_and_config(body_text, body_start, config) {
+            if row.texts.first().is_none_or(|head| head != "include") || row.texts.len() != 2 {
+                continue;
+            }
+            let name = &row.texts[1];
+            let Some(target) = resolve_path(name, workspace_root, home) else {
+                continue;
+            };
+            let Some(tok) = row.argv.get(1) else { continue };
+            let Some((anchor_start, anchor_end)) = link_anchor(source, dialect, tok) else {
+                continue;
+            };
+            let start = line_index.position_at_utf16(anchor_start, source);
+            let end = line_index.position_at_utf16(anchor_end, source);
+            links.push(DocumentLink {
+                start_line: start.line,
+                start_character: start.character.get(),
+                end_line: end.line,
+                end_character: end.character.get(),
+                target,
+                tooltip: Some(name.clone()),
+            });
+        }
+    }
     links
 }
 
@@ -573,6 +660,55 @@ mod tests {
                 "puts hello\n",
                 tcl_registry::model::ingress::resolve_environment("tcl").analyser_profile(),
                 None
+            )
+            .is_empty()
+        );
+    }
+
+    /// A pack's `include NAME` row links to the sibling file the loader would
+    /// read, anchored on the name alone.
+    #[test]
+    fn a_pack_include_row_links_to_its_sibling_file() {
+        let src = "speclib mylib 1 {\n    include shared.tclspec\n}\n";
+        let links = document_links(
+            src,
+            crate::profile_for_dialect("spectcl"),
+            Some("/home/user/project/.tcl-lsp"),
+        );
+        assert_eq!(links.len(), 1, "{links:?}");
+        assert_eq!(
+            links[0].target,
+            "file:///home/user/project/.tcl-lsp/shared.tclspec"
+        );
+        assert_eq!(links[0].start_line, 1);
+        assert_eq!(links[0].tooltip.as_deref(), Some("shared.tclspec"));
+    }
+
+    /// `include from … into …` composes a surface out of loaded packs and
+    /// names no file, so it must not be offered as one.
+    #[test]
+    fn a_surface_roster_include_is_not_a_file_link() {
+        let src = "speclib mylib 1 {\n    include from vendor into mylib { a b }\n}\n";
+        assert!(
+            document_links(
+                src,
+                crate::profile_for_dialect("spectcl"),
+                Some("/home/user/project"),
+            )
+            .is_empty()
+        );
+    }
+
+    /// The gate is the document's own grammar: an ordinary Tcl script calling
+    /// a proc of its own named `include` is not a pack.
+    #[test]
+    fn an_ordinary_tcl_include_call_is_not_a_link() {
+        let src = "speclib mylib 1 {\n    include shared.tclspec\n}\n";
+        assert!(
+            document_links(
+                src,
+                tcl_registry::model::ingress::resolve_environment("tcl").analyser_profile(),
+                Some("/home/user/project"),
             )
             .is_empty()
         );

--- a/rust/tcl-lsp-core/src/document_links.rs
+++ b/rust/tcl-lsp-core/src/document_links.rs
@@ -193,8 +193,7 @@ pub fn document_links_in_context(
         source,
         dialect,
         &line_index,
-        workspace_root,
-        home,
+        script_path,
     ));
 
     for seg in segment_commands_with_offset_and_config(
@@ -299,11 +298,18 @@ pub fn document_links_in_context(
 /// names.
 ///
 /// A pack's `include` row is the one statement in the `SpecTcl` vocabulary
-/// that names another file: `include NAME` resolves against the including
-/// pack's **own directory** and nothing else (`IncludeContext::for_file`), so
-/// the `workspace_root` the server already passes — the document's enclosing
-/// directory — is exactly the anchor the loader uses, and no path arithmetic
-/// of this provider's own is involved.
+/// that names another file, and the link has to land where the *loader* reads
+/// — anywhere else it navigates to a file the pack never included. So this
+/// spells out `IncludeContext::for_file`'s rule and only that rule: the name is
+/// joined to the including document's own directory, with no tilde expansion
+/// and no `workspace_root` fallback. The general `source <path>` resolver does
+/// both, and `include ~` under it linked to the user's home directory while the
+/// loader read a sibling literally named `~`.
+///
+/// A name carrying path structure gets no link either, because it names no
+/// file: `loader::include_name` drops such a row before the resolver is ever
+/// asked, so the declarations behind it are not loaded and there is nothing to
+/// navigate to.
 ///
 /// The gate is the registry, not the dialect's name: a document whose command
 /// surface declares a [`DefinerFamily::SpecTcl`] document grammar *is* a pack,
@@ -319,8 +325,7 @@ fn pack_include_links(
     source: &str,
     dialect: &'static tcl_dialect::DialectProfile,
     line_index: &LineIndex,
-    workspace_root: Option<&str>,
-    home: Option<&str>,
+    script_path: Option<&str>,
 ) -> Vec<DocumentLink> {
     if crate::registry_for_dialect_profile(dialect)
         .document_grammar()
@@ -328,6 +333,14 @@ fn pack_include_links(
     {
         return Vec::new();
     }
+    // The loader's anchor is `path.parent()` of the including pack; a document
+    // with no path of its own has no such directory and so no include to link.
+    let Some(dir) = script_path
+        .map(std::path::Path::new)
+        .and_then(std::path::Path::parent)
+    else {
+        return Vec::new();
+    };
     let config = tcl_lexer::LexerConfig::for_file_grammar(dialect.grammar);
     let mut links = Vec::new();
     for pack in segment_commands_with_offset_and_config(source, 0, config) {
@@ -351,9 +364,10 @@ fn pack_include_links(
                 continue;
             }
             let name = &row.texts[1];
-            let Some(target) = resolve_path(name, workspace_root, home) else {
+            if name.is_empty() || name.contains(['/', '\\']) || name.contains("..") {
                 continue;
-            };
+            }
+            let target = file_uri_for_path(&dir.join(name).to_string_lossy());
             let Some(tok) = row.argv.get(1) else { continue };
             let Some((anchor_start, anchor_end)) = link_anchor(source, dialect, tok) else {
                 continue;
@@ -665,16 +679,32 @@ mod tests {
         );
     }
 
+    /// Links for a pack at `/home/user/project/.tcl-lsp/mylib.tclspec`, given
+    /// the full context the server supplies — the include anchor is the
+    /// document's own path, so `document_links` alone cannot express one.
+    ///
+    /// `workspace_root` and `home` are populated deliberately: an include that
+    /// reached for either would resolve to a *different* file, so the tests
+    /// below can tell the loader's rule from the `source` resolver's.
+    fn pack_links(src: &str, dialect: &'static tcl_dialect::DialectProfile) -> Vec<DocumentLink> {
+        document_links_in_context(
+            src,
+            dialect,
+            &LinkContext {
+                imported_constants: None,
+                workspace_root: Some("/home/user/project/.tcl-lsp"),
+                home: Some("/home/user"),
+                script_path: Some("/home/user/project/.tcl-lsp/mylib.tclspec"),
+            },
+        )
+    }
+
     /// A pack's `include NAME` row links to the sibling file the loader would
     /// read, anchored on the name alone.
     #[test]
     fn a_pack_include_row_links_to_its_sibling_file() {
         let src = "speclib mylib 1 {\n    include shared.tclspec\n}\n";
-        let links = document_links(
-            src,
-            crate::profile_for_dialect("spectcl"),
-            Some("/home/user/project/.tcl-lsp"),
-        );
+        let links = pack_links(src, crate::profile_for_dialect("spectcl"));
         assert_eq!(links.len(), 1, "{links:?}");
         assert_eq!(
             links[0].target,
@@ -684,19 +714,38 @@ mod tests {
         assert_eq!(links[0].tooltip.as_deref(), Some("shared.tclspec"));
     }
 
+    /// The link goes where the loader reads, and the loader does not expand
+    /// `~`: `include ~` makes it read a sibling literally named `~`, so that
+    /// is the file the link has to name — not the user's home directory.
+    #[test]
+    fn a_pack_include_does_not_expand_a_tilde() {
+        let links = pack_links(
+            "speclib mylib 1 {\n    include ~\n}\n",
+            crate::profile_for_dialect("spectcl"),
+        );
+        assert_eq!(links.len(), 1, "{links:?}");
+        assert_eq!(links[0].target, "file:///home/user/project/.tcl-lsp/~");
+    }
+
+    /// A name carrying path structure is dropped by `loader::include_name`
+    /// before the resolver sees it, so it names no file to navigate to.
+    #[test]
+    fn a_pack_include_with_path_structure_is_not_a_link() {
+        for row in ["include ../outside.tclspec", "include sub/shared.tclspec"] {
+            let src = format!("speclib mylib 1 {{\n    {row}\n}}\n");
+            assert!(
+                pack_links(&src, crate::profile_for_dialect("spectcl")).is_empty(),
+                "{row}"
+            );
+        }
+    }
+
     /// `include from … into …` composes a surface out of loaded packs and
     /// names no file, so it must not be offered as one.
     #[test]
     fn a_surface_roster_include_is_not_a_file_link() {
         let src = "speclib mylib 1 {\n    include from vendor into mylib { a b }\n}\n";
-        assert!(
-            document_links(
-                src,
-                crate::profile_for_dialect("spectcl"),
-                Some("/home/user/project"),
-            )
-            .is_empty()
-        );
+        assert!(pack_links(src, crate::profile_for_dialect("spectcl")).is_empty());
     }
 
     /// The gate is the document's own grammar: an ordinary Tcl script calling
@@ -705,10 +754,9 @@ mod tests {
     fn an_ordinary_tcl_include_call_is_not_a_link() {
         let src = "speclib mylib 1 {\n    include shared.tclspec\n}\n";
         assert!(
-            document_links(
+            pack_links(
                 src,
                 tcl_registry::model::ingress::resolve_environment("tcl").analyser_profile(),
-                Some("/home/user/project"),
             )
             .is_empty()
         );

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -17625,15 +17625,26 @@ impl Backend {
             });
         }
 
-        // `tclLsp.diagnostics.exclude` (#1556) promises *no* diagnostics for a
-        // matching file, and pack notices publish outside the analyser
-        // pipeline's exclusion gate, so filter them here too. A newly excluded
-        // URI drops out of `by_uri`, joins the stale set below, and has its
-        // previously published notices cleared on this rescan (adding an
-        // exclusion reloads packs via `ReloadTrigger::Config`).
+        // The settings that promise *no* diagnostics for a file —
+        // `tclLsp.features.diagnostics = false` and a `tclLsp.diagnostics.exclude`
+        // match (#1556) — are honoured here, where the notice layer is set,
+        // rather than at the two sites that union it in
+        // ([`DiagnosticPublisher::with_pack_notices`], reached from both the
+        // pull report and every push). A layer that does not stand cannot be
+        // unioned back by either, so the pulled report and the pushed set agree
+        // by construction instead of by two checks that have to be kept in
+        // step; the alternative — gating the unions — left whichever site was
+        // missed republishing the squiggles the switch had just cleared.
+        //
+        // A URI a setting now silences drops out of `by_uri`, joins the stale
+        // set below and has its standing notices cleared on this pass; either
+        // setting moving reloads packs (`ReloadTrigger::Config`), so the flip
+        // itself is what runs it, and flipping back restores them the same way.
         let candidates: Vec<Uri> = by_uri.keys().cloned().collect();
         for uri in candidates {
-            if self.diagnostics_excluded(&uri).await {
+            if !self.feature_enabled("diagnostics", &uri).await
+                || self.diagnostics_excluded(&uri).await
+            {
                 by_uri.remove(&uri);
             }
         }

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -2496,6 +2496,9 @@ struct DiagnosticMailboxState {
 struct DiagnosticPublisher {
     client: Client,
     state: std::sync::Mutex<DiagnosticMailboxState>,
+    /// The pack-load notices standing on each URI, unioned into every set
+    /// published for it — see [`DiagnosticPublisher::with_pack_notices`].
+    pack_notices: std::sync::Mutex<HashMap<Uri, Vec<tower_lsp_server::ls_types::Diagnostic>>>,
     ready: tokio::sync::Notify,
     started: std::sync::atomic::AtomicBool,
 }
@@ -2505,15 +2508,89 @@ impl DiagnosticPublisher {
         Self {
             client,
             state: std::sync::Mutex::new(DiagnosticMailboxState::default()),
+            pack_notices: std::sync::Mutex::new(HashMap::new()),
             ready: tokio::sync::Notify::new(),
             started: std::sync::atomic::AtomicBool::new(false),
         }
+    }
+
+    /// `diagnostics` unioned with the pack-load notices standing on `uri`.
+    ///
+    /// A `.tclspec` is both a spec pack and — `.tclspec` being a Tcl source
+    /// extension — an analysed document, and `publishDiagnostics` replaces a
+    /// URI's whole set. Two independent producers publishing the same URI
+    /// therefore overwrite each other, and editing an open pack used to show
+    /// the analyser's view alone until the next reload restored the loader's
+    /// notices. Making this the one place a URI's set is assembled means the
+    /// two are merged rather than raced: whichever producer moved last, the
+    /// other's findings survive it.
+    ///
+    /// The notices are the *pack* layer; everything else a document produces
+    /// is the analysed layer and stays owned by the diagnostics pipeline. A
+    /// URI with no notices — every document that is not a pack file, and every
+    /// pack that loaded cleanly — pays one hash lookup and keeps its vector.
+    fn with_pack_notices(
+        &self,
+        uri: &Uri,
+        mut diagnostics: Vec<tower_lsp_server::ls_types::Diagnostic>,
+    ) -> Vec<tower_lsp_server::ls_types::Diagnostic> {
+        let notices = self
+            .pack_notices
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if let Some(standing) = notices.get(uri) {
+            diagnostics.extend(standing.iter().cloned());
+        }
+        diagnostics
+    }
+
+    /// Replace the standing pack notices with `by_uri` and report which URIs
+    /// changed — the ones whose published set has to be reassembled.
+    fn set_pack_notices(
+        &self,
+        by_uri: HashMap<Uri, Vec<tower_lsp_server::ls_types::Diagnostic>>,
+    ) -> Vec<Uri> {
+        let mut notices = self
+            .pack_notices
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let mut touched: Vec<Uri> = notices
+            .keys()
+            .filter(|uri| !by_uri.contains_key(*uri))
+            .cloned()
+            .collect();
+        // Only a URI whose notices actually moved needs its set reassembled: a
+        // reload that finds the same problems must not restate them, or every
+        // unrelated watched-file event would republish every pack file.
+        touched.extend(
+            by_uri
+                .iter()
+                .filter(|(uri, fresh)| notices.get(*uri) != Some(*fresh))
+                .map(|(uri, _)| uri.clone()),
+        );
+        *notices = by_uri;
+        touched
     }
 
     /// Commit one publication and return an acknowledgement for its eventual
     /// delivery. A superseded pending item is explicitly settled as such, so
     /// its caller cannot emit a completion marker for a state never delivered.
     fn enqueue(
+        self: &Arc<Self>,
+        uri: Uri,
+        diagnostics: Vec<tower_lsp_server::ls_types::Diagnostic>,
+        version: Option<i32>,
+        client_supports_pull: bool,
+        announce: bool,
+    ) -> tokio::sync::oneshot::Receiver<DiagnosticPublishOutcome> {
+        let diagnostics = self.with_pack_notices(&uri, diagnostics);
+        self.enqueue_assembled(uri, diagnostics, version, client_supports_pull, announce)
+    }
+
+    /// [`Self::enqueue`] for a set the caller has already assembled — the pull
+    /// path, which has to cache the same bytes it publishes and so merges the
+    /// pack notices in itself.
+    fn enqueue_assembled(
         self: &Arc<Self>,
         uri: Uri,
         diagnostics: Vec<tower_lsp_server::ls_types::Diagnostic>,
@@ -2734,6 +2811,11 @@ impl DeliveryCtx<'_> {
         &self,
         diags: Vec<tower_lsp_server::ls_types::Diagnostic>,
     ) -> tokio::sync::oneshot::Receiver<DiagnosticPublishOutcome> {
+        // Assemble once, before the cache entry is taken: a pulled report and
+        // a pushed one are the same set, so a `.tclspec`'s pack-load notices
+        // have to be in the bytes the cache serves as well as in the ones the
+        // publisher sends.
+        let diags = self.diagnostic_publisher.with_pack_notices(self.uri, diags);
         self.documents
             .retag_held("cache_and_enqueue: pull_diag_cache");
         self.pull_diag_cache.lock().await.insert(
@@ -2744,7 +2826,7 @@ impl DeliveryCtx<'_> {
                 diagnostics: diags.clone(),
             },
         );
-        self.diagnostic_publisher.enqueue(
+        self.diagnostic_publisher.enqueue_assembled(
             self.uri.clone(),
             diags,
             self.version,
@@ -5965,9 +6047,6 @@ pub struct Backend {
     /// one published, so whichever runs last re-reads the true state. It costs
     /// nothing on the common path: reloads are workspace-scoped, not per-edit.
     spec_pack_reload: Arc<Mutex<()>>,
-    /// URIs currently carrying published pack-load diagnostics, so a reload
-    /// that fixes a pack clears the badge it left behind.
-    spec_pack_diagnostic_uris: Arc<Mutex<HashSet<Uri>>>,
     /// Absolute watch globs currently registered for pack directories that lie
     /// **outside every workspace folder** — the per-user tier, and any
     /// absolute `tclLsp.specPacks` entry.
@@ -7359,7 +7438,6 @@ impl Backend {
             spec_packs: Arc::new(Mutex::new(PublishedPackSet::default())),
             spec_pack_reload: Arc::new(Mutex::new(())),
             spec_pack_reload_seq: std::sync::atomic::AtomicU64::new(0),
-            spec_pack_diagnostic_uris: Arc::new(Mutex::new(HashSet::new())),
             external_pack_watch_globs: Arc::new(Mutex::new(Vec::new())),
             pack_source_extensions: Arc::new(Mutex::new(Vec::new())),
             bigip_version: Mutex::new(None),
@@ -9649,10 +9727,6 @@ impl Backend {
             closed_diag_gen: _,
             closed_diag_order: _,
             semantic_tokens_convergence: _,
-            // Keyed by pack-file URI, owned by the SpecTcl reload path: a
-            // pack's notices are cleared when the *pack* changes, never when a
-            // document is retired (the pack file may not even be open).
-            spec_pack_diagnostic_uris: _,
             // Owned by the SpecTcl reload path: watch registrations track the
             // configured pack roots, not any document's lifetime.
             external_pack_watch_globs: _,
@@ -16310,7 +16384,26 @@ impl Backend {
         diagnostics
     }
 
+    /// The pull path's whole report for `uri` — the analysed set, unioned with
+    /// any pack-load notices standing on the file.
+    ///
+    /// The union is what the push path publishes (see
+    /// [`DiagnosticPublisher::with_pack_notices`]), and a pulled report has to
+    /// match a pushed one diagnostic for diagnostic.
     async fn full_diagnostics_for(
+        &self,
+        uri: &Uri,
+        text: Arc<str>,
+        dialect: String,
+        language_id: &str,
+    ) -> Vec<tower_lsp_server::ls_types::Diagnostic> {
+        let analysed = self
+            .analysed_diagnostics_for(uri, text, dialect, language_id)
+            .await;
+        self.diagnostic_publisher.with_pack_notices(uri, analysed)
+    }
+
+    async fn analysed_diagnostics_for(
         &self,
         uri: &Uri,
         text: Arc<str>,
@@ -17492,17 +17585,18 @@ impl Backend {
     /// "unknown property `arty` dropped" on the line they typed it, in the
     /// editor they typed it in, exactly as they would a diagnostic on Tcl code.
     ///
-    /// # Known limitation: an *open* pack file
+    /// # An *open* pack file
     ///
     /// `.tclspec` is in `TCL_SOURCE_EXTENSIONS` (a pack is one Tcl script), so
     /// an open pack buffer is also an analysed document, and `publishDiagnostics`
-    /// replaces a URI's whole set. The two publishers therefore overwrite each
-    /// other: whichever ran last wins, so editing an open pack shows the
-    /// analyser's view until the next reload restores the notices. Fixing it
-    /// properly means merging pack notices into the document's diagnostic set
-    /// on both the push and the pull path (which has its own cache) rather than
-    /// publishing them separately — worth doing, and deliberately not smuggled
-    /// into this change.
+    /// replaces a URI's whole set. So this is not a second publisher: it hands
+    /// the notices to [`DiagnosticPublisher::set_pack_notices`], which unions
+    /// them into every set published for that URI — the push path, the fast
+    /// tier, and the pull cache alike. A URI nobody has open is then published
+    /// straight from here (its analysed layer is empty, so the union is the
+    /// notices); an open one is rescheduled instead, so the set that lands
+    /// carries the analyser's findings *and* the loader's rather than
+    /// whichever producer ran last.
     async fn publish_spec_pack_notices(
         &self,
         packs: &tcl_spectcl::PackSet,
@@ -17522,7 +17616,9 @@ impl Backend {
             by_uri.entry(uri).or_default().push(Diagnostic {
                 range: whole_line_range(self.store.as_ref(), &notice.path, notice.line),
                 severity: Some(severity),
-                code: Some(NumberOrString::String(SPEC_PACK_DIAGNOSTIC_CODE.to_owned())),
+                code: Some(NumberOrString::String(
+                    core_code_actions::SPEC_PACK_DIAGNOSTIC_CODE.to_owned(),
+                )),
                 source: Some("tcl-lsp".to_owned()),
                 message: format!("{}: {}", notice.context, notice.message),
                 ..Diagnostic::default()
@@ -17542,28 +17638,30 @@ impl Backend {
             }
         }
 
-        // Files that had notices last time and do not now must be cleared, or
-        // a fixed pack keeps its badge until the editor restarts.
-        let stale: Vec<Uri> = {
-            let mut tracked = self.spec_pack_diagnostic_uris.lock().await;
-            let stale = tracked
+        // A file that had notices last time and does not now must be cleared,
+        // or a fixed pack keeps its badge until the editor restarts — which
+        // `set_pack_notices` reports as a touched URI just as a new notice is.
+        let touched = self.diagnostic_publisher.set_pack_notices(by_uri);
+        // Which of them the editor has open, taken once: an open buffer's set
+        // belongs to the diagnostics pipeline, and publishing the notices
+        // alone here would drop the analyser's findings until the next edit.
+        // Rescheduling makes the pipeline reassemble both, through the same
+        // union every other publish for this URI now goes through.
+        let open: HashMap<Uri, String> = {
+            let docs = self.documents.lock("publish_spec_pack_notices").await;
+            touched
                 .iter()
-                .filter(|uri| !by_uri.contains_key(*uri))
-                .cloned()
-                .collect();
-            *tracked = by_uri.keys().cloned().collect();
-            stale
+                .filter_map(|uri| docs.get(uri).map(|doc| (uri.clone(), doc.dialect.clone())))
+                .collect()
         };
-        for uri in stale {
+        for uri in touched {
+            if let Some(dialect) = open.get(&uri) {
+                self.reschedule_diagnostics(uri, dialect.clone()).await;
+                continue;
+            }
             let receipt = self
                 .diagnostic_publisher
                 .enqueue(uri, Vec::new(), None, false, false);
-            let _ = receipt.await;
-        }
-        for (uri, diagnostics) in by_uri {
-            let receipt = self
-                .diagnostic_publisher
-                .enqueue(uri, diagnostics, None, false, false);
             let _ = receipt.await;
         }
     }
@@ -18596,26 +18694,45 @@ async fn log_range_convergence_settled(
 /// extract-rule actions: the generic Tcl code-action path yields nothing
 /// useful on a non-Tcl config, so these extend rather than replace it —
 /// mirroring the references / document-links BIG-IP routing.  iRules
-/// additionally gets the `# Profiles:` header source action.
+/// additionally gets the `# Profiles:` header source action, and an authoring
+/// dialect whose loader dropped a word gets the did-you-mean rewrite for it.
 fn push_dialect_code_actions(
     actions: &mut Vec<core_code_actions::CodeAction>,
     source: &str,
     range: core_definition::LspRange,
-    uri_str: &str,
-    dialect: &'static tcl_dialect::DialectProfile,
-    analysis: &tcl_compiler::analyser::AnalysisResult,
-    registry: &tcl_registry::CommandRegistry,
+    inputs: &DialectActionInputs<'_>,
 ) {
-    if Backend::is_bigip_dialect(dialect.name) {
+    if Backend::is_bigip_dialect(inputs.dialect.name) {
         actions.extend(core_code_actions::bigip_code_actions(
-            source, range, uri_str,
+            source, range, inputs.uri,
         ));
     }
-    if dialect.is_irules()
-        && let Some(a) = core_code_actions::profiles_action(source, analysis, registry)
+    if inputs.dialect.is_irules()
+        && let Some(a) =
+            core_code_actions::profiles_action(source, inputs.analysis, inputs.registry)
     {
         actions.push(a);
     }
+    // A pack's load notices reach here on the request's context diagnostics,
+    // like any other finding the editor is showing: they are published on the
+    // pack file's own URI, merged into its set by the publisher.
+    actions.extend(core_code_actions::spec_pack_quick_fixes(
+        source,
+        inputs.dialect,
+        inputs.context_diags,
+    ));
+}
+
+/// What the dialect-specific code actions read and the generic Tcl set does
+/// not — grouped so a new dialect's inputs do not change every call site.
+struct DialectActionInputs<'a> {
+    uri: &'a str,
+    dialect: &'static tcl_dialect::DialectProfile,
+    analysis: &'a tcl_compiler::analyser::AnalysisResult,
+    registry: &'a tcl_registry::CommandRegistry,
+    /// The diagnostics the editor is currently showing on the document — the
+    /// channel a notice published outside the analyser pipeline arrives on.
+    context_diags: &'a [core_code_actions::ContextDiagnostic],
 }
 
 /// The context-diagnostic actions, plus the fuzzy `package require`
@@ -21326,15 +21443,14 @@ impl LanguageServer for Backend {
                 &analysis,
                 &context_diags,
             );
-            push_dialect_code_actions(
-                &mut actions,
-                &doc.text,
-                range,
-                &uri_str,
-                tcl_lsp_core::profile_for_dialect(&dialect),
-                &analysis,
-                &registry,
-            );
+            let dialect_inputs = DialectActionInputs {
+                uri: &uri_str,
+                dialect: tcl_lsp_core::profile_for_dialect(&dialect),
+                analysis: &analysis,
+                registry: &registry,
+                context_diags: &context_diags,
+            };
+            push_dialect_code_actions(&mut actions, &doc.text, range, &dialect_inputs);
             let checks = tcl_lsp_db::compiler_check_diagnostics_uncached(
                 &doc.text,
                 &registry,
@@ -24954,14 +25070,6 @@ fn compute_source_inheritance(
         unresolvable_source,
     }
 }
-
-/// The diagnostic code every `SpecTcl` pack-load notice carries.
-///
-/// One code for the family rather than one per notice kind: the notices are
-/// *degradations* the loader chose to report, not a diagnostic catalogue with
-/// per-code documentation and quick fixes behind it. A user who does not want
-/// them silences the family.
-const SPEC_PACK_DIAGNOSTIC_CODE: &str = "SPECTCL";
 
 /// A range covering line `line` (1-based) of `path`, for a pack-load notice.
 ///
@@ -31423,7 +31531,6 @@ mod tests {
             spec_packs: Arc::new(Mutex::new(PublishedPackSet::default())),
             spec_pack_reload: Arc::new(Mutex::new(())),
             spec_pack_reload_seq: std::sync::atomic::AtomicU64::new(0),
-            spec_pack_diagnostic_uris: Arc::new(Mutex::new(HashSet::new())),
             external_pack_watch_globs: Arc::new(Mutex::new(Vec::new())),
             pack_source_extensions: Arc::new(Mutex::new(Vec::new())),
             bigip_version: Mutex::new(None),

--- a/rust/tcl-lsp-server/tests/e2e/spec_packs.rs
+++ b/rust/tcl-lsp-server/tests/e2e/spec_packs.rs
@@ -1475,3 +1475,54 @@ fn a_pack_include_row_is_a_document_link() {
 
     let _ = std::fs::remove_dir_all(&root);
 }
+
+/// `tclLsp.features.diagnostics = false` clears a pack's load notices too.
+///
+/// The notices are a layer the publisher unions into every set a `.tclspec`
+/// gets — the pushed one and the pulled one alike — so a master switch that
+/// only emptied the *analysed* set left the squiggles standing, which is the
+/// one thing that switch promises not to do. Both paths are asserted, and
+/// re-enabling has to bring the notice back: a clear that cannot be undone is
+/// as wrong as one that never happens.
+#[test]
+fn the_diagnostics_master_switch_clears_a_packs_notices() {
+    let pack = "speclib mylib 1 {\n    command mylib::x {\n        arty 1\n    }\n}\n";
+    let (root, mut lsp, uri) = open_pack("master-switch-notices", pack);
+
+    let has_notice = |diags: &[Value]| {
+        diags
+            .iter()
+            .any(|d| d.get("code").and_then(Value::as_str) == Some("SPECTCL"))
+    };
+    let pushed =
+        lsp.await_diagnostics_settled(&uri, std::time::Duration::from_secs(15), has_notice);
+    assert!(has_notice(&pushed), "{pushed:#?}");
+    let pulled = lsp.pull_diagnostics(&uri);
+    assert!(
+        has_notice(&pulled),
+        "the pull path carries it too: {pulled:#?}"
+    );
+
+    let since = lsp.notification_cursor();
+    lsp.apply_configuration(json!({ "features": { "diagnostics": false } }));
+    assert_eq!(
+        lsp.await_diagnostics_master_off(&uri, std::time::Duration::from_secs(20), since),
+        Vec::<Value>::new(),
+        "the push path must clear the notice"
+    );
+    let pulled = lsp.pull_diagnostics(&uri);
+    assert_eq!(
+        pulled,
+        Vec::<Value>::new(),
+        "…and the pull path must agree with it: {pulled:#?}"
+    );
+
+    lsp.apply_configuration(json!({ "features": { "diagnostics": true } }));
+    let pushed =
+        lsp.await_diagnostics_settled(&uri, std::time::Duration::from_secs(20), has_notice);
+    assert!(has_notice(&pushed), "re-enabling restores it: {pushed:#?}");
+    let pulled = lsp.pull_diagnostics(&uri);
+    assert!(has_notice(&pulled), "…on both paths: {pulled:#?}");
+
+    let _ = std::fs::remove_dir_all(&root);
+}

--- a/rust/tcl-lsp-server/tests/e2e/spec_packs.rs
+++ b/rust/tcl-lsp-server/tests/e2e/spec_packs.rs
@@ -1142,3 +1142,336 @@ speclib envprobe 2.0 {
 
     let _ = std::fs::remove_dir_all(&root);
 }
+
+// ---------------------------------------------------------------------------
+// The pack file as a *document*: what a spec author sees while writing one.
+//
+// Everything above is about a pack's effect on the Tcl around it. These are
+// about the `.tclspec` buffer itself — the Spec Studio's Pack DSL editor is a
+// client of this very server, so whatever the server answers here is what a
+// pack author gets, in the studio and in their own editor alike.
+// ---------------------------------------------------------------------------
+
+/// A pack with one command and enough shape to exercise every document
+/// surface: nested blocks to outline and fold, statement words to hover, and
+/// braced prose the formatter must not touch.
+const AUTHORING_PACK: &str = "speclib mylib 1 {\n\
+                              \x20   command mylib::x {\n\
+                              \x20       arity 1\n\
+                              \x20       hover {\n\
+                              \x20           summary {Do a thing.}\n\
+                              \x20       }\n\
+                              \x20   }\n\
+                              }\n";
+
+/// Open a `.tclspec` in a workspace of its own and settle its diagnostics.
+fn open_pack(name: &str, body: &str) -> (PathBuf, Lsp, String) {
+    let root = workspace(name);
+    let pack = root.join(".tcl-lsp/mylib.tclspec");
+    write(&pack, body);
+    let mut lsp =
+        Lsp::with_config_at_root(json!({ "features": { "linkedEditingRange": true } }), &root);
+    let uri = file_uri(&pack);
+    await_pack_named(&mut lsp, "mylib");
+    lsp.open_ready(&uri, body);
+    (root, lsp, uri)
+}
+
+/// Every symbol name a document-symbol reply carries, parents before children.
+fn symbol_names(node: &Value, out: &mut Vec<String>) {
+    if let Some(name) = node.get("name").and_then(Value::as_str) {
+        out.push(name.to_owned());
+    }
+    for child in node
+        .get("children")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+    {
+        symbol_names(child, out);
+    }
+}
+
+/// A pack outlines as its declarations. Its dialect declares a document
+/// grammar, so its *blocks* are its structure — the analyser's proc/namespace
+/// symbolizer has nothing to find in a file that declares rather than runs.
+#[test]
+fn a_pack_outlines_as_its_own_declarations() {
+    let (root, mut lsp, uri) = open_pack("outline", AUTHORING_PACK);
+
+    let symbols = lsp.document_symbols(&uri);
+    let mut names = Vec::new();
+    for node in symbols.as_array().into_iter().flatten() {
+        symbol_names(node, &mut names);
+    }
+    assert!(
+        names.iter().any(|n| n.contains("speclib mylib")),
+        "the pack itself is the outline root: {symbols:#?}"
+    );
+    assert!(
+        names.iter().any(|n| n.contains("command mylib::x")),
+        "each declared command is a child: {symbols:#?}"
+    );
+    assert!(
+        names.iter().any(|n| n.contains("hover")),
+        "and a nested block is a child of the command: {symbols:#?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+/// Hover on a pack's own statement word answers from the `SpecTcl` command
+/// pack — through the real handler, not the provider in isolation.
+#[test]
+fn a_pack_statement_word_hovers_from_the_spectcl_surface() {
+    let (root, mut lsp, uri) = open_pack("authoring-hover", AUTHORING_PACK);
+
+    let speclib = hover_text(&lsp.hover(&uri, 0, 2));
+    assert!(
+        speclib.contains("Open a SpecTcl command pack."),
+        "the document's root word hovers as SpecTcl vocabulary; got:\n{speclib}"
+    );
+    // …and a *property* word, which only means anything inside a `command`
+    // body: the same word in an ordinary Tcl script is not a command at all.
+    let arity = hover_text(&lsp.hover(&uri, 2, 9));
+    assert!(
+        arity.contains("Declare how many argument words the call takes."),
+        "a property word inside a command body hovers too; got:\n{arity}"
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+/// Signature help on a pack statement offers that statement's own form, not
+/// an ordinary Tcl command's.
+#[test]
+fn a_pack_statement_offers_signature_help() {
+    let (root, mut lsp, uri) = open_pack("authoring-signature", AUTHORING_PACK);
+
+    let help = lsp.signature_help(&uri, 0, 8);
+    let label = help
+        .get("signatures")
+        .and_then(Value::as_array)
+        .and_then(|sigs| sigs.first())
+        .and_then(|sig| sig.get("label"))
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_owned();
+    assert!(
+        label.contains("speclib"),
+        "signature help names the statement being written; got {help:#?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+/// A pack folds on its blocks: the `speclib` body, the `command` body, and the
+/// `hover` body inside it.
+#[test]
+fn a_packs_blocks_are_folding_ranges() {
+    let (root, mut lsp, uri) = open_pack("authoring-folding", AUTHORING_PACK);
+
+    let ranges = lsp.folding_range(&uri);
+    let starts: Vec<i64> = ranges
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(|r| r.get("startLine").and_then(Value::as_i64))
+        .collect();
+    for (line, what) in [(0, "speclib"), (1, "command"), (3, "hover")] {
+        assert!(
+            starts.contains(&line),
+            "the `{what}` block must fold (line {line}); got {ranges:#?}"
+        );
+    }
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+/// Formatting a pack must leave its byte-significant prose alone.
+///
+/// `summary` / `description` / `snippet` / `examples` are every byte between
+/// their braces, verbatim — that is what lets a ported field compare byte for
+/// byte with the `&'static str` it came from — so a formatter that rewrapped
+/// one would quietly change what the editor shows for the command the pack
+/// describes. (`tcl-spectcl`'s `pack_formatting` suite makes the same claim
+/// over the shipped example packs, by reloading them; this one pins that the
+/// real `textDocument/formatting` handler is the thing being asked.)
+#[test]
+fn formatting_a_pack_keeps_its_prose_verbatim() {
+    const PROSE: &str = "Two  spaces and\n            an indented line.";
+    let body = format!(
+        "speclib mylib 1 {{\n\
+         \x20   command mylib::x {{\n\
+         \x20     arity 1\n\
+         \x20       hover {{\n\
+         \x20           summary {{{PROSE}}}\n\
+         \x20       }}\n\
+         \x20   }}\n\
+         }}\n"
+    );
+    let (root, mut lsp, uri) = open_pack("authoring-formatting", &body);
+
+    let edits = lsp.formatting(&uri, 4, true);
+    let formatted = edits
+        .as_array()
+        .into_iter()
+        .flatten()
+        .next()
+        .and_then(|edit| edit.get("newText"))
+        .and_then(Value::as_str)
+        .map_or_else(|| body.clone(), ToOwned::to_owned);
+    assert!(
+        formatted.contains(PROSE),
+        "the formatter rewrote the pack's prose:\n{formatted}"
+    );
+    assert!(
+        formatted.contains("        arity 1"),
+        "…while still doing its job on the declarations:\n{formatted}"
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+/// An **open** pack keeps its load notices while it is edited.
+///
+/// A `.tclspec` is both a spec pack and an analysed Tcl document, and
+/// `publishDiagnostics` replaces a URI's whole set — so the two used to
+/// overwrite each other and editing a pack showed the analyser's view alone
+/// until the next reload put the notices back. The published set is now the
+/// union, which is what this asserts: an analyser diagnostic the *edit*
+/// introduces and the loader's `SPECTCL` notice, on screen together.
+#[test]
+fn an_open_pack_keeps_its_notices_while_it_is_edited() {
+    /// A word the pack cannot already carry, so the settle barrier below is a
+    /// fact of the edited buffer and not of the one it replaced.
+    const ADDED: &str = "a_word_only_this_edit_carries";
+
+    let pack = "speclib mylib 1 {\n    command mylib::x {\n        arity 1\n        \
+                nonsense_property yes\n    }\n}\n";
+    let (root, mut lsp, uri) = open_pack("open-pack-notices", pack);
+
+    let has_notice = |diags: &[Value]| {
+        diags.iter().any(|d| {
+            d.get("code").and_then(Value::as_str) == Some("SPECTCL")
+                && d.get("message")
+                    .and_then(Value::as_str)
+                    .is_some_and(|m| m.contains("nonsense_property"))
+        })
+    };
+    let settled =
+        lsp.await_diagnostics_settled(&uri, std::time::Duration::from_secs(15), |diags| {
+            has_notice(diags)
+        });
+    assert!(has_notice(&settled), "{settled:#?}");
+
+    // Edit the buffer so the *analyser* has something of its own to say that
+    // it could not have said before — the settle barrier must be a fact of the
+    // edited text, or a stale pre-edit publication satisfies it.
+    let edited = format!("{pack}\n{ADDED}\n");
+    lsp.replace_document(&uri, 2, &edited);
+    let mentions_edit = |diags: &[Value]| {
+        diags.iter().any(|d| {
+            d.get("code").and_then(Value::as_str) != Some("SPECTCL")
+                && d.get("message")
+                    .and_then(Value::as_str)
+                    .is_some_and(|m| m.contains(ADDED))
+        })
+    };
+    let after = lsp.await_diagnostics_settled(&uri, std::time::Duration::from_secs(20), |diags| {
+        mentions_edit(diags)
+    });
+    assert!(
+        mentions_edit(&after),
+        "the analyser must have its say on the edited buffer: {after:#?}"
+    );
+    assert!(
+        has_notice(&after),
+        "…and the loader's notice must survive alongside it: {after:#?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+/// A dropped property offers the word the author meant.
+///
+/// The `SpecTcl` vocabulary is closed — a property word is a member of the
+/// grammar in force where it was written — so a notice naming a dropped word
+/// is a typo with one computable correction.
+#[test]
+fn a_dropped_property_offers_a_did_you_mean_fix() {
+    let pack = "speclib mylib 1 {\n    command mylib::x {\n        arty 1\n    }\n}\n";
+    let (root, mut lsp, uri) = open_pack("did-you-mean", pack);
+
+    let diagnostics =
+        lsp.await_diagnostics_settled(&uri, std::time::Duration::from_secs(15), |diags| {
+            diags.iter().any(|d| {
+                d.get("message")
+                    .and_then(Value::as_str)
+                    .is_some_and(|m| m.contains("arty"))
+            })
+        });
+    let notice = diagnostics
+        .iter()
+        .find(|d| {
+            d.get("message")
+                .and_then(Value::as_str)
+                .is_some_and(|m| m.contains("arty"))
+        })
+        .unwrap_or_else(|| panic!("the dropped-property notice: {diagnostics:#?}"))
+        .clone();
+
+    let actions = lsp.code_actions(&uri, notice["range"].clone(), json!([notice]));
+    let fix = actions
+        .as_array()
+        .into_iter()
+        .flatten()
+        .find(|a| {
+            a.get("title")
+                .and_then(Value::as_str)
+                .is_some_and(|t| t.contains("arity"))
+        })
+        .unwrap_or_else(|| panic!("a did-you-mean quick fix: {actions:#?}"));
+    assert_eq!(fix.get("kind").and_then(Value::as_str), Some("quickfix"));
+    let edit = fix["edit"]["changes"][&uri][0].clone();
+    assert_eq!(edit.get("newText").and_then(Value::as_str), Some("arity"));
+    assert_eq!(edit["range"]["start"]["line"].as_i64(), Some(2));
+    assert_eq!(edit["range"]["start"]["character"].as_i64(), Some(8));
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+/// A pack's `include NAME` row is a document link to the sibling file it
+/// names — the same file the loader's include resolver would read.
+#[test]
+fn a_pack_include_row_is_a_document_link() {
+    let pack = "speclib mylib 1 {\n    include shared.tclspec\n    \
+                command mylib::x {\n        arity 1\n    }\n}\n";
+    let root = workspace("include-link");
+    write(&root.join(".tcl-lsp/shared.tclspec"), "");
+    let file = root.join(".tcl-lsp/mylib.tclspec");
+    write(&file, pack);
+    let mut lsp =
+        Lsp::with_config_at_root(json!({ "features": { "linkedEditingRange": true } }), &root);
+    let uri = file_uri(&file);
+    await_pack_named(&mut lsp, "mylib");
+    lsp.open_ready(&uri, pack);
+
+    let links = lsp.request(
+        "textDocument/documentLink",
+        json!({ "textDocument": { "uri": &uri } }),
+    );
+    let link = links
+        .as_array()
+        .into_iter()
+        .flatten()
+        .find(|l| {
+            l.get("target")
+                .and_then(Value::as_str)
+                .is_some_and(|t| t.ends_with("shared.tclspec"))
+        })
+        .unwrap_or_else(|| panic!("a link to the included pack: {links:#?}"));
+    assert_eq!(link["range"]["start"]["line"].as_i64(), Some(1));
+
+    let _ = std::fs::remove_dir_all(&root);
+}

--- a/rust/tcl-spectcl/tests/pack_formatting.rs
+++ b/rust/tcl-spectcl/tests/pack_formatting.rs
@@ -1,0 +1,173 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Formatting a `.tclspec` must not change the pack it loads.
+//!
+//! A pack file is a Tcl script, so `textDocument/formatting` on one runs the
+//! ordinary Tcl formatter — and much of what a pack says is **byte-significant
+//! prose**. `description`, `summary`, `snippet` and `examples` are every byte
+//! between their braces, verbatim: the loader never reflows, dedents or joins
+//! one, because that is what lets a ported field compare byte for byte against
+//! the `&'static str` it came from. A formatter that rewrapped one would
+//! silently change what the editor shows for the command the pack describes,
+//! and nothing else in the tree would notice.
+//!
+//! So this is a round trip over the **shipped example packs**
+//! (`docs/design/spec-dsl-examples/`, the frozen syntax's own worked
+//! examples): format each one, load both spellings, and require the loaded
+//! packs to agree.
+//!
+//! Two differences are legitimate and are normalised away rather than
+//! asserted against:
+//!
+//! * **Declaration lines move.** The formatter removes a blank line and
+//!   re-indents; a declaration's recorded `line` follows the text it is on.
+//!   That is the formatter doing its job, and every consumer of a line reads
+//!   it against the same buffer.
+//! * **A hook body is laid out.** A hook body is ordinary Tcl held as text
+//!   and run in the sandbox, so laying it out — re-indenting it under its new
+//!   column, splitting `a ; b`, moving a long word onto a continuation line —
+//!   is exactly what the formatter is for, and none of it changes what the
+//!   body does. The body *text* is therefore exempt; that a hook is still
+//!   declared, on the same field, with the same parameter list, is not.
+//!
+//! Everything else — every property, every trait, every prose field, every
+//! arity — must survive untouched.
+//!
+//! registry-metadata: `SpecTcl` is our own DSL, so its own worked examples
+//! are the oracle here, not C Tcl.
+
+use std::path::{Path, PathBuf};
+
+use tcl_spectcl::discovery::{Origin, PackFile, Tier};
+
+/// The frozen syntax's worked examples — the richest packs in the tree, and
+/// the ones whose prose fields a rewrap would visibly damage.
+fn example_packs() -> Vec<PathBuf> {
+    let dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root")
+        .join("docs/design/spec-dsl-examples");
+    let mut packs: Vec<PathBuf> = std::fs::read_dir(&dir)
+        .unwrap_or_else(|e| panic!("reading {}: {e}", dir.display()))
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| path.extension().is_some_and(|ext| ext == "tclspec"))
+        .collect();
+    packs.sort();
+    assert!(
+        !packs.is_empty(),
+        "no example packs under {}",
+        dir.display()
+    );
+    packs
+}
+
+/// The pack `source` loads to, rendered so two loads can be compared.
+fn loaded(path: &Path, source: &str) -> Vec<String> {
+    let set = tcl_spectcl::pack::load_in_memory(vec![(
+        PackFile {
+            tier: Tier::Workspace,
+            path: path.to_path_buf(),
+            origin: Origin::DotDir,
+        },
+        source.to_owned(),
+    )]);
+    assert!(!set.packs.is_empty(), "{} loaded no pack", path.display());
+    normalise(&format!("{:#?}", set.packs))
+}
+
+/// Erase the two differences formatting is *allowed* to make (see the module
+/// docs): a declaration's line number, and the whitespace inside a hook body.
+fn normalise(dump: &str) -> Vec<String> {
+    dump.lines()
+        .map(|line| {
+            let trimmed = line.trim_start();
+            if let Some(rest) = trimmed.strip_prefix("line: ") {
+                return format!(
+                    "line: <moved>{}",
+                    rest.trim_matches(|c: char| c.is_ascii_digit())
+                );
+            }
+            if trimmed.starts_with("body: \"") {
+                return "body: <laid out>".to_owned();
+            }
+            trimmed.to_owned()
+        })
+        .collect()
+}
+
+#[test]
+fn formatting_a_pack_does_not_change_the_pack_it_loads() {
+    let registry = tcl_lsp_core::registry_for_dialect("spectcl");
+    for path in example_packs() {
+        let source = std::fs::read_to_string(&path).expect("example pack");
+        let formatted = tcl_lsp_core::formatting::format_tcl(
+            &source,
+            &tcl_lsp_core::formatting::FormatterConfig::default(),
+            registry,
+        );
+        let before = loaded(&path, &source);
+        let after = loaded(&path, &formatted);
+        // A whole `Pack` dump is thousands of lines wide; report the first
+        // field that moved rather than both dumps.
+        let first_difference = before
+            .iter()
+            .zip(&after)
+            .enumerate()
+            .find(|(_, (a, b))| a != b)
+            .map(|(at, (a, b))| format!("field {at}:\n  before: {a}\n  after:  {b}"));
+        assert!(
+            first_difference.is_none() && before.len() == after.len(),
+            "formatting changed the pack {} loads — {}",
+            path.display(),
+            first_difference.unwrap_or_else(|| format!(
+                "{} fields before, {} after",
+                before.len(),
+                after.len()
+            )),
+        );
+    }
+}
+
+/// The narrower claim the one above rests on, stated where a failure names it:
+/// a braced prose word comes out of the formatter byte for byte.
+///
+/// The formatter *may* move such a word onto its own continuation line — a
+/// backslash-newline is a word separator, so the word it introduces is
+/// unchanged — but it may never reflow, re-indent or rewrap what is inside the
+/// braces.
+#[test]
+fn formatting_leaves_a_packs_prose_byte_for_byte() {
+    const PROSE: &str = "Two  spaces, a line break,\n    and a deliberately indented line.";
+    let source = format!(
+        "speclib mylib 1 {{\n    command mylib::x {{\n        arity 1\n        \
+         hover {{\n            summary {{One line.}}\n            \
+         description {{{PROSE}}}\n        }}\n    }}\n}}\n"
+    );
+    let formatted = tcl_lsp_core::formatting::format_tcl(
+        &source,
+        &tcl_lsp_core::formatting::FormatterConfig::default(),
+        tcl_lsp_core::registry_for_dialect("spectcl"),
+    );
+    assert!(
+        formatted.contains(PROSE),
+        "the prose was rewritten:\n{formatted}"
+    );
+}


### PR DESCRIPTION
## Summary

Five gaps in what the language server does for SpecTcl packs — which is what a spec author sees in their editor **and** in the Spec Studio, whose Pack DSL pane is a client of this same server compiled to wasm.

**A pack file had no outline.** `is_declaration_document` delegated to a check hardcoded to the `sslictcl` package, so a `.tclspec` fell through to the analyser's proc/namespace/class symbolizer and found nothing — a pack is declarative. Fixed generically: a document whose registry declares a `document_grammar()` *is* a declaration document, which is exactly what the grammar means. `.tclspec` now outlines `speclib` → `command` → its properties, and any future authoring dialect gets one free without a second hardcoded name.

**An open pack lost its notices.** Two publishers raced for one URI and `publishDiagnostics` replaces the whole set, so editing a pack showed the analyser's view until the next reload restored the loader's — a limitation the server's own comment documented. `DiagnosticPublisher` now carries the pack-notice layer and is the single place a URI's published set is assembled; `publish_spec_pack_notices` hands its map over and reschedules an open document rather than publishing across it. The new e2e test was confirmed to **fail** with the merge disabled.

**A dropped property had no fix to offer.** The vocabulary is closed, so an unknown row keyword or flag now gets a did-you-mean action. Candidates come from the registry — the member vocabulary of the grammar in force at that offset, the same source completion uses — and it reuses the existing `suggest_similar` / `scaled_max_distance` rather than adding an edit-distance helper.

**`include` named a file nothing could open.** It is a document link now, resolved against the same workspace root the loader's `IncludeContext::for_file` uses, gated on the document grammar's family rather than a dialect name. Only the two-word form: `include from … into …` names no file.

**Formatting was never proven safe**, and the loader treats some prose fields as byte-significant. It is: every shipped example pack now formats, reloads, and compares equal in both spellings. Two differences are normalised and stated — declaration line numbers move (the formatter removes blank lines and re-indents), and a hook body is laid out as the ordinary Tcl it is. Hover, signature help, folding, formatting, document symbols, the include link and the quick fix are all pinned through the real handlers, none of which had a test before.

### One gap left open, deliberately

The static TextMate grammar still has no SpecTcl keywords, and both ways of closing it are worse than the gap:

- Adding them to the shared `source.tcl` buckets would paint `value`, `detail`, `arity`, `traits` and `name` as keywords in **every** Tcl file — every Tcl-family language id points at that one grammar. This is precisely why the registry already excludes SpecTcl from `all_dialect_command_names`.
- A separate `source.tclspec` scope **cannot work**: `tcl.tmLanguage.json`'s `braces` rule recurses with `{"include": "source.tcl"}` by scope name, not `$self`, so inside `speclib { … }` — where every SpecTcl word actually lives — the active grammar is `source.tcl` again and a `source.tclspec` rule never fires.

Closing it means forking the whole Tcl lexical grammar into a second file that would then drift, which is the exact failure the generator exists to prevent (#1469). The cost of leaving it is a `.tclspec` in a plain viewer; a pack author gets correct, nested, context-sensitive colour from semantic tokens the moment the server attaches.

### Also not covered

The did-you-mean action handles row keywords and flags, not misspelled trait / dialect / taint-colour / hook names. Those catalogues live in `tcl-spectcl`, which depends on `tcl-lsp-core` and not the reverse; reaching them means inverting that dependency or duplicating the vocabulary, and neither belongs in this change.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

```
cargo fmt --all
cargo clippy -p tcl-lsp-core -p tcl-lsp-server -p tcl-registry -p tcl-spectcl -p xtask --all-targets   # no warnings
cargo test -p tcl-lsp-core        # 2208 unit + 34 integration suites
cargo test -p tcl-spectcl         # incl. the new pack_formatting
cargo test -p tcl-registry        # 832 + suites
cargo test -p tcl-lsp-server      # 511 unit, 1560 e2e
make codegen                      # regenerated nothing
make xtask-check                  # exit 0; gen-tmlanguage-keywords --check in sync
```

## Compiler / diagnostics checklist

- [x] Did this change alter a compiler fact contract? — No compiler fact changed. It changes which documents are treated as declaration documents (now asked of the registry) and how one URI's diagnostics are assembled; no `CommandSpec` field or analysis result moved.
- [x] If yes, I updated the owning design doc — no contract moved, so no design doc changed. The `SPECTCL` diagnostic's meaning is unchanged; it simply survives an edit now, and has a quick fix.
- [x] If I added or changed a diagnostic or optimisation code — none added or changed.
- [x] If I added a design doc, I linked it — no new doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AWimhq6f4xQHmdN8Gr6CY2

---
_Generated by [Claude Code](https://claude.ai/code/session_01AWimhq6f4xQHmdN8Gr6CY2)_