### PR TITLE
fix(tcl-vm): let a rename's callbacks see the command under both names

### DIFF
--- a/docs/design/runtime/trace-implementation.md
+++ b/docs/design/runtime/trace-implementation.md
@@ -90,6 +90,51 @@ leave-trace error replaces its result, `rename`/`delete` callback errors are
 ignored, traces follow a `rename`, and a redefinition fires the `delete`
 trace.
 
+### The `rename` trace window
+
+C's `TclRenameCommand` (`tclBasic.c` 9.0.4) creates the destination hash
+entry, fires the `rename` traces, and only *then* deletes the source entry.
+Both entries reference the one `Command`, and the traces hang off that, not
+off either entry. So for the callbacks' duration the vacating name **is** the
+destination command:
+
+- both names resolve and are callable;
+- `trace info command <old>` and `… <new>` answer the same list, and a
+  `trace add` or `trace remove` through either name edits it;
+- a `rename` or a delete through *either* name moves or destroys that one
+  command — and C's `CMD_TRACE_ACTIVE` keeps the pass's remaining callbacks
+  from re-firing when it does.
+
+The VM reproduces that window rather than the naive "mutate, then fire":
+`cmd_rename` registers the destination, `on_command_renamed_traces` moves the
+sidecars to the destination key and fires from there (passing the old
+fully-qualified name for the callback's first word), and only afterwards does
+`retire_renamed_command_source` drop the source entry — the VM's spelling of
+`Tcl_DeleteHashEntry(oldHPtr)`, a plain table removal that fires no `delete`
+trace.
+
+The VM has no shared command object to hang that equivalence on, so an open
+window records it as a source→destination pair (`rename_windows`, a stack, one
+frame per nested rename). `renamed_command_key` resolves a key through it —
+used by `trace add`/`remove`/`info` and by `prepare_command_rename`, which is
+what makes a callback's `rename <old> <third>` and `rename <old> {}` act on
+the destination. A nested rename would otherwise strand that state on the key
+it just vacated, so `relocate_rename_state` retargets every enclosing window
+*and* every `firing_cmd_traces` record — the key-addressed stand-in for
+`CMD_TRACE_ACTIVE`, which C gets for free from the `Command` being one object.
+
+Two residues of that same missing shared identity are not emulated, both
+because C's own behaviour there is a torn-state artefact rather than a
+contract: re-*creating* the vacating name from a callback (`proc <old> {} …`)
+kills the destination in C but not in the VM, and 8.6 and 9.0 disagree with
+each other on what `info commands <old>` reports after a callback deletes the
+command.
+
+**Known gap:** `runtime/rust` fires the `rename` traces *before* any table
+mutation, so a callback there sees the old name but not yet the new one — the
+mirror image of the divergence the VM used to have. Its window has not been
+brought onto C's ordering yet.
+
 ## Callback shape and firing order
 
 A callback is evaluated as a script: the verbatim command prefix with the

--- a/rust/tcl-vm/src/command.rs
+++ b/rust/tcl-vm/src/command.rs
@@ -582,11 +582,15 @@ fn cmd_rename(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
         }
         vm.install_renamed_command(&mut rename, &key, cmd);
         vm.commit_renamed_command(&rename);
-        // The rename happened: fire the command's `rename` traces
-        // (`callback ::old ::new rename`, both fully qualified — tclsh-
-        // pinned) and move every trace to the new key so it keeps firing
-        // under the new name (also pinned).
+        // The rename happened: move every trace to the new key so it keeps
+        // firing under the new name, then fire the command's `rename` traces
+        // (`callback ::old ::new rename`, both fully qualified — tclsh-pinned).
+        // The source is still registered here, matching C's window between
+        // creating the destination entry and `Tcl_DeleteHashEntry(oldHPtr)`:
+        // a callback resolves *both* names, and reaches the one trace list
+        // through either (tclsh-pinned on 8.6.16 and 9.0.4).
         vm.on_command_renamed_traces(&old_key, &key);
+        vm.retire_renamed_command_source(&rename);
     }
     ok(Value::empty())
 }

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -613,6 +613,12 @@ impl CommandSidecarKey {
             Self::Visible(name) | Self::Hidden(name) => name,
         }
     }
+
+    fn into_name(self) -> String {
+        match self {
+            Self::Visible(name) | Self::Hidden(name) => name,
+        }
+    }
 }
 
 /// Metadata and any release-hidden destination displaced while a command is
@@ -841,6 +847,17 @@ pub struct InterpState {
     /// `trace add execution` registrations (`enter`/`leave`/`enterstep`/
     /// `leavestep` ops), keyed like [`Self::cmd_traces`] and moved on rename.
     pub(crate) exec_traces: HashMap<CommandSidecarKey, Vec<Rc<CmdTraceEntry>>>,
+    /// Source→destination pairs for the `rename` windows currently open,
+    /// innermost last. C creates the destination hash entry, fires the
+    /// `rename` traces and only then deletes the source, and *both* entries
+    /// reference the one `Command` — so for the callbacks' duration the
+    /// vacating name **is** the destination command: it answers `trace info`,
+    /// takes `trace add`/`remove`, and a `rename` or delete through it moves
+    /// or destroys the destination (tclsh-pinned, 8.6.16 and 9.0.4 identical).
+    /// The VM keys its tables by table key, so each open window records that
+    /// equivalence, and [`Self::relocate_rename_state`] retargets every
+    /// enclosing window when a nested rename moves the destination on again.
+    rename_windows: Vec<(CommandSidecarKey, CommandSidecarKey)>,
     /// Weak registry of in-flight sidecar identities. Relocation updates live
     /// handles without retaining completed invocations.
     active_sidecar_handles: Vec<Weak<RefCell<Option<CommandSidecarKey>>>>,
@@ -1663,6 +1680,7 @@ impl InterpState {
             next_var_trace_id: 0,
             cmd_traces: HashMap::new(),
             exec_traces: HashMap::new(),
+            rename_windows: Vec::new(),
             active_sidecar_handles: Vec::new(),
             exec_step_scopes: Vec::new(),
             trace_deopt_epoch: std::cell::Cell::new(0),
@@ -2564,7 +2582,15 @@ impl Vm {
         &self,
         name: &str,
     ) -> Option<(Command, CommandRenameTransaction)> {
-        let old_key = self.resolve_command_fqn(self.current_ns(), name)?;
+        // Inside an open rename window the source name still resolves, but it
+        // names the *destination* command — so `rename <old> <third>` and
+        // `rename <old> {}` from a callback move or destroy that one command
+        // rather than a second copy standing at the vacating key.
+        let old_key = self
+            .renamed_command_key(CommandSidecarKey::visible(
+                self.resolve_command_fqn(self.current_ns(), name)?,
+            ))
+            .into_name();
         let command = self.commands.get(&old_key)?;
         if !self.builtin_command_visible_for_surface(&old_key, command) {
             return None;
@@ -2606,12 +2632,15 @@ impl Vm {
         // [`Self::note_rename_destination`] before the alias-loop check, and
         // `register_command` re-inserts the same key, which the order owner
         // leaves where that call put it.
-        // Keep the successful rename's established source-removal then
-        // destination-registration order.  The caller has already completed
-        // every rejection path, so this is now allowed to fire destination
-        // delete traces and invalidate command/trace guard state.
-        self.take_command_unchecked_key(&transaction.old_key)
-            .expect("the prepared rename source remains registered");
+        //
+        // The source entry stays put: C only deletes it once the `rename`
+        // traces have run (`tclBasic.c` 9.0.4 `TclRenameCommand` — create
+        // `hPtr`, fire the traces, then `Tcl_DeleteHashEntry(oldHPtr)`), so a
+        // callback still resolves the old name.  `cmd_rename` closes the
+        // window with [`Self::retire_renamed_command_source`].  The caller has
+        // already completed every rejection path, so this is now allowed to
+        // fire destination delete traces and invalidate command/trace guard
+        // state.
         self.register_command(new_key, command.clone());
         self.command_generations
             .insert(new_key.to_owned(), transaction.source_generation);
@@ -2638,6 +2667,16 @@ impl Vm {
             &CommandSidecarKey::visible(&transaction.old_key),
             &CommandSidecarKey::visible(new_key),
         );
+    }
+
+    /// Drop the source half of a rename once its `rename` traces have run —
+    /// C's `Tcl_DeleteHashEntry(oldHPtr)` at the tail of `TclRenameCommand`.
+    /// This is a plain table removal, not a command deletion: no `delete`
+    /// trace fires, and the command lives on under its new key.  A callback
+    /// may have deleted the source itself (C guards the same case with a
+    /// refcount), so a vacated entry is not an error.
+    pub(crate) fn retire_renamed_command_source(&mut self, transaction: &CommandRenameTransaction) {
+        self.take_command_unchecked_key(&transaction.old_key);
     }
 
     /// Remove the source for an already validated `rename old {}`. Deletion
@@ -5857,8 +5896,9 @@ impl Vm {
         };
         let is_step = is_step_capable(&ops);
         // The trace belongs to the token standing at this key now, not to the
-        // name (C hangs it off `cmdPtr->tracePtr`).
-        let sidecar = CommandSidecarKey::visible(key);
+        // name (C hangs it off `cmdPtr->tracePtr`) — and inside a rename's
+        // callbacks the vacating name reaches the destination's list.
+        let sidecar = self.renamed_command_key(CommandSidecarKey::visible(key));
         let token = self
             .command_token_identity(&sidecar)
             .map(|identity| identity.generation);
@@ -5895,12 +5935,12 @@ impl Vm {
             return err(format!("unknown command \"{name}\""));
         };
         let is_step = is_step_capable(ops);
+        let key = self.renamed_command_key(CommandSidecarKey::visible(key));
         let table = if execution {
             &mut self.exec_traces
         } else {
             &mut self.cmd_traces
         };
-        let key = CommandSidecarKey::visible(key);
         let mut removed = false;
         if let Some(list) = table.get_mut(&key) {
             // Newest-first first match, as `remove_var_trace` explains.
@@ -5945,7 +5985,8 @@ impl Vm {
         } else {
             &self.cmd_traces
         };
-        let Some(list) = table.get(&CommandSidecarKey::visible(key)) else {
+        let Some(list) = table.get(&self.renamed_command_key(CommandSidecarKey::visible(key)))
+        else {
             return ok(Value::empty());
         };
         ok(Value::list(
@@ -5995,12 +6036,20 @@ impl Vm {
         res
     }
 
-    /// Fire the `rename`/`delete` command traces of `key` as
+    /// Fire the `rename`/`delete` command traces held at `key` as
     /// `callback oldName newName op` — names fully qualified (tclsh-pinned:
     /// `::victim ::victim2 rename`; a delete passes `{}` for the new name).
-    /// Callback errors are ignored (C: "Any errors in these traces are
-    /// ignored").
-    fn fire_command_traces_for(&mut self, key: &CommandSidecarKey, new_display: &str, op: &str) {
+    /// `old_display` is passed rather than derived from `key`: a rename fires
+    /// from the destination's list (see [`Self::on_command_renamed_traces`])
+    /// but still names the command it is leaving.  Callback errors are ignored
+    /// (C: "Any errors in these traces are ignored").
+    fn fire_command_traces_for(
+        &mut self,
+        key: &CommandSidecarKey,
+        old_display: &str,
+        new_display: &str,
+        op: &str,
+    ) {
         // C's per-`Command` `CMD_TRACE_ACTIVE`/`CMD_DYING`: a rename/delete of
         // *this* command from inside its own callback does not fire again. A
         // different command's traces still do.
@@ -6011,7 +6060,6 @@ impl Vm {
             return;
         };
         self.firing_cmd_traces.push(key.clone());
-        let old_display = format!("::{}", key.name());
         // C prepends each new command trace (`Tcl_TraceCommand`, tclTrace.c
         // 9.0.4:1016-1018) and `CallCommandTraces` walks the list head→tail
         // (tclBasic.c:3972-3974), so the newest fires first. Our Vec pushes
@@ -6033,7 +6081,7 @@ impl Vm {
             let _ = self.run_cmd_trace_callback(
                 &entry,
                 &[
-                    Value::string(old_display.clone()),
+                    Value::string(old_display),
                     Value::string(new_display),
                     Value::string(op),
                 ],
@@ -6060,7 +6108,7 @@ impl Vm {
             .map(|identity| identity.generation);
         let mut removed_trace = false;
         if !self.cmd_traces.is_empty() {
-            self.fire_command_traces_for(key, "", "delete");
+            self.fire_command_traces_for(key, &format!("::{}", key.name()), "", "delete");
             removed_trace |= self.drop_retired_cmd_traces(key, dying);
         }
         if !self.exec_traces.is_empty()
@@ -6099,29 +6147,72 @@ impl Vm {
         removed
     }
 
-    /// A command moved `old_key` → `new_key` (`rename`): fire its `rename`
-    /// traces with both fully-qualified names, then move every trace with it
-    /// (tclsh-pinned: an execution trace keeps firing under the new name).
+    /// A command moved `old_key` → `new_key` (`rename`): move every trace with
+    /// it (tclsh-pinned: an execution trace keeps firing under the new name),
+    /// then fire its `rename` traces with both fully-qualified names.
+    ///
+    /// The move comes *first* because C's traces hang off the shared `Command`
+    /// rather than off either hash entry, so a callback reaches one list under
+    /// either name: `trace info command <old>` and `… <new>` answer the same
+    /// thing, and a `trace remove` through either name edits it.  Publishing
+    /// the move and aliasing the source key onto the destination for the
+    /// callbacks' duration reproduces that; `cmd_rename` keeps the source
+    /// command registered across this call so the old name still resolves.
     pub(crate) fn on_command_renamed_traces(&mut self, old_key: &str, new_key: &str) {
+        let old_display = format!("::{old_key}");
+        let new_display = format!("::{new_key}");
         let old_key = CommandSidecarKey::visible(old_key);
         let new_key = CommandSidecarKey::visible(new_key);
         self.relocate_active_sidecars(&old_key, &new_key);
+        self.relocate_rename_state(&old_key, &new_key);
         let mut moved_trace = false;
-        if !self.cmd_traces.is_empty() {
-            self.fire_command_traces_for(&old_key, &format!("::{}", new_key.name()), "rename");
-            if let Some(entries) = self.cmd_traces.remove(&old_key) {
-                self.cmd_traces.insert(new_key.clone(), entries);
-                moved_trace = true;
-            }
+        if !self.cmd_traces.is_empty()
+            && let Some(entries) = self.cmd_traces.remove(&old_key)
+        {
+            self.cmd_traces.insert(new_key.clone(), entries);
+            moved_trace = true;
         }
         if !self.exec_traces.is_empty()
             && let Some(entries) = self.exec_traces.remove(&old_key)
         {
-            self.exec_traces.insert(new_key, entries);
+            self.exec_traces.insert(new_key.clone(), entries);
             moved_trace = true;
         }
         if moved_trace {
             self.invalidate_guard_domain(GuardDomain::CommandTrace);
+        }
+        self.rename_windows.push((old_key, new_key.clone()));
+        self.fire_command_traces_for(&new_key, &old_display, &new_display, "rename");
+        self.rename_windows.pop();
+    }
+
+    /// The key a command's state lives under now, following any open rename
+    /// window (see [`Self::rename_windows`]). Identity outside one.
+    fn renamed_command_key(&self, key: CommandSidecarKey) -> CommandSidecarKey {
+        match self.rename_windows.iter().find(|(from, _)| *from == key) {
+            Some((_, to)) => to.clone(),
+            None => key,
+        }
+    }
+
+    /// A rename moved `old_key` → `new_key`: point every open window and every
+    /// in-flight firing record that named the old key at the new one. C needs
+    /// no equivalent — both its hash entries reference one `Command` object, so
+    /// a nested rename cannot strand them — but the VM's key-addressed state
+    /// would otherwise be left on a key the move just vacated: an enclosing
+    /// window would stop answering through the source name, and the
+    /// `firing_cmd_traces` record standing in for `CMD_TRACE_ACTIVE` would stop
+    /// suppressing the command's own remaining callbacks.
+    fn relocate_rename_state(&mut self, old_key: &CommandSidecarKey, new_key: &CommandSidecarKey) {
+        for (_, destination) in &mut self.rename_windows {
+            if destination == old_key {
+                destination.clone_from(new_key);
+            }
+        }
+        for firing in &mut self.firing_cmd_traces {
+            if firing == old_key {
+                firing.clone_from(new_key);
+            }
         }
     }
 
@@ -6129,6 +6220,7 @@ impl Vm {
     /// hide/expose is not a Tcl rename, so no callback is fired.
     fn move_command_traces(&mut self, old_key: &CommandSidecarKey, new_key: CommandSidecarKey) {
         self.relocate_active_sidecars(old_key, &new_key);
+        self.relocate_rename_state(old_key, &new_key);
         // The list travels with the token, so re-stamp it to whatever token
         // now stands at the destination; a later deletion there still tells
         // this list from a replacement's.

--- a/rust/tcl-vm/tests/command_traces_e2e.rs
+++ b/rust/tcl-vm/tests/command_traces_e2e.rs
@@ -183,6 +183,106 @@ const VECTORS: &[Vector] = &[
                  puts after-redef:[dup]\n",
         want: "T:::dup||delete\nafter-redef:NEW",
     },
+    // The `rename` trace window. C creates the destination hash entry, fires
+    // the traces, and only then deletes the source one (`tclBasic.c` 9.0.4
+    // `TclRenameCommand`), and the traces themselves hang off the shared
+    // `Command` rather than off either entry — so a callback resolves *both*
+    // names and reaches one trace list through either of them.
+    Vector {
+        name: "a rename callback still resolves the vacating name",
+        script: "proc victim {} { return V }\n\
+                 proc et args {}\n\
+                 proc tracer args {\n\
+                     puts \"live:[llength [info commands ::victim]]|\
+                 [llength [info commands ::victim2]]|[victim]|[victim2]\"\n\
+                     puts \"cmd:[trace info command victim]|\
+                 [trace info command victim2]\"\n\
+                     puts \"exec:[trace info execution victim]|\
+                 [trace info execution victim2]\"\n\
+                 }\n\
+                 trace add command victim rename tracer\n\
+                 trace add execution victim enter et\n\
+                 rename victim victim2\n\
+                 puts \"after:[llength [info commands ::victim]]|\
+                 [llength [info commands ::victim2]]\"\n",
+        want: "live:1|1|V|V\n\
+               cmd:{rename tracer}|{rename tracer}\n\
+               exec:{enter et}|{enter et}\n\
+               after:0|1",
+    },
+    Vector {
+        name: "a rename callback's trace remove through the old name is honoured",
+        script: "proc victim {} {}\n\
+                 proc c1 args {\n\
+                     trace remove command victim rename c1\n\
+                     puts \"c1:[trace info command victim]\"\n\
+                 }\n\
+                 proc c2 args { puts \"c2:[trace info command victim2]\" }\n\
+                 trace add command victim rename c2\n\
+                 trace add command victim rename c1\n\
+                 rename victim victim2\n\
+                 puts \"after:[trace info command victim2]\"\n",
+        want: "c1:{rename c2}\nc2:{rename c2}\nafter:{rename c2}",
+    },
+    Vector {
+        name: "a rename callback's trace add through the old name follows the command",
+        script: "proc victim {} {}\n\
+                 proc d1 args { puts \"D:[join $args |]\" }\n\
+                 proc r1 args { trace add command victim delete d1 }\n\
+                 trace add command victim rename r1\n\
+                 rename victim victim2\n\
+                 puts \"info:[trace info command victim2]\"\n\
+                 rename victim2 {}\n",
+        want: "info:{delete d1} {rename r1}\nD:::victim2||delete",
+    },
+    // Both entries reference one `Command`, so a callback that renames or
+    // deletes through *either* name moves or destroys that one command — and
+    // C's `CMD_TRACE_ACTIVE` keeps the remaining callbacks of the pass from
+    // re-firing when it does.
+    Vector {
+        name: "a rename callback renaming the vacating name moves the one command",
+        script: "proc victim {} { return V }\n\
+                 proc c1 args { puts c1; rename victim victim3 }\n\
+                 proc c2 args { puts c2 }\n\
+                 trace add command victim rename c2\n\
+                 trace add command victim rename c1\n\
+                 rename victim victim2\n\
+                 puts \"live:[llength [info commands ::victim]]|\
+                 [llength [info commands ::victim2]]|\
+                 [llength [info commands ::victim3]]\"\n\
+                 puts \"info:[trace info command victim3]|[victim3]\"\n",
+        want: "c1\nc2\n\
+               live:0|0|1\n\
+               info:{rename c1} {rename c2}|V",
+    },
+    Vector {
+        name: "a rename callback deleting the vacating name destroys the one command",
+        script: "proc victim {} {}\n\
+                 proc cb args { rename victim {} }\n\
+                 trace add command victim rename cb\n\
+                 rename victim victim2\n\
+                 puts \"live:[llength [info commands ::victim]]|\
+                 [llength [info commands ::victim2]]\"\n",
+        want: "live:0|0",
+    },
+    Vector {
+        name: "a nested rename keeps the vacating name pointed at the command",
+        script: "proc victim {} {}\n\
+                 proc dd args { puts \"D:[join $args |]\" }\n\
+                 proc cb args {\n\
+                     rename victim2 victim3\n\
+                     puts \"in:[trace info command victim]|\
+                 [trace info command victim3]\"\n\
+                     trace add command victim delete dd\n\
+                 }\n\
+                 trace add command victim rename cb\n\
+                 rename victim victim2\n\
+                 puts \"after:[trace info command victim3]\"\n\
+                 rename victim3 {}\n",
+        want: "in:{rename cb}|{rename cb}\n\
+               after:{delete dd} {rename cb}\n\
+               D:::victim3||delete",
+    },
     Vector {
         name: "namespace-qualified names arrive fully qualified",
         script: "proc tracer args { puts \"T:[join $args |]\" }\n\
@@ -381,17 +481,9 @@ const VECTORS: &[Vector] = &[
     // half. `CallCommandTraces` walks `nextPtr` (`tclBasic.c` 9.0.4:3972-3993)
     // and `Tcl_UntraceCommand` unlinks at once, so a trace a callback removes
     // does not fire in that pass — for `enter` and `delete`, which walk
-    // newest-first, and for `leave`, which C scans in reverse and so reaches
-    // the *oldest* first.
-    //
-    // The `rename` op is deliberately absent. C's `TclRenameCommand` inserts
-    // the *new* hash entry, fires the rename traces while the old entry is
-    // still present, and only then removes it — and the traces hang off the
-    // shared `Command`, so a callback sees one list under either name. This VM
-    // renames first and moves its name-keyed trace list afterwards, so a
-    // callback's `trace info`/`trace remove` finds neither name traced. Fixing
-    // that is a change to when `cmd_rename` publishes the sidecar, not to the
-    // firing walk.
+    // newest-first, for `leave`, which C scans in reverse and so reaches the
+    // *oldest* first, and for `rename`, whose callback reaches the list
+    // through the name the command is vacating.
     Vector {
         name: "a callback's trace remove is honoured mid-firing for command and execution traces",
         script: "proc target {} { return T }\n\
@@ -416,12 +508,22 @@ const VECTORS: &[Vector] = &[
                  puts \"l2 info: [trace info execution lt]\" }\n\
                  trace add execution lt leave l2\n\
                  trace add execution lt leave l1\n\
-                 lt\n",
+                 lt\n\
+                 puts ---\n\
+                 proc rv {} {}\n\
+                 proc r1 args { trace remove command rv rename r2\n\
+                 puts \"r1 info: [trace info command rv]\" }\n\
+                 proc r2 args { puts \"r2 fired\" }\n\
+                 trace add command rv rename r2\n\
+                 trace add command rv rename r1\n\
+                 rename rv rv2\n",
         want: "e1 info: {enter e1}\n\
                ---\n\
                d1 info: {delete d1}\n\
                ---\n\
-               l2 info: {leave l2}",
+               l2 info: {leave l2}\n\
+               ---\n\
+               r1 info: {rename r1}",
     },
     // A **delete** walk is handed the dying token's own trace list
     // (`CallCommandTraces`, `tclBasic.c` 9.0.4:3972-3993), so a callback that


### PR DESCRIPTION
## The bug

C's `TclRenameCommand` (`tclBasic.c` 9.0.4) inserts the **destination** hash entry, leaves the **source** entry in place, fires the `rename` traces, and only then deletes the source. Both entries reference the one `Command`, and the traces hang off that rather than off either entry — so for the callbacks' duration the vacating name **is** the destination command.

`cmd_rename` did the opposite. It installed and committed the rename (removing the source entry), then called `on_command_renamed_traces`, which fired the callbacks and *afterwards* moved the sidecars. Inside a rename callback, therefore:

- `trace info command <old>` / `trace remove command <old> …` errored with `unknown command "<old>"` — the old name was already gone;
- `trace info command <new>` answered empty — the trace list had not moved yet.

Measured on tclsh 8.6.16 and 9.0.4 (identical on both), this sheet prints two lines:

```tcl
proc rv {} {}
proc c1 args { trace remove command rv rename c1; puts "c1 info: [trace info command rv]" }
proc c2 args { puts "c2 fired: [trace info command rv2]" }
trace add command rv rename c2
trace add command rv rename c1
rename rv rv2
```

```
c1 info: {rename c2}
c2 fired: {rename c2}
```

The VM printed only `c2 fired: ` — c1's callback errored on the `trace remove`, and command-trace callback errors are ignored.

## The fix

- `install_renamed_command` registers the destination **without** removing the source.
- `on_command_renamed_traces` moves the trace sidecars to the destination key **before** firing, and fires from there.
- New `retire_renamed_command_source` drops the source entry afterwards — the VM's spelling of `Tcl_DeleteHashEntry(oldHPtr)`: a plain table removal that fires no `delete` trace and tolerates a callback having deleted the source itself.

The VM has no shared command object to hang C's equivalence on, so an open window records it as a source→destination pair (`rename_windows`, a stack, one frame per nested rename):

- `renamed_command_key` resolves a key through it. `trace add` / `remove` / `info` consult it, and so does `prepare_command_rename` — which is what makes a callback's `rename <old> <third>` and `rename <old> {}` act on the one command rather than on a second copy standing at the vacating key.
- `relocate_rename_state` retargets every enclosing window **and** every `firing_cmd_traces` record when a nested rename moves the destination on again. That record is the key-addressed stand-in for `CMD_TRACE_ACTIVE`, which C gets for free from the `Command` being one object; without the retarget, a callback that renamed the command on again made the pass's remaining callbacks fire twice.

`fire_command_traces_for` takes the old display name explicitly now: a rename fires from the *destination's* list but still names the command it is leaving.

## Verification

Six new vectors in `rust/tcl-vm/tests/command_traces_e2e.rs`, plus the `rename` sub-case restored to the row-8 vector, each run by the existing harness against the VM **and** against real `tclsh8.6` / `tclsh9.0`:

1. both names live, callable, and sharing one command *and* execution trace list mid-callback;
2. the sheet's `trace remove` through the old name (and the second trace still firing);
3. a `trace add` through the old name following the command through to its later `delete`;
4. a callback that renames through the vacating name — one command survives, under the third name, carrying the traces, with the pass's remaining callback firing exactly once;
5. a callback that deletes through the vacating name — nothing survives;
6. a nested rename — the vacating name still answers `trace info`, and a `trace add` through it lands on the command's new location.

Also hand-checked against both tclsh versions and now byte-identical: `interp alias` renames, `namespace import` renames, and cross-namespace renames, in each case resolving *both* names from inside the callback.

`cargo test -p tcl-vm` — 1140 passed, 0 failed across 45 binaries. `make rust-check` and `make prep-pr` green.

## Relationship to #1878

#1878 landed the issue #1633 row 8 firing-walk fix but had to exclude the `rename` op, documenting the reason as "a `cmd_rename` ordering question, not a change to the firing walk". This is that ordering question. With it fixed, the `rename` sub-case is back in that vector and the exclusion comment is gone — a callback's `trace remove command <old> rename …` is now honoured mid-pass, and the trace it removed does not fire:

```
r1 info: {rename r1}
```

(identical on tclsh 8.6.16 and 9.0.4; `r2` correctly never fires).

## Review feedback

Both Codex P2 comments reproduced against real tclsh and are fixed; verifying the first turned up a third, related divergence (the double-firing above) that is fixed too. Vectors 4–6 pin all three.

## Divergences this deliberately leaves open

**`runtime/rust` has the mirror-image bug.** The tree-walker fires the `rename` traces *before* any table mutation, so a callback there sees the old name but not yet the new one; on the sheet above it prints only `c1 info: {rename c2}` (c2's callback errors on `trace info command rv2` and is swallowed). Bringing its window onto C's ordering means restructuring `Namespaces::rename` and its interleaved import / TclOO / coroutine / ensemble handling — a separate change in a separate engine. Recorded as a known gap in `docs/design/runtime/trace-implementation.md`.

**Two residues of the missing shared command identity**, both places where C's own behaviour is a torn-state artefact rather than a contract: re-*creating* the vacating name from a callback (`proc <old> {} …`) kills the destination in C but not in the VM, and 8.6 and 9.0 disagree with each other on what `info commands <old>` reports after a callback deletes the command.

**A coroutine called by its old name mid-rename.** C resumes it through either name; the VM reports `invalid command name`, because `cmd_coro::on_command_renamed` re-keys the coroutine sidecar before the window opens and, unlike the trace sidecars, it is not resolved through it. Pre-existing and the observable message is unchanged by this PR.


## Docs

`docs/design/runtime/trace-implementation.md` gains a *The `rename` trace window* section under the bytecode-VM heading, describing C's ordering, the equivalence it implies, how the VM reproduces it, and the gaps above.

Related: #1633, #1878

🤖 Generated with [Claude Code](https://claude.com/claude-code)
