### PR TITLE
fix(tclvm): run a proc's pre-compiled body, and compile every body as a proc

### DIFF
--- a/docs/design/compiler/data-structure-reference.md
+++ b/docs/design/compiler/data-structure-reference.md
@@ -128,8 +128,8 @@ type inference, and `liveness_dead_stores()`
 | `Instruction` | `op`, `operands: Vec<Operand>`, `comment`, `offset`, plus source-mapping and emitter hint fields |
 | `LiteralTable` | Intern pool: string → object-array index |
 | `LocalVarTable` | LVT: variable name → slot index |
-| `FunctionAsm` | `name`, `literals`, `lvt`, `instructions`, `labels`, `loop_targets`, `error_regions` |
-| `ModuleAsm` | `top_level: FunctionAsm` + `procedures: HashMap<String, FunctionAsm>` |
+| `FunctionAsm` | `name`, `literals`, `lvt`, `instructions`, `labels`, `loop_targets`, `proc_body_src`, `error_regions` |
+| `ModuleAsm` | `top_level` (as a script) + `top_level_body` (the same source as a proc body) + `procedures: HashMap<String, FunctionAsm>` |
 
 ### Orchestration (`compilation_unit.rs`)
 

--- a/docs/design/example-script-walkthroughs.md
+++ b/docs/design/example-script-walkthroughs.md
@@ -570,14 +570,26 @@ pub struct FunctionAsm {
     pub labels: HashMap<String, usize>,   // label → byte offset
     pub loop_targets: HashMap<usize, (Option<i32>, Option<i32>)>,
     pub body_base_line: u32,
+    pub proc_body_src: Option<String>,    // procedures only: the body word compiled
     pub error_regions: Vec<ErrorRegion>,
 }
 
 pub struct ModuleAsm {
-    pub top_level: FunctionAsm,
+    pub top_level: FunctionAsm,        // entered as a script
+    pub top_level_body: FunctionAsm,   // the same source, emitted as a proc body
     pub procedures: HashMap<String, FunctionAsm>,   // keyed by qualified name
 }
 ```
+
+A unit's top level is emitted twice because the consumer, not the compiler,
+knows how it will be entered. A body compiled at run time — `proc`'s body when
+the pre-compiled entry misses, an `apply` lambda, a `TclOO` method — arrives as
+a bare script, and running it as one would deny it the `is_proc` specialisation
+(`STORE_SCALAR1`, `LAPPEND_SCALAR1`, the compiled `unset`, the inline `catch`)
+that an AOT-compiled proc of the same source gets. `proc_body_src` lets a
+consumer keyed by *name* — the VM's pre-compiled body cache — confirm that the
+body it was handed is the body that was compiled, since one name is reachable
+from several `proc` commands with different bodies.
 
 ### Orchestration (`rust/tcl-compiler/src/compilation_unit.rs`)
 

--- a/rust/tcl-bytecode/src/format.rs
+++ b/rust/tcl-bytecode/src/format.rs
@@ -393,6 +393,7 @@ mod tests {
             labels: HashMap::new(),
             loop_targets: HashMap::new(),
             body_base_line: 0,
+            proc_body_src: None,
             error_regions: Vec::new(),
         };
 

--- a/rust/tcl-bytecode/src/lib.rs
+++ b/rust/tcl-bytecode/src/lib.rs
@@ -1342,6 +1342,22 @@ pub struct FunctionAsm {
     /// `N = instruction_line − body_base_line + 1`, so the line is relative to
     /// the proc, not the whole module. `0` for the top level / hand-built asm.
     pub body_base_line: u32,
+    /// For an entry in [`ModuleAsm::procedures`], the `proc` command's body
+    /// **word value** — the source text with the one substitution braces permit
+    /// applied, so it compares equal to the value a runtime `proc` is handed.
+    /// `None` for every other function (both top-level shapes, hand-built
+    /// assembly, a synthetic proc with no source).
+    ///
+    /// A runtime consumer keyed by *name* cannot assume the body it is handed
+    /// is the body that was compiled: a name is reachable from more than one
+    /// `proc` command (a redefinition, opposite arms of an `if`, a second
+    /// `eval` after a `rename`), and a compiled unit records only the first.
+    /// Comparing this against the body word actually supplied turns that
+    /// ambiguity into a cache miss instead of a wrong body.
+    ///
+    /// A body the script *builds* (`proc p {} "return $x"`) never matches — the
+    /// compiler records the unsubstituted word — so it misses and recompiles.
+    pub proc_body_src: Option<String>,
     /// Inline command-body regions (`eval {…}` / `while`/`for`/`foreach` bodies)
     /// folded into this function's instruction stream. As an error unwinds past
     /// a covering region the executor synthesises the body frame the *uncompiled*
@@ -1388,8 +1404,28 @@ pub struct ModuleAsm {
     /// must reject an AOT module compiled for another profile rather than
     /// treating its specialised opcodes as belonging to its current surface.
     pub profile: &'static tcl_dialect::DialectProfile,
-    /// Top-level script assembly.
+    /// Top-level script assembly — the unit entered as a *script*.
     pub top_level: FunctionAsm,
+    /// The same top level emitted as a **procedure body**: LVT variable forms
+    /// (`STORE_SCALAR1`, `INCR_SCALAR1`, `LAPPEND_SCALAR1`, the compiled
+    /// `unset`) and the proc return protocol, exactly as an entry in
+    /// [`Self::procedures`] is emitted.
+    ///
+    /// A body compiled at run time — `proc`'s body when the pre-compiled entry
+    /// misses, an `apply` lambda, a `TclOO` method — is the *whole* source the
+    /// compiler was handed, so it arrives here as a top level rather than as a
+    /// procedure. Running that as a script would deny every dynamically
+    /// compiled body the `is_proc` specialisation an AOT-compiled one gets, and
+    /// the two would diverge on any semantics the specialised opcodes carry
+    /// (C's `INST_LAPPEND_SCALAR` omits `TCL_TRACE_READS`; `INST_UNSET_ARRAY`
+    /// reports a two-part access). Both shapes are emitted so the consumer
+    /// picks by how it will *enter* the code, not by how it was compiled.
+    ///
+    /// The local variable table is not pre-seeded with parameter names (the
+    /// compiler is handed a body, never its parameter list), so slot *order*
+    /// can differ from the AOT form. Slots resolve by name at run time, so this
+    /// is a disassembly difference only.
+    pub top_level_body: FunctionAsm,
     /// Procedure assemblies keyed by qualified name.
     pub procedures: HashMap<String, FunctionAsm>,
 }

--- a/rust/tcl-compiler/src/codegen/cmd_subst.rs
+++ b/rust/tcl-compiler/src/codegen/cmd_subst.rs
@@ -994,7 +994,7 @@ impl CodegenCtx<'_> {
 
     fn emit_inline_incr(&mut self, args: &[(String, bool)]) {
         let var_name = &args[0].0;
-        if self.is_proc && !is_qualified(var_name) {
+        if self.compiles_locals() && !is_qualified(var_name) {
             let slot = bytecode_imm(self.lvt.intern(var_name));
             if args.len() == 1 {
                 self.emit_comment(
@@ -1074,7 +1074,7 @@ impl CodegenCtx<'_> {
     fn emit_inline_info_exists(&mut self, args: &[(String, bool)]) {
         self.used_inline_cmd_subst = true;
         let var_name = &args[1].0;
-        if self.is_proc && !is_qualified(var_name) {
+        if self.compiles_locals() && !is_qualified(var_name) {
             let slot = bytecode_imm(self.lvt.intern(var_name));
             self.emit_comment(
                 Op::EXIST_SCALAR,
@@ -1519,7 +1519,8 @@ impl CodegenCtx<'_> {
     fn emit_inline_array(&mut self, args: &[(String, bool)]) {
         let sub = &args[0].0;
         let rest = &args[1..];
-        if sub == "exists" && rest.len() == 1 && self.is_proc && !is_qualified(&rest[0].0) {
+        if sub == "exists" && rest.len() == 1 && self.compiles_locals() && !is_qualified(&rest[0].0)
+        {
             self.used_inline_cmd_subst = true;
             let slot = bytecode_imm(self.lvt.intern(&rest[0].0));
             self.emit_comment(

--- a/rust/tcl-compiler/src/codegen/cmd_subst.rs
+++ b/rust/tcl-compiler/src/codegen/cmd_subst.rs
@@ -250,46 +250,48 @@ fn skip_word_seps(bytes: &[u8], n: usize, mut i: usize) -> usize {
     i
 }
 
-/// Strip the outer `{…}` from a body word, as the inline body emitters do.
-///
-/// The inlining *guard* and the emitter must look at the same text, so both go
-/// through this.
-#[must_use]
-pub fn strip_body_braces(body_text: &str) -> &str {
-    let body = body_text.trim();
-    if body.starts_with('{') && body.ends_with('}') {
-        &body[1..body.len() - 1]
-    } else {
-        body
-    }
-}
-
 /// Whether `body` is a body the *single-command* inline emitters
 /// ([`CodegenCtx::emit_catch_body`], [`CodegenCtx::emit_try_handler_body`])
 /// can compile.
 ///
 /// Those emitters split the body into *words* with [`parse_cmd_parts`] and emit
-/// one command from them, so anything else — two commands separated by `;` or a
-/// newline, or a comment — is flattened into a single bogus invocation
-/// (`[catch {set y 1; set z 2} m]` emitted `set y 1 set z 2`). Ask the
-/// segmenter, the same command splitter lowering uses, rather than re-deriving
-/// the separator rules here.
+/// one command from them, so the body must be one command and nothing else.
+/// Two questions, because neither answers the whole thing:
 ///
-/// An empty body is inlinable — the emitters push the empty result for it. A
-/// comment-only body is not: it segments to no command at all, while the word
-/// splitter would take the `#` for a command name.
+/// * [`has_command_separator`] — is there a `;` or newline the *word splitter*
+///   would swallow into a word? A segment count does not catch this: both
+///   `{error boom;}` and `{# note<newline>error boom}` hold one command, while
+///   the splitter reads `boom;` as an argument and `#` as a command name.
+///   This is the same question, and the same owner, that
+///   [`CodegenCtx::emit_inline_cmd_subst`] already asks before deferring a
+///   multi-command substitution to `EVAL_STK`.
+/// * the segmenter — is there exactly one command at all? A body that is only
+///   a comment has no separator and no command, and must not reach an emitter
+///   that would take its `#` for a command name.
 ///
-/// `config` is the compile's own lexer config: command separation is
-/// dialect-dependent (iRules' `}{` ghost separator), and answering under the
-/// default grammar would under-count an iRules body's commands and inline one
-/// this emitter cannot compile.
+/// A `{*}` body is rejected outright: [`parse_cmd_parts`] has no expansion
+/// form, so it reads the prefix as a braced word and the emitters pass a
+/// literal `*` plus the unexpanded list (`catch {cfg {*}$a}` called
+/// `cfg * {-verbose b}`). The value-position dispatcher reaches for
+/// [`parse_cmd_parts_expand`] here; these emitters have no such path, so they
+/// decline instead.
+///
+/// An empty body is inlinable: the emitters push the empty result for it.
+///
+/// The caller must also have established that the body is a **braced** word.
+/// This reads the text the compiler can see, and an unbraced body
+/// (`catch $script`) merely *names* a script whose commands are not known
+/// until run time.
 #[must_use]
 pub fn is_single_command_body(body: &str, config: tcl_lexer::LexerConfig) -> bool {
-    match crate::segmenter::segment_commands_with_offset_and_config(body, 0, config).len() {
-        0 => body.trim().is_empty(),
-        1 => true,
-        _ => false,
+    if body.trim().is_empty() {
+        return true;
     }
+    if has_command_separator(body) || body.contains("{*}") {
+        return false;
+    }
+    let segments = crate::segmenter::segment_commands_with_offset_and_config(body, 0, config);
+    matches!(segments.as_slice(), [only] if !only.is_partial)
 }
 
 /// Parse a command-substitution body into `(text, braced)` parts.
@@ -930,13 +932,15 @@ impl CodegenCtx<'_> {
             }
             // The inline form compiles the body as one command, so it is only
             // reachable for a body that *is* one command (`is_single_command_body`).
+            // The inline form compiles the body as one command it can see, so it
+            // needs a *braced* body (an unbraced `catch $script` names a script
+            // whose commands are not known until run time) that is exactly one
+            // command.
             Some(InlineCodegenHookId::Catch)
                 if self.is_proc
                     && (1..=3).contains(&args.len())
-                    && is_single_command_body(
-                        strip_body_braces(&args[0].0),
-                        self.lexer_config(),
-                    ) =>
+                    && args[0].1
+                    && is_single_command_body(&args[0].0, self.lexer_config()) =>
             {
                 let result_var = args.get(1).map(|(s, _)| s.as_str());
                 if result_var.is_some_and(|v| v.starts_with("::")) {

--- a/rust/tcl-compiler/src/codegen/cmd_subst.rs
+++ b/rust/tcl-compiler/src/codegen/cmd_subst.rs
@@ -250,6 +250,48 @@ fn skip_word_seps(bytes: &[u8], n: usize, mut i: usize) -> usize {
     i
 }
 
+/// Strip the outer `{…}` from a body word, as the inline body emitters do.
+///
+/// The inlining *guard* and the emitter must look at the same text, so both go
+/// through this.
+#[must_use]
+pub fn strip_body_braces(body_text: &str) -> &str {
+    let body = body_text.trim();
+    if body.starts_with('{') && body.ends_with('}') {
+        &body[1..body.len() - 1]
+    } else {
+        body
+    }
+}
+
+/// Whether `body` is a body the *single-command* inline emitters
+/// ([`CodegenCtx::emit_catch_body`], [`CodegenCtx::emit_try_handler_body`])
+/// can compile.
+///
+/// Those emitters split the body into *words* with [`parse_cmd_parts`] and emit
+/// one command from them, so anything else — two commands separated by `;` or a
+/// newline, or a comment — is flattened into a single bogus invocation
+/// (`[catch {set y 1; set z 2} m]` emitted `set y 1 set z 2`). Ask the
+/// segmenter, the same command splitter lowering uses, rather than re-deriving
+/// the separator rules here.
+///
+/// An empty body is inlinable — the emitters push the empty result for it. A
+/// comment-only body is not: it segments to no command at all, while the word
+/// splitter would take the `#` for a command name.
+///
+/// `config` is the compile's own lexer config: command separation is
+/// dialect-dependent (iRules' `}{` ghost separator), and answering under the
+/// default grammar would under-count an iRules body's commands and inline one
+/// this emitter cannot compile.
+#[must_use]
+pub fn is_single_command_body(body: &str, config: tcl_lexer::LexerConfig) -> bool {
+    match crate::segmenter::segment_commands_with_offset_and_config(body, 0, config).len() {
+        0 => body.trim().is_empty(),
+        1 => true,
+        _ => false,
+    }
+}
+
 /// Parse a command-substitution body into `(text, braced)` parts.
 /// `braced=true` means the text was a `{...}` literal — the caller
 /// should not interpolate it.  Strips the outer `[...]` if present.
@@ -886,7 +928,16 @@ impl CodegenCtx<'_> {
             Some(InlineCodegenHookId::DictGet) if args.len() >= 3 => {
                 self.emit_inline_dict_get(args);
             }
-            Some(InlineCodegenHookId::Catch) if self.is_proc && (1..=3).contains(&args.len()) => {
+            // The inline form compiles the body as one command, so it is only
+            // reachable for a body that *is* one command (`is_single_command_body`).
+            Some(InlineCodegenHookId::Catch)
+                if self.is_proc
+                    && (1..=3).contains(&args.len())
+                    && is_single_command_body(
+                        strip_body_braces(&args[0].0),
+                        self.lexer_config(),
+                    ) =>
+            {
                 let result_var = args.get(1).map(|(s, _)| s.as_str());
                 if result_var.is_some_and(|v| v.starts_with("::")) {
                     self.used_inline_cmd_subst = false;

--- a/rust/tcl-compiler/src/codegen/control_flow.rs
+++ b/rust/tcl-compiler/src/codegen/control_flow.rs
@@ -28,7 +28,7 @@ use crate::cfg::Function as CfgFunction;
 use crate::expr_ast::{BinOp, ExprNode};
 use crate::ir::Statement;
 
-use super::cmd_subst::{is_single_command_body, parse_cmd_parts, strip_body_braces};
+use super::cmd_subst::{is_single_command_body, parse_cmd_parts};
 use super::values::is_qualified;
 use super::{CodegenCtx, Op, Operand, bytecode_imm};
 
@@ -690,7 +690,12 @@ impl CodegenCtx<'_> {
         result_var: Option<&str>,
         options_var: Option<&str>,
     ) {
-        let body = strip_body_braces(body_text);
+        // `body_text` is already the body word's *value* — `parse_cmd_parts`
+        // removed the braces that delimited the `catch` argument. Any braces
+        // still here belong to the script: `[catch {{set x 1}} m]` runs the
+        // one-word command `set x 1` and catches `invalid command name`, so
+        // stripping a second layer would compile a successful `set` instead.
+        let body = body_text.trim();
 
         // Pre-intern result_var so it gets a lower LVT slot
         if let Some(rv) = result_var
@@ -838,15 +843,18 @@ impl CodegenCtx<'_> {
                     self.emit_expr(&node);
                 }
             }
-            // Both bodies go to a single-command emitter, so both must be one
-            // command (`is_single_command_body`).
+            // Both bodies go to a single-command emitter, so both must be a
+            // braced word holding exactly one command — the same rule the
+            // value-position `catch` arm applies.
             Some(InlineCodegenHookId::Try)
                 if self.is_proc
                     && body_args.len() == 5
                     && body_args[1].0 == "on"
                     && body_args[2].0 == "error"
-                    && is_single_command_body(strip_body_braces(&body_args[0].0), cfg)
-                    && is_single_command_body(strip_body_braces(&body_args[4].0), cfg) =>
+                    && body_args[0].1
+                    && body_args[4].1
+                    && is_single_command_body(&body_args[0].0, cfg)
+                    && is_single_command_body(&body_args[4].0, cfg) =>
             {
                 let try_sc = self.fresh_label("catch_body_end");
                 self.emit_comment(

--- a/rust/tcl-compiler/src/codegen/control_flow.rs
+++ b/rust/tcl-compiler/src/codegen/control_flow.rs
@@ -28,7 +28,7 @@ use crate::cfg::Function as CfgFunction;
 use crate::expr_ast::{BinOp, ExprNode};
 use crate::ir::Statement;
 
-use super::cmd_subst::parse_cmd_parts;
+use super::cmd_subst::{is_single_command_body, parse_cmd_parts, strip_body_braces};
 use super::values::is_qualified;
 use super::{CodegenCtx, Op, Operand, bytecode_imm};
 
@@ -243,11 +243,8 @@ impl CodegenCtx<'_> {
             return false;
         }
         // The body must be a straight-line sequence of simple commands.
-        let body_ir = crate::lowering::lower_to_ir_with_config(
-            body_text,
-            self.registry,
-            tcl_lexer::LexerConfig::for_profile(self.registry.profile()),
-        );
+        let body_ir =
+            crate::lowering::lower_to_ir_with_config(body_text, self.registry, self.lexer_config());
         if !body_ir.procedures.is_empty()
             || !body_ir.methods.is_empty()
             || !is_straight_line_body(&body_ir.top_level, self.registry)
@@ -351,11 +348,8 @@ impl CodegenCtx<'_> {
         if !self.is_proc {
             return false;
         }
-        let body_ir = crate::lowering::lower_to_ir_with_config(
-            body_text,
-            self.registry,
-            tcl_lexer::LexerConfig::for_profile(self.registry.profile()),
-        );
+        let body_ir =
+            crate::lowering::lower_to_ir_with_config(body_text, self.registry, self.lexer_config());
         if !body_ir.procedures.is_empty()
             || !body_ir.methods.is_empty()
             || body_ir.top_level.statements.is_empty()
@@ -490,11 +484,8 @@ impl CodegenCtx<'_> {
         if vars.iter().any(|v| is_qualified(v) || v.contains('(')) {
             return false;
         }
-        let body_ir = crate::lowering::lower_to_ir_with_config(
-            body_text,
-            self.registry,
-            tcl_lexer::LexerConfig::for_profile(self.registry.profile()),
-        );
+        let body_ir =
+            crate::lowering::lower_to_ir_with_config(body_text, self.registry, self.lexer_config());
         if !body_ir.procedures.is_empty()
             || !body_ir.methods.is_empty()
             || body_ir.top_level.statements.is_empty()
@@ -594,11 +585,8 @@ impl CodegenCtx<'_> {
         if !self.is_proc || is_qualified(dict_var) || dict_var.contains('(') {
             return false;
         }
-        let body_ir = crate::lowering::lower_to_ir_with_config(
-            body_text,
-            self.registry,
-            tcl_lexer::LexerConfig::for_profile(self.registry.profile()),
-        );
+        let body_ir =
+            crate::lowering::lower_to_ir_with_config(body_text, self.registry, self.lexer_config());
         if !body_ir.procedures.is_empty()
             || !body_ir.methods.is_empty()
             || body_ir.top_level.statements.is_empty()
@@ -702,13 +690,7 @@ impl CodegenCtx<'_> {
         result_var: Option<&str>,
         options_var: Option<&str>,
     ) {
-        // Strip outer braces from body text.
-        let body = body_text.trim();
-        let body = if body.starts_with('{') && body.ends_with('}') {
-            &body[1..body.len() - 1]
-        } else {
-            body
-        };
+        let body = strip_body_braces(body_text);
 
         // Pre-intern result_var so it gets a lower LVT slot
         if let Some(rv) = result_var
@@ -787,6 +769,11 @@ impl CodegenCtx<'_> {
 
     /// Compile a single-command catch body inline.
     ///
+    /// The caller must have checked
+    /// [`is_single_command_body`](super::cmd_subst::is_single_command_body):
+    /// this splits `body` into *words*, so a body holding two commands would be
+    /// emitted as one bogus invocation.
+    ///
     /// Both classifications here are registry data: the
     /// `startCommand`-wrapping set is [`Traits::NEEDS_START_CMD`] and
     /// the per-command inline emitters dispatch on the spec's
@@ -794,6 +781,7 @@ impl CodegenCtx<'_> {
     /// `::`-qualified spellings (`catch {::error x}`) on the generic
     /// path, exactly as the retired raw-word `match` did.
     pub fn emit_catch_body(&mut self, body: &str) {
+        let cfg = self.lexer_config();
         let body_parts = parse_cmd_parts(body);
         if body_parts.is_empty() {
             self.push_lit("");
@@ -850,11 +838,15 @@ impl CodegenCtx<'_> {
                     self.emit_expr(&node);
                 }
             }
+            // Both bodies go to a single-command emitter, so both must be one
+            // command (`is_single_command_body`).
             Some(InlineCodegenHookId::Try)
                 if self.is_proc
                     && body_args.len() == 5
                     && body_args[1].0 == "on"
-                    && body_args[2].0 == "error" =>
+                    && body_args[2].0 == "error"
+                    && is_single_command_body(strip_body_braces(&body_args[0].0), cfg)
+                    && is_single_command_body(strip_body_braces(&body_args[4].0), cfg) =>
             {
                 let try_sc = self.fresh_label("catch_body_end");
                 self.emit_comment(
@@ -868,8 +860,12 @@ impl CodegenCtx<'_> {
                 self.seen_generic_invoke = true;
             }
             _ => {
-                // Generic command call
-                self.push_lit(body_cmd);
+                // Generic command call. The command *name* may itself be a
+                // substitution (`catch {$proc_name}` — the shape an event
+                // dispatcher uses), so it goes through the same per-word path as
+                // the arguments; pushing it as a bare literal invoked a command
+                // literally named `$proc_name`, which `catch` then swallowed.
+                self.emit_cmd_word(body_cmd, false);
                 for (arg, braced) in body_args {
                     self.emit_cmd_subst_arg(arg, *braced);
                 }
@@ -1149,6 +1145,8 @@ impl CodegenCtx<'_> {
 
     /// Compile a try/on handler body inline with `startCommand`.
     pub fn emit_try_handler_body(&mut self, body_text: &str) {
+        // Single-command only, like `emit_catch_body` — guarded at the `Try`
+        // arm that reaches `emit_try_on_error_inline`.
         let parts = parse_cmd_parts(body_text);
         if parts.is_empty() {
             self.push_lit("");
@@ -1172,7 +1170,9 @@ impl CodegenCtx<'_> {
                 self.store_var(&cmd_args[0].0);
             }
             _ => {
-                self.push_lit(cmd);
+                // The command name may be a substitution — see the same arm in
+                // [`Self::emit_catch_body`].
+                self.emit_cmd_word(cmd, false);
                 for (a, b) in cmd_args {
                     self.emit_cmd_subst_arg(a, *b);
                 }

--- a/rust/tcl-compiler/src/codegen/control_flow.rs
+++ b/rust/tcl-compiler/src/codegen/control_flow.rs
@@ -470,7 +470,7 @@ impl CodegenCtx<'_> {
     /// unless proc context, a plain-local dict var and targets, and a
     /// straight-line body whose final statement yields a value.
     pub fn emit_dict_update(&mut self, rest: &[String]) -> bool {
-        if !self.is_proc || rest.len() < 4 || !rest.len().is_multiple_of(2) {
+        if !self.compiles_locals() || rest.len() < 4 || !rest.len().is_multiple_of(2) {
             return false;
         }
         let dict_var = &rest[0];
@@ -582,7 +582,7 @@ impl CodegenCtx<'_> {
     /// final statement yields a value. The path form (`dict with d k … {body}`)
     /// is left to the runtime invoke.
     pub fn emit_dict_with(&mut self, dict_var: &str, body_text: &str) -> bool {
-        if !self.is_proc || is_qualified(dict_var) || dict_var.contains('(') {
+        if !self.compiles_locals() || is_qualified(dict_var) || dict_var.contains('(') {
             return false;
         }
         let body_ir =

--- a/rust/tcl-compiler/src/codegen/emitter/bytecoded.rs
+++ b/rust/tcl-compiler/src/codegen/emitter/bytecoded.rs
@@ -195,7 +195,7 @@ fn lset(ctx: &mut CodegenCtx, args: &[String]) -> bool {
     let indices = &args[1..args.len() - 1];
     let value = args.last().expect("args.len() >= 3");
 
-    if ctx.is_proc && !is_qualified(var_name) && !indices.is_empty() {
+    if ctx.compiles_locals() && !is_qualified(var_name) && !indices.is_empty() {
         let slot = ctx.lvt.intern(var_name);
         for idx in indices {
             ctx.emit_value_interpolated(idx);
@@ -282,13 +282,13 @@ fn dict(ctx: &mut CodegenCtx, args: &[String]) -> bool {
     // Non-proc (or qualified-var) mutating `dict` subcommand → the top-level
     // ensemble-rewrite `INVOKE_REPLACE` form (see [`dict_ensemble`]); the
     // proc-local scalar path below keeps its specialised `DICT_*` opcodes.
-    let proc_local = ctx.is_proc && !is_qualified(&rest[0]);
+    let proc_local = ctx.compiles_locals() && !is_qualified(&rest[0]);
     if !proc_local && matches!(sub, "set" | "unset" | "incr" | "append" | "lappend") {
         dict_ensemble(ctx, sub, rest);
         return true;
     }
 
-    if !ctx.is_proc || args.len() < 3 {
+    if !ctx.compiles_locals() || args.len() < 3 {
         return false;
     }
     let var_name = &rest[0];
@@ -508,7 +508,7 @@ fn array(ctx: &mut CodegenCtx, args: &[String], used_generic_invoke: &mut bool) 
         return true;
     }
 
-    if ctx.is_proc {
+    if ctx.compiles_locals() {
         return false;
     }
     match sub {
@@ -540,7 +540,7 @@ fn array(ctx: &mut CodegenCtx, args: &[String], used_generic_invoke: &mut bool) 
 /// dynamic `$…` / `[…]` reference. The shared gate for the statement-
 /// position `append`/`lappend` specialisations.
 fn is_compilable_local(ctx: &CodegenCtx, var: &str) -> bool {
-    ctx.is_proc && !is_qualified(var) && !var.starts_with('$') && !var.starts_with('[')
+    ctx.compiles_locals() && !is_qualified(var) && !var.starts_with('$') && !var.starts_with('[')
 }
 
 /// [`is_compilable_local`] restricted to a *scalar*: an `arr(k)`-shaped name is
@@ -693,7 +693,7 @@ fn lappend_cmd(ctx: &mut CodegenCtx, args: &[String]) -> bool {
 /// the bare `push ""` return in tail position). Mirrors C Tcl's
 /// `TclCompileUnsetCmd`. Toplevel falls back to the generic invoke.
 fn unset_cmd(ctx: &mut CodegenCtx, args: &[String]) -> bool {
-    if !ctx.is_proc {
+    if !ctx.compiles_locals() {
         return false;
     }
     // Leading options: `-nocomplain` clears the complain flag; `--` ends
@@ -814,7 +814,7 @@ fn concat_cmd(ctx: &mut CodegenCtx, args: &[String]) -> bool {
 /// nops (or the bare `push ""` return in tail position). Qualified/dynamic
 /// names, or top-level context, fall back to the generic invoke.
 fn global_cmd(ctx: &mut CodegenCtx, args: &[String]) -> bool {
-    if !ctx.is_proc || args.is_empty() {
+    if !ctx.compiles_locals() || args.is_empty() {
         return false;
     }
     if !args.iter().all(|n| is_compilable_scalar_local(ctx, n)) {
@@ -855,7 +855,7 @@ fn is_upvar_level(arg: &str) -> bool {
 /// must be a simple proc-local name. A dynamic level, a malformed pair
 /// count, a qualified/dynamic local, or top-level context fall back.
 fn upvar_cmd(ctx: &mut CodegenCtx, args: &[String]) -> bool {
-    if !ctx.is_proc || args.len() < 2 {
+    if !ctx.compiles_locals() || args.len() < 2 {
         return false;
     }
     let (level, pairs): (&str, &[String]) = if is_upvar_level(&args[0]) {

--- a/rust/tcl-compiler/src/codegen/emitter/bytecoded.rs
+++ b/rust/tcl-compiler/src/codegen/emitter/bytecoded.rs
@@ -543,6 +543,22 @@ fn is_compilable_local(ctx: &CodegenCtx, var: &str) -> bool {
     ctx.is_proc && !is_qualified(var) && !var.starts_with('$') && !var.starts_with('[')
 }
 
+/// [`is_compilable_local`] restricted to a *scalar*: an `arr(k)`-shaped name is
+/// rejected too.
+///
+/// The link commands (`global`, `upvar`) take this stricter gate, mirroring C's
+/// `LocalScalar` (`tclCompCmds.c` — `TclPushVarName` with `TCL_NO_ELEMENT`,
+/// which answers -1 and abandons the compile for an element-looking name). It
+/// is not a nicety: the link is the *point* at which C reports `bad variable
+/// name "…": can't create a scalar variable that looks like an array element`,
+/// and that report lives in the commands. Compiling these names to
+/// `nsupvar`/`upvar` would silently create the mislinked variable instead.
+/// `append`/`lappend`/`unset` keep the looser gate — they have real element
+/// opcodes.
+fn is_compilable_scalar_local(ctx: &CodegenCtx, var: &str) -> bool {
+    is_compilable_local(ctx, var) && split_array_ref(var).is_none()
+}
+
 /// `append varName value ...` — statement-position specialisation for a
 /// proc-local variable. A single value emits `appendScalar`/`appendArray`;
 /// multiple scalar values push all, `reverse N`, then `appendScalar; pop`
@@ -801,10 +817,7 @@ fn global_cmd(ctx: &mut CodegenCtx, args: &[String]) -> bool {
     if !ctx.is_proc || args.is_empty() {
         return false;
     }
-    if args
-        .iter()
-        .any(|n| is_qualified(n) || n.starts_with('$') || n.starts_with('['))
-    {
+    if !args.iter().all(|n| is_compilable_scalar_local(ctx, n)) {
         return false;
     }
     ctx.push_lit("::");
@@ -853,10 +866,10 @@ fn upvar_cmd(ctx: &mut CodegenCtx, args: &[String]) -> bool {
     if pairs.is_empty() || pairs.len() % 2 != 0 {
         return false;
     }
-    // Every `local` (the odd-indexed words) must be a simple compiled local.
+    // Every `local` (the odd-indexed words) must be a simple compiled *scalar*
+    // local. The `other` side may legally be an element (`upvar 0 arr(k) v`).
     for pair in pairs.as_chunks::<2>().0 {
-        let local = &pair[1];
-        if is_qualified(local) || local.starts_with('$') || local.starts_with('[') {
+        if !is_compilable_scalar_local(ctx, &pair[1]) {
             return false;
         }
     }

--- a/rust/tcl-compiler/src/codegen/emitter/generate.rs
+++ b/rust/tcl-compiler/src/codegen/emitter/generate.rs
@@ -837,6 +837,7 @@ fn finalize_function(
         labels,
         loop_targets,
         body_base_line: 0,
+        proc_body_src: None,
         error_regions,
     }
 }

--- a/rust/tcl-compiler/src/codegen/emitter/generate.rs
+++ b/rust/tcl-compiler/src/codegen/emitter/generate.rs
@@ -856,6 +856,19 @@ pub fn generate(ctx: &mut CodegenCtx, cfg: &CfgFunction, proc_defs: &[IrProcedur
     let mut state = GenerateState::new(proc_defs);
     state.try_finally_info = detect_try_finally(cfg, &block_order);
 
+    // The same-frame script bodies folded into this function, so the variable
+    // emitters can decline the compiled-local forms inside them
+    // (`CodegenCtx::compiles_locals`). Same regions the `errorInfo` body frames
+    // are built from at the end of this function.
+    ctx.same_frame_eval_spans = cfg
+        .inline_body_error_sites
+        .iter()
+        .filter(|site| {
+            site.context == tcl_registry::InlineBodyErrorContext::SameFrameScriptEvaluation
+        })
+        .map(|site| (site.span.start(), site.span.end()))
+        .collect();
+
     let fe = setup_foreach(ctx, cfg, &mut loop_ctx);
 
     // Mark try_end/try_finally/try_after_finally as skipped — they

--- a/rust/tcl-compiler/src/codegen/emitter/mod.rs
+++ b/rust/tcl-compiler/src/codegen/emitter/mod.rs
@@ -195,6 +195,12 @@ pub fn codegen_module(
         command_bindings: &command_bindings,
     };
     let top = codegen_function_src(&cfg_module.top_level, &[], false, &[], &module, 0);
+    // The same top level as a *procedure body*. A body compiled at run time
+    // (`proc` on a cache miss, an `apply` lambda, a method) reaches the
+    // compiler as a bare script, so without this it would run script-shaped and
+    // lose every `is_proc` specialisation its AOT-compiled twin gets — see
+    // [`ModuleAsm::top_level_body`].
+    let top_body = codegen_function_src(&cfg_module.top_level, &[], true, &[], &module, 0);
     let mut procs: HashMap<String, FunctionAsm> = HashMap::new();
     for (qname, cfg_func) in &cfg_module.procedures {
         let ir_proc = ir_module.procedures.get(qname);
@@ -216,14 +222,24 @@ pub fn codegen_module(
                 .line
                 .saturating_add(1)
         });
-        procs.insert(
-            qname.clone(),
-            codegen_function_src(cfg_func, &params, true, &[], &module, base_line),
-        );
+        let mut asm = codegen_function_src(cfg_func, &params, true, &[], &module, base_line);
+        // The body word this assembly was compiled from, so a runtime consumer
+        // keyed by name can tell it apart from another `proc` of the same name
+        // (see `FunctionAsm::proc_body_src`). Recorded as the word *value*, not
+        // as the source text: lowering keeps the written word, but the value a
+        // runtime `proc` is handed has had the one substitution braces permit
+        // applied — a `\<newline>` continuation folded to a space — and the
+        // comparison is against that. Without the fold, every body holding a
+        // continuation missed.
+        asm.proc_body_src = ir_proc
+            .and_then(|p| p.body_source.as_deref())
+            .map(|body| module.word_rules.collapse_braced_word(body).into_owned());
+        procs.insert(qname.clone(), asm);
     }
     ModuleAsm {
         profile: emit_profile(dialect).unwrap_or_else(tcl_dialect::DialectProfile::plain_tcl),
         top_level: top,
+        top_level_body: top_body,
         procedures: procs,
     }
 }

--- a/rust/tcl-compiler/src/codegen/emitter/terminator.rs
+++ b/rust/tcl-compiler/src/codegen/emitter/terminator.rs
@@ -31,6 +31,7 @@
 use crate::cfg::{Function as CfgFunction, Terminator};
 use crate::expr_ast::ExprNode;
 
+use super::super::cmd_subst::is_pure_cmd_subst;
 use super::super::{CodegenCtx, Op, Operand};
 use super::ordering::fold_const_branch;
 
@@ -193,7 +194,12 @@ impl CodegenCtx<'_> {
         // Stamp the return's source span onto its instructions.
         self.current_span = term.span();
         let val = value.as_deref().unwrap_or("");
-        let is_cmd_subst = expr.is_none() && val.starts_with('[') && val.ends_with(']');
+        // The *whole* value must be one balanced `[…]`: the inline emitter
+        // strips the outer brackets and word-splits what is left, so a value
+        // that merely begins and ends with a bracket (`[llength $a]:[join $a ,]`
+        // — a three-part concatenation) would be mangled into a single bogus
+        // command. `is_pure_cmd_subst` matches the bracket, not the ends.
+        let is_cmd_subst = expr.is_none() && is_pure_cmd_subst(val);
         let is_final = next_block.is_none();
 
         // startCommand count: 2 when return wraps [expr {...}]

--- a/rust/tcl-compiler/src/codegen/mod.rs
+++ b/rust/tcl-compiler/src/codegen/mod.rs
@@ -306,6 +306,14 @@ impl<'r> CodegenCtx<'r> {
         }
     }
 
+    /// The compile's own lexer config — the dialect grammar every nested
+    /// re-lex in codegen (a re-lowered body, a segmented catch body) must use,
+    /// rather than the default grammar.
+    #[must_use]
+    pub fn lexer_config(&self) -> tcl_lexer::LexerConfig {
+        tcl_lexer::LexerConfig::for_profile(self.registry.profile())
+    }
+
     /// Set the module source text (see [`Self::source`]) so emitted instructions
     /// carry their command's surface text for `errorInfo`.
     pub fn set_source(&mut self, source: &str) {
@@ -451,6 +459,7 @@ impl<'r> CodegenCtx<'r> {
             labels,
             loop_targets: HashMap::new(),
             body_base_line: 0,
+            proc_body_src: None,
             error_regions: Vec::new(),
         }
     }

--- a/rust/tcl-compiler/src/codegen/mod.rs
+++ b/rust/tcl-compiler/src/codegen/mod.rs
@@ -166,7 +166,21 @@ pub struct CodegenCtx<'r> {
     /// Monotonic counter for generating unique label names.
     label_counter: u32,
     /// Whether we are compiling a proc body (affects LVT vs stack ops).
+    ///
+    /// This is the *function's* shape. It is not the same question as "may a
+    /// variable here be addressed as a compiled local" — see
+    /// [`Self::compiles_locals`].
     pub is_proc: bool,
+    /// Source spans of the same-frame script bodies this function folded into
+    /// its own instruction stream (`eval {…}`), from the CFG's
+    /// `inline_body_error_sites`.
+    ///
+    /// The fold is this compiler's optimisation; C has no `eval` compiler, so
+    /// the script becomes its own unit whose variables are *not* the enclosing
+    /// proc's compiled locals. Codegen therefore keeps the dispatched variable
+    /// forms inside these spans, which is what makes an in-proc
+    /// `eval {lappend l z}` fire the `read` C fires.
+    pub(crate) same_frame_eval_spans: Vec<(u32, u32)>,
     /// Command index for `startCommand` numbering.
     pub cmd_index: u32,
     /// End label for the current `startCommand` (paired by `end_command`).
@@ -284,6 +298,7 @@ impl<'r> CodegenCtx<'r> {
             label_positions: HashMap::new(),
             label_counter: 0,
             is_proc,
+            same_frame_eval_spans: Vec::new(),
             cmd_index: 0,
             start_cmd_end_label: None,
             break_target: None,
@@ -304,6 +319,31 @@ impl<'r> CodegenCtx<'r> {
             line_index: None,
             cmd_arg_braced: Vec::new(),
         }
+    }
+
+    /// Whether a variable named here may be addressed as a *compiled local* of
+    /// this function.
+    ///
+    /// A proc body's variables are its frame's locals — except inside a
+    /// same-frame script body this compiler folded in
+    /// ([`Self::same_frame_eval_spans`]), which C compiles as a separate unit
+    /// with no access to the enclosing proc's local table. Every emitter that
+    /// chooses between a slot form and its dispatched `*Stk` sibling asks this,
+    /// not [`Self::is_proc`].
+    #[must_use]
+    pub fn compiles_locals(&self) -> bool {
+        self.is_proc && !self.inside_same_frame_eval()
+    }
+
+    /// Whether the statement being emitted lies inside a folded same-frame
+    /// script body. Matched by source containment, exactly as the executor
+    /// matches an instruction to its [`tcl_bytecode::ErrorRegion`].
+    fn inside_same_frame_eval(&self) -> bool {
+        self.current_span.is_some_and(|span| {
+            self.same_frame_eval_spans
+                .iter()
+                .any(|(start, end)| span.start() >= *start && span.end() <= *end)
+        })
     }
 
     /// The compile's own lexer config — the dialect grammar every nested

--- a/rust/tcl-compiler/src/codegen/statements.rs
+++ b/rust/tcl-compiler/src/codegen/statements.rs
@@ -24,7 +24,7 @@
 
 use crate::ir::Statement;
 
-use super::cmd_subst::{has_command_separator, parse_cmd_parts};
+use super::cmd_subst::{has_command_separator, is_pure_cmd_subst, parse_cmd_parts};
 use super::helpers::{SubstPart, parse_subst_template};
 use super::values::{is_qualified, needs_stk_var_ref, parse_simple_var_ref, split_array_ref};
 use super::{CodegenCtx, Op, Operand};
@@ -632,8 +632,11 @@ impl CodegenCtx<'_> {
     /// keep the literal + `subst_word` path, which the inline command-parser
     /// cannot match on escaped brackets.
     fn assign_value_inlines_cmd_subst(value: &str) -> bool {
-        value.starts_with('[')
-            && value.ends_with(']')
+        // `is_pure_cmd_subst`, not "starts and ends with a bracket": the inline
+        // emitter strips the outer brackets and word-splits the rest, so
+        // `set r [llength $a]:[join $a ,]` — three concatenated parts — would
+        // be mangled into one bogus command.
+        is_pure_cmd_subst(value)
             && value.len() > 2
             && value[1..value.len() - 1].contains(' ')
             && !value.starts_with("[list ")

--- a/rust/tcl-compiler/src/codegen/statements.rs
+++ b/rust/tcl-compiler/src/codegen/statements.rs
@@ -233,7 +233,7 @@ impl CodegenCtx<'_> {
             } => {
                 let target = self.store_target(name, *name_braced);
                 let name = target.name.as_str();
-                if needs_stk_var_ref(name, self.is_proc) {
+                if needs_stk_var_ref(name, self.compiles_locals()) {
                     self.push_var_ref(name, target.key_is_literal);
                 }
                 // A constant value is verbatim: push it as-is so the VM does
@@ -269,9 +269,9 @@ impl CodegenCtx<'_> {
                 let inline = Self::assign_value_inlines_cmd_subst(&value);
                 let target = self.store_target(name, *name_braced);
                 let name = target.name.as_str();
-                if needs_stk_var_ref(name, self.is_proc) {
+                if needs_stk_var_ref(name, self.compiles_locals()) {
                     self.push_var_ref(name, target.key_is_literal);
-                } else if inline && self.is_proc && !is_qualified(name) {
+                } else if inline && self.compiles_locals() && !is_qualified(name) {
                     // Pre-intern the target so it gets a lower LVT slot than any
                     // variable introduced inside the substitution (catch result
                     // var, etc.) — matches tclsh slot order.
@@ -294,7 +294,7 @@ impl CodegenCtx<'_> {
             } => {
                 let target = self.store_target(name, *name_braced);
                 let name = target.name.as_str();
-                if needs_stk_var_ref(name, self.is_proc) {
+                if needs_stk_var_ref(name, self.compiles_locals()) {
                     self.push_var_ref(name, target.key_is_literal);
                 }
                 let inner_end = self.fresh_label("cmd_end");
@@ -717,7 +717,7 @@ impl CodegenCtx<'_> {
         };
         // In a proc the base is the LVT slot `store_var` names; only the key
         // goes on the stack.
-        if !self.is_proc || is_qualified(name) {
+        if !self.compiles_locals() || is_qualified(name) {
             self.push_lit_exact(base);
         }
         if key_is_literal {

--- a/rust/tcl-compiler/src/codegen/values.rs
+++ b/rust/tcl-compiler/src/codegen/values.rs
@@ -304,9 +304,13 @@ pub fn is_qualified(name: &str) -> bool {
 
 /// True when a store/load needs the name/key pushed onto the stack
 /// first (i.e. uses `*Stk` instructions).
+///
+/// `compiles_locals` is [`CodegenCtx::compiles_locals`], not
+/// [`CodegenCtx::is_proc`]: a name inside a folded same-frame `eval` body is
+/// not a compiled local even though the enclosing function is a proc.
 #[must_use]
-pub fn needs_stk_var_ref(name: &str, is_proc: bool) -> bool {
-    if !is_proc {
+pub fn needs_stk_var_ref(name: &str, compiles_locals: bool) -> bool {
+    if !compiles_locals {
         return true;
     }
     if is_qualified(name) {
@@ -414,7 +418,7 @@ impl CodegenCtx<'_> {
     /// Proc context uses LVT-based opcodes; top-level uses stack-based.
     /// Array references are decomposed into base + element.
     pub fn load_var(&mut self, name: &str) {
-        if self.is_proc && !is_qualified(name) {
+        if self.compiles_locals() && !is_qualified(name) {
             if let Some((base, elem)) = split_array_ref(name) {
                 let slot = self.lvt.intern(base);
                 self.push_array_key(elem);
@@ -465,7 +469,7 @@ impl CodegenCtx<'_> {
     /// `storeScalar1`/`storeArray1`.  For top-level, caller must have
     /// pushed name (and key for arrays) before the value.
     pub fn store_var(&mut self, name: &str) {
-        if self.is_proc && !is_qualified(name) {
+        if self.compiles_locals() && !is_qualified(name) {
             if let Some((base, _elem)) = split_array_ref(name) {
                 let slot = self.lvt.intern(base);
                 self.emit_comment(
@@ -504,7 +508,7 @@ impl CodegenCtx<'_> {
     /// [`push_var_ref`](CodegenCtx::push_var_ref) documents, so a name the
     /// compiler already resolved is never word-substituted again by the VM.
     pub fn emit_incr(&mut self, name: &str, key_is_literal: bool, amount: Option<&str>) {
-        if self.is_proc && !is_qualified(name) {
+        if self.compiles_locals() && !is_qualified(name) {
             self.emit_incr_local(name, amount);
         } else {
             self.emit_incr_global_or_array(name, key_is_literal, amount);

--- a/rust/tcl-compiler/tests/codegen.rs
+++ b/rust/tcl-compiler/tests/codegen.rs
@@ -2122,3 +2122,65 @@ fn the_fold_gate_holds_through_the_simplified_value_emitter() {
         "`lset`'s value word must keep the real `dict create` call: {deleted:?}"
     );
 }
+
+// -- the unit's two top-level shapes --------------------------------------
+
+/// Every compiled unit carries its top level twice: as a *script* and as a
+/// *procedure body*.
+///
+/// A body compiled at run time — `proc`'s body when the pre-compiled entry
+/// misses, an `apply` lambda, a `TclOO` method — reaches the compiler as a bare
+/// script, so without the second shape it would run with the dispatched `*Stk`
+/// variable forms while an AOT-compiled proc of the same source ran the
+/// specialised ones. The two must be the *same* source compiled two ways, not
+/// two different programs.
+#[test]
+fn a_unit_carries_its_top_level_as_a_script_and_as_a_proc_body() {
+    let m = asm_for("set x 1\nincr x\nlappend l $x\nunset x\n");
+
+    let script = opcodes(&m.top_level);
+    assert!(
+        script.contains(&Op::STORE_STK) && !script.contains(&Op::STORE_SCALAR1),
+        "the script shape reaches variables through the stack forms: {script:?}"
+    );
+
+    let body = opcodes(&m.top_level_body);
+    for op in [
+        Op::STORE_SCALAR1,
+        Op::INCR_SCALAR1_IMM,
+        Op::LAPPEND_SCALAR1,
+        Op::UNSET_SCALAR,
+    ] {
+        assert!(
+            body.contains(&op),
+            "the body shape must use {}: {body:?}",
+            op.mnemonic()
+        );
+    }
+}
+
+/// The body shape is emitted exactly as an entry in `procedures` is, so a proc
+/// whose body the compiler *did* pre-compile and one that has to be compiled
+/// from its body word at run time run the same instructions.
+#[test]
+fn the_body_shape_matches_the_same_source_compiled_as_a_procedure() {
+    let body_src = "set t 0\nincr t 2\nlappend acc $t\nreturn $t\n";
+    let as_proc = opcodes(&proc_asm(&format!("proc p {{}} {{{body_src}}}"), "::p"));
+    let as_body = opcodes(&asm_for(body_src).top_level_body);
+    assert_eq!(as_proc, as_body);
+}
+
+/// A procedure's assembly records the body word it was compiled from, so a
+/// consumer keyed by *name* can tell it apart from another `proc` of the same
+/// name — the two arms of an `if`, a redefinition, a second `eval`.
+#[test]
+fn a_procedure_records_the_body_word_it_was_compiled_from() {
+    let m = asm_for("proc p {} {return A}\nproc q {} {}\n");
+    assert_eq!(
+        m.procedures["::p"].proc_body_src.as_deref(),
+        Some("return A")
+    );
+    assert_eq!(m.procedures["::q"].proc_body_src.as_deref(), Some(""));
+    assert_eq!(m.top_level.proc_body_src, None);
+    assert_eq!(m.top_level_body.proc_body_src, None);
+}

--- a/rust/tcl-vm/src/cmd_coro.rs
+++ b/rust/tcl-vm/src/cmd_coro.rs
@@ -242,7 +242,9 @@ fn cmd_coroutine(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     // quoting preserves the words exactly), dispatched through the compiled
     // `INVOKE` path so a proc call stays on the coroutine's explicit stack.
     let body_src = Value::list(words).to_str();
-    let Some(body) = vm.compile_dynamic_body(&body_src) else {
+    // A *script*, not a proc body: the wrapper runs as the coroutine's own
+    // top-level activation, not through a call frame of its own.
+    let Some(body) = vm.compile_dynamic_script(&body_src) else {
         if let Some(p) = &temp_proc {
             vm.take_command_unchecked(p);
         }

--- a/rust/tcl-vm/src/command.rs
+++ b/rust/tcl-vm/src/command.rs
@@ -1301,10 +1301,18 @@ fn cmd_proc(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     // bare proc name resolves against the current namespace, so two procs that
     // share an unqualified name in different namespaces (`::a::p` vs `::b::p`)
     // must not collide on one cached body — keying by `reg_name` keeps them
-    // distinct. Global procs (`reg_name == ::name`) still hit the compiler's
-    // `::name`-keyed entry; namespaced bodies the compiler globalised under
-    // `::name` simply miss and recompile via `compile_dynamic_body`.
-    let body_key = reg_name.clone();
+    // distinct.
+    //
+    // The cache is filled from `ModuleAsm::procedures`, whose keys are the
+    // compiler's **rooted** qnames (`::p`, `::a::p`), while `qualify_name`
+    // answers the unrooted command key (`p`, `a::p`) every other command table
+    // in this interpreter is keyed by. Root the lookup rather than unrooting
+    // the merge: `module_procs` mirrors a compiler artefact, and the two
+    // spellings must not be allowed to collide in it. Missing the root here
+    // meant *every* proc missed its pre-compiled body and silently recompiled
+    // as a top-level script, so no proc body anywhere ran with `is_proc`
+    // codegen.
+    let body_key = format!("::{reg_name}");
     // `reg_name` is canonical (single `::`s); the shared qualifier split keeps
     // the namespace correct for colon-run sources too (`proc foo:::baz` in an
     // existing `foo` defines `::foo::baz`, tclsh8.6-verified — the old
@@ -1324,16 +1332,22 @@ fn cmd_proc(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
         Ok(p) => p,
         Err(e) => return err(e),
     };
-    // The pre-compiled `module_procs` cache is keyed by name, and the compiler
-    // keeps only the *first* definition of a name, so it is stale for a
-    // *redefinition* (`proc p {} …` then `proc p {bar} …` — common in test
-    // suites). A redefinition therefore compiles the body actually supplied to
-    // this call; the first definition keeps the pre-compiled fast path (so
-    // loading a library does not recompile every proc body).
+    // The pre-compiled `module_procs` cache is keyed by name, and one name is
+    // reachable from several `proc` commands with different bodies — a
+    // redefinition (`proc p {} …` then `proc p {bar} …`, common in test
+    // suites), the two arms of an `if`, a second `eval` after a `rename` —
+    // while a compiled unit records only the first. Take the cached assembly
+    // only when its body word is *exactly* the one supplied here; anything
+    // else compiles the body actually given. Matching on the text rather than
+    // on "is this the first definition?" is what makes the fast path sound:
+    // the alternative silently runs a body the script never asked for.
+    //
+    // A body built by substitution (`proc p {} "return $x"`) never matches,
+    // since the compiler recorded the unsubstituted word — it simply misses.
     let body_str = body_text.to_str();
-    let pre = (!vm.is_proc_defined(&reg_name))
-        .then(|| vm.module_proc(&body_key))
-        .flatten();
+    let pre = vm
+        .module_proc(&body_key)
+        .filter(|asm| asm.proc_body_src.as_deref() == Some(&*body_str));
     let body = match pre {
         Some(b) => b,
         None => match vm.compile_dynamic_body(&body_str) {

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -871,7 +871,10 @@ pub struct InterpState {
     /// a similarly named command. The registry decides when this table applies;
     /// this map merely retains the registered implementation.
     fixed_math_builtins: HashMap<String, BuiltinFn>,
-    /// Pre-compiled proc bodies from the module(s), keyed by qualified name.
+    /// Pre-compiled proc bodies from the module(s). Unlike every other table
+    /// here, this one mirrors a compiler artefact and is keyed the compiler's
+    /// way — `ModuleAsm::procedures`' **rooted** qnames (`::p`, `::a::p`) —
+    /// not the unrooted command key. `cmd_proc` roots its lookup to match.
     module_procs: HashMap<String, Rc<FunctionAsm>>,
     /// Current-namespace stack (canonical, no leading `::`; `""` = global). The
     /// top governs `proc`/command/variable name resolution. `namespace eval`
@@ -7141,12 +7144,37 @@ impl Vm {
         self.module_procs.get(qname).cloned()
     }
 
-    /// Compile a proc body at runtime (for `proc` with a dynamically-built
-    /// body that wasn't pre-compiled into a module). The body is compiled as a
-    /// script; its parameters resolve through the call frame (`loadStk`), so a
-    /// top-level compilation runs correctly as a proc body. Any procs the body
-    /// itself defines are merged into the registry.
+    /// Compile a **script** at runtime — a unit that is entered the way the
+    /// top level of a file is, not through a call frame of its own (the
+    /// `coroutine` wrapper). Any procs the script itself defines are merged
+    /// into the pre-compiled body cache.
+    pub(crate) fn compile_dynamic_script(&mut self, src: &str) -> Option<Rc<FunctionAsm>> {
+        self.compile_dynamic(src, |module| module.top_level)
+    }
+
+    /// Compile a **body** at runtime — a `proc` body the compiler did not
+    /// pre-compile, an `apply` lambda, a `TclOO` method — as a *procedure*
+    /// rather than as a top-level script.
+    ///
+    /// The shape is not cosmetic. A script-shaped body reaches every variable
+    /// through the dispatched `*Stk` forms, so it never executes the
+    /// specialised arms (`STORE_SCALAR1`, `INCR_SCALAR1`,
+    /// `LAPPEND_{SCALAR,ARRAY}`, the compiled `unset`) an AOT-compiled proc
+    /// body runs — and those arms carry semantics of their own, so the same
+    /// source would observe different variable traces depending only on
+    /// whether the compiler happened to pre-compile it. See
+    /// [`ModuleAsm::top_level_body`](tcl_bytecode::ModuleAsm::top_level_body).
     pub(crate) fn compile_dynamic_body(&mut self, src: &str) -> Option<Rc<FunctionAsm>> {
+        self.compile_dynamic(src, |module| module.top_level_body)
+    }
+
+    /// Compile `src` for the interpreter's current profile and take one of the
+    /// module's two top-level shapes, merging any procs it defines.
+    fn compile_dynamic(
+        &mut self,
+        src: &str,
+        shape: fn(ModuleAsm) -> FunctionAsm,
+    ) -> Option<Rc<FunctionAsm>> {
         let module = self
             .compiler
             .as_ref()?
@@ -7154,7 +7182,7 @@ impl Vm {
             .ok()?;
         self.validate_module_profile(&module).ok()?;
         self.merge_procs(&module.procedures);
-        Some(Rc::new(module.top_level))
+        Some(Rc::new(shape(module)))
     }
 
     /// Enforce the bytecode artifact's exact profile at every consumption
@@ -7217,7 +7245,11 @@ impl Vm {
         }
         self.merge_procs(&module.procedures);
         let mut fresh = (*proc).clone();
-        fresh.body = Rc::new(module.top_level);
+        // A proc body, not a script: keep the recompile on the same shape the
+        // definition-time compile produced (see [`Self::compile_dynamic_body`]),
+        // so crossing a trace-deopt or profile generation cannot silently
+        // demote a body out of its `is_proc` forms.
+        fresh.body = Rc::new(module.top_level_body);
         fresh.compiled_epoch = want_epoch;
         fresh.compiled_profile_generation = want_profile;
         Rc::new(fresh)
@@ -7567,12 +7599,6 @@ impl Vm {
             Some(Command::Proc(p)) => Some(p),
             _ => None,
         }
-    }
-
-    /// Whether `name` is already a defined user proc — distinguishes a `proc`
-    /// redefinition (which must recompile its body) from a first definition.
-    pub(crate) fn is_proc_defined(&self, name: &str) -> bool {
-        matches!(self.lookup_command(name), Some(Command::Proc(_)))
     }
 
     /// The invocation argv of the frame at absolute `level` (`info level N`).

--- a/rust/tcl-vm/tests/command_traces_e2e.rs
+++ b/rust/tcl-vm/tests/command_traces_e2e.rs
@@ -25,6 +25,11 @@
 //! traces, `{cmd-string op}` / `{cmd-string code result op}` argument forms,
 //! an enter-trace error aborting the command, a leave-trace error replacing
 //! its result, traces following `rename`, and redefinition firing `delete`.
+//!
+//! The table also carries the *variable*-trace shapes that depend on which
+//! opcode a command compiled to — the operation set an in-proc `lappend` or
+//! `unset` reports — since this is the file that owns the differential harness
+//! those shapes have to be pinned against.
 
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -657,6 +662,39 @@ const VECTORS: &[Vector] = &[
                delqux delete\n\
                hi\n\
                0",
+    },
+    // Which *operations* a variable trace sees depends on the opcode the
+    // command compiled to, and inside a procedure body that is the specialised
+    // form. C's `INST_LAPPEND_{SCALAR,ARRAY}` read the old value without
+    // `TCL_TRACE_READS` (`tclExecute.c`), so a single-value `lappend` fires
+    // `write` alone. C's `INST_UNSET_ARRAY` passes a two-part access, so the
+    // callback is told `name1 = a`, `name2 = k`, not `name1 = a(k)`.
+    //
+    // Every proc body used to be compiled as a top-level *script*, so none of
+    // those arms ever ran and this vector could not have been written.
+    Vector {
+        name: "in-proc lappend/unset report the operations the compiled forms report",
+        script: "proc log {n1 n2 op} { puts \"$op|$n1|$n2\" }\n\
+                 proc p {} {\n\
+                     set l {a b}\n\
+                     trace add variable l {read write} log\n\
+                     lappend l z\n\
+                     trace remove variable l {read write} log\n\
+                     array set arr {k {1 2}}\n\
+                     trace add variable arr {read write} log\n\
+                     lappend arr(k) z\n\
+                     trace remove variable arr {read write} log\n\
+                     set a(k) 1\n\
+                     trace add variable a {read write unset} log\n\
+                     unset a(k)\n\
+                     trace remove variable a {read write unset} log\n\
+                     return \"$l|$arr(k)\"\n\
+                 }\n\
+                 puts [p]\n",
+        want: "write|l|\n\
+               write|arr|k\n\
+               unset|a|k\n\
+               a b z|1 2 z",
     },
 ];
 

--- a/rust/tcl-vm/tests/opcode_c_parity.rs
+++ b/rust/tcl-vm/tests/opcode_c_parity.rs
@@ -91,6 +91,7 @@ impl Asm {
             labels: resolved,
             loop_targets: HashMap::new(),
             body_base_line: 0,
+            proc_body_src: None,
             error_regions: Vec::new(),
         }
     }
@@ -1119,26 +1120,35 @@ fn irule_operators_agree_with_the_core_commands() {
 
 // -- yield / yieldToInvoke / coroName ----------------------------------------
 
+/// The body text the seeded assembly stands in for — the cache is keyed by name
+/// *and* body word, so the seed must claim the same text the `proc` supplies.
+const SEEDED_BODY: &str = "this body is replaced by the seeded one";
+
 /// Run `body` as the compiled body of a global proc `p`.
 ///
 /// The seam is the pre-compiled-body cache: `cmd_proc` takes the module-supplied
-/// assembly for the first definition of a name, so seeding `p` here (under the
-/// VM's own registration key — `p`, unrooted) and then defining it from source
-/// gives a proc whose body is this hand-built stream. That is the only way to
-/// reach an opcode from *inside* a coroutine or a method call, which is where the
-/// coroutine and `TclOO` opcodes live.
+/// assembly for a `proc` whose name *and* body word match the compiled unit's,
+/// so seeding `p` here — under the compiler's own qname for a global proc
+/// (`::p`, rooted, the spelling `ModuleAsm::procedures` uses) and claiming
+/// [`SEEDED_BODY`] as the body it was compiled from — and then defining `p` from
+/// that exact source gives a proc whose body is this hand-built stream. That is
+/// the only way to reach an opcode from *inside* a coroutine or a method call,
+/// which is where the coroutine and `TclOO` opcodes live.
 fn vm_with_seeded_proc(body: Asm) -> Vm {
+    let mut seeded = body.build();
+    seeded.proc_body_src = Some(SEEDED_BODY.to_owned());
     let mut procedures = HashMap::new();
-    procedures.insert("p".to_string(), body.build());
+    procedures.insert("::p".to_string(), seeded);
     let module = ModuleAsm {
         profile: tcl_dialect::DialectProfile::plain_tcl(),
         top_level: Asm::new().build(),
+        top_level_body: tcl_bytecode::FunctionAsm::default(),
         procedures,
     };
     let mut vm = Vm::new();
     vm.set_compiler(Box::new(compiler::svc()));
     assert_eq!(vm.run_module(&module).code, Code::Ok, "seeding failed");
-    vm.eval_source("proc p {} {this body is replaced by the seeded one}")
+    vm.eval_source(&format!("proc p {{}} {{{SEEDED_BODY}}}"))
         .expect("proc defines");
     vm
 }

--- a/rust/tcl-vm/tests/opcode_catch_parity.rs
+++ b/rust/tcl-vm/tests/opcode_catch_parity.rs
@@ -86,6 +86,7 @@ fn assemble(
         labels: label_offsets,
         loop_targets: HashMap::new(),
         body_base_line: 0,
+        proc_body_src: None,
         error_regions: Vec::new(),
     }
 }

--- a/rust/tcl-vm/tests/opcode_dispatch_coverage.rs
+++ b/rust/tcl-vm/tests/opcode_dispatch_coverage.rs
@@ -96,6 +96,7 @@ impl Asm {
             labels: resolved,
             loop_targets: HashMap::new(),
             body_base_line: 0,
+            proc_body_src: None,
             error_regions: Vec::new(),
         }
     }

--- a/rust/tcl-vm/tests/run_script.rs
+++ b/rust/tcl-vm/tests/run_script.rs
@@ -1943,6 +1943,81 @@ fn an_inlined_catch_body_substitutes_its_command_name() {
     );
 }
 
+/// The inline `catch` needs a body it can *see*: a braced word holding exactly
+/// one command, and nothing else.
+///
+/// Three ways a body defeats the word splitter that the segment count alone
+/// does not catch. An unbraced body (`catch $script`) only *names* a script —
+/// its commands are not known until run time, so compiling it as one command
+/// invoked the whole script value as a command name. A trailing separator
+/// (`{error boom;}`) and a leading comment (`{# note\nerror boom}`) each still
+/// segment to one command, but the splitter reads `boom;` as an argument and
+/// `#` as a command name. All three now take the dispatched `catch`.
+#[test]
+fn the_inline_catch_needs_a_braced_body_that_is_only_one_command() {
+    // A dynamic body, single- and multi-command alike.
+    assert_eq!(
+        run(
+            "proc p {} { set s {set x 1; set x 2}; set c [catch $s m]; return \"$c/$m\" }\n\
+             puts [p]"
+        )
+        .2,
+        "0/2\n"
+    );
+    assert_eq!(
+        run("proc p {} { set s {set x 9}; set c [catch $s m]; return \"$c/$m\" }\nputs [p]").2,
+        "0/9\n"
+    );
+    // A trailing `;` is a separator, not part of the argument.
+    assert_eq!(
+        run("proc p {} { set c [catch {error boom;} m]; return \"$c/$m\" }\nputs [p]").2,
+        "1/boom\n"
+    );
+    // A leading comment is not the command.
+    assert_eq!(
+        run("proc p {} { set c [catch {# note\nerror boom} m]; return \"$c/$m\" }\nputs [p]").2,
+        "1/boom\n"
+    );
+}
+
+/// A `{*}`-expanded word inside an inlined `catch` body still expands.
+///
+/// The single-command emitters split with `parse_cmd_parts`, which has no
+/// expansion form and reads the `{*}` prefix as a braced word — so
+/// `catch {cfg {*}$a}` called `cfg * {-verbose b}`. That is how `tcltest`'s
+/// option parser came to report `ambiguous option *`.
+#[test]
+fn an_inlined_catch_body_expands_a_star_word() {
+    assert_eq!(
+        run("proc cfg {args} { return \"[llength $args]:$args\" }\n\
+             proc p {} { set a {-verbose b}; set c [catch {cfg {*}$a} m]; return \"$c/$m\" }\n\
+             puts [p]")
+        .2,
+        "0/2:-verbose b\n"
+    );
+    assert_eq!(
+        run("proc cfg {args} { return \"[llength $args]:$args\" }\n\
+             proc p {} { set a {x y}; set c [catch {cfg {*}$a extra} m]; return \"$c/$m\" }\n\
+             puts [p]")
+        .2,
+        "0/3:x y extra\n"
+    );
+}
+
+/// The body word reaching the inline emitter is already the `catch` argument's
+/// *value*, so the braces still in it belong to the script.
+///
+/// `[catch {{set x 1}} m]` runs the one-word command `set x 1` and catches
+/// `invalid command name`; stripping a second brace layer compiled a
+/// successful `set` instead.
+#[test]
+fn an_inlined_catch_body_keeps_the_braces_that_belong_to_its_script() {
+    assert_eq!(
+        run("proc p {} { set c [catch {{set x 1}} m]; return \"$c/$m\" }\nputs [p]").2,
+        "1/invalid command name \"set x 1\"\n"
+    );
+}
+
 /// A braced word inside an inlined command substitution is already the finished
 /// value, so it is pushed verbatim: the VM's word substitution would otherwise
 /// read a value that merely looks like a braced word as one and strip a brace

--- a/rust/tcl-vm/tests/run_script.rs
+++ b/rust/tcl-vm/tests/run_script.rs
@@ -1237,11 +1237,13 @@ fn run_asm(literals: &[&str], instrs: Vec<tcl_bytecode::Instruction>) -> String 
         labels,
         loop_targets: std::collections::HashMap::new(),
         body_base_line: 0,
+        proc_body_src: None,
         error_regions: Vec::new(),
     };
     let module = ModuleAsm {
         profile: tcl_dialect::DialectProfile::plain_tcl(),
         top_level: top,
+        top_level_body: FunctionAsm::default(),
         procedures: std::collections::HashMap::new(),
     };
     let mut vm = Vm::new();
@@ -1761,5 +1763,214 @@ fn inline_cmd_subst_review_fixes() {
     assert_eq!(
         run("set x [set y 1; concat a {*}{b c}]; puts $x").2,
         "a b c\n"
+    );
+}
+
+// -- the pre-compiled proc-body cache -------------------------------------
+
+/// Build a VM whose pre-compiled body cache holds one entry: a hand-built
+/// assembly returning `marker`, filed under `qname` — the compiler's **rooted**
+/// spelling — and claiming `body_src` as the body word it was compiled from.
+fn vm_with_cached_body(qname: &str, body_src: &str, marker: &str) -> Vm {
+    use tcl_bytecode::{FunctionAsm, Instruction, LiteralTable, LocalVarTable, ModuleAsm, Op};
+
+    let mut literals = LiteralTable::new();
+    literals.intern(marker);
+    let mut instructions = vec![pushv(0), Instruction::new(Op::DONE, vec![])];
+    let labels =
+        tcl_bytecode::layout::resolve_layout(&mut instructions, &std::collections::HashMap::new());
+    let cached = FunctionAsm {
+        name: qname.to_owned(),
+        literals,
+        lvt: LocalVarTable::new(&[]),
+        instructions,
+        labels,
+        loop_targets: std::collections::HashMap::new(),
+        body_base_line: 0,
+        proc_body_src: Some(body_src.to_owned()),
+        error_regions: Vec::new(),
+    };
+
+    let mut procedures = std::collections::HashMap::new();
+    procedures.insert(qname.to_owned(), cached);
+    let module = ModuleAsm {
+        profile: tcl_dialect::DialectProfile::plain_tcl(),
+        top_level: FunctionAsm::default(),
+        top_level_body: FunctionAsm::default(),
+        procedures,
+    };
+
+    let mut vm = Vm::new();
+    vm.set_compiler(Box::new(CompilerSvc {
+        registry: CommandRegistry::build_default(),
+    }));
+    assert!(vm.run_module(&module).code.is_ok(), "seeding failed");
+    vm
+}
+
+/// `proc` runs the body the compiler already emitted for it.
+///
+/// `ModuleAsm::procedures` is keyed by the compiler's **rooted** qname (`::p`),
+/// while the VM's own command tables use the unrooted key `qualify_name`
+/// answers (`p`); the lookup roots itself to bridge the two. When it did not,
+/// every proc missed its pre-compiled entry and silently recompiled its body as
+/// a *top-level script*, so no proc body anywhere ran with the `is_proc`
+/// specialisation — an invisible failure, since a script-shaped body still
+/// computes the right answer.
+///
+/// The qualified case takes the same route: the runtime key is `a::p`, the
+/// compiler's `::a::p`.
+#[test]
+fn a_proc_runs_the_body_the_compiler_emitted_for_it() {
+    let mut vm = vm_with_cached_body("::p", "return SOURCE", "PRECOMPILED");
+    vm.eval_source("proc p {} {return SOURCE}").expect("define");
+    assert_eq!(
+        &*vm.eval_source("p").expect("call").result.to_str(),
+        "PRECOMPILED"
+    );
+
+    let mut vm = vm_with_cached_body("::a::p", "return SOURCE", "PRECOMPILED");
+    vm.eval_source("namespace eval a {}\nproc a::p {} {return SOURCE}")
+        .expect("define");
+    assert_eq!(
+        &*vm.eval_source("a::p").expect("call").result.to_str(),
+        "PRECOMPILED"
+    );
+}
+
+/// The cached entry is taken only for the body word it was compiled from.
+///
+/// One name is reachable from several `proc` commands with different bodies,
+/// and a compiled unit records only the first — so a name-only cache would run
+/// a body the script never asked for. Matching the body word turns that into a
+/// miss.
+#[test]
+fn a_proc_with_a_different_body_word_compiles_the_body_it_was_given() {
+    let mut vm = vm_with_cached_body("::p", "return SOURCE", "PRECOMPILED");
+    vm.eval_source("proc p {} {return OTHER}").expect("define");
+    assert_eq!(
+        &*vm.eval_source("p").expect("call").result.to_str(),
+        "OTHER"
+    );
+}
+
+/// The same rule, seen from Tcl: whichever `proc` command actually runs defines
+/// the body that runs with it — the arm of an `if` the script took, the last
+/// definition after a `rename`, the body a nested `proc` supplied.
+///
+/// tclsh 8.6.16 / 9.0.4 print `B` for each.
+#[test]
+fn the_proc_command_that_runs_is_the_one_whose_body_is_installed() {
+    assert_eq!(
+        run("if {0} { proc p {} {return A} } else { proc p {} {return B} }\nputs [p]").2,
+        "B\n"
+    );
+    assert_eq!(
+        run("eval {proc q {} {return A}}\nrename q {}\neval {proc q {} {return B}}\nputs [q]").2,
+        "B\n"
+    );
+    assert_eq!(
+        run("proc mk {} { proc r {} {return A} }\nmk\nrename r {}\n\
+             proc mk2 {} { proc r {} {return B} }\nmk2\nputs [r]")
+        .2,
+        "B\n"
+    );
+}
+
+// -- the inline emitters a proc-shaped body reaches ------------------------
+//
+// These paths are gated on `is_proc`, so until a proc body actually ran with
+// the procedure codegen none of them executed through the `proc` command. Every
+// expectation below is byte-checked against tclsh 8.6.16 and 9.0.4.
+
+/// A value-position `catch` inlines only a body it can compile — *one* command.
+///
+/// The inline emitter splits the body into words and emits a single invocation
+/// from them, so a two-command body became `set y 1 set z 2` (one `set` with
+/// four arguments) and a comment body invoked a command named `#`. Both now
+/// fall back to the dispatched `catch`.
+#[test]
+fn a_value_position_catch_inlines_only_a_single_command_body() {
+    assert_eq!(
+        run("proc p {} { set c [catch { set y 1; set z 2 } m]; return \"$c/$m\" }\nputs [p]").2,
+        "0/2\n"
+    );
+    assert_eq!(
+        run("proc p {} { set c [catch { set y 1\nset z 2 } m]; return \"$c/$m\" }\nputs [p]").2,
+        "0/2\n"
+    );
+    assert_eq!(
+        run("proc p {} { set c [catch { # nothing } m]; return \"$c/$m\" }\nputs [p]").2,
+        "0/\n"
+    );
+    // A single command still inlines, and still reports what C reports.
+    assert_eq!(
+        run("proc p {} { set c [catch { error one } m]; return \"$c/$m\" }\nputs [p]").2,
+        "1/one\n"
+    );
+    // The nested `try … on error` form takes the same rule for both its bodies.
+    assert_eq!(
+        run(
+            "proc p {} { set c [catch { try { set a 1; error e } on error {e} { set b 2 } } m]; \
+             return \"$c/$m\" }\nputs [p]"
+        )
+        .2,
+        "0/2\n"
+    );
+    assert_eq!(
+        run(
+            "proc p {} { set c [catch { try { error e } on error {e} { set b 2; set d 3 } } m]; \
+             return \"$c/$m\" }\nputs [p]"
+        )
+        .2,
+        "0/3\n"
+    );
+}
+
+/// An inlined catch body's *command name* may itself be a substitution.
+///
+/// `catch {$handler}` is how an event dispatcher calls a handler it looked up;
+/// pushing the name as a bare literal invoked a command called `$handler`, and
+/// the `catch` swallowed the resulting error, so the handler simply never ran.
+#[test]
+fn an_inlined_catch_body_substitutes_its_command_name() {
+    assert_eq!(
+        run("proc bump {} { set ::hit 1; return B }\n\
+             proc p {} { set n bump; set c [catch {$n} m]; return \"$c/$m\" }\n\
+             puts [p]\nputs [info exists ::hit]")
+        .2,
+        "0/B\n1\n"
+    );
+}
+
+/// A braced word inside an inlined command substitution is already the finished
+/// value, so it is pushed verbatim: the VM's word substitution would otherwise
+/// read a value that merely looks like a braced word as one and strip a brace
+/// layer that was never there.
+#[test]
+fn a_braced_argument_of_an_inlined_command_substitution_keeps_its_braces() {
+    assert_eq!(
+        run("proc p {} { return \"[string index {{}} 0][string length {{}}]\" }\nputs [p]").2,
+        "{2\n"
+    );
+}
+
+/// A `return`/`set` value that merely *begins and ends* with a bracket is not
+/// one command substitution: `[llength $a]:[join $a ,]` is three concatenated
+/// parts. Treating it as one mangled it into a single bogus invocation.
+#[test]
+fn a_value_that_is_not_one_whole_command_substitution_still_concatenates() {
+    assert_eq!(
+        run("proc p {args} { return [llength $args]:[join $args ,] }\nputs [p x y]").2,
+        "2:x,y\n"
+    );
+    assert_eq!(
+        run("proc p {args} { set r [llength $args]:[join $args ,]; return $r }\nputs [p x y]").2,
+        "2:x,y\n"
+    );
+    // The genuine whole-word form is unaffected.
+    assert_eq!(
+        run("proc p {args} { return [llength $args] }\nputs [p x y]").2,
+        "2\n"
     );
 }

--- a/rust/tcl-vm/tests/variable_trace_semantics_e2e.rs
+++ b/rust/tcl-vm/tests/variable_trace_semantics_e2e.rs
@@ -291,17 +291,14 @@ const VECTORS: &[Vector] = &[
     // missed and its body was recompiled as a top-level script, losing every
     // `is_proc` specialisation. Rooting that lookup made both correct.
     //
-    // Residual, deliberately absent from this sheet: an in-proc
-    // `eval {lappend l z}`. C has no `eval` compiler — the script becomes its
-    // own unit, where `l` is not a compiled local, so `lappend` dispatches and
-    // fires `read write`. This compiler *relaxes* a literal `eval` body into
-    // the enclosing function (`try_lower_eval_static` → `Statement::Block`),
-    // and the CFG builder flattens it, so inside a proc the body inherits the
-    // proc's compiled locals and fires `write` alone. The divergence is the
-    // relaxation, not the trace code, and it predates the lookup fix — a
-    // script-shaped proc body simply masked it. Closing it means carrying
-    // eval-body provenance through the CFG to codegen, or not relaxing `eval`
-    // inside a proc at all.
+    // `proc-eval` is the one that separates "is a proc body" from "is a
+    // compiled local". C has no `eval` compiler: the script becomes its own
+    // unit, where `l` is not a compiled local, so `lappend` dispatches and
+    // fires `read write` — even though the enclosing frame is a proc. This
+    // compiler *relaxes* a literal `eval` body into the enclosing function
+    // (`try_lower_eval_static` → `Statement::Block`, flattened by the CFG
+    // builder), so codegen asks `CodegenCtx::compiles_locals` — which excludes
+    // the folded body's span — rather than `is_proc`.
     Vector {
         name: "lappend fires read on the dispatched and multi-value paths only",
         script: "proc R {n1 n2 op} { lappend ::log $op }\n\
@@ -336,6 +333,9 @@ const VECTORS: &[Vector] = &[
                  set ::log {}\n\
                  lappend l z\n\
                  puts \"proc-local1: $::log\"\n\
+                 set ::log {}\n\
+                 eval {lappend l z}\n\
+                 puts \"proc-eval: $::log\"\n\
                  array set arr {k a}\n\
                  trace add variable arr(k) {read write} R\n\
                  set ::log {}\n\
@@ -354,6 +354,7 @@ const VECTORS: &[Vector] = &[
                proc-local2: read write\n\
                proc-local0: read\n\
                proc-local1: write\n\
+               proc-eval: read write\n\
                proc-elem2: read write\n\
                proc-elem1: write",
     },

--- a/rust/tcl-vm/tests/variable_trace_semantics_e2e.rs
+++ b/rust/tcl-vm/tests/variable_trace_semantics_e2e.rs
@@ -284,15 +284,24 @@ const VECTORS: &[Vector] = &[
     // `INST_LAPPEND_{SCALAR,ARRAY,STK,ARRAY_STK}` omit `TCL_TRACE_READS`
     // (`tclExecute.c:3110-3121`) and fire `write` only, and so do this VM's.
     //
-    // Residual, deliberately absent from this sheet: an in-proc *single-value*
-    // `lappend l z` / `lappend arr(k) z` still reaches this VM's dispatched
-    // `lappend` rather than its write-only `LAPPEND_SCALAR`/`LAPPEND_ARRAY`
-    // arms, so it fires `read write` where C fires `write`. The cause is not
-    // the trace code: `cmd_proc` looks the pre-compiled body up under the
-    // *unqualified* `reg_name` while the compiler keys module procedures by
-    // `::name`, so a global proc always misses and its body is recompiled as a
-    // top-level script — losing every `is_proc` specialisation. Fixing that
-    // lookup makes these two spellings correct with no change here.
+    // The in-proc single-value spellings (`proc-local1`, `proc-elem1`) reach
+    // the write-only opcodes and are on this sheet: `cmd_proc` used to look the
+    // pre-compiled body up under the *unqualified* `reg_name` while the
+    // compiler keys module procedures by `::name`, so a global proc always
+    // missed and its body was recompiled as a top-level script, losing every
+    // `is_proc` specialisation. Rooting that lookup made both correct.
+    //
+    // Residual, deliberately absent from this sheet: an in-proc
+    // `eval {lappend l z}`. C has no `eval` compiler — the script becomes its
+    // own unit, where `l` is not a compiled local, so `lappend` dispatches and
+    // fires `read write`. This compiler *relaxes* a literal `eval` body into
+    // the enclosing function (`try_lower_eval_static` → `Statement::Block`),
+    // and the CFG builder flattens it, so inside a proc the body inherits the
+    // proc's compiled locals and fires `write` alone. The divergence is the
+    // relaxation, not the trace code, and it predates the lookup fix — a
+    // script-shaped proc body simply masked it. Closing it means carrying
+    // eval-body provenance through the CFG to codegen, or not relaxing `eval`
+    // inside a proc at all.
     Vector {
         name: "lappend fires read on the dispatched and multi-value paths only",
         script: "proc R {n1 n2 op} { lappend ::log $op }\n\
@@ -325,13 +334,16 @@ const VECTORS: &[Vector] = &[
                  lappend l\n\
                  puts \"proc-local0: $::log\"\n\
                  set ::log {}\n\
-                 eval {lappend l z}\n\
-                 puts \"proc-eval: $::log\"\n\
+                 lappend l z\n\
+                 puts \"proc-local1: $::log\"\n\
                  array set arr {k a}\n\
                  trace add variable arr(k) {read write} R\n\
                  set ::log {}\n\
                  lappend arr(k) a b\n\
                  puts \"proc-elem2: $::log\"\n\
+                 set ::log {}\n\
+                 lappend arr(k) z\n\
+                 puts \"proc-elem1: $::log\"\n\
                  }\n\
                  p\n",
         want: "top-1: read write\n\
@@ -341,8 +353,9 @@ const VECTORS: &[Vector] = &[
                top-if: read write\n\
                proc-local2: read write\n\
                proc-local0: read\n\
-               proc-eval: read write\n\
-               proc-elem2: read write",
+               proc-local1: write\n\
+               proc-elem2: read write\n\
+               proc-elem1: write",
     },
     // Rows 3 + 4: the read a read-modify-write command performs treats a
     // trace error as "no current value" rather than as a failure — `incr`


### PR DESCRIPTION
## The bug

`Vm::qualify_name` answers the VM's **unrooted** command key (`p`, `a::p`); `ModuleAsm::procedures` is keyed by the compiler's **rooted** qname (`::p`, `::a::p`). `cmd_proc` looked the pre-compiled body up under the unrooted spelling, so the lookup missed for *every* proc and the body fell through to `compile_dynamic_body`, which compiled it as a **top-level script**.

No proc body anywhere ran with `is_proc` codegen — no local variable table, no `STORE_SCALAR1`/`INCR_SCALAR1`, no `LAPPEND_{SCALAR,ARRAY}`, no compiled `unset`, no inline `catch`. The failure was invisible because a script-shaped body still computes the right answer.

Instrumented before/after: every proc printed `pre=false`; now every proc in a compiled unit hits, except `namespace eval` procs, which `codegen_module` deliberately skips to match C's lazy compile.

## Rooting the lookup alone is unsound

The cache is keyed by name, and one name is reachable from several `proc` commands with different bodies — a redefinition, the two arms of an `if`, a second `eval` after a `rename` — while a compiled unit records only the first. Simply enabling the lookup made this run body `A`:

```tcl
if {0} { proc p {} {return A} } else { proc p {} {return B} }
puts [p]
```

`FunctionAsm::proc_body_src` now carries the body word each procedure assembly was compiled from, and a hit requires an exact match. That replaces the old `is_proc_defined` "first definition wins" test, which was both weaker and — the lookup never hitting — had never actually run. It is recorded as the word *value*: without folding `\<newline>` continuations, every body containing one missed (the bootstrap's own `unknown` did).

## Why `ModuleAsm` grew a second top level

A body compiled at run time reaches the compiler as a bare script, so the proc shape has to be emitted for it. A `CompileService` method was not an option: the trait has **52 implementations**, ~40 of them near-identical test services that override only `compile`. A new method would have left them all on the old shape — the tests would pass while the real binaries diverged.

`codegen_module` instead emits the top level twice, as `top_level` and `top_level_body`, fixing every host at one change point. `compile_dynamic_body`, `ensure_proc_traced`, `apply`, method bodies and `define_procedure` take the body shape; the `coroutine` wrapper keeps the script shape through the renamed `compile_dynamic_script`.

## Five latent defects this surfaced

None had ever executed through `proc`, because no proc body had ever run proc-shaped. All fixed, all pinned against tclsh 8.6.16 and 9.0.4:

| Shape | Was |
|---|---|
| `[catch {set y 1; set z 2} m]` | emitted `set y 1 set z 2` — the inline emitter word-splits a body it assumes is one command. Now gated on the segmenter, threaded with the compile's own lexer config. |
| `catch {$handler}` | invoked a command literally named `$handler`; the `catch` swallowed the error, so an event dispatcher's handler silently never ran. This is what broke the iRule simulator. |
| `[string index {{}} 0]` | returned empty — a de-braced argument pushed non-verbatim had its braces stripped again by `subst_word` (same bug and fix as #1602, in the sibling emitter). |
| `return [llength $a]:[join $a ,]` | mangled into one bogus invocation. "Starts and ends with a bracket" is not "is one command substitution"; fixed through the existing `is_pure_cmd_subst`, in `return` and in `set`. |
| `proc p {} {global (x)}` | stopped erroring — the compiled `nsupvar`/`upvar` bypass the element-name check that lives in the commands. Gated as C's `LocalScalar` does. |

## Measured

A/B on one machine, proc-call-heavy workload: **2.26s → 2.00s (~12%)**. The second codegen pass costs ~2% on a compile-bound workload (`apply` in a loop — the worst case, since its body is recompiled per call).

## Tests

- `rust/tcl-compiler/tests/codegen.rs` — both top-level shapes, the body shape matching the same source compiled as a procedure, and the recorded body word.
- `rust/tcl-vm/tests/run_script.rs` — the rooted lookup (plain and namespaced), the body-word guard, the three Tcl-level staleness shapes, and one test per inline-emitter defect above.
- `rust/tcl-vm/tests/command_traces_e2e.rs` — an in-proc `lappend`/`unset` trace vector, which now runs through the compiled arms; the file's differential harness checks it against both installed tclsh releases.
- `rust/tcl-vm/tests/opcode_c_parity.rs` — the seeded-proc helper documents the new seam (rooted key + body word).

## Verification

`cargo test --workspace` (292 test binaries), `cargo test -p tcl-vm -p tcl-compiler -p tcl-bytecode -p tcl-irule-test` (115), and `make rust-check` all pass on the rebased tree.

Two notes:

- `make prep-pr` fails, but not on this change: `rust/tcl-spec-studio/web` and `rust/bigip-report-gen/frontend` pin `typescript@^7.0.2` (#1867, #1868) while `@typescript-eslint/eslint-plugin@^8.69.0` in the same packages caps at `typescript >=4.8.4 <6.1.0`, so `npm install` cannot resolve. The same conflicting pair is on `rust` itself; this branch touches no JS or package files.
- `rust/tcl-version`'s `linked_worktree_dependencies_exist_and_follow_its_branch` fails on macOS only — it compares a `git worktree` gitdir that resolves through `/private/var` against a `std::env::temp_dir()` path under `/var`. Pre-existing, and this branch does not touch that crate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
