### PR TITLE
fix: route the hand-spelled option words through OptionTable and the ensemble owner (#1607)

### DIFF
--- a/docs/design/contracts/shared-utility-contracts-rust.md
+++ b/docs/design/contracts/shared-utility-contracts-rust.md
@@ -515,7 +515,10 @@ entry point, or gate moves without this contract being updated.
   set and borrows only the sentence), plus their `string` and
   `tcl::prefix` ensembles — `tcl::prefix`'s enumeration used to come
   from `prefix::choice_list_bytes`, the wrong owner, which happens to
-  agree only because that list has three entries.
+  agree only because that list has three entries — and their `dict` and
+  `array` ensembles, where resolving the word first is also what makes
+  `array e a` fire the variable's `array` trace under the canonical
+  name.
 - `index` — Tcl index parsing (`Tcl_GetIntForIndex`: `end`, `end-2`,
   `1+1`) and nested-index drilling.
 - `prefix` — the `Tcl_GetIndexFromObjStruct` port, with
@@ -887,6 +890,12 @@ helper without reading the rationale:
   test module in `runtime/rust`
   (`string_and_prefix_ensembles_resolve_like_tclsh`, which also pins
   `string is`'s `class` and `option` nouns).
+- `rust/tcl-vm/tests/cmd_collections_e2e.rs`
+  (`array_bad_subcommand`, `dict_bad_subcommand` — both tightened from
+  `starts_with` to full text) and the `cmd_array.rs` / `cmd_dict.rs`
+  test modules in `runtime/rust`, plus
+  `prefix.rs::dict_filter_type_noun_and_abbreviations` for the owner's
+  own `filterType` row.
 - `rust/tcl-compiler/src/interprocedural.rs` —
   `namespace_parts_from_proc_extracts_segments` (colon-run rows).
 - `rust/tcl-syntax/src/list.rs` — `list_element_matches_tcl9` (the single

--- a/docs/design/contracts/shared-utility-contracts-rust.md
+++ b/docs/design/contracts/shared-utility-contracts-rust.md
@@ -518,7 +518,9 @@ entry point, or gate moves without this contract being updated.
   agree only because that list has three entries — and their `dict` and
   `array` ensembles, where resolving the word first is also what makes
   `array e a` fire the variable's `array` trace under the canonical
-  name.
+  name — and their `binary`, `binary encode`/`decode` (the one
+  `prefixes = false` pair, whose miss is `unknown subcommand`),
+  `encoding`, `chan`, `zlib` and `namespace` ensembles.
 - `index` — Tcl index parsing (`Tcl_GetIntForIndex`: `end`, `end-2`,
   `1+1`) and nested-index drilling.
 - `prefix` — the `Tcl_GetIndexFromObjStruct` port, with
@@ -896,6 +898,12 @@ helper without reading the rationale:
   test modules in `runtime/rust`, plus
   `prefix.rs::dict_filter_type_noun_and_abbreviations` for the owner's
   own `filterType` row.
+- `rust/tcl-vm/tests/builtins_e2e.rs`
+  (`ensemble_subcommand_words_resolve_like_tclsh`) and the
+  `cmd_binary.rs`, `cmd_misc.rs`, `cmd_zlib.rs`, `cmd_namespace.rs`
+  test modules in `runtime/rust` — the `binary`/`encoding`/`zlib`/
+  `namespace` surfaces, including `zlib gzip`'s and `gunzip`'s option
+  tables (C's order is `-header, -level`, not alphabetical).
 - `rust/tcl-compiler/src/interprocedural.rs` —
   `namespace_parts_from_proc_extracts_segments` (colon-run rows).
 - `rust/tcl-syntax/src/list.rs` — `list_element_matches_tcl9` (the single

--- a/docs/design/contracts/shared-utility-contracts-rust.md
+++ b/docs/design/contracts/shared-utility-contracts-rust.md
@@ -507,6 +507,12 @@ entry point, or gate moves without this contract being updated.
   path. `subcommand_choices` is the ensemble enumeration, which keeps
   a comma before `or` even for two entries (`bar, or baz`) — the
   wording `prefix::choice_list` must not be used for.
+  Consumers of the scan and of `unknown_subcommand_message`: both
+  engines' script ensembles, and — since #1607 — their built-in `info`
+  and `file` ensembles (the VM's two hand-rolled
+  exact-then-unique-prefix loops and its list-less miss sentence are
+  gone; the runtime's `file` keeps the registry's release-gated name
+  set and borrows only the sentence).
 - `index` — Tcl index parsing (`Tcl_GetIntForIndex`: `end`, `end-2`,
   `1+1`) and nested-index drilling.
 - `prefix` — the `Tcl_GetIndexFromObjStruct` port, with
@@ -867,6 +873,10 @@ helper without reading the rationale:
   `update_and_after_words_resolve_like_tcl_get_index_from_obj`,
   `try_handler_type_resolves_like_tcl_get_index_from_obj`, and
   `seek_origin_resolves_like_tcl_get_index_from_obj`.
+- `rust/tcl-vm/tests/cmd_info_prefix_e2e.rs` —
+  `info_and_file_ensemble_misses_carry_the_full_option_list`; the
+  `cmd_info.rs` / `cmd_fs.rs` test modules in `runtime/rust` carry the
+  matching `*_ensemble_miss_carries_the_full_option_list` rows.
 - `rust/tcl-compiler/src/interprocedural.rs` —
   `namespace_parts_from_proc_extracts_segments` (colon-run rows).
 - `rust/tcl-syntax/src/list.rs` — `list_element_matches_tcl9` (the single

--- a/docs/design/contracts/shared-utility-contracts-rust.md
+++ b/docs/design/contracts/shared-utility-contracts-rust.md
@@ -526,7 +526,26 @@ entry point, or gate moves without this contract being updated.
   `tcl::prefix match -message property`, so it abbreviates),
   `definitionnamespace`'s `kind`, and `method`'s `export flag` — while
   every *method* list is joined by `tcloo_choice_list_bytes`, which
-  drops the Oxford comma the option tables keep.
+  drops the Oxford comma the option tables keep. Resolving the word is
+  only half of each of these: `info object isa` then checks an **exact**
+  count per resolved category (`InfoObjectIsACmd` checks the argument
+  count twice — once before the category resolves, once after), and the
+  `$child` shorthand words every arity message from `invoked_word` while
+  the *option* identity comes from the table.
+
+  **The table a scan runs over is release-gated.** A `TclMakeEnsemble`
+  subcommand set is a release fact, both engines are release-selectable,
+  and a name from the wrong release changes prefix verdicts for words
+  that have nothing to do with it (`dict g` is `get` on 8.6, ambiguous
+  on 9.0 once `getdef`/`getwithdefault` exist). Each engine's
+  `environment::release_subcommands` filters its table through the
+  selected release's registry surface — removal only, so the engine
+  still owns which names it dispatches and their order — and it is
+  memoised per `(command, release)` because it sits on the `dict` /
+  `string` / `info` dispatch path. A resolution miss must then *report*
+  rather than fall through with the raw word: dispatch arms match
+  canonical names, so an exact 9-only spelling would otherwise still
+  run under an 8.6 pin.
 - `index` — Tcl index parsing (`Tcl_GetIntForIndex`: `end`, `end-2`,
   `1+1`) and nested-index drilling.
 - `prefix` — the `Tcl_GetIndexFromObjStruct` port, with

--- a/docs/design/contracts/shared-utility-contracts-rust.md
+++ b/docs/design/contracts/shared-utility-contracts-rust.md
@@ -773,12 +773,27 @@ entry point, or gate moves without this contract being updated.
 
 ## Known deliberate exceptions
 
-- `string match` / `string map` `-nocase`: C hand-rolls a
-  `length > 1` prefix test (`strncmp`) instead of
-  `Tcl_GetIndexFromObj`, which differs from the table rule on a lone
-  `-` (`string match - a b` is `bad option`, where the table rule
-  would call it ambiguous) — kept hand-rolled, with the probe cited at
-  the site (`tcl-cmd-core::string`).
+- `string match` / `string map` / `string compare` / `string equal`
+  option words: C hand-rolls a `length > 1` prefix test (`strncmp`,
+  `StringCmpOpts`) instead of `Tcl_GetIndexFromObj`, which differs from
+  the table rule on the empty word and a lone `-` (`string match - a b`
+  and `string compare "" a b` are both `bad option`, where the table
+  rule would call them ambiguous) — kept hand-rolled, with the probe
+  cited at the site (`tcl-cmd-core::string`).
+- `try`'s completion codes (`TclGetCompletionCodeFromObj`) are
+  `TCL_EXACT` with a custom `…, or an integer` trailer, and `after`'s
+  subcommand scan is a NULL-interp lookup whose miss falls through to
+  an integer parse: both compose their own sentence, so only the
+  matcher — never an `OptionTable` message — is shared.
+- TclOO method dispatch, `oo::define`'s slot ops, and its body-command
+  lookup are hash probes, not tables: only the **join**
+  (`prefix::tcloo_choice_list_bytes`) is shared.
+- `tcl_registry::abbrev::KeywordTable` is a fourth prefix matcher (it
+  supports `min_abbrev` and carries the ambiguous candidates), reached
+  through `CommandSpec::resolve_subcommand_word` by the WASM runtime's
+  `file` dispatch and the VM's `namespace`. It is out of scope for the
+  "new command modules MUST resolve through `OptionTable`" rule above;
+  reconciling the two matchers is its own piece of work (#1607).
 
 Each of these is a *documented* divergence — keep the comment at the
 site pointing back here, and do not "fix" them onto the canonical

--- a/docs/design/contracts/shared-utility-contracts-rust.md
+++ b/docs/design/contracts/shared-utility-contracts-rust.md
@@ -525,7 +525,9 @@ entry point, or gate moves without this contract being updated.
   match` `-message`). Consumers: `switch`/`lsort`/`lsearch`/`regexp`/
   `regsub`/`trace`/`string is` option words (this crate), the VM's
   `tcl::prefix match` and `string is`, the WASM runtime's `string`
-  ensemble, `tcl::prefix match`, and OO option tables. New command
+  ensemble, `tcl::prefix match`, OO option tables, and — since #1607 —
+  both engines' `interp debug` option word (noun `debug option`) and
+  `interp limit` type word (noun `limit type`). New command
   modules MUST resolve through `OptionTable` (or `scan` +
   `bad_key_message` where a byte noun or interleaved control flow
   demands composition) — never a hand-rolled scan.
@@ -830,6 +832,11 @@ helper without reading the rationale:
   resolution/creation pinned against tclsh8.6.
 - `rust/tcl-vm/tests/cmd_info_prefix_e2e.rs` — `tcl::prefix` message
   texts pinned against tclsh.
+- `rust/tcl-vm/tests/builtins_e2e.rs` and the `builtins.rs` test module
+  in `runtime/rust` — `interp_debug_option_uses_c_noun_and_abbreviates`
+  and `interp_limit_type_word_resolves_like_tcl_get_index_from_obj`, the
+  `interp` option/type nouns pinned against tclsh 8.6.16 and 9.0.4 on
+  both engines.
 - `rust/tcl-compiler/src/interprocedural.rs` —
   `namespace_parts_from_proc_extracts_segments` (colon-run rows).
 - `rust/tcl-syntax/src/list.rs` — `list_element_matches_tcl9` (the single

--- a/docs/design/contracts/shared-utility-contracts-rust.md
+++ b/docs/design/contracts/shared-utility-contracts-rust.md
@@ -788,6 +788,20 @@ entry point, or gate moves without this contract being updated.
 - TclOO method dispatch, `oo::define`'s slot ops, and its body-command
   lookup are hash probes, not tables: only the **join**
   (`prefix::tcloo_choice_list_bytes`) is shared.
+- `glob` is **not** an exception — both engines resolve its option words
+  through `OptionTable` since #1607 — but the two halves landed for
+  different reasons and the record belongs here. The WASM runtime's
+  scan already rejected an unknown option exactly as C does, so its
+  conversion changed no accept/reject decision. The bytecode VM's
+  silently *skipped* any unrecognised `-word`, so `glob -x a` ran and
+  `-types d` leaked its value into the pattern list; converting it makes
+  the VM reject unknown options, which is a deliberate behaviour change
+  ruled on for that sweep rather than an incidental one. Because the
+  table now advertises `-tails` and `-types`, the VM honours them too —
+  no engine may advertise an option it ignores. Both engines' text is
+  tclsh 8.6.16/9.0.4-exact (`bad option "-x": must be -directory, -join,
+  -nocomplain, -path, -tails, -types, or --`), pinned in
+  `glob_option_words_resolve_like_tcl_get_index_from_obj` on each side.
 - `tcl_registry::abbrev::KeywordTable` is a fourth prefix matcher (it
   supports `min_abbrev` and carries the ambiguous candidates), reached
   through `CommandSpec::resolve_subcommand_word` by the WASM runtime's
@@ -925,6 +939,10 @@ helper without reading the rationale:
   test modules in `runtime/rust` — the `binary`/`encoding`/`zlib`/
   `namespace` surfaces, including `zlib gzip`'s and `gunzip`'s option
   tables (C's order is `-header, -level`, not alphabetical).
+- `rust/tcl-vm/tests/builtins_e2e.rs` and the `cmd_fs.rs` test module in
+  `runtime/rust` — `glob_option_words_resolve_like_tcl_get_index_from_obj`
+  on each side, which pins the VM's *new* rejection of an unknown option
+  as well as the shared abbreviation verdicts.
 - `rust/tcl-vm/tests/cmd_oo_e2e.rs`
   (`info_object_isa_category_resolves_like_tcl_get_index_from_obj`,
   `tip558_configurable_property_abbreviates`) and the `cmd_oo.rs` test

--- a/docs/design/contracts/shared-utility-contracts-rust.md
+++ b/docs/design/contracts/shared-utility-contracts-rust.md
@@ -536,7 +536,11 @@ entry point, or gate moves without this contract being updated.
   subcommand word and `package prefer`'s `preference` word resolve here
   too (they are `Tcl_GetIndexFromObj` tables, not an ensemble, despite
   both engines having worded their misses `unknown or ambiguous
-  subcommand` before #1607). New command
+  subcommand` before #1607), as do `update`'s option, `try`'s
+  `handler type`, and `seek`'s `origin`. `after` shares only the
+  `scan` — C looks its subcommands up with a NULL interp and composes
+  its own `bad argument …, or an integer` sentence, so no
+  `OptionTable` message may surface there. New command
   modules MUST resolve through `OptionTable` (or `scan` +
   `bad_key_message` where a byte noun or interleaved control flow
   demands composition) — never a hand-rolled scan.
@@ -857,6 +861,12 @@ helper without reading the rationale:
   release axis of `package`'s table (`prefer` from 8.5, `files` from
   9.0) pinned in
   `rust/tcl-vm/tests/cross_version_command_surface_e2e.rs`.
+- `rust/tcl-vm/tests/cmd_event_e2e.rs` /
+  `cmd_control_e2e.rs` / `builtins_e2e.rs` and the `cmd_event.rs`,
+  `cmd_error.rs`, `cmd_chan.rs` test modules in `runtime/rust` —
+  `update_and_after_words_resolve_like_tcl_get_index_from_obj`,
+  `try_handler_type_resolves_like_tcl_get_index_from_obj`, and
+  `seek_origin_resolves_like_tcl_get_index_from_obj`.
 - `rust/tcl-compiler/src/interprocedural.rs` —
   `namespace_parts_from_proc_extracts_segments` (colon-run rows).
 - `rust/tcl-syntax/src/list.rs` — `list_element_matches_tcl9` (the single

--- a/docs/design/contracts/shared-utility-contracts-rust.md
+++ b/docs/design/contracts/shared-utility-contracts-rust.md
@@ -526,8 +526,13 @@ entry point, or gate moves without this contract being updated.
   `regsub`/`trace`/`string is` option words (this crate), the VM's
   `tcl::prefix match` and `string is`, the WASM runtime's `string`
   ensemble, `tcl::prefix match`, OO option tables, and — since #1607 —
-  both engines' `interp debug` option word (noun `debug option`) and
-  `interp limit` type word (noun `limit type`). New command
+  both engines' `interp debug` option word (noun `debug option`),
+  `interp limit` type word (noun `limit type`), and the `interp`
+  ensemble, child-as-command, `interp create` and `interp invokehidden`
+  option words. Where an engine advertises only the subcommands it
+  dispatches (#1412 item 3), the miss message is composed with `scan` +
+  `bad_key_message` over the shorter table — the way C reports
+  `interp`'s own misses against `optionsNoSlaves[]`. New command
   modules MUST resolve through `OptionTable` (or `scan` +
   `bad_key_message` where a byte noun or interleaved control flow
   demands composition) — never a hand-rolled scan.
@@ -832,11 +837,16 @@ helper without reading the rationale:
   resolution/creation pinned against tclsh8.6.
 - `rust/tcl-vm/tests/cmd_info_prefix_e2e.rs` — `tcl::prefix` message
   texts pinned against tclsh.
-- `rust/tcl-vm/tests/builtins_e2e.rs` and the `builtins.rs` test module
-  in `runtime/rust` — `interp_debug_option_uses_c_noun_and_abbreviates`
-  and `interp_limit_type_word_resolves_like_tcl_get_index_from_obj`, the
-  `interp` option/type nouns pinned against tclsh 8.6.16 and 9.0.4 on
-  both engines.
+- `rust/tcl-vm/tests/builtins_e2e.rs` and the `builtins.rs` /
+  `cmd_alias.rs` test modules in `runtime/rust` —
+  `interp_debug_option_uses_c_noun_and_abbreviates`,
+  `interp_limit_type_word_resolves_like_tcl_get_index_from_obj`,
+  `interp_subcommand_words_resolve_like_tcl_get_index_from_obj`, and
+  `interp_create_and_invokehidden_options_resolve_like_tcl_get_index_from_obj`,
+  the `interp` family's option/type nouns and abbreviation verdicts
+  pinned against tclsh 8.6.16 and 9.0.4 on both engines
+  (`runtime/rust/tests/rename_interp_semantics.rs` pins the runtime's
+  deliberately shortened enumeration).
 - `rust/tcl-compiler/src/interprocedural.rs` —
   `namespace_parts_from_proc_extracts_segments` (colon-run rows).
 - `rust/tcl-syntax/src/list.rs` — `list_element_matches_tcl9` (the single

--- a/docs/design/contracts/shared-utility-contracts-rust.md
+++ b/docs/design/contracts/shared-utility-contracts-rust.md
@@ -512,7 +512,10 @@ entry point, or gate moves without this contract being updated.
   and `file` ensembles (the VM's two hand-rolled
   exact-then-unique-prefix loops and its list-less miss sentence are
   gone; the runtime's `file` keeps the registry's release-gated name
-  set and borrows only the sentence).
+  set and borrows only the sentence), plus their `string` and
+  `tcl::prefix` ensembles — `tcl::prefix`'s enumeration used to come
+  from `prefix::choice_list_bytes`, the wrong owner, which happens to
+  agree only because that list has three entries.
 - `index` — Tcl index parsing (`Tcl_GetIntForIndex`: `end`, `end-2`,
   `1+1`) and nested-index drilling.
 - `prefix` — the `Tcl_GetIndexFromObjStruct` port, with
@@ -877,6 +880,13 @@ helper without reading the rationale:
   `info_and_file_ensemble_misses_carry_the_full_option_list`; the
   `cmd_info.rs` / `cmd_fs.rs` test modules in `runtime/rust` carry the
   matching `*_ensemble_miss_carries_the_full_option_list` rows.
+- `rust/tcl-vm/tests/cmd_info_prefix_e2e.rs`
+  (`prefix_ensemble_and_match_options_resolve_like_tclsh`),
+  `cmd_string_e2e.rs` (`string_subcommand_dispatch`, tightened from
+  `starts_with` to the full tclsh 9.0.4 text), and the `cmd_string.rs`
+  test module in `runtime/rust`
+  (`string_and_prefix_ensembles_resolve_like_tclsh`, which also pins
+  `string is`'s `class` and `option` nouns).
 - `rust/tcl-compiler/src/interprocedural.rs` —
   `namespace_parts_from_proc_extracts_segments` (colon-run rows).
 - `rust/tcl-syntax/src/list.rs` — `list_element_matches_tcl9` (the single

--- a/docs/design/contracts/shared-utility-contracts-rust.md
+++ b/docs/design/contracts/shared-utility-contracts-rust.md
@@ -521,6 +521,12 @@ entry point, or gate moves without this contract being updated.
   name — and their `binary`, `binary encode`/`decode` (the one
   `prefixes = false` pair, whose miss is `unknown subcommand`),
   `encoding`, `chan`, `zlib` and `namespace` ensembles.
+  TclOO's own tables resolve through `prefix` too — `info object isa`'s
+  `category`, `configure`'s `property` (C reaches it through
+  `tcl::prefix match -message property`, so it abbreviates),
+  `definitionnamespace`'s `kind`, and `method`'s `export flag` — while
+  every *method* list is joined by `tcloo_choice_list_bytes`, which
+  drops the Oxford comma the option tables keep.
 - `index` — Tcl index parsing (`Tcl_GetIntForIndex`: `end`, `end-2`,
   `1+1`) and nested-index drilling.
 - `prefix` — the `Tcl_GetIndexFromObjStruct` port, with
@@ -904,6 +910,14 @@ helper without reading the rationale:
   test modules in `runtime/rust` — the `binary`/`encoding`/`zlib`/
   `namespace` surfaces, including `zlib gzip`'s and `gunzip`'s option
   tables (C's order is `-header, -level`, not alphabetical).
+- `rust/tcl-vm/tests/cmd_oo_e2e.rs`
+  (`info_object_isa_category_resolves_like_tcl_get_index_from_obj`,
+  `tip558_configurable_property_abbreviates`) and the `cmd_oo.rs` test
+  module in `runtime/rust`
+  (`oo_option_tables_resolve_like_tcl_get_index_from_obj`,
+  `configure_property_word_abbreviates`) — the four TclOO nouns plus a
+  four-entry `unknown method` list, which is the shortest one where the
+  two join styles differ.
 - `rust/tcl-compiler/src/interprocedural.rs` —
   `namespace_parts_from_proc_extracts_segments` (colon-run rows).
 - `rust/tcl-syntax/src/list.rs` — `list_element_matches_tcl9` (the single

--- a/docs/design/contracts/shared-utility-contracts-rust.md
+++ b/docs/design/contracts/shared-utility-contracts-rust.md
@@ -532,7 +532,11 @@ entry point, or gate moves without this contract being updated.
   option words. Where an engine advertises only the subcommands it
   dispatches (#1412 item 3), the miss message is composed with `scan` +
   `bad_key_message` over the shorter table — the way C reports
-  `interp`'s own misses against `optionsNoSlaves[]`. New command
+  `interp`'s own misses against `optionsNoSlaves[]`. `package`'s
+  subcommand word and `package prefer`'s `preference` word resolve here
+  too (they are `Tcl_GetIndexFromObj` tables, not an ensemble, despite
+  both engines having worded their misses `unknown or ambiguous
+  subcommand` before #1607). New command
   modules MUST resolve through `OptionTable` (or `scan` +
   `bad_key_message` where a byte noun or interleaved control flow
   demands composition) — never a hand-rolled scan.
@@ -847,6 +851,12 @@ helper without reading the rationale:
   pinned against tclsh 8.6.16 and 9.0.4 on both engines
   (`runtime/rust/tests/rename_interp_semantics.rs` pins the runtime's
   deliberately shortened enumeration).
+- `rust/tcl-vm/tests/builtins_e2e.rs` and the `cmd_package.rs` test
+  module in `runtime/rust` —
+  `package_option_words_resolve_like_tcl_get_index_from_obj`, with the
+  release axis of `package`'s table (`prefer` from 8.5, `files` from
+  9.0) pinned in
+  `rust/tcl-vm/tests/cross_version_command_surface_e2e.rs`.
 - `rust/tcl-compiler/src/interprocedural.rs` —
   `namespace_parts_from_proc_extracts_segments` (colon-run rows).
 - `rust/tcl-syntax/src/list.rs` — `list_element_matches_tcl9` (the single

--- a/runtime/rust/src/builtins.rs
+++ b/runtime/rust/src/builtins.rs
@@ -1289,6 +1289,74 @@ mod tests {
         });
     }
 
+    /// Issue #1607: `interp debug`'s option word is a `Tcl_GetIndexFromObj`
+    /// table whose noun is `debug option` (`debugTypes[]`, `tclInterp.c`), so
+    /// `-f`/`-fr` abbreviate and the one-entry table never says `ambiguous`.
+    ///
+    /// tclsh 8.6.16 / 9.0.4:
+    ///   interp debug i {}     -> bad debug option "": must be -frame
+    ///   interp debug i -x     -> bad debug option "-x": must be -frame
+    ///   interp debug i -f     -> 0
+    ///   interp debug i -fr 1  -> 1
+    ///   i debug -f            -> 1   (after the latch)
+    ///   i debug -x 1 2        -> wrong # args: should be "i debug ?-frame ?bool??"
+    #[test]
+    fn interp_debug_option_uses_c_noun_and_abbreviates() {
+        leak_free(|i| {
+            ok(i, b"interp create i");
+            assert_eq!(i.eval_str(b"interp debug i {}"), Code::Error);
+            assert_eq!(i.result_bytes(), b"bad debug option \"\": must be -frame");
+            assert_eq!(i.eval_str(b"interp debug i -x"), Code::Error);
+            assert_eq!(i.result_bytes(), b"bad debug option \"-x\": must be -frame");
+            assert_eq!(ok(i, b"interp debug i -f"), b"0");
+            assert_eq!(ok(i, b"interp debug i -fr 1"), b"1");
+            assert_eq!(ok(i, b"i debug -f"), b"1");
+            assert_eq!(i.eval_str(b"i debug -x 1 2"), Code::Error);
+            assert_eq!(
+                i.result_bytes(),
+                b"wrong # args: should be \"i debug ?-frame ?bool??\""
+            );
+        });
+    }
+
+    /// Issue #1607: `interp limit`'s type word is `Tcl_GetIndexFromObj(…,
+    /// "limit type", 0)` (`limitTypes[]`, `tclInterp.c`), so `c`/`t`
+    /// abbreviate and the empty word — a prefix of both entries — is
+    /// `ambiguous`.
+    ///
+    /// tclsh 8.6.16 / 9.0.4:
+    ///   interp limit i {} -> ambiguous limit type "": must be commands or time
+    ///   interp limit i x  -> bad limit type "x": must be commands or time
+    ///   interp limit i c  -> -command {} -granularity 1 -value {}
+    ///   i limit {}        -> ambiguous limit type "": must be commands or time
+    #[test]
+    fn interp_limit_type_word_resolves_like_tcl_get_index_from_obj() {
+        const MUST: &str = "must be commands or time";
+        leak_free(|i| {
+            ok(i, b"interp create i");
+            assert_eq!(i.eval_str(b"interp limit i {}"), Code::Error);
+            assert_eq!(
+                i.result_bytes(),
+                format!("ambiguous limit type \"\": {MUST}").as_bytes()
+            );
+            assert_eq!(i.eval_str(b"interp limit i x"), Code::Error);
+            assert_eq!(
+                i.result_bytes(),
+                format!("bad limit type \"x\": {MUST}").as_bytes()
+            );
+            assert_eq!(
+                ok(i, b"interp limit i c"),
+                b"-command {} -granularity 1 -value {}"
+            );
+            assert_eq!(i.eval_str(b"i limit {}"), Code::Error);
+            assert_eq!(
+                i.result_bytes(),
+                format!("ambiguous limit type \"\": {MUST}").as_bytes()
+            );
+            assert_eq!(ok(i, b"i limit c"), b"-command {} -granularity 1 -value {}");
+        });
+    }
+
     #[test]
     fn unset_nocomplain_and_dashdash() {
         leak_free(|i| {

--- a/runtime/rust/src/cmd_alias.rs
+++ b/runtime/rust/src/cmd_alias.rs
@@ -389,10 +389,7 @@ fn interp_limit(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     let ltype = obj_bytes(argv[3]);
     // Validate the limit type before the current-interp guard so a bad type is
     // reported ahead of the inaccessibility error (interp-35.3 vs .23).
-    if ltype.as_slice() != b"commands" && ltype.as_slice() != b"time" {
-        let mut m = b"bad limit type \"".to_vec();
-        m.extend_from_slice(&ltype);
-        m.extend_from_slice(b"\": must be commands or time");
+    if let Err(m) = crate::interp::LIMIT_TYPES.index_of(&ltype) {
         return interp.set_error(&m);
     }
     if path.is_empty() {

--- a/runtime/rust/src/cmd_alias.rs
+++ b/runtime/rust/src/cmd_alias.rs
@@ -112,6 +112,75 @@ fn alias_loop_error(interp: &mut Interp, simple: &[u8]) -> Code {
 
 // -- interp ----------------------------------------------------------------
 
+/// `interp`'s subcommand words, in C table order (`options[]`, `tclInterp.c`).
+/// C resolves them with `Tcl_GetIndexFromObj(…, "option", 0)`, so `cr`
+/// abbreviates `create` and the empty word — a prefix of every entry — is
+/// `ambiguous option ""`.
+///
+/// The table names only the subcommands this runtime dispatches (issue #1412
+/// item 3): `cancel`, `share`, and `transfer` need infrastructure it has none
+/// of. `slaves` is 8.x's deprecated spelling of `children`: it still resolves
+/// (as it does in C, whose `options[]` keeps it) but
+/// [`interp_option_choices`] drops it from the 9.0 enumeration, exactly as C
+/// reports its misses against `optionsNoSlaves[]`.
+const INTERP_OPTIONS: &[&[u8]] = &[
+    b"alias",
+    b"aliases",
+    b"bgerror",
+    b"children",
+    b"create",
+    b"debug",
+    b"delete",
+    b"eval",
+    b"exists",
+    b"expose",
+    b"hide",
+    b"hidden",
+    b"issafe",
+    b"invokehidden",
+    b"limit",
+    b"marktrusted",
+    b"recursionlimit",
+    b"slaves",
+    b"target",
+];
+
+/// The `interp` subcommands the miss message enumerates for the emulated
+/// release: 9.0 retired `slaves` from the advertised list while still
+/// dispatching it.
+fn interp_option_choices(interp: &Interp) -> Vec<&'static [u8]> {
+    if interp.runtime_version() >= tcl_dialect::TclVersion::V9_0 {
+        INTERP_OPTIONS
+            .iter()
+            .copied()
+            .filter(|name| *name != b"slaves")
+            .collect()
+    } else {
+        INTERP_OPTIONS.to_vec()
+    }
+}
+
+/// Resolve an `interp`-family subcommand word through the shared owner:
+/// `dispatch` is the table the word may resolve against, `advertised` the
+/// (possibly shorter) table the miss message enumerates — C splits the two the
+/// same way for `slaves`.
+pub(crate) fn resolve_interp_option(
+    dispatch: &'static [&'static [u8]],
+    advertised: &[&'static [u8]],
+    word: &[u8],
+) -> Result<&'static [u8], Vec<u8>> {
+    match tcl_cmd_core::prefix::scan(dispatch, word, false) {
+        tcl_cmd_core::prefix::Resolution::Exact(i)
+        | tcl_cmd_core::prefix::Resolution::UniquePrefix(i) => Ok(dispatch[i]),
+        miss => Err(tcl_cmd_core::prefix::bad_key_message(
+            advertised,
+            b"option",
+            word,
+            matches!(miss, tcl_cmd_core::prefix::Resolution::Ambiguous),
+        )),
+    }
+}
+
 /// The `interp` ensemble. `alias`, `aliases`, `create`, `delete`, `eval`,
 /// `exists`, `hide`, `expose`, `hidden`, `invokehidden`, `issafe`,
 /// `marktrusted`, `recursionlimit`, `bgerror`, `debug`, `limit`, and `target`
@@ -125,7 +194,12 @@ fn interp_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     if argv.len() < 2 {
         return interp.wrong_args(b"interp cmd ?arg ...?");
     }
-    match obj_bytes(argv[1]).as_slice() {
+    let choices = interp_option_choices(interp);
+    let sub = match resolve_interp_option(INTERP_OPTIONS, &choices, &obj_bytes(argv[1])) {
+        Ok(name) => name,
+        Err(m) => return interp.set_error(&m),
+    };
+    match sub {
         b"alias" => interp_alias(interp, argv),
         b"aliases" => interp_aliases(interp, argv),
         b"create" => interp_create(interp, argv),
@@ -217,14 +291,12 @@ fn interp_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             }
         }
         b"target" => interp_target(interp, argv),
+        // Unreachable: every name in `INTERP_OPTIONS` has an arm above.
         other => {
             let mut m = b"bad option \"".to_vec();
             m.extend_from_slice(other);
-            m.extend_from_slice(
-                b"\": must be alias, aliases, bgerror, children, create, \
-                  debug, delete, eval, exists, expose, hide, hidden, issafe, \
-                  invokehidden, limit, marktrusted, recursionlimit, or target",
-            );
+            m.extend_from_slice(b"\": must be ");
+            m.extend_from_slice(&tcl_cmd_core::prefix::choice_list_bytes(&choices));
             interp.set_error(&m)
         }
     }
@@ -268,6 +340,19 @@ fn interp_target(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     }
 }
 
+/// `interp create`'s option words (`createOptions[]`, `tclInterp.c`), resolved
+/// with `Tcl_GetIndexFromObj(…, "option", 0)`: `-s` abbreviates `-safe` and the
+/// lone `-` — a prefix of both entries — is `ambiguous option "-"`. Only a word
+/// starting with `-` reaches the table, so an empty word is a path, not a miss.
+const CREATE_OPTIONS: tcl_cmd_core::prefix::OptionTable<'static, &[u8]> =
+    tcl_cmd_core::prefix::OptionTable::abbreviating("option", &[b"-safe", b"--"]);
+
+/// `interp invokehidden`'s leading option words (`hiddenOptions[]`,
+/// `tclInterp.c`), resolved the same way: `-g`/`-n` abbreviate and the lone `-`
+/// is `ambiguous option "-"`. Only a word starting with `-` reaches the table.
+const HIDDEN_OPTIONS: tcl_cmd_core::prefix::OptionTable<'static, &[u8]> =
+    tcl_cmd_core::prefix::OptionTable::abbreviating("option", &[b"-global", b"-namespace", b"--"]);
+
 /// `interp create ?-safe? ?--? ?path?` — create a child interpreter, returning
 /// its name (auto-generated `interpN` when omitted). `-safe` hides the
 /// host-touching commands (the Safe Base's re-aliasing is a follow-up).
@@ -282,20 +367,17 @@ fn interp_create(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     while i < argv.len() {
         let a = obj_bytes(argv[i]);
         if !last && a.first() == Some(&b'-') {
-            match a.as_slice() {
-                b"-safe" => {
+            match CREATE_OPTIONS.index_of(&a) {
+                Ok(0) => {
                     safe = true;
                     i += 1;
                     continue;
                 }
-                b"--" => {
+                Ok(_) => {
                     i += 1;
                     last = true;
                 }
-                _ => {
-                    let mut m = b"bad option \"".to_vec();
-                    m.extend_from_slice(&a);
-                    m.extend_from_slice(b"\": must be -safe or --");
+                Err(m) => {
                     return interp.set_error(&m);
                 }
             }
@@ -559,12 +641,12 @@ fn interp_invokehidden(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         if opt.first() != Some(&b'-') {
             break;
         }
-        match opt.as_slice() {
-            b"-global" => {
+        match HIDDEN_OPTIONS.index_of(&opt) {
+            Ok(0) => {
                 ns_name = Some(b"::".to_vec());
                 i += 1;
             }
-            b"-namespace" => {
+            Ok(1) => {
                 i += 1;
                 if i == argv.len() {
                     // C: "there must be more arguments" — stop scanning
@@ -574,16 +656,11 @@ fn interp_invokehidden(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
                 ns_name = Some(obj_bytes(argv[i]));
                 i += 1;
             }
-            b"--" => {
+            Ok(_) => {
                 i += 1;
                 break;
             }
-            _ => {
-                let mut m = b"bad option \"".to_vec();
-                m.extend_from_slice(&opt);
-                m.extend_from_slice(b"\": must be -global, -namespace, or --");
-                return interp.set_error(&m);
-            }
+            Err(m) => return interp.set_error(&m),
         }
     }
     if i >= argv.len() {
@@ -817,6 +894,120 @@ mod tests {
             counters::live_bufs()
         );
         assert_eq!(counters::double_free_count(), 0);
+    }
+
+    /// Issue #1607: the `interp` ensemble and the child-as-command dispatch
+    /// are `Tcl_GetIndexFromObj(…, "option", 0)` tables (`options[]` in
+    /// `Tcl_InterpObjCmd` and `NRChildCmd`, `tclInterp.c`), so subcommands
+    /// abbreviate and the empty word — a prefix of every entry — is
+    /// `ambiguous option ""`. The `interp` list still names only what this
+    /// runtime dispatches (#1412 item 3); the child list is tclsh's in full.
+    ///
+    /// tclsh 8.6.16 / 9.0.4 (the verdicts, not the shortened `interp` list):
+    ///   interp {}       -> ambiguous option "": must be …
+    ///   interp c j      -> ambiguous option "c": must be …
+    ///   interp cr j     -> j
+    ///   interp e {}     -> ambiguous option "e": must be …
+    ///   interp sl       -> the children list (8.x's deprecated spelling)
+    ///   kid ev {set x 1} -> 1   ;  kid h / kid hi -> ambiguous option "h" / "hi"
+    ///   kid x           -> bad option "x": must be alias, aliases, bgerror,
+    ///                      debug, eval, expose, hide, hidden, issafe,
+    ///                      invokehidden, limit, marktrusted, or recursionlimit
+    #[test]
+    fn interp_subcommand_words_resolve_like_tcl_get_index_from_obj() {
+        const MUST: &str = "must be alias, aliases, bgerror, children, create, debug, \
+                            delete, eval, exists, expose, hide, hidden, issafe, \
+                            invokehidden, limit, marktrusted, recursionlimit, or target";
+        const CHILD_MUST: &str = "must be alias, aliases, bgerror, debug, eval, expose, \
+                                  hide, hidden, issafe, invokehidden, limit, marktrusted, \
+                                  or recursionlimit";
+        leak_free(|i| {
+            let err = |i: &mut Interp, script: &[u8]| {
+                assert_eq!(i.eval_str(script), Code::Error, "expected an error");
+                String::from_utf8_lossy(&i.result_bytes()).into_owned()
+            };
+            assert_eq!(
+                err(i, b"interp {}"),
+                format!("ambiguous option \"\": {MUST}")
+            );
+            assert_eq!(err(i, b"interp x"), format!("bad option \"x\": {MUST}"));
+            assert_eq!(
+                err(i, b"interp c j"),
+                format!("ambiguous option \"c\": {MUST}")
+            );
+            assert_eq!(i.eval_str(b"interp cr j"), Code::Ok);
+            assert_eq!(i.result_bytes(), b"j");
+            assert_eq!(
+                err(i, b"interp e {set x 1}"),
+                format!("ambiguous option \"e\": {MUST}")
+            );
+            assert_eq!(i.eval_str(b"interp ev {} {set x 1}"), Code::Ok);
+            assert_eq!(i.result_bytes(), b"1");
+            // 8.x's deprecated `slaves` spelling still resolves and dispatches.
+            assert_eq!(i.eval_str(b"llength [interp sl]"), Code::Ok);
+            assert_eq!(i.result_bytes(), b"1");
+            // The child-as-command table.
+            assert_eq!(i.eval_str(b"interp create kid"), Code::Ok);
+            assert_eq!(err(i, b"kid x"), format!("bad option \"x\": {CHILD_MUST}"));
+            assert_eq!(
+                err(i, b"kid {}"),
+                format!("ambiguous option \"\": {CHILD_MUST}")
+            );
+            assert_eq!(
+                err(i, b"kid h"),
+                format!("ambiguous option \"h\": {CHILD_MUST}")
+            );
+            assert_eq!(
+                err(i, b"kid hi"),
+                format!("ambiguous option \"hi\": {CHILD_MUST}")
+            );
+            assert_eq!(i.eval_str(b"kid ev {set x 1}"), Code::Ok);
+            assert_eq!(i.result_bytes(), b"1");
+        });
+    }
+
+    /// Issue #1607: `interp create`'s and `interp invokehidden`'s leading
+    /// options are `Tcl_GetIndexFromObj(…, "option", 0)` tables
+    /// (`createOptions[]` / `hiddenOptions[]`, `tclInterp.c`), so they
+    /// abbreviate and the lone `-` — a prefix of every entry — is `ambiguous`.
+    ///
+    /// tclsh 8.6.16 / 9.0.4:
+    ///   interp create -x k         -> bad option "-x": must be -safe or --
+    ///   interp create - k          -> ambiguous option "-": must be -safe or --
+    ///   interp create -s k         -> k
+    ///   interp invokehidden i -x f -> bad option "-x": must be -global, -namespace, or --
+    ///   interp invokehidden i - f  -> ambiguous option "-": must be -global, -namespace, or --
+    #[test]
+    fn interp_create_and_invokehidden_options_resolve_like_tcl_get_index_from_obj() {
+        const CREATE_MUST: &str = "must be -safe or --";
+        const HIDDEN_MUST: &str = "must be -global, -namespace, or --";
+        leak_free(|i| {
+            let err = |i: &mut Interp, script: &[u8]| {
+                assert_eq!(i.eval_str(script), Code::Error, "expected an error");
+                String::from_utf8_lossy(&i.result_bytes()).into_owned()
+            };
+            assert_eq!(
+                err(i, b"interp create -x k"),
+                format!("bad option \"-x\": {CREATE_MUST}")
+            );
+            assert_eq!(
+                err(i, b"interp create - k"),
+                format!("ambiguous option \"-\": {CREATE_MUST}")
+            );
+            assert_eq!(i.eval_str(b"interp create -s k"), Code::Ok);
+            assert_eq!(i.result_bytes(), b"k");
+            assert_eq!(i.eval_str(b"interp create -- k2"), Code::Ok);
+            assert_eq!(i.result_bytes(), b"k2");
+            assert_eq!(i.eval_str(b"interp create kid"), Code::Ok);
+            assert_eq!(
+                err(i, b"interp invokehidden kid -x foo"),
+                format!("bad option \"-x\": {HIDDEN_MUST}")
+            );
+            assert_eq!(
+                err(i, b"interp invokehidden kid - foo"),
+                format!("ambiguous option \"-\": {HIDDEN_MUST}")
+            );
+        });
     }
 
     // Needs the numeric tower: the child's `dbl` proc computes via `expr`.

--- a/runtime/rust/src/cmd_array.rs
+++ b/runtime/rust/src/cmd_array.rs
@@ -60,29 +60,35 @@ fn array_name_index(sub: &[u8]) -> Option<usize> {
         .map(|(_, index)| *index)
 }
 
-/// `unknown or ambiguous subcommand "x": must be a, b, or c`, over the same
-/// table.
+/// The subcommand names alone, for the shared ensemble scan and its miss
+/// sentence — `array` is a `TclMakeEnsemble` command, so both belong to
+/// `tcl_cmd_core::ensemble` (its enumeration keeps a comma before `or`).
+fn subcommand_names() -> Vec<&'static [u8]> {
+    SUBCOMMANDS.iter().map(|(name, _)| *name).collect()
+}
+
 fn unknown_subcommand(interp: &mut Interp, sub: &[u8]) -> Code {
-    let mut m = b"unknown or ambiguous subcommand \"".to_vec();
-    m.extend_from_slice(sub);
-    m.extend_from_slice(b"\": must be ");
-    for (i, (name, _)) in SUBCOMMANDS.iter().enumerate() {
-        if i > 0 {
-            m.extend_from_slice(b", ");
-        }
-        if i + 1 == SUBCOMMANDS.len() {
-            m.extend_from_slice(b"or ");
-        }
-        m.extend_from_slice(name);
-    }
-    interp.set_error(&m)
+    interp.set_error(&tcl_cmd_core::ensemble::unknown_subcommand_message(
+        &subcommand_names(),
+        sub,
+        true,
+        b"::tcl::array",
+    ))
 }
 
 fn array_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     if argv.len() < 3 {
         return interp.wrong_args(b"array subcommand arrayName ?arg ...?");
     }
-    let sub = obj_bytes(argv[1]);
+    let word = obj_bytes(argv[1]);
+    // Resolve the subcommand first — exact match, else a unique prefix — so
+    // `array e a` reaches `exists` *and* fires its `array` trace under the
+    // canonical name, as C does.
+    let names = subcommand_names();
+    let sub: &[u8] = match tcl_cmd_core::ensemble::resolve_subcommand(&names, &word, true) {
+        Some(index) => names[index],
+        None => return unknown_subcommand(interp, &word),
+    };
     // C's `LocateArray` (tclVar.c:330-350) sits at the top of every `array`
     // subcommand and fires the variable's `array` traces before the subcommand
     // reads anything — `array names`, `array get`, `array set`, `array exists`
@@ -91,12 +97,12 @@ fn array_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     // one site (issue #1569), not a per-subcommand branch: the array command
     // owns the hook, so the only per-subcommand fact it needs is where the
     // array name is.
-    if let Some(name_obj) = array_name_index(&sub).and_then(|i| argv.get(i)) {
+    if let Some(name_obj) = array_name_index(sub).and_then(|i| argv.get(i)) {
         if let Some(code) = interp.fire_array_trace(&obj_bytes(*name_obj)) {
             return code;
         }
     }
-    let sub_str = String::from_utf8_lossy(&sub);
+    let sub_str = String::from_utf8_lossy(sub);
     // The read-side + `unset` are the shared `tcl_cmd_core::array` core (over
     // this runtime's `VarStore`/`Frames`/`ValueOps`); a fresh-or-borrowed result
     // object is retained by `set_result`.
@@ -112,10 +118,12 @@ fn array_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     // Per-runtime: `set` (per-element write traces), `default` (TIP 508), `for`
     // (Family-B iteration), and the unknown-subcommand message.
     let name = obj_bytes(argv[2]);
-    match sub.as_slice() {
+    match sub {
         b"set" => array_set(interp, argv, &name),
         b"for" => array_for(interp, argv),
         b"default" => array_default(interp, argv),
+        // Unreachable: every `SUBCOMMANDS` name is handled above or by the
+        // shared core.
         other => unknown_subcommand(interp, other),
     }
 }
@@ -127,9 +135,21 @@ fn array_default(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     if argv.len() < 4 {
         return interp.wrong_args(b"array default subcommand arrayName ?value?");
     }
-    let sub = obj_bytes(argv[2]);
+    // TIP 508's own option table (`tclVar.c`), resolved with
+    // `Tcl_GetIndexFromObj(…, "option", 0)` in C *table* order — not
+    // alphabetical — so `e`/`ex` abbreviate `exists` and the empty word is
+    // `ambiguous option ""`.
+    const DEFAULT_OPTIONS: tcl_cmd_core::prefix::OptionTable<'static, &[u8]> =
+        tcl_cmd_core::prefix::OptionTable::abbreviating(
+            "option",
+            &[b"get", b"set", b"exists", b"unset"],
+        );
+    let sub = match DEFAULT_OPTIONS.index_of(&obj_bytes(argv[2])) {
+        Ok(i) => DEFAULT_OPTIONS.names()[i],
+        Err(m) => return interp.set_error(&m),
+    };
     let name = obj_bytes(argv[3]);
-    match sub.as_slice() {
+    match sub {
         b"set" => {
             if argv.len() != 5 {
                 return interp.wrong_args(b"array default set arrayName value");
@@ -198,10 +218,14 @@ fn array_default(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             interp.set_result_bytes(b"");
             Code::Ok
         }
+        // Unreachable: `DEFAULT_OPTIONS` has exactly the four arms above.
         other => {
-            let mut m = b"unknown or ambiguous subcommand \"".to_vec();
+            let mut m = b"bad option \"".to_vec();
             m.extend_from_slice(other);
-            m.extend_from_slice(b"\": must be exists, get, set, or unset");
+            m.extend_from_slice(b"\": must be ");
+            m.extend_from_slice(&tcl_cmd_core::prefix::choice_list_bytes(
+                DEFAULT_OPTIONS.names(),
+            ));
             interp.set_error(&m)
         }
     }
@@ -361,6 +385,55 @@ mod tests {
             String::from_utf8_lossy(src)
         );
         i.result_bytes()
+    }
+
+    /// Issue #1607: `array` is a `TclMakeEnsemble` command, so its scan and
+    /// miss sentence belong to `tcl_cmd_core::ensemble` — this matched exactly
+    /// and hand-joined the list. Resolving first also means `array e a` fires
+    /// the variable's `array` trace under the canonical name (#1569's hook).
+    /// `array default`'s own word is a `Tcl_GetIndexFromObj(…, "option", 0)`
+    /// table in *C table* order, not alphabetical.
+    ///
+    /// tclsh 9.0.4 (the verdicts, not this runtime's shortened list):
+    ///   array e a          -> 1        ;  array ex a -> 1
+    ///   array s a          -> unknown or ambiguous subcommand "s": must be …
+    ///   array default {} a -> ambiguous option "": must be get, set, exists, or unset
+    ///   array default x a  -> bad option "x": must be get, set, exists, or unset
+    ///   array default e a  -> 0        ;  array default ex a -> 0
+    #[test]
+    fn array_ensemble_and_default_option_resolve_like_tclsh() {
+        const MUST: &str = "must be default, exists, for, get, names, set, size, or unset";
+        const DEFAULT_MUST: &str = "must be get, set, exists, or unset";
+        leak_free(|i| {
+            let err_of = |i: &mut Interp, src: &[u8]| {
+                assert_eq!(i.eval_str(src), Code::Error, "expected an error");
+                String::from_utf8_lossy(&i.result_bytes()).into_owned()
+            };
+            run(i, b"array set a {x 1}");
+            assert_eq!(run(i, b"array e a"), b"1");
+            assert_eq!(run(i, b"array ex a"), b"1");
+            assert_eq!(run(i, b"array n a"), b"x");
+            assert_eq!(
+                err_of(i, b"array s a"),
+                format!("unknown or ambiguous subcommand \"s\": {MUST}")
+            );
+            assert_eq!(
+                err_of(i, b"array {} a"),
+                format!("unknown or ambiguous subcommand \"\": {MUST}")
+            );
+            // `array default`'s own table.
+            assert_eq!(
+                err_of(i, b"array default {} a"),
+                format!("ambiguous option \"\": {DEFAULT_MUST}")
+            );
+            assert_eq!(
+                err_of(i, b"array default x a"),
+                format!("bad option \"x\": {DEFAULT_MUST}")
+            );
+            assert_eq!(run(i, b"array default e a"), b"0");
+            assert_eq!(run(i, b"array default ex a"), b"0");
+            i.eval_str(b"unset a");
+        });
     }
 
     #[test]

--- a/runtime/rust/src/cmd_array.rs
+++ b/runtime/rust/src/cmd_array.rs
@@ -63,13 +63,23 @@ fn array_name_index(sub: &[u8]) -> Option<usize> {
 /// The subcommand names alone, for the shared ensemble scan and its miss
 /// sentence — `array` is a `TclMakeEnsemble` command, so both belong to
 /// `tcl_cmd_core::ensemble` (its enumeration keeps a comma before `or`).
-fn subcommand_names() -> Vec<&'static [u8]> {
-    SUBCOMMANDS.iter().map(|(name, _)| *name).collect()
+/// `default` and `for` are Tcl 9 additions, so the scan and the sentence both
+/// take the emulated release's slice of the table — under an 8.6 pin `array f`
+/// must not reach `for`, and `array d` must not be made ambiguous by
+/// `default`.
+fn subcommand_names(interp: &Interp) -> Vec<&'static [u8]> {
+    let table: Vec<&'static [u8]> = SUBCOMMANDS.iter().map(|(name, _)| *name).collect();
+    crate::environment::release_subcommands(
+        interp.runtime_version().dialect_profile_name(),
+        "array",
+        &table,
+    )
 }
 
 fn unknown_subcommand(interp: &mut Interp, sub: &[u8]) -> Code {
+    let names = subcommand_names(interp);
     interp.set_error(&tcl_cmd_core::ensemble::unknown_subcommand_message(
-        &subcommand_names(),
+        &names,
         sub,
         true,
         b"::tcl::array",
@@ -84,7 +94,7 @@ fn array_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     // Resolve the subcommand first — exact match, else a unique prefix — so
     // `array e a` reaches `exists` *and* fires its `array` trace under the
     // canonical name, as C does.
-    let names = subcommand_names();
+    let names = subcommand_names(interp);
     let sub: &[u8] = match tcl_cmd_core::ensemble::resolve_subcommand(&names, &word, true) {
         Some(index) => names[index],
         None => return unknown_subcommand(interp, &word),

--- a/runtime/rust/src/cmd_array.rs
+++ b/runtime/rust/src/cmd_array.rs
@@ -67,7 +67,7 @@ fn array_name_index(sub: &[u8]) -> Option<usize> {
 /// take the emulated release's slice of the table — under an 8.6 pin `array f`
 /// must not reach `for`, and `array d` must not be made ambiguous by
 /// `default`.
-fn subcommand_names(interp: &Interp) -> Vec<&'static [u8]> {
+fn subcommand_names(interp: &Interp) -> &'static [&'static [u8]] {
     let table: Vec<&'static [u8]> = SUBCOMMANDS.iter().map(|(name, _)| *name).collect();
     crate::environment::release_subcommands(
         interp.runtime_version().dialect_profile_name(),
@@ -79,7 +79,7 @@ fn subcommand_names(interp: &Interp) -> Vec<&'static [u8]> {
 fn unknown_subcommand(interp: &mut Interp, sub: &[u8]) -> Code {
     let names = subcommand_names(interp);
     interp.set_error(&tcl_cmd_core::ensemble::unknown_subcommand_message(
-        &names,
+        names,
         sub,
         true,
         b"::tcl::array",
@@ -95,7 +95,7 @@ fn array_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     // `array e a` reaches `exists` *and* fires its `array` trace under the
     // canonical name, as C does.
     let names = subcommand_names(interp);
-    let sub: &[u8] = match tcl_cmd_core::ensemble::resolve_subcommand(&names, &word, true) {
+    let sub: &[u8] = match tcl_cmd_core::ensemble::resolve_subcommand(names, &word, true) {
         Some(index) => names[index],
         None => return unknown_subcommand(interp, &word),
     };

--- a/runtime/rust/src/cmd_binary.rs
+++ b/runtime/rust/src/cmd_binary.rs
@@ -46,6 +46,9 @@ fn err(interp: &mut Interp, msg: &[u8]) -> Code {
 }
 
 /// `binary`'s subcommand set, alphabetical as `TclMakeEnsemble` sorts it.
+/// `encode`/`decode` (TIP 317) arrive in 8.6, so the table is filtered to the
+/// emulated release before the scan — under an 8.5 pin `binary d` is not
+/// `decode`, it is a miss over `format, or scan`.
 const BINARY_SUBS: &[&[u8]] = &[b"decode", b"encode", b"format", b"scan"];
 
 /// `binary encode`/`binary decode`'s format set. These two are ensembles with
@@ -59,15 +62,20 @@ fn binary_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         return interp.wrong_args(b"binary subcommand ?arg ...?");
     }
     let word = obj_bytes(argv[1]);
-    let Some(index) = tcl_cmd_core::ensemble::resolve_subcommand(BINARY_SUBS, &word, true) else {
+    let subs = crate::environment::release_subcommands(
+        interp.runtime_version().dialect_profile_name(),
+        "binary",
+        BINARY_SUBS,
+    );
+    let Some(index) = tcl_cmd_core::ensemble::resolve_subcommand(subs, &word, true) else {
         return interp.set_error(&tcl_cmd_core::ensemble::unknown_subcommand_message(
-            BINARY_SUBS,
+            subs,
             &word,
             true,
             b"::tcl::binary",
         ));
     };
-    match BINARY_SUBS[index] {
+    match subs[index] {
         b"format" => binary_format(interp, argv),
         b"scan" => binary_scan(interp, argv),
         b"encode" => binary_encode(interp, argv),

--- a/runtime/rust/src/cmd_binary.rs
+++ b/runtime/rust/src/cmd_binary.rs
@@ -45,21 +45,34 @@ fn err(interp: &mut Interp, msg: &[u8]) -> Code {
     interp.set_error(msg)
 }
 
+/// `binary`'s subcommand set, alphabetical as `TclMakeEnsemble` sorts it.
+const BINARY_SUBS: &[&[u8]] = &[b"decode", b"encode", b"format", b"scan"];
+
+/// `binary encode`/`binary decode`'s format set. These two are ensembles with
+/// **`-prefixes` off**, so nothing abbreviates and the miss is worded
+/// `unknown subcommand`, never `unknown or ambiguous` (tclsh: `binary encode
+/// h a` → `unknown subcommand "h": must be base64, hex, or uuencode`).
+const BINARY_FORMATS: &[&[u8]] = &[b"base64", b"hex", b"uuencode"];
+
 fn binary_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     if argv.len() < 2 {
         return interp.wrong_args(b"binary subcommand ?arg ...?");
     }
-    match obj_bytes(argv[1]).as_slice() {
+    let word = obj_bytes(argv[1]);
+    let Some(index) = tcl_cmd_core::ensemble::resolve_subcommand(BINARY_SUBS, &word, true) else {
+        return interp.set_error(&tcl_cmd_core::ensemble::unknown_subcommand_message(
+            BINARY_SUBS,
+            &word,
+            true,
+            b"::tcl::binary",
+        ));
+    };
+    match BINARY_SUBS[index] {
         b"format" => binary_format(interp, argv),
         b"scan" => binary_scan(interp, argv),
         b"encode" => binary_encode(interp, argv),
-        b"decode" => binary_decode(interp, argv),
-        other => {
-            let mut m = b"unknown or ambiguous subcommand \"".to_vec();
-            m.extend_from_slice(other);
-            m.extend_from_slice(b"\": must be decode, encode, format, or scan");
-            interp.set_error(&m)
-        }
+        // Unreachable: `BINARY_SUBS` has exactly the four arms here.
+        _ => binary_decode(interp, argv),
     }
 }
 
@@ -91,10 +104,12 @@ fn binary_encode(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
 }
 
 fn binary_encode_bad(interp: &mut Interp, fmt: &[u8]) -> Code {
-    let mut m = b"unknown subcommand \"".to_vec();
-    m.extend_from_slice(fmt);
-    m.extend_from_slice(b"\": must be base64, hex, or uuencode");
-    interp.set_error(&m)
+    interp.set_error(&tcl_cmd_core::ensemble::unknown_subcommand_message(
+        BINARY_FORMATS,
+        fmt,
+        false,
+        b"::tcl::binary::encode",
+    ))
 }
 
 /// `binary encode base64|uuencode ?-maxlen n? ?-wrapchar c? data`.
@@ -303,6 +318,48 @@ mod tests {
             String::from_utf8_lossy(&i.result_bytes())
         );
         i.result_bytes()
+    }
+
+    /// Issue #1607: `binary` is a `TclMakeEnsemble` command, while
+    /// `binary encode`/`binary decode` are ensembles with **`-prefixes` off**
+    /// — nothing abbreviates there and the miss is worded `unknown
+    /// subcommand`, never `unknown or ambiguous`. All three matched exactly
+    /// and spelled their sentences by hand.
+    ///
+    /// tclsh 8.6.16 / 9.0.4:
+    ///   binary e hex a       -> 61
+    ///   binary {}            -> unknown or ambiguous subcommand "": must be
+    ///                           decode, encode, format, or scan
+    ///   binary encode h a    -> unknown subcommand "h": must be base64, hex,
+    ///                           or uuencode
+    ///   binary decode b YQ== -> unknown subcommand "b": must be <same>
+    #[test]
+    fn binary_ensembles_resolve_like_tclsh() {
+        const FORMATS: &str = "must be base64, hex, or uuencode";
+        leak_free(|i| {
+            let err_of = |i: &mut Interp, src: &[u8]| {
+                assert_eq!(i.eval_str(src), Code::Error, "expected an error");
+                String::from_utf8_lossy(&i.result_bytes()).into_owned()
+            };
+            assert_eq!(ok(i, b"binary e hex a"), b"61");
+            assert_eq!(ok(i, b"binary en hex a"), b"61");
+            assert_eq!(
+                err_of(i, b"binary {}"),
+                "unknown or ambiguous subcommand \"\": must be decode, encode, format, or scan"
+            );
+            assert_eq!(
+                err_of(i, b"binary encode h a"),
+                format!("unknown subcommand \"h\": {FORMATS}")
+            );
+            assert_eq!(
+                err_of(i, b"binary encode {} a"),
+                format!("unknown subcommand \"\": {FORMATS}")
+            );
+            assert_eq!(
+                err_of(i, b"binary decode b YQ=="),
+                format!("unknown subcommand \"b\": {FORMATS}")
+            );
+        });
     }
 
     #[test]

--- a/runtime/rust/src/cmd_chan.rs
+++ b/runtime/rust/src/cmd_chan.rs
@@ -557,6 +557,13 @@ fn fblocked_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     Code::Ok
 }
 
+/// `seek`'s origin word, in C table order (`originOptions[]`, `tclIOCmd.c`):
+/// `Tcl_GetIndexFromObj(…, "origin", 0)`, so `s`/`c`/`e` abbreviate, the empty
+/// word — a prefix of all three — is `ambiguous origin ""`, and the offending
+/// word is quoted in the message.
+const SEEK_ORIGINS: tcl_cmd_core::prefix::OptionTable<'static, &[u8]> =
+    tcl_cmd_core::prefix::OptionTable::abbreviating("origin", &[b"start", b"current", b"end"]);
+
 fn seek_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     use std::io::SeekFrom;
     if argv.len() < 3 || argv.len() > 4 {
@@ -567,15 +574,17 @@ fn seek_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         .ok()
         .and_then(|s| s.trim().parse().ok())
         .unwrap_or(0);
-    let origin = argv
-        .get(3)
-        .map(|&a| obj_bytes(a))
-        .unwrap_or_else(|| b"start".to_vec());
-    let from = match origin.as_slice() {
-        b"start" => SeekFrom::Start(offset.max(0) as u64),
-        b"current" => SeekFrom::Current(offset),
-        b"end" => SeekFrom::End(offset),
-        _ => return interp.set_error(b"bad origin: must be start, current, or end"),
+    let origin = match argv.get(3) {
+        None => 0,
+        Some(&a) => match SEEK_ORIGINS.index_of(&obj_bytes(a)) {
+            Ok(i) => i,
+            Err(m) => return interp.set_error(&m),
+        },
+    };
+    let from = match origin {
+        1 => SeekFrom::Current(offset),
+        2 => SeekFrom::End(offset),
+        _ => SeekFrom::Start(offset.max(0) as u64),
     };
     let op = {
         let mut channels = interp.channels.borrow_mut();
@@ -677,6 +686,53 @@ mod tests {
             b"chan pipe is not supported under the WASM runtime"
         );
         assert_eq!(i.eval_str(b"chan"), Code::Error);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// Issue #1607: `seek`'s origin word is a `Tcl_GetIndexFromObj(…,
+    /// "origin", 0)` table (`originOptions[]`, `tclIOCmd.c`). This matched
+    /// exactly and left the offending word out of the message entirely
+    /// (`bad origin: must be …`); C quotes it, abbreviates `s`/`c`/`e`, and
+    /// words the empty origin — a prefix of all three — `ambiguous`.
+    ///
+    /// tclsh 8.6.16 / 9.0.4:
+    ///   seek $f 0 x  -> bad origin "x": must be start, current, or end
+    ///   seek $f 0 {} -> ambiguous origin "": must be start, current, or end
+    ///   seek $f 0 e; tell $f -> the file size
+    ///   chan seek $f 0 x -> bad origin "x": must be start, current, or end
+    #[test]
+    fn seek_origin_resolves_like_tcl_get_index_from_obj() {
+        const MUST: &str = "must be start, current, or end";
+        let mut i = Interp::new();
+        let path = std::env::temp_dir().join(format!("tclrt_seek_{}.txt", std::process::id()));
+        let p = path.display();
+        ok(&mut i, format!("set f [open {p} w]").as_bytes());
+        ok(&mut i, b"puts -nonewline $f abcdef");
+        ok(&mut i, b"close $f");
+        ok(&mut i, format!("set f [open {p} r]").as_bytes());
+        assert_eq!(i.eval_str(b"seek $f 0 x"), Code::Error);
+        assert_eq!(
+            i.result_bytes(),
+            format!("bad origin \"x\": {MUST}").as_bytes()
+        );
+        assert_eq!(i.eval_str(b"seek $f 0 {}"), Code::Error);
+        assert_eq!(
+            i.result_bytes(),
+            format!("ambiguous origin \"\": {MUST}").as_bytes()
+        );
+        assert_eq!(i.eval_str(b"chan seek $f 0 x"), Code::Error);
+        assert_eq!(
+            i.result_bytes(),
+            format!("bad origin \"x\": {MUST}").as_bytes()
+        );
+        // Abbreviations resolve.
+        ok(&mut i, b"seek $f 0 e");
+        assert_eq!(ok(&mut i, b"tell $f"), b"6");
+        ok(&mut i, b"seek $f 2 s");
+        assert_eq!(ok(&mut i, b"tell $f"), b"2");
+        ok(&mut i, b"seek $f 1 c");
+        assert_eq!(ok(&mut i, b"tell $f"), b"3");
+        ok(&mut i, b"close $f");
         let _ = std::fs::remove_file(&path);
     }
 

--- a/runtime/rust/src/cmd_chan.rs
+++ b/runtime/rust/src/cmd_chan.rs
@@ -170,10 +170,10 @@ fn chan_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         "chan",
         SUBS,
     );
-    let Some(idx) = tcl_cmd_core::ensemble::resolve_subcommand(&names, &sub, true) else {
+    let Some(idx) = tcl_cmd_core::ensemble::resolve_subcommand(names, &sub, true) else {
         // The whole sentence, not just its enumeration, is the owner's.
         return interp.set_error(&tcl_cmd_core::ensemble::unknown_subcommand_message(
-            &names,
+            names,
             &sub,
             true,
             b"::tcl::chan",

--- a/runtime/rust/src/cmd_chan.rs
+++ b/runtime/rust/src/cmd_chan.rs
@@ -163,7 +163,13 @@ fn chan_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         return interp.wrong_args(b"chan subcommand ?arg ...?");
     }
     let sub = obj_bytes(argv[1]);
-    let names: Vec<Vec<u8>> = SUBS.iter().map(|s| s.to_vec()).collect();
+    // `isbinary` is Tcl 9 and `pipe`/`pop`/`push` 8.6, so the table follows the
+    // emulated release rather than pinning 9.0's for every pin.
+    let names = crate::environment::release_subcommands(
+        interp.runtime_version().dialect_profile_name(),
+        "chan",
+        SUBS,
+    );
     let Some(idx) = tcl_cmd_core::ensemble::resolve_subcommand(&names, &sub, true) else {
         // The whole sentence, not just its enumeration, is the owner's.
         return interp.set_error(&tcl_cmd_core::ensemble::unknown_subcommand_message(
@@ -176,7 +182,7 @@ fn chan_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     // `argv[1..]` is `subcommand args…`; each target reads its arguments from
     // `argv[1..]` and uses `argv[0]` (the subcommand word) only for error text.
     let rest = &argv[1..];
-    match SUBS[idx] {
+    match names[idx] {
         b"blocked" => fblocked_cmd(interp, rest),
         b"close" => close_cmd(interp, rest),
         b"configure" => fconfigure_cmd(interp, rest),

--- a/runtime/rust/src/cmd_chan.rs
+++ b/runtime/rust/src/cmd_chan.rs
@@ -165,11 +165,13 @@ fn chan_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     let sub = obj_bytes(argv[1]);
     let names: Vec<Vec<u8>> = SUBS.iter().map(|s| s.to_vec()).collect();
     let Some(idx) = tcl_cmd_core::ensemble::resolve_subcommand(&names, &sub, true) else {
-        let mut m = b"unknown or ambiguous subcommand \"".to_vec();
-        m.extend_from_slice(&sub);
-        m.extend_from_slice(b"\": must be ");
-        m.extend_from_slice(&tcl_cmd_core::ensemble::subcommand_choices(&names));
-        return interp.set_error(&m);
+        // The whole sentence, not just its enumeration, is the owner's.
+        return interp.set_error(&tcl_cmd_core::ensemble::unknown_subcommand_message(
+            &names,
+            &sub,
+            true,
+            b"::tcl::chan",
+        ));
     };
     // `argv[1..]` is `subcommand args…`; each target reads its arguments from
     // `argv[1..]` and uses `argv[0]` (the subcommand word) only for error text.

--- a/runtime/rust/src/cmd_dict.rs
+++ b/runtime/rust/src/cmd_dict.rs
@@ -43,11 +43,22 @@ fn dict_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     if argv.len() < 2 {
         return interp.wrong_args(b"dict subcommand ?arg ...?");
     }
-    let sub = obj_bytes(argv[1]);
+    let word = obj_bytes(argv[1]);
+    // `dict` is a `TclMakeEnsemble` command: exact match, else a unique
+    // prefix, so `dict k` is `dict keys` (this matched exactly before #1607).
+    let Some(index) = tcl_cmd_core::ensemble::resolve_subcommand(DICT_SUBS, &word, true) else {
+        return interp.set_error(&tcl_cmd_core::ensemble::unknown_subcommand_message(
+            DICT_SUBS,
+            &word,
+            true,
+            b"::tcl::dict",
+        ));
+    };
+    let sub = DICT_SUBS[index];
     // Pure dict subcommands now live in the shared command core; the runtime is
     // a thin adapter. Variable-mutating subcommands fall through to the legacy
     // match below.
-    if let Ok(sub_str) = std::str::from_utf8(&sub) {
+    if let Ok(sub_str) = std::str::from_utf8(sub) {
         if let Some(result) = tcl_cmd_core::dict::dispatch_canon(interp, sub_str, &argv[2..]) {
             return match result {
                 Ok(v) => {
@@ -75,7 +86,7 @@ fn dict_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             };
         }
     }
-    match sub.as_slice() {
+    match sub {
         b"create" => create(interp, argv),
         b"get" => get(interp, argv),
         b"set" => set(interp, argv),
@@ -94,16 +105,43 @@ fn dict_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         b"lappend" => lappend(interp, argv),
         b"incr" => incr(interp, argv),
         b"info" => info(interp, argv),
-        _ => {
-            let mut m = b"unknown or ambiguous subcommand \"".to_vec();
-            m.extend_from_slice(&sub);
-            m.extend_from_slice(
-                b"\": must be append, create, exists, filter, for, get, getdef, getwithdefault, incr, info, keys, lappend, map, merge, remove, replace, set, size, unset, update, values, or with",
-            );
-            interp.set_error(&m)
-        }
+        // Unreachable: every name in `DICT_SUBS` is handled above or by the
+        // shared core.
+        other => interp.set_error(&tcl_cmd_core::ensemble::unknown_subcommand_message(
+            DICT_SUBS,
+            other,
+            true,
+            b"::tcl::dict",
+        )),
     }
 }
+
+/// `dict`'s subcommand set, alphabetical as `TclMakeEnsemble` sorts it — the
+/// full Tcl 9 table.
+const DICT_SUBS: &[&[u8]] = &[
+    b"append",
+    b"create",
+    b"exists",
+    b"filter",
+    b"for",
+    b"get",
+    b"getdef",
+    b"getwithdefault",
+    b"incr",
+    b"info",
+    b"keys",
+    b"lappend",
+    b"map",
+    b"merge",
+    b"remove",
+    b"replace",
+    b"set",
+    b"size",
+    b"unset",
+    b"update",
+    b"values",
+    b"with",
+];
 
 // -- read subcommands (operate on a dict value) ----------------------------
 
@@ -1140,6 +1178,48 @@ mod tests {
         let (c, b) = run(src);
         assert_eq!(c, Code::Ok, "result={:?}", String::from_utf8_lossy(&b));
         b
+    }
+
+    /// Issue #1607: `dict` is a `TclMakeEnsemble` command — this matched every
+    /// subcommand exactly and spelled the 22-entry list out as a literal beside
+    /// the table. `dict filter`'s type word is a `Tcl_GetIndexFromObj(…,
+    /// "filterType", 0)` table in the shared core.
+    ///
+    /// tclsh 9.0.4:
+    ///   dict k {a 1}          -> a       ;  dict si {a 1} -> 1
+    ///   dict g {a 1} a        -> unknown or ambiguous subcommand "g": must be
+    ///                            append, create, exists, filter, for, get,
+    ///                            getdef, getwithdefault, incr, info, keys,
+    ///                            lappend, map, merge, remove, replace, set,
+    ///                            size, unset, update, values, or with
+    ///   dict {} {a 1}         -> unknown or ambiguous subcommand "": must be <same>
+    ///   dict filter {a 1} k * -> a 1
+    ///   dict filter {a 1} {} *-> ambiguous filterType "": must be key, script, or value
+    #[test]
+    fn dict_ensemble_and_filter_type_resolve_like_tclsh() {
+        const MUST: &str = "must be append, create, exists, filter, for, get, getdef, \
+                            getwithdefault, incr, info, keys, lappend, map, merge, remove, \
+                            replace, set, size, unset, update, values, or with";
+        let err_of = |src: &[u8]| {
+            let (c, b) = run(src);
+            assert_eq!(c, Code::Error, "expected an error");
+            String::from_utf8_lossy(&b).into_owned()
+        };
+        assert_eq!(ok(b"dict k {a 1}"), b"a");
+        assert_eq!(ok(b"dict si {a 1}"), b"1");
+        assert_eq!(
+            err_of(b"dict g {a 1} a"),
+            format!("unknown or ambiguous subcommand \"g\": {MUST}")
+        );
+        assert_eq!(
+            err_of(b"dict {} {a 1}"),
+            format!("unknown or ambiguous subcommand \"\": {MUST}")
+        );
+        assert_eq!(ok(b"dict filter {a 1} k *"), b"a 1");
+        assert_eq!(
+            err_of(b"dict filter {a 1} {} *"),
+            "ambiguous filterType \"\": must be key, script, or value"
+        );
     }
 
     #[test]

--- a/runtime/rust/src/cmd_dict.rs
+++ b/runtime/rust/src/cmd_dict.rs
@@ -46,15 +46,23 @@ fn dict_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     let word = obj_bytes(argv[1]);
     // `dict` is a `TclMakeEnsemble` command: exact match, else a unique
     // prefix, so `dict k` is `dict keys` (this matched exactly before #1607).
-    let Some(index) = tcl_cmd_core::ensemble::resolve_subcommand(DICT_SUBS, &word, true) else {
+    // `getdef`/`getwithdefault` are Tcl 9 (TIP 342), so the table is the
+    // emulated release's: under an 8.6 pin they must neither resolve nor make
+    // `dict g` — a word that has nothing to do with them — ambiguous.
+    let subs = crate::environment::release_subcommands(
+        interp.runtime_version().dialect_profile_name(),
+        "dict",
+        DICT_SUBS,
+    );
+    let Some(index) = tcl_cmd_core::ensemble::resolve_subcommand(&subs, &word, true) else {
         return interp.set_error(&tcl_cmd_core::ensemble::unknown_subcommand_message(
-            DICT_SUBS,
+            &subs,
             &word,
             true,
             b"::tcl::dict",
         ));
     };
-    let sub = DICT_SUBS[index];
+    let sub = subs[index];
     // Pure dict subcommands now live in the shared command core; the runtime is
     // a thin adapter. Variable-mutating subcommands fall through to the legacy
     // match below.

--- a/runtime/rust/src/cmd_dict.rs
+++ b/runtime/rust/src/cmd_dict.rs
@@ -54,9 +54,9 @@ fn dict_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         "dict",
         DICT_SUBS,
     );
-    let Some(index) = tcl_cmd_core::ensemble::resolve_subcommand(&subs, &word, true) else {
+    let Some(index) = tcl_cmd_core::ensemble::resolve_subcommand(subs, &word, true) else {
         return interp.set_error(&tcl_cmd_core::ensemble::unknown_subcommand_message(
-            &subs,
+            subs,
             &word,
             true,
             b"::tcl::dict",

--- a/runtime/rust/src/cmd_error.rs
+++ b/runtime/rust/src/cmd_error.rs
@@ -239,6 +239,14 @@ fn errorcode_prefix_match(pattern: &[u8], errorcode: &[u8]) -> bool {
     pat.len() <= ec.len() && pat.iter().zip(ec.iter()).all(|(a, b)| a == b)
 }
 
+/// `try`'s handler-type words, in C table order (`TryObjCmd`'s `handlerNames`,
+/// `tclCmdMZ.c`): `Tcl_GetIndexFromObj(…, "handler type", 0)`, so `f`/`o`/`t`
+/// abbreviate and the empty word — a prefix of all three — is
+/// `ambiguous handler type ""`. The type is resolved before the clause's
+/// arity, as it is in C (`try {} x` → `bad handler type "x"`).
+const HANDLER_TYPES: tcl_cmd_core::prefix::OptionTable<'static, &[u8]> =
+    tcl_cmd_core::prefix::OptionTable::abbreviating("handler type", &[b"finally", b"on", b"trap"]);
+
 /// `try body ?handler ...? ?finally script?` — structured exception handling
 /// (TIP 329). Handlers are `on code varList script` and `trap pattern varList
 /// script`, tried in order; the first match runs and its completion becomes the
@@ -255,7 +263,11 @@ fn try_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     let mut finally: Option<*mut TclObj> = None;
     let mut j = 2;
     while j < argv.len() {
-        match obj_bytes(argv[j]).as_slice() {
+        let handler_type = match HANDLER_TYPES.index_of(&obj_bytes(argv[j])) {
+            Ok(i) => HANDLER_TYPES.names()[i],
+            Err(m) => return interp.set_error(&m),
+        };
+        match handler_type {
             b"finally" => {
                 if j < argv.len() - 2 {
                     return interp.set_error(b"finally clause must be last");
@@ -313,10 +325,14 @@ fn try_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
                 });
                 j += 4;
             }
+            // Unreachable: `HANDLER_TYPES` has exactly the three arms above.
             other => {
                 let mut m = b"bad handler type \"".to_vec();
                 m.extend_from_slice(other);
-                m.extend_from_slice(b"\": must be finally, on, or trap");
+                m.extend_from_slice(b"\": must be ");
+                m.extend_from_slice(&tcl_cmd_core::prefix::choice_list_bytes(
+                    HANDLER_TYPES.names(),
+                ));
                 return interp.set_error(&m);
             }
         }
@@ -504,6 +520,37 @@ mod tests {
             String::from_utf8_lossy(src)
         );
         i.result_bytes()
+    }
+
+    /// Issue #1607: `try`'s handler-type word is a `Tcl_GetIndexFromObj(…,
+    /// "handler type", 0)` table, so the three types abbreviate and the empty
+    /// word — a prefix of all three — is `ambiguous handler type ""`.
+    ///
+    /// tclsh 8.6.16 / 9.0.4:
+    ///   try {} o error {} {}  -> {}   ;  try {} f {} -> {}  ;  try {} t {} {} {} -> {}
+    ///   try {} {} error {} {} -> ambiguous handler type "": must be finally, on, or trap
+    ///   try {} x              -> bad handler type "x": … (the type precedes the arity)
+    #[test]
+    fn try_handler_type_resolves_like_tcl_get_index_from_obj() {
+        const MUST: &str = "must be finally, on, or trap";
+        leak_free(|i| {
+            // Unique prefixes resolve to their clause grammar.
+            assert_eq!(run(i, b"try {set x ok} o error {} {set x h}"), b"ok");
+            assert_eq!(run(i, b"try {set x ok} f {set y 1}"), b"ok");
+            assert_eq!(run(i, b"try {set x ok} t {} {} {set x h}"), b"ok");
+            // The empty word prefixes all three ⇒ ambiguous.
+            assert_eq!(i.eval_str(b"try good {} error {} {x}"), Code::Error);
+            assert_eq!(
+                i.result_bytes(),
+                format!("ambiguous handler type \"\": {MUST}").as_bytes()
+            );
+            // The type is resolved before the clause's arity.
+            assert_eq!(i.eval_str(b"try good x"), Code::Error);
+            assert_eq!(
+                i.result_bytes(),
+                format!("bad handler type \"x\": {MUST}").as_bytes()
+            );
+        });
     }
 
     #[test]

--- a/runtime/rust/src/cmd_event.rs
+++ b/runtime/rust/src/cmd_event.rs
@@ -145,6 +145,15 @@ fn err(interp: &mut Interp, m: &[u8]) -> Code {
     interp.set_error(m)
 }
 
+/// `after`'s subcommand words, in C table order (`afterSubCmds[]`,
+/// `tclTimer.c`). C scans them at flags `0` with a NULL interp, so
+/// abbreviations resolve (`in` → `info`, `ca` → `cancel`) but the miss is
+/// silent and `after` composes its own `bad argument …, or an integer`
+/// sentence — an `OptionTable` message must never surface here, only the scan
+/// is shared. `i` is ambiguous (idle/info) and so lands on the integer path,
+/// exactly as in tclsh.
+const AFTER_SUBCOMMANDS: &[&[u8]] = &[b"cancel", b"idle", b"info"];
+
 /// `after ms ?script ...?` / `after idle ?script ...?` / `after cancel id|script`
 /// / `after info ?id?`. With a bare `after ms` (no script) it processes events
 /// until `ms` has elapsed (a delay). Multiple script args are concatenated as a
@@ -157,7 +166,14 @@ fn after_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         );
     }
     let first = obj_bytes(argv[1]);
-    match first.as_slice() {
+    let scanned = match tcl_cmd_core::prefix::scan(AFTER_SUBCOMMANDS, &first, false) {
+        tcl_cmd_core::prefix::Resolution::Exact(i)
+        | tcl_cmd_core::prefix::Resolution::UniquePrefix(i) => AFTER_SUBCOMMANDS[i],
+        tcl_cmd_core::prefix::Resolution::Ambiguous | tcl_cmd_core::prefix::Resolution::NoMatch => {
+            b""
+        }
+    };
+    match scanned {
         b"idle" => {
             if argv.len() < 3 {
                 return err(interp, b"wrong # args: should be \"after idle script\"");
@@ -246,14 +262,26 @@ fn vwait_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     Code::Ok
 }
 
+/// `update`'s one option word (`tclCmdIL.c`): `Tcl_GetIndexFromObj(…,
+/// "option", 0)`, so `i` abbreviates `idletasks` and a one-entry table's miss
+/// is always `bad`, never `ambiguous`. This reported `wrong # args` for a
+/// misspelled option, where C reports `bad option`.
+const UPDATE_OPTIONS: tcl_cmd_core::prefix::OptionTable<'static, &[u8]> =
+    tcl_cmd_core::prefix::OptionTable::abbreviating("option", &[b"idletasks"]);
+
 /// `update` / `update idletasks` — service the events that are ready now, then
 /// return. `idletasks` services *only* idle events — it must not run timer
 /// events (C's `Tcl_UpdateObjCmd`: `TCL_IDLE_EVENTS` excludes timers).
 fn update_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
-    if argv.len() > 2 || (argv.len() == 2 && obj_bytes(argv[1]) != b"idletasks") {
+    if argv.len() > 2 {
         return err(interp, b"wrong # args: should be \"update ?idletasks?\"");
     }
     let idletasks = argv.len() == 2;
+    if idletasks {
+        if let Err(m) = UPDATE_OPTIONS.index_of(&obj_bytes(argv[1])) {
+            return err(interp, &m);
+        }
+    }
     interp.process_bg_errors();
     // Drain everything ready *now* (does not wait for future timers); for
     // `idletasks`, only idle handlers.
@@ -364,4 +392,64 @@ fn parse_after_id(s: &[u8]) -> Option<u64> {
 /// detection (a missing variable and an empty one are distinguished).
 fn read_var_snapshot(interp: &mut Interp, name: &[u8]) -> Option<Vec<u8>> {
     interp.var_get(name).map(obj_bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::interp::{Code, Interp};
+
+    fn ok(i: &mut Interp, src: &[u8]) -> Vec<u8> {
+        assert_eq!(
+            i.eval_str(src),
+            Code::Ok,
+            "eval {:?}",
+            String::from_utf8_lossy(src)
+        );
+        i.result_bytes()
+    }
+
+    /// Issue #1607: `update`'s option and `after`'s subcommand word both
+    /// resolve through the one `Tcl_GetIndexFromObj` matcher. `update`'s is an
+    /// ordinary one-entry table, so a miss is always `bad` — this reported
+    /// `wrong # args` instead. `after`'s scan is *silent* in C
+    /// (`Tcl_GetIndexFromObj` with a NULL interp), so a miss falls through to
+    /// the integer parse and `after` composes its own sentence — including for
+    /// the ambiguous `i`.
+    ///
+    /// tclsh 8.6.16 / 9.0.4:
+    ///   update {}  -> bad option "": must be idletasks
+    ///   update x   -> bad option "x": must be idletasks
+    ///   update i   -> {}     (abbreviation accepted)
+    ///   after in   -> {}     (info)      ;  after ca 1 -> {}   (cancel)
+    ///   after i    -> bad argument "i": must be cancel, idle, info, or an integer
+    ///   after {}   -> bad argument "": must be cancel, idle, info, or an integer
+    #[test]
+    fn update_and_after_words_resolve_like_tcl_get_index_from_obj() {
+        let mut i = Interp::new();
+        assert_eq!(i.eval_str(b"update {}"), Code::Error);
+        assert_eq!(i.result_bytes(), b"bad option \"\": must be idletasks");
+        assert_eq!(i.eval_str(b"update x"), Code::Error);
+        assert_eq!(i.result_bytes(), b"bad option \"x\": must be idletasks");
+        assert_eq!(i.eval_str(b"update a b"), Code::Error);
+        assert_eq!(
+            i.result_bytes(),
+            b"wrong # args: should be \"update ?idletasks?\""
+        );
+        // A unique prefix resolves.
+        ok(&mut i, b"update i");
+        // `after`'s silent scan: `in` and `ca` resolve; `i` is ambiguous and so
+        // reaches the integer parse, where `after` words its own miss.
+        assert_eq!(ok(&mut i, b"after in"), b"");
+        assert_eq!(ok(&mut i, b"after ca 1"), b"");
+        assert_eq!(i.eval_str(b"after i"), Code::Error);
+        assert_eq!(
+            i.result_bytes(),
+            b"bad argument \"i\": must be cancel, idle, info, or an integer"
+        );
+        assert_eq!(i.eval_str(b"after {}"), Code::Error);
+        assert_eq!(
+            i.result_bytes(),
+            b"bad argument \"\": must be cancel, idle, info, or an integer"
+        );
+    }
 }

--- a/runtime/rust/src/cmd_fs.rs
+++ b/runtime/rust/src/cmd_fs.rs
@@ -348,20 +348,14 @@ fn file_unknown_subcommand(
         })
         .map(|sub| sub.name)
         .collect();
-    let mut message = b"unknown or ambiguous subcommand \"".to_vec();
-    message.extend_from_slice(raw);
-    message.extend_from_slice(b"\": must be ");
-    for (index, name) in visible.iter().enumerate() {
-        if index > 0 {
-            message.extend_from_slice(if index + 1 == visible.len() {
-                b", or "
-            } else {
-                b", "
-            });
-        }
-        message.extend_from_slice(name.as_bytes());
-    }
-    interp.set_error(&message)
+    // The join — including the ensemble's comma before `or`, even for two
+    // entries — belongs to `tcl_cmd_core::ensemble`, not to this module.
+    interp.set_error(&tcl_cmd_core::ensemble::unknown_subcommand_message(
+        &visible,
+        raw,
+        true,
+        b"::tcl::file",
+    ))
 }
 
 /// `file delete ?-force? ?--? ?pathname ...?` — delete files / directories.
@@ -1291,6 +1285,44 @@ mod tests {
             String::from_utf8_lossy(&i.result_bytes())
         );
         i.result_bytes()
+    }
+
+    /// Issue #1607: `file`'s ensemble miss sentence — the
+    /// `unknown or ambiguous subcommand "` prefix and the comma-before-`or`
+    /// join — is `tcl_cmd_core::ensemble`'s, not this module's. The visible
+    /// name set still comes from the registry, so it stays release-gated.
+    ///
+    /// tclsh 9.0.4:
+    ///   file {}   -> unknown or ambiguous subcommand "": must be atime,
+    ///                attributes, channels, copy, delete, dirname, executable,
+    ///                exists, extension, home, isdirectory, isfile, join,
+    ///                link, lstat, mkdir, mtime, nativename, normalize, owned,
+    ///                pathtype, readable, readlink, rename, rootname,
+    ///                separator, size, split, stat, system, tail, tempdir,
+    ///                tempfile, tildeexpand, type, volumes, or writable
+    ///   file ex / -> unknown or ambiguous subcommand "ex": must be <same>
+    ///                (exists/executable/extension all start with `ex`)
+    ///   file ext /a.b -> .b   (a unique prefix still resolves)
+    #[test]
+    fn file_ensemble_miss_carries_the_full_option_list() {
+        const MUST: &str = "must be atime, attributes, channels, copy, delete, dirname, \
+                            executable, exists, extension, home, isdirectory, isfile, join, \
+                            link, lstat, mkdir, mtime, nativename, normalize, owned, pathtype, \
+                            readable, readlink, rename, rootname, separator, size, split, \
+                            stat, system, tail, tempdir, tempfile, tildeexpand, type, volumes, \
+                            or writable";
+        let mut i = Interp::new();
+        assert_eq!(i.eval_str(b"file {}"), Code::Error);
+        assert_eq!(
+            i.result_bytes(),
+            format!("unknown or ambiguous subcommand \"\": {MUST}").as_bytes()
+        );
+        assert_eq!(i.eval_str(b"file ex /"), Code::Error);
+        assert_eq!(
+            i.result_bytes(),
+            format!("unknown or ambiguous subcommand \"ex\": {MUST}").as_bytes()
+        );
+        assert_eq!(ok(&mut i, b"file ext /a.b"), b".b");
     }
 
     #[test]

--- a/runtime/rust/src/cmd_fs.rs
+++ b/runtime/rust/src/cmd_fs.rs
@@ -1067,6 +1067,33 @@ fn cd_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
 
 // -- glob ------------------------------------------------------------------
 
+/// `glob`'s option words, in C table order (`globOptions[]`, `tclFileName.c`),
+/// resolved with `Tcl_GetIndexFromObj(…, "option", 0)`: `-n`/`-d`/`-j`
+/// abbreviate, `-t` prefixes both `-tails` and `-types` and so is
+/// `ambiguous option "-t"`, and the lone `-` prefixes every entry. Only a word
+/// starting with `-` reaches the table, so the empty word is a pattern
+/// (tclsh: `glob {}` → `.`), never a miss.
+///
+/// This scan already rejected an unknown option exactly as C does, so routing
+/// it through the owner changes no accept/reject decision — it only makes the
+/// words abbreviate, and turns the lone `-` from `bad` into `ambiguous`. The
+/// bytecode VM's `glob` is a separate, deliberately non-erroring
+/// simplification and is *not* converted (issue #1607; see the contract's
+/// "Known deliberate exceptions").
+const GLOB_OPTIONS: tcl_cmd_core::prefix::OptionTable<'static, &[u8]> =
+    tcl_cmd_core::prefix::OptionTable::abbreviating(
+        "option",
+        &[
+            b"-directory",
+            b"-join",
+            b"-nocomplain",
+            b"-path",
+            b"-tails",
+            b"-types",
+            b"--",
+        ],
+    );
+
 /// `glob ?-nocomplain? ?-directory dir? ?-tails? ?-join? ?--? pattern ...` —
 /// filesystem name matching.
 fn glob_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
@@ -1077,15 +1104,23 @@ fn glob_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     let mut types: Vec<u8> = Vec::new();
     let mut i = 1;
     while i < argv.len() {
-        match obj_bytes(argv[i]).as_slice() {
-            b"-nocomplain" => nocomplain = true,
-            b"-tails" => tails = true,
-            b"-join" => join_mode = true,
-            b"-directory" | b"-path" => {
+        let word = obj_bytes(argv[i]);
+        // Only a `-`-leading word reaches the table, as in C — a bare word
+        // (the empty one included) is the first pattern.
+        if !word.starts_with(b"-") {
+            break;
+        }
+        match GLOB_OPTIONS.index_of(&word) {
+            // `-directory dir` and `-path prefix` are distinct in C; this
+            // runtime models both as the search root.
+            Ok(0 | 3) => {
                 i += 1;
                 directory = argv.get(i).map(|&a| obj_bytes(a));
             }
-            b"-type" | b"-types" => {
+            Ok(1) => join_mode = true,
+            Ok(2) => nocomplain = true,
+            Ok(4) => tails = true,
+            Ok(5) => {
                 i += 1;
                 // The value is a list of type specifiers (`d`, `f`, `r`, …); a
                 // name must satisfy every requested test (`tclFileName.c`).
@@ -1097,19 +1132,12 @@ fn glob_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
                         .collect();
                 }
             }
-            b"--" => {
+            // `--` ends the option scan.
+            Ok(_) => {
                 i += 1;
                 break;
             }
-            opt if opt.starts_with(b"-") => {
-                let mut m = b"bad option \"".to_vec();
-                m.extend_from_slice(opt);
-                m.extend_from_slice(
-                    b"\": must be -directory, -join, -nocomplain, -path, -tails, -types, or --",
-                );
-                return interp.set_error(&m);
-            }
-            _ => break,
+            Err(m) => return interp.set_error(&m),
         }
         i += 1;
     }
@@ -1584,6 +1612,60 @@ mod tests {
         assert_eq!(ok(&mut i, cmd.as_bytes()), b"a.tcl");
         let none = format!("glob -nocomplain -directory {} *.zzz", dir.display());
         assert_eq!(ok(&mut i, none.as_bytes()), b"");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// Issue #1607: `glob`'s option words are a
+    /// `Tcl_GetIndexFromObj(…, "option", 0)` table (`globOptions[]`,
+    /// `tclFileName.c`). This scan already rejected an unknown option exactly
+    /// as C does — it just matched every name exactly, so nothing abbreviated
+    /// and the lone `-` was `bad` rather than `ambiguous`.
+    ///
+    /// tclsh 8.6.16 / 9.0.4:
+    ///   glob -x a  -> bad option "-x": must be -directory, -join, -nocomplain,
+    ///                 -path, -tails, -types, or --
+    ///   glob - a   -> ambiguous option "-": must be <same>
+    ///   glob -t …  -> ambiguous option "-t": must be <same>  (-tails/-types)
+    ///   glob {}    -> .    (the empty word is a pattern, not an option)
+    ///   glob -n /nonexistent* -> {}      (`-n` → -nocomplain)
+    ///   glob -nocomplain -d <dir> -ta *.tcl -> the tails    (-d, -ta)
+    #[test]
+    fn glob_option_words_resolve_like_tcl_get_index_from_obj() {
+        const MUST: &str = "must be -directory, -join, -nocomplain, -path, -tails, -types, or --";
+        let mut i = Interp::new();
+        let err_of = |i: &mut Interp, src: &[u8]| {
+            assert_eq!(i.eval_str(src), Code::Error, "expected an error");
+            String::from_utf8_lossy(&i.result_bytes()).into_owned()
+        };
+        // Only a `-`-leading word reaches the table.
+        assert_eq!(ok(&mut i, b"glob -nocomplain {}"), b"");
+        // Unique prefixes resolve: `-n` is `-nocomplain`.
+        assert_eq!(ok(&mut i, b"glob -n /nonexistent-zz/*"), b"");
+        let dir = std::env::temp_dir().join(format!("tclrt_globopt_{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("a.tcl"), b"").unwrap();
+        // `-d` is `-directory`, `-ta` is `-tails`, `-ty` is `-types`.
+        let cmd = format!("glob -n -d {} -ta -ty f *.tcl", dir.display());
+        assert_eq!(ok(&mut i, cmd.as_bytes()), b"a.tcl");
+        assert_eq!(
+            err_of(&mut i, b"glob -x a"),
+            format!("bad option \"-x\": {MUST}")
+        );
+        assert_eq!(
+            err_of(&mut i, b"glob - a"),
+            format!("ambiguous option \"-\": {MUST}")
+        );
+        // `-t` prefixes both `-tails` and `-types`.
+        assert_eq!(
+            err_of(&mut i, b"glob -t d a"),
+            format!("ambiguous option \"-t\": {MUST}")
+        );
+        // `-j` is `-join`, and `--` still ends the scan.
+        let joined = format!("glob -n -d {} -j -- *.tcl", dir.display());
+        assert_eq!(
+            ok(&mut i, joined.as_bytes()),
+            dir.join("a.tcl").display().to_string().as_bytes()
+        );
         std::fs::remove_dir_all(&dir).ok();
     }
 }

--- a/runtime/rust/src/cmd_info.rs
+++ b/runtime/rust/src/cmd_info.rs
@@ -74,18 +74,9 @@ fn info_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         b"vars",
     ];
     let raw = obj_bytes(argv[1]);
-    let sub: &[u8] = if SUBS.contains(&raw.as_slice()) {
-        &raw
-    } else {
-        let hits: Vec<&&[u8]> = SUBS
-            .iter()
-            .filter(|s| s.starts_with(raw.as_slice()))
-            .collect();
-        if hits.len() == 1 {
-            hits[0]
-        } else {
-            &raw // 0 or ambiguous → the error arm
-        }
+    let sub: &[u8] = match tcl_cmd_core::ensemble::resolve_subcommand(SUBS, &raw, true) {
+        Some(index) => SUBS[index],
+        None => &raw, // 0 matches or ambiguous → the error arm
     };
     match sub {
         b"exists" => info_exists(interp, argv),
@@ -239,14 +230,12 @@ fn info_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             Interp::consts_in_namespace,
             Interp::visible_const_names,
         ),
-        other => {
-            let mut m = b"unknown or ambiguous subcommand \"".to_vec();
-            m.extend_from_slice(other);
-            m.extend_from_slice(b"\": must be ");
-            let subs: Vec<Vec<u8>> = SUBS.iter().map(|s| s.to_vec()).collect();
-            m.extend_from_slice(&tcl_cmd_core::ensemble::subcommand_choices(&subs));
-            interp.set_error(&m)
-        }
+        other => interp.set_error(&tcl_cmd_core::ensemble::unknown_subcommand_message(
+            SUBS,
+            other,
+            true,
+            b"::tcl::info",
+        )),
     }
 }
 
@@ -584,6 +573,43 @@ mod tests {
             String::from_utf8_lossy(src)
         );
         i.result_bytes()
+    }
+
+    /// Issue #1607: `info` is a `TclMakeEnsemble` command, so both the prefix
+    /// scan and the whole miss sentence belong to `tcl_cmd_core::ensemble` —
+    /// the prefix loop and the `unknown or ambiguous subcommand "` literal
+    /// were duplicated here beside the owner's `subcommand_choices`.
+    ///
+    /// tclsh 9.0.4:
+    ///   info {}   -> unknown or ambiguous subcommand "": must be args, body,
+    ///                class, cmdcount, cmdtype, commands, complete, constant,
+    ///                consts, coroutine, default, errorstack, exists, frame,
+    ///                functions, globals, hostname, level, library, loaded,
+    ///                locals, nameofexecutable, object, patchlevel, procs,
+    ///                script, sharedlibextension, tclversion, or vars
+    ///   info e x  -> unknown or ambiguous subcommand "e": must be <same>
+    ///   info ex x -> 0        (a unique prefix still resolves)
+    #[test]
+    fn info_ensemble_miss_carries_the_full_option_list() {
+        const MUST: &str = "must be args, body, class, cmdcount, cmdtype, commands, complete, \
+                            constant, consts, coroutine, default, errorstack, exists, frame, \
+                            functions, globals, hostname, level, library, loaded, locals, \
+                            nameofexecutable, object, patchlevel, procs, script, \
+                            sharedlibextension, tclversion, or vars";
+        leak_free(|i| {
+            assert_eq!(i.eval_str(b"info {}"), Code::Error);
+            assert_eq!(
+                i.result_bytes(),
+                format!("unknown or ambiguous subcommand \"\": {MUST}").as_bytes()
+            );
+            assert_eq!(i.eval_str(b"info e x"), Code::Error);
+            assert_eq!(
+                i.result_bytes(),
+                format!("unknown or ambiguous subcommand \"e\": {MUST}").as_bytes()
+            );
+            assert_eq!(run(i, b"set x 1; info ex x"), b"1");
+            assert_eq!(run(i, b"info comm set"), b"set");
+        });
     }
 
     #[test]

--- a/runtime/rust/src/cmd_info.rs
+++ b/runtime/rust/src/cmd_info.rs
@@ -86,9 +86,9 @@ fn info_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     // A miss reports here rather than falling through with the raw word: the
     // arms below match on the canonical name, so a word the *pinned release*
     // does not have (`info cmdtype` under 8.6) would otherwise still dispatch.
-    let Some(index) = tcl_cmd_core::ensemble::resolve_subcommand(&subs, &raw, true) else {
+    let Some(index) = tcl_cmd_core::ensemble::resolve_subcommand(subs, &raw, true) else {
         return interp.set_error(&tcl_cmd_core::ensemble::unknown_subcommand_message(
-            &subs,
+            subs,
             &raw,
             true,
             b"::tcl::info",

--- a/runtime/rust/src/cmd_info.rs
+++ b/runtime/rust/src/cmd_info.rs
@@ -74,10 +74,27 @@ fn info_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         b"vars",
     ];
     let raw = obj_bytes(argv[1]);
-    let sub: &[u8] = match tcl_cmd_core::ensemble::resolve_subcommand(SUBS, &raw, true) {
-        Some(index) => SUBS[index],
-        None => &raw, // 0 matches or ambiguous → the error arm
+    // The table is a release fact: `cmdtype`/`constant`/`consts` are Tcl 9,
+    // `class`/`coroutine`/`errorstack`/`object` 8.6, `frame` 8.5. Filtered to
+    // the emulated release, `info cm` is `cmdcount` on 8.6 and ambiguous with
+    // `cmdtype` on 9.0, exactly as tclsh has it.
+    let subs = crate::environment::release_subcommands(
+        interp.runtime_version().dialect_profile_name(),
+        "info",
+        SUBS,
+    );
+    // A miss reports here rather than falling through with the raw word: the
+    // arms below match on the canonical name, so a word the *pinned release*
+    // does not have (`info cmdtype` under 8.6) would otherwise still dispatch.
+    let Some(index) = tcl_cmd_core::ensemble::resolve_subcommand(&subs, &raw, true) else {
+        return interp.set_error(&tcl_cmd_core::ensemble::unknown_subcommand_message(
+            &subs,
+            &raw,
+            true,
+            b"::tcl::info",
+        ));
     };
+    let sub: &[u8] = subs[index];
     match sub {
         b"exists" => info_exists(interp, argv),
         // commands/procs route through the shared namespace-aware core (over the

--- a/runtime/rust/src/cmd_misc.rs
+++ b/runtime/rust/src/cmd_misc.rs
@@ -119,7 +119,8 @@ fn noop(interp: &mut Interp, _argv: &[*mut TclObj]) -> Code {
 
 /// `encoding`'s subcommand set, alphabetical as `TclMakeEnsemble` sorts it.
 /// 9.0's table also carries `profiles` and `user`, which need the encoding
-/// machinery this runtime does not model.
+/// machinery this runtime does not model. `dirs` arrives in 8.5, so the table
+/// is filtered to the emulated release before the scan.
 const ENCODING_SUBS: &[&[u8]] = &[b"convertfrom", b"convertto", b"dirs", b"names", b"system"];
 
 fn encoding_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
@@ -127,15 +128,20 @@ fn encoding_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         return interp.wrong_args(b"encoding subcommand ?arg ...?");
     }
     let word = obj_bytes(argv[1]);
-    let Some(index) = tcl_cmd_core::ensemble::resolve_subcommand(ENCODING_SUBS, &word, true) else {
+    let subs = crate::environment::release_subcommands(
+        interp.runtime_version().dialect_profile_name(),
+        "encoding",
+        ENCODING_SUBS,
+    );
+    let Some(index) = tcl_cmd_core::ensemble::resolve_subcommand(subs, &word, true) else {
         return interp.set_error(&tcl_cmd_core::ensemble::unknown_subcommand_message(
-            ENCODING_SUBS,
+            subs,
             &word,
             true,
             b"::tcl::encoding",
         ));
     };
-    match ENCODING_SUBS[index] {
+    match subs[index] {
         // `encoding dirs ?list?` — we don't search encoding files; accept + ignore.
         b"dirs" => {
             interp.set_result_bytes(b"");
@@ -158,7 +164,7 @@ fn encoding_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             Code::Ok
         }
         other => interp.set_error(&tcl_cmd_core::ensemble::unknown_subcommand_message(
-            ENCODING_SUBS,
+            subs,
             other,
             true,
             b"::tcl::encoding",

--- a/runtime/rust/src/cmd_misc.rs
+++ b/runtime/rust/src/cmd_misc.rs
@@ -201,4 +201,30 @@ mod tests {
         assert_eq!(i.eval_str(b"encoding na"), Code::Ok);
         assert_eq!(i.result_bytes(), b"utf-8 unicode ascii iso8859-1");
     }
+
+    /// Issue #1607: `clock` is an ensemble too — its list was spelled out
+    /// beside the dispatch and matched exactly, so `clock se` failed.
+    ///
+    /// tclsh 8.6.16 / 9.0.4:
+    ///   clock se -> the seconds count
+    ///   clock m  -> unknown or ambiguous subcommand "m": must be add, clicks,
+    ///               format, microseconds, milliseconds, scan, or seconds
+    ///   clock {} -> unknown or ambiguous subcommand "": must be <same>
+    #[test]
+    fn clock_ensemble_resolves_like_tclsh() {
+        const MUST: &str = "must be add, clicks, format, microseconds, milliseconds, scan, \
+                            or seconds";
+        let mut i = Interp::new();
+        assert_eq!(i.eval_str(b"clock se"), Code::Ok);
+        assert_eq!(i.eval_str(b"clock m"), Code::Error);
+        assert_eq!(
+            i.result_bytes(),
+            format!("unknown or ambiguous subcommand \"m\": {MUST}").as_bytes()
+        );
+        assert_eq!(i.eval_str(b"clock {}"), Code::Error);
+        assert_eq!(
+            i.result_bytes(),
+            format!("unknown or ambiguous subcommand \"\": {MUST}").as_bytes()
+        );
+    }
 }

--- a/runtime/rust/src/cmd_misc.rs
+++ b/runtime/rust/src/cmd_misc.rs
@@ -117,11 +117,25 @@ fn noop(interp: &mut Interp, _argv: &[*mut TclObj]) -> Code {
     Code::Ok
 }
 
+/// `encoding`'s subcommand set, alphabetical as `TclMakeEnsemble` sorts it.
+/// 9.0's table also carries `profiles` and `user`, which need the encoding
+/// machinery this runtime does not model.
+const ENCODING_SUBS: &[&[u8]] = &[b"convertfrom", b"convertto", b"dirs", b"names", b"system"];
+
 fn encoding_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     if argv.len() < 2 {
         return interp.wrong_args(b"encoding subcommand ?arg ...?");
     }
-    match obj_bytes(argv[1]).as_slice() {
+    let word = obj_bytes(argv[1]);
+    let Some(index) = tcl_cmd_core::ensemble::resolve_subcommand(ENCODING_SUBS, &word, true) else {
+        return interp.set_error(&tcl_cmd_core::ensemble::unknown_subcommand_message(
+            ENCODING_SUBS,
+            &word,
+            true,
+            b"::tcl::encoding",
+        ));
+    };
+    match ENCODING_SUBS[index] {
         // `encoding dirs ?list?` — we don't search encoding files; accept + ignore.
         b"dirs" => {
             interp.set_result_bytes(b"");
@@ -143,11 +157,48 @@ fn encoding_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             interp.set_result(data);
             Code::Ok
         }
-        other => {
-            let mut m = b"unknown or ambiguous subcommand \"".to_vec();
-            m.extend_from_slice(other);
-            m.extend_from_slice(b"\": must be convertfrom, convertto, dirs, names, or system");
-            interp.set_error(&m)
-        }
+        other => interp.set_error(&tcl_cmd_core::ensemble::unknown_subcommand_message(
+            ENCODING_SUBS,
+            other,
+            true,
+            b"::tcl::encoding",
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::interp::{Code, Interp};
+
+    /// Issue #1607: `encoding` is a `TclMakeEnsemble` command, so its
+    /// exact-then-unique-prefix scan and its miss sentence belong to
+    /// `tcl_cmd_core::ensemble`; this matched exactly and spelled the sentence
+    /// out by hand. The list still names only what this runtime implements
+    /// (9.0's table also carries `profiles` and `user`).
+    ///
+    /// tclsh 8.6.16 / 9.0.4 (the verdicts, not the shortened list):
+    ///   encoding s  -> the system encoding
+    ///   encoding c  -> unknown or ambiguous subcommand "c": must be …
+    ///                  (convertfrom/convertto)
+    ///   encoding {} -> unknown or ambiguous subcommand "": must be …
+    #[test]
+    fn encoding_ensemble_resolves_like_tclsh() {
+        const MUST: &str = "must be convertfrom, convertto, dirs, names, or system";
+        let mut i = Interp::new();
+        assert_eq!(i.eval_str(b"encoding s"), Code::Ok);
+        assert_eq!(i.result_bytes(), b"utf-8");
+        assert_eq!(i.eval_str(b"encoding c"), Code::Error);
+        assert_eq!(
+            i.result_bytes(),
+            format!("unknown or ambiguous subcommand \"c\": {MUST}").as_bytes()
+        );
+        assert_eq!(i.eval_str(b"encoding {}"), Code::Error);
+        assert_eq!(
+            i.result_bytes(),
+            format!("unknown or ambiguous subcommand \"\": {MUST}").as_bytes()
+        );
+        // A unique prefix resolves.
+        assert_eq!(i.eval_str(b"encoding na"), Code::Ok);
+        assert_eq!(i.result_bytes(), b"utf-8 unicode ascii iso8859-1");
     }
 }

--- a/runtime/rust/src/cmd_namespace.rs
+++ b/runtime/rust/src/cmd_namespace.rs
@@ -74,22 +74,15 @@ fn namespace_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     // Resolve the subcommand by exact name or unambiguous prefix (the ensemble
     // contract), so e.g. `namespace exist` → `exists`.
     let raw = obj_bytes(argv[1]);
-    let sub: &[u8] = if let Some(c) = NAMESPACE_SUBS.iter().find(|c| **c == raw.as_slice()) {
-        c
-    } else {
-        let mut it = NAMESPACE_SUBS
-            .iter()
-            .filter(|c| c.starts_with(raw.as_slice()));
-        match (it.next(), it.next()) {
-            (Some(c), None) => c,
-            _ => {
-                let mut m = b"unknown or ambiguous subcommand \"".to_vec();
-                m.extend_from_slice(&raw);
-                m.extend_from_slice(b"\": must be children, code, current, delete, ensemble, eval, exists, export, forget, import, inscope, origin, parent, path, qualifiers, tail, unknown, upvar, or which");
-                return interp.set_error(&m);
-            }
-        }
+    let Some(index) = tcl_cmd_core::ensemble::resolve_subcommand(NAMESPACE_SUBS, &raw, true) else {
+        return interp.set_error(&tcl_cmd_core::ensemble::unknown_subcommand_message(
+            NAMESPACE_SUBS,
+            &raw,
+            true,
+            b"::tcl::namespace",
+        ));
     };
+    let sub: &[u8] = NAMESPACE_SUBS[index];
     match sub {
         b"current" => ns_current(interp, argv),
         b"delete" => ns_delete(interp, argv),
@@ -1081,6 +1074,40 @@ mod tests {
             counters::live_bufs()
         );
         assert_eq!(counters::double_free_count(), 0);
+    }
+
+    /// Issue #1607: `namespace` is a `TclMakeEnsemble` command, so its
+    /// exact-then-unique-prefix scan and its whole miss sentence belong to
+    /// `tcl_cmd_core::ensemble` — both were hand-rolled here, the 19-entry
+    /// enumeration as a literal beside the table it duplicates.
+    ///
+    /// tclsh 8.6.16 / 9.0.4:
+    ///   namespace cu -> ::
+    ///   namespace {} -> unknown or ambiguous subcommand "": must be children,
+    ///                   code, current, delete, ensemble, eval, exists, export,
+    ///                   forget, import, inscope, origin, parent, path,
+    ///                   qualifiers, tail, unknown, upvar, or which
+    ///   namespace e  -> unknown or ambiguous subcommand "e": must be <same>
+    ///                   (ensemble/eval/exists/export)
+    #[test]
+    fn namespace_ensemble_miss_comes_from_the_owner() {
+        const MUST: &str = "must be children, code, current, delete, ensemble, eval, exists, \
+                            export, forget, import, inscope, origin, parent, path, qualifiers, \
+                            tail, unknown, upvar, or which";
+        leak_free(|i| {
+            assert_eq!(i.eval_str(b"namespace cu"), Code::Ok);
+            assert_eq!(i.result_bytes(), b"::");
+            assert_eq!(i.eval_str(b"namespace {}"), Code::Error);
+            assert_eq!(
+                i.result_bytes(),
+                format!("unknown or ambiguous subcommand \"\": {MUST}").as_bytes()
+            );
+            assert_eq!(i.eval_str(b"namespace e"), Code::Error);
+            assert_eq!(
+                i.result_bytes(),
+                format!("unknown or ambiguous subcommand \"e\": {MUST}").as_bytes()
+            );
+        });
     }
 
     #[test]

--- a/runtime/rust/src/cmd_oo.rs
+++ b/runtime/rust/src/cmd_oo.rs
@@ -3194,6 +3194,14 @@ pub(crate) fn info_object(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     if sub == b"call" && argv.len() != 5 {
         return wrong_args(interp, b"info object call objName methodName");
     }
+    // `isa` reads `category objName ?className?`, and C checks that both of
+    // the first two are present *before* it resolves the category
+    // (`InfoObjectIsACmd`, tclOOInfo.c) — so `info object isa object` is this
+    // message, not a category error. The per-category counts follow in the
+    // arm, once the word is known.
+    if sub == b"isa" && argv.len() < 5 {
+        return wrong_args(interp, b"info object isa category objName ?arg ...?");
+    }
     if argv.len() < 4 {
         return wrong_args(interp, b"info object subcommand objName ?arg ...?");
     }
@@ -3236,12 +3244,22 @@ pub(crate) fn info_object(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
                 Ok(index) => ISA_CATEGORIES.names()[index],
                 Err(m) => return interp.set_error(&m),
             };
-            // `mixin` and `typeof` need the trailing class word.
-            if matches!(cat, b"mixin" | b"typeof") && argv.len() < 6 {
-                let mut m = b"wrong # args: should be \"info object isa ".to_vec();
+            // Each category then pins an *exact* count — C's second stage,
+            // `Tcl_WrongNumArgs(interp, 2, objv, …)`, so the noun carries the
+            // resolved category word (an index-typed argument prints as its
+            // table entry): `info object isa t o` is
+            // `"info object isa typeof objName className"`, and a trailing
+            // extra word is an error rather than being ignored.
+            let (want, tail) = match cat {
+                b"mixin" | b"typeof" => (6, b" objName className".as_slice()),
+                // class / metaclass / object.
+                _ => (5, b" objName".as_slice()),
+            };
+            if argv.len() != want {
+                let mut m = b"info object isa ".to_vec();
                 m.extend_from_slice(cat);
-                m.extend_from_slice(b" objName className\"");
-                return interp.set_error(&m);
+                m.extend_from_slice(tail);
+                return wrong_args(interp, &m);
             }
             // Resolve the object name following import aliases to the origin
             // command, so an imported object command is recognised (oo-1.10).
@@ -6193,6 +6211,87 @@ mod tests {
     ///   oo::define D {method n -x {} {}}
     ///                         -> bad export flag "-x": must be -export,
     ///                            -private, or -unexport
+    /// The other half of `info object isa`'s dispatch: once the category
+    /// resolves, C checks an **exact** argument count per category
+    /// (`InfoObjectIsACmd`, tclOOInfo.c) — two trailing words for
+    /// `class`/`metaclass`/`object`, three for `mixin`/`typeof`. Resolving the
+    /// category by prefix without that second stage answers `0` for
+    /// `info object isa t $obj` (a missing class name) and `1` for
+    /// `info object isa ob $obj extra` (a word C refuses).
+    ///
+    /// The noun is C's `Tcl_WrongNumArgs(interp, 2, objv, …)`, so it carries
+    /// the *resolved* category word: an index-typed argument prints as its
+    /// table entry, which is why `isa t o` reports `typeof`. The
+    /// two-words-missing case is checked before the category is resolved at
+    /// all, so `info object isa object` is the generic message.
+    ///
+    /// tclsh 8.6.16 and 9.0.4, byte-identical:
+    ///   info object isa                -> wrong # args: should be "info
+    ///                                     object isa category objName ?arg ...?"
+    ///   info object isa object         -> <same>
+    ///   info object isa t o            -> wrong # args: should be "info
+    ///                                     object isa typeof objName className"
+    ///   info object isa ob o extra     -> wrong # args: should be "info
+    ///                                     object isa object objName"
+    ///   info object isa cl o extra     -> … "info object isa class objName"
+    ///   info object isa metaclass o e  -> … "info object isa metaclass objName"
+    ///   info object isa mi o           -> … "info object isa mixin objName className"
+    ///   info object isa mixin o C x    -> <same>
+    ///   info object isa ty o C x       -> … "info object isa typeof objName className"
+    #[test]
+    fn info_object_isa_enforces_the_per_category_arity() {
+        leak_free(|i| {
+            let err_of = |i: &mut Interp, src: &[u8]| {
+                assert_eq!(
+                    i.eval_str(src),
+                    Code::Error,
+                    "expected an error for {:?}",
+                    String::from_utf8_lossy(src)
+                );
+                String::from_utf8_lossy(&i.result_bytes()).into_owned()
+            };
+            ok(i, b"oo::class create C");
+            ok(i, b"C create o");
+            const GENERIC: &str =
+                "wrong # args: should be \"info object isa category objName ?arg ...?\"";
+            assert_eq!(err_of(i, b"info object isa"), GENERIC);
+            assert_eq!(err_of(i, b"info object isa object"), GENERIC);
+            for (src, want) in [
+                (
+                    b"info object isa t o".as_slice(),
+                    "typeof objName className",
+                ),
+                (
+                    b"info object isa mi o".as_slice(),
+                    "mixin objName className",
+                ),
+                (
+                    b"info object isa mixin o C extra".as_slice(),
+                    "mixin objName className",
+                ),
+                (
+                    b"info object isa ty o C extra".as_slice(),
+                    "typeof objName className",
+                ),
+                (b"info object isa ob o extra".as_slice(), "object objName"),
+                (b"info object isa cl o extra".as_slice(), "class objName"),
+                (
+                    b"info object isa metaclass o extra".as_slice(),
+                    "metaclass objName",
+                ),
+            ] {
+                assert_eq!(
+                    err_of(i, src),
+                    format!("wrong # args: should be \"info object isa {want}\"")
+                );
+            }
+            // The exact counts still answer.
+            assert_eq!(ok(i, b"info object isa object nosuchobj"), b"0");
+            assert_eq!(ok(i, b"info object isa typeof o C"), b"1");
+            assert_eq!(ok(i, b"info object isa mixin o C"), b"0");
+        });
+    }
+
     #[test]
     fn oo_option_tables_resolve_like_tcl_get_index_from_obj() {
         const CATEGORY: &str = "must be class, metaclass, mixin, object, or typeof";

--- a/runtime/rust/src/cmd_oo.rs
+++ b/runtime/rust/src/cmd_oo.rs
@@ -888,12 +888,23 @@ fn get_property_name(
 ) -> Result<Vec<u8>, Code> {
     let given = obj_bytes(given);
     let cands = interp.object_property_list(obj, writable, true);
-    if cands.contains(&given) {
-        return Ok(given);
-    }
+    // C's `oo::configuresupport` reaches this through
+    // `tcl::prefix match -message property`, so an abbreviation resolves
+    // (`-ye` → `-yellow`) and a word prefixing several — `""` and a lone `-`
+    // included — is `ambiguous property`. This matched exactly and hand-joined
+    // the enumeration beside the owner that already words both verdicts.
+    let miss = match tcl_cmd_core::prefix::OptionTable::abbreviating("property", &cands)
+        .index_of(&given)
+    {
+        Ok(index) => return Ok(cands[index].clone()),
+        Err(message) => message,
+    };
     // Accessible the other way? Report read-only / write-only.
     let other = interp.object_property_list(obj, !writable, true);
-    if other.contains(&given) {
+    if tcl_cmd_core::prefix::OptionTable::abbreviating("property", &other)
+        .index_of(&given)
+        .is_ok()
+    {
         let mut m = b"property \"".to_vec();
         m.extend_from_slice(&given);
         m.extend_from_slice(b"\" is ");
@@ -901,34 +912,8 @@ fn get_property_name(
         m.extend_from_slice(b" only");
         return Err(interp.set_error(&m));
     }
-    // Otherwise a plain bad-property error listing the candidates (Oxford comma).
-    let mut m = b"bad property \"".to_vec();
-    m.extend_from_slice(&given);
-    m.extend_from_slice(b"\": must be ");
-    m.extend_from_slice(&oxford_join(&cands));
-    let mut code = b"TCL LOOKUP INDEX property ".to_vec();
-    code.extend_from_slice(&given);
-    Err(interp.error_with_code(&m, &code))
-}
-
-/// Join names as `a`, `a or b`, or `a, b, or c` (Tcl's option-table style).
-fn oxford_join(items: &[Vec<u8>]) -> Vec<u8> {
-    let mut out = Vec::new();
-    let n = items.len();
-    for (i, it) in items.iter().enumerate() {
-        if i > 0 {
-            if n > 2 {
-                out.extend_from_slice(b", ");
-            } else {
-                out.push(b' ');
-            }
-            if i == n - 1 {
-                out.extend_from_slice(b"or ");
-            }
-        }
-        out.extend_from_slice(it);
-    }
-    out
+    let code = crate::interp::error_code_list(&[b"TCL", b"LOOKUP", b"INDEX", b"property", &given]);
+    Err(interp.error_with_code(&miss, &code))
 }
 
 /// Parse the `info … properties` option flags (`-all`, `-readable` [default],
@@ -1416,12 +1401,9 @@ impl Interp {
         let mut msg = b"unknown method \"".to_vec();
         msg.extend_from_slice(requested);
         msg.extend_from_slice(b"\": must be ");
-        for (i, n) in names.iter().enumerate() {
-            if i > 0 {
-                msg.extend_from_slice(if i == names.len() - 1 { b" or " } else { b", " });
-            }
-            msg.extend_from_slice(n);
-        }
+        // TclOO's method-list style: no Oxford comma before the final `or`,
+        // unlike the option tables. The rule lives in the shared owner.
+        msg.extend_from_slice(&tcl_cmd_core::prefix::tcloo_choice_list_bytes(&names));
         self.error(&msg)
     }
 }
@@ -1853,15 +1835,9 @@ fn def_definitionnamespace(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     }
     // Default kind is `-class`.
     let instance = if argv.len() == 3 {
-        match obj_bytes(argv[1]).as_slice() {
-            b"-class" => false,
-            b"-instance" => true,
-            other => {
-                let mut m = b"bad kind \"".to_vec();
-                m.extend_from_slice(other);
-                m.extend_from_slice(b"\": must be -class or -instance");
-                return err(interp, &m);
-            }
+        match DEFINITION_KINDS.index_of(&obj_bytes(argv[1])) {
+            Ok(index) => index == 1,
+            Err(m) => return err(interp, &m),
         }
     } else {
         false
@@ -1891,20 +1867,31 @@ fn def_definitionnamespace(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     Code::Ok
 }
 
+/// `oo::define … definitionnamespace`'s kind word (`tclOODefineCmds.c`),
+/// resolved with `Tcl_GetIndexFromObj(…, "kind", 0)`: `-c`/`-i` abbreviate and
+/// the empty word — a prefix of both — is `ambiguous kind ""`.
+const DEFINITION_KINDS: tcl_cmd_core::prefix::OptionTable<'static, &[u8]> =
+    tcl_cmd_core::prefix::OptionTable::abbreviating("kind", &[b"-class", b"-instance"]);
+
+/// `oo::define … method`'s TIP 500 export flag (`tclOODefineCmds.c`), resolved
+/// with `Tcl_GetIndexFromObj(…, "export flag", 0)`: `-e`/`-p`/`-u` abbreviate.
+const EXPORT_FLAGS: tcl_cmd_core::prefix::OptionTable<'static, &[u8]> =
+    tcl_cmd_core::prefix::OptionTable::abbreviating(
+        "export flag",
+        &[b"-export", b"-private", b"-unexport"],
+    );
+
 fn def_method(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     // `method name ?-export|-unexport|-private? args body` (TIP 500 flags).
     let name = obj_bytes(argv[1]);
     let (flag_vis, rest): (Option<MethodVis>, &[*mut TclObj]) =
         match argv.get(2).map(|&a| obj_bytes(a)) {
-            Some(f) if f == b"-private" => (Some(MethodVis::Private), &argv[3..]),
-            Some(f) if f == b"-export" => (Some(MethodVis::Public), &argv[3..]),
-            Some(f) if f == b"-unexport" => (Some(MethodVis::Unexported), &argv[3..]),
-            Some(f) if f.starts_with(b"-") => {
-                let mut m = b"bad export flag \"".to_vec();
-                m.extend_from_slice(&f);
-                m.extend_from_slice(b"\": must be -export, -private, or -unexport");
-                return err(interp, &m);
-            }
+            Some(f) if f.starts_with(b"-") => match EXPORT_FLAGS.index_of(&f) {
+                Ok(0) => (Some(MethodVis::Public), &argv[3..]),
+                Ok(1) => (Some(MethodVis::Private), &argv[3..]),
+                Ok(_) => (Some(MethodVis::Unexported), &argv[3..]),
+                Err(m) => return err(interp, &m),
+            },
             _ => (None, &argv[2..]),
         };
     if rest.len() != 2 {
@@ -2114,11 +2101,20 @@ fn slot_op_split(args: &[Vec<u8>], default: SlotOp) -> Result<(SlotOp, &[Vec<u8>
         Some(b"-appendifnew") => (SlotOp::AppendIfNew, &args[1..]),
         Some(b"-clear") => (SlotOp::Clear, &[]),
         Some(op) if op.first() == Some(&b'-') => {
+            // A TclOO method list, so the join drops the Oxford comma the
+            // option tables keep — the rule lives in the shared owner.
+            const SLOT_OPS: &[&[u8]] = &[
+                b"-append",
+                b"-appendifnew",
+                b"-clear",
+                b"-prepend",
+                b"-remove",
+                b"-set",
+            ];
             let mut m = b"unknown method \"".to_vec();
             m.extend_from_slice(op);
-            m.extend_from_slice(
-                b"\": must be -append, -appendifnew, -clear, -prepend, -remove or -set",
-            );
+            m.extend_from_slice(b"\": must be ");
+            m.extend_from_slice(&tcl_cmd_core::prefix::tcloo_choice_list_bytes(SLOT_OPS));
             return Err(m);
         }
         _ => (default, args),
@@ -3226,12 +3222,31 @@ pub(crate) fn info_object(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             Code::Ok
         }
         b"isa" => {
-            // info object isa category objName ?arg?
-            let cat = obj_bytes(argv[3]);
+            // `info object isa category objName ?arg?`. C resolves the category
+            // with `Tcl_GetIndexFromObj(…, "category", 0)` (`categories[]`,
+            // `tclOOInfo.c`), so `cl`/`ob`/`t` abbreviate, `m` is ambiguous
+            // (metaclass/mixin), and an unknown word is an error — this used to
+            // answer a plain `0`.
+            const ISA_CATEGORIES: tcl_cmd_core::prefix::OptionTable<'static, &[u8]> =
+                tcl_cmd_core::prefix::OptionTable::abbreviating(
+                    "category",
+                    &[b"class", b"metaclass", b"mixin", b"object", b"typeof"],
+                );
+            let cat = match ISA_CATEGORIES.index_of(&obj_bytes(argv[3])) {
+                Ok(index) => ISA_CATEGORIES.names()[index],
+                Err(m) => return interp.set_error(&m),
+            };
+            // `mixin` and `typeof` need the trailing class word.
+            if matches!(cat, b"mixin" | b"typeof") && argv.len() < 6 {
+                let mut m = b"wrong # args: should be \"info object isa ".to_vec();
+                m.extend_from_slice(cat);
+                m.extend_from_slice(b" objName className\"");
+                return interp.set_error(&m);
+            }
             // Resolve the object name following import aliases to the origin
             // command, so an imported object command is recognised (oo-1.10).
             let target = interp.oo_resolve_object(&obj_bytes(argv[4]));
-            let yes = match cat.as_slice() {
+            let yes = match cat {
                 b"object" => interp.oo.borrow().objects.contains_key(&target),
                 b"class" => interp.oo.borrow().classes.contains_key(&target),
                 // A metaclass is a class whose own hierarchy includes
@@ -3269,6 +3284,7 @@ pub(crate) fn info_object(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
                             .skip(1)
                             .any(|p| *p == want)
                 }
+                // Unreachable: `ISA_CATEGORIES` has exactly these five names.
                 _ => false,
             };
             interp.set_result_bytes(if yes { b"1" } else { b"0" });
@@ -3978,17 +3994,12 @@ pub(crate) fn info_class(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             } else {
                 b"-class".to_vec()
             };
-            let ns = match kind.as_slice() {
+            let ns = match DEFINITION_KINDS.index_of(&kind) {
                 // The namespace used to define this class itself.
-                b"-class" => interp.oo.borrow().classes[&cls].class_def_ns.clone(),
+                Ok(0) => interp.oo.borrow().classes[&cls].class_def_ns.clone(),
                 // The namespace used to define this class's instances.
-                b"-instance" => interp.oo.borrow().classes[&cls].def_ns.clone(),
-                _ => {
-                    let mut m = b"bad kind \"".to_vec();
-                    m.extend_from_slice(&kind);
-                    m.extend_from_slice(b"\": must be -class or -instance");
-                    return err(interp, &m);
-                }
+                Ok(_) => interp.oo.borrow().classes[&cls].def_ns.clone(),
+                Err(m) => return err(interp, &m),
             };
             interp.set_result_bytes(&ns.unwrap_or_default());
             Code::Ok
@@ -6157,6 +6168,134 @@ mod tests {
     /// Whether `haystack` contains the byte subsequence `needle`.
     fn contains(haystack: &[u8], needle: &[u8]) -> bool {
         haystack.windows(needle.len()).any(|w| w == needle)
+    }
+
+    /// Issue #1607: TclOO's four option tables — `info object isa`'s
+    /// `category`, `configure`'s `property` (which C reaches through
+    /// `tcl::prefix match -message property`), `definitionnamespace`'s `kind`,
+    /// and `method`'s `export flag` — were all matched exactly, with their
+    /// enumerations hand-joined. `info object isa` answered a plain `0` for an
+    /// unknown category instead of erroring.
+    ///
+    /// tclsh 9.0.4 (8.6.16 agrees on the `category` rows):
+    ///   info object isa x o   -> bad category "x": must be class, metaclass,
+    ///                            mixin, object, or typeof
+    ///   info object isa {} o  -> ambiguous category "": must be <same>
+    ///   info object isa m o   -> ambiguous category "m": must be <same>
+    ///   info object isa cl o  -> 0  ; ob o -> 1 ; me o -> 0
+    ///   q configure -zz       -> bad property "-zz": must be -yellow or -zed
+    ///   q configure {}        -> ambiguous property "": must be <same>
+    ///   q configure -ye 1     -> {}   ;  q configure -ye -> 1
+    ///   oo::define D definitionnamespace {} ::foo
+    ///                         -> ambiguous kind "": must be -class or -instance
+    ///   info class definitionnamespace D -x
+    ///                         -> bad kind "-x": must be -class or -instance
+    ///   oo::define D {method n -x {} {}}
+    ///                         -> bad export flag "-x": must be -export,
+    ///                            -private, or -unexport
+    #[test]
+    fn oo_option_tables_resolve_like_tcl_get_index_from_obj() {
+        const CATEGORY: &str = "must be class, metaclass, mixin, object, or typeof";
+        const KIND: &str = "must be -class or -instance";
+        leak_free(|i| {
+            let err_of = |i: &mut Interp, src: &[u8]| {
+                assert_eq!(
+                    i.eval_str(src),
+                    Code::Error,
+                    "expected an error for {:?}",
+                    String::from_utf8_lossy(src)
+                );
+                String::from_utf8_lossy(&i.result_bytes()).into_owned()
+            };
+            ok(i, b"oo::class create C");
+            ok(i, b"oo::define C method m {} {return 1}");
+            ok(i, b"C create o");
+            assert_eq!(
+                err_of(i, b"info object isa x o"),
+                format!("bad category \"x\": {CATEGORY}")
+            );
+            assert_eq!(
+                err_of(i, b"info object isa {} o"),
+                format!("ambiguous category \"\": {CATEGORY}")
+            );
+            assert_eq!(
+                err_of(i, b"info object isa m o"),
+                format!("ambiguous category \"m\": {CATEGORY}")
+            );
+            assert_eq!(ok(i, b"info object isa cl o"), b"0");
+            assert_eq!(ok(i, b"info object isa ob o"), b"1");
+            assert_eq!(ok(i, b"info object isa me o"), b"0");
+            // The method list keeps TclOO's own join, which drops the Oxford
+            // comma the option tables above keep.
+            assert_eq!(
+                err_of(i, b"o x"),
+                "unknown method \"x\": must be destroy or m"
+            );
+            ok(i, b"oo::class create C3");
+            ok(
+                i,
+                b"oo::define C3 {method a {} {}; method b {} {}; method c {} {}}",
+            );
+            ok(i, b"C3 create o3");
+            assert_eq!(
+                err_of(i, b"o3 zz"),
+                "unknown method \"zz\": must be a, b, c or destroy"
+            );
+            // `definitionnamespace`'s kind, both spellings.
+            ok(i, b"oo::class create D");
+            assert_eq!(
+                err_of(i, b"oo::define D definitionnamespace {} ::foo"),
+                format!("ambiguous kind \"\": {KIND}")
+            );
+            assert_eq!(
+                err_of(i, b"info class definitionnamespace D -x"),
+                format!("bad kind \"-x\": {KIND}")
+            );
+            assert_eq!(ok(i, b"info class definitionnamespace D -i"), b"");
+            // `method`'s TIP 500 export flag.
+            assert_eq!(
+                err_of(i, b"oo::define D {method n -x {} {}}"),
+                "bad export flag \"-x\": must be -export, -private, or -unexport"
+            );
+            ok(i, b"oo::define D {method n -e {} {}}");
+            ok(i, b"oo::define D {method n2 -p {} {}}");
+            i.eval_str(b"C destroy; D destroy");
+        });
+    }
+
+    /// Issue #1607's `property` half, which needs a configurable class.
+    #[test]
+    fn configure_property_word_abbreviates() {
+        const MUST: &str = "must be -yellow or -zed";
+        leak_free(|i| {
+            let err_of = |i: &mut Interp, src: &[u8]| {
+                assert_eq!(i.eval_str(src), Code::Error, "expected an error");
+                String::from_utf8_lossy(&i.result_bytes()).into_owned()
+            };
+            ok(
+                i,
+                b"oo::configurable create Q { property yellow zed\n\
+                   constructor {} { my configure -yellow 0 -zed 0 } }",
+            );
+            ok(i, b"Q create q");
+            assert_eq!(
+                err_of(i, b"q configure -zz"),
+                format!("bad property \"-zz\": {MUST}")
+            );
+            assert_eq!(
+                err_of(i, b"q configure {}"),
+                format!("ambiguous property \"\": {MUST}")
+            );
+            assert_eq!(
+                err_of(i, b"q configure -"),
+                format!("ambiguous property \"-\": {MUST}")
+            );
+            // A unique prefix resolves — and writes the *canonical* property.
+            ok(i, b"q configure -ye 1");
+            assert_eq!(ok(i, b"q configure -yellow"), b"1");
+            assert_eq!(ok(i, b"q configure -ye"), b"1");
+            i.eval_str(b"Q destroy");
+        });
     }
 
     #[test]

--- a/runtime/rust/src/cmd_package.rs
+++ b/runtime/rust/src/cmd_package.rs
@@ -97,11 +97,46 @@ pub fn install(interp: &mut Interp) {
     interp.register_builtin(b"package", package_cmd);
 }
 
+/// `package`'s subcommand words, in C table order (`pkgOptions[]`,
+/// `tclPkg.c`). C resolves them with `Tcl_GetIndexFromObj(…, "option", 0)`,
+/// so `n` resolves to `names` while `v` and `pr` are ambiguous, and the empty
+/// word — a prefix of every entry — is `ambiguous option ""`.
+///
+/// As with `interp` (#1412 item 3), the table names only what this runtime
+/// dispatches: C also carries `files` (9.0), `forget`, and `prefer`, which
+/// need a package loader and a preference latch this runtime has none of.
+/// tclsh 9.0.4, for contrast:
+///   package x -> bad option "x": must be files, forget, ifneeded, names,
+///                prefer, present, provide, require, unknown, vcompare,
+///                versions, or vsatisfies
+const PACKAGE_OPTIONS: &[&[u8]] = &[
+    b"ifneeded",
+    b"names",
+    b"present",
+    b"provide",
+    b"require",
+    b"unknown",
+    b"vcompare",
+    b"versions",
+    b"vsatisfies",
+];
+
 fn package_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     if argv.len() < 2 {
         return interp.wrong_args(b"package subcommand ?arg ...?");
     }
-    match obj_bytes(argv[1]).as_slice() {
+    let word = obj_bytes(argv[1]);
+    let sub = match tcl_cmd_core::prefix::OptionTable::abbreviating("option", PACKAGE_OPTIONS)
+        .index_of(&word)
+    {
+        Ok(i) => PACKAGE_OPTIONS[i],
+        Err(message) => {
+            let code =
+                crate::interp::error_code_list(&[b"TCL", b"LOOKUP", b"INDEX", b"option", &word]);
+            return interp.error_with_code(&message, &code);
+        }
+    };
+    match sub {
         b"provide" => provide(interp, argv),
         b"require" => require(interp, argv),
         b"present" => present(interp, argv),
@@ -111,10 +146,12 @@ fn package_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         b"versions" => versions(interp, argv),
         b"vsatisfies" => vsatisfies_cmd(interp, argv),
         b"vcompare" => vcompare_cmd(interp, argv),
+        // Unreachable: every name in `PACKAGE_OPTIONS` has an arm above.
         other => {
-            let mut m = b"unknown or ambiguous subcommand \"".to_vec();
+            let mut m = b"bad option \"".to_vec();
             m.extend_from_slice(other);
-            m.extend_from_slice(b"\": must be ifneeded, names, present, provide, require, unknown, vcompare, versions, or vsatisfies");
+            m.extend_from_slice(b"\": must be ");
+            m.extend_from_slice(&tcl_cmd_core::prefix::choice_list_bytes(PACKAGE_OPTIONS));
             interp.set_error(&m)
         }
     }
@@ -466,6 +503,50 @@ mod tests {
             String::from_utf8_lossy(src)
         );
         i.result_bytes()
+    }
+
+    /// Issue #1607: `package`'s subcommand word is a `Tcl_GetIndexFromObj(…,
+    /// "option", 0)` table (`pkgOptions[]`, `tclPkg.c`), not an ensemble —
+    /// this said `unknown or ambiguous subcommand "x"`, which is the ensemble
+    /// wording, and matched exactly so nothing abbreviated. The list still
+    /// names only what this runtime dispatches (`files`, `forget`, and
+    /// `prefer` need a loader and a preference latch it has none of).
+    ///
+    /// tclsh 8.6.16 / 9.0.4 (the verdicts, not the shortened list):
+    ///   package x  -> bad option "x": must be …    [TCL LOOKUP INDEX option x]
+    ///   package {} -> ambiguous option "": must be …
+    ///   package v  -> ambiguous option "v": must be …  (vcompare/versions/vsatisfies)
+    ///   package n  -> the names list
+    #[test]
+    fn package_option_word_resolves_like_tcl_get_index_from_obj() {
+        const MUST: &str = "must be ifneeded, names, present, provide, require, unknown, \
+                            vcompare, versions, or vsatisfies";
+        leak_free(|i| {
+            let err = |i: &mut Interp, script: &[u8]| {
+                assert_eq!(i.eval_str(script), Code::Error, "expected an error");
+                String::from_utf8_lossy(&i.result_bytes()).into_owned()
+            };
+            assert_eq!(err(i, b"package x"), format!("bad option \"x\": {MUST}"));
+            assert_eq!(
+                err(i, b"package {}"),
+                format!("ambiguous option \"\": {MUST}")
+            );
+            assert_eq!(
+                err(i, b"package v"),
+                format!("ambiguous option \"v\": {MUST}")
+            );
+            // A unique prefix resolves.
+            assert_eq!(run(i, b"package provide foo 1.0"), b"");
+            assert_eq!(
+                run(i, b"llength [lsearch -all -exact [package n] foo]"),
+                b"1"
+            );
+            // C's lookup error code travels with the message.
+            assert_eq!(
+                run(i, b"catch {package x} e opts; dict get $opts -errorcode"),
+                b"TCL LOOKUP INDEX option x"
+            );
+        });
     }
 
     #[test]

--- a/runtime/rust/src/cmd_string.rs
+++ b/runtime/rust/src/cmd_string.rs
@@ -132,13 +132,13 @@ fn string_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         "string",
         STRING_SUBCOMMANDS,
     );
-    let canonical: &[u8] = match tcl_cmd_core::ensemble::resolve_subcommand(&subs, &sub, true) {
+    let canonical: &[u8] = match tcl_cmd_core::ensemble::resolve_subcommand(subs, &sub, true) {
         Some(index) => subs[index],
         // The whole sentence — including the ensemble's comma before `or` —
         // belongs to the owner, not to a literal beside the table.
         None => {
             return interp.set_error(&tcl_cmd_core::ensemble::unknown_subcommand_message(
-                &subs,
+                subs,
                 &sub,
                 true,
                 b"::tcl::string",

--- a/runtime/rust/src/cmd_string.rs
+++ b/runtime/rust/src/cmd_string.rs
@@ -125,15 +125,20 @@ fn string_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     // (`Tcl_GetIndexFromObj`): `string fir` → `first`, `string trim` wins over
     // its `trimleft`/`trimright` prefixes via the exact-match rule.
     let sub = obj_bytes(argv[1]);
-    let canonical: &[u8] = match index_lookup(STRING_SUBCOMMANDS, &sub) {
-        Resolution::Exact(i) | Resolution::UniquePrefix(i) => STRING_SUBCOMMANDS[i],
-        Resolution::NoMatch | Resolution::Ambiguous => {
-            let mut m = b"unknown or ambiguous subcommand \"".to_vec();
-            m.extend_from_slice(&sub);
-            m.extend_from_slice(b"\": must be cat, compare, equal, first, index, insert, is, last, length, map, match, range, repeat, replace, reverse, tolower, totitle, toupper, trim, trimleft, trimright, wordend, or wordstart");
-            return interp.set_error(&m);
-        }
-    };
+    let canonical: &[u8] =
+        match tcl_cmd_core::ensemble::resolve_subcommand(STRING_SUBCOMMANDS, &sub, true) {
+            Some(index) => STRING_SUBCOMMANDS[index],
+            // The whole sentence — including the ensemble's comma before `or` —
+            // belongs to the owner, not to a literal beside the table.
+            None => {
+                return interp.set_error(&tcl_cmd_core::ensemble::unknown_subcommand_message(
+                    STRING_SUBCOMMANDS,
+                    &sub,
+                    true,
+                    b"::tcl::string",
+                ));
+            }
+        };
     // Portable subcommands now live in the shared command core (`tcl-cmd-core`),
     // driven over this runtime's `*mut TclObj` `ValueOps`. The runtime is a thin
     // adapter: map `Result<*mut TclObj, CmdError>` onto set_result/set_error.
@@ -335,35 +340,33 @@ fn tcl_string_reverse(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     str_reverse(interp, &shifted)
 }
 
-/// Render an option set as Tcl's `a, b, or c` / `a or b` / `a` enumeration —
-/// the shared `Tcl_GetIndexFromObjStruct` formatter.
-fn enum_must_be(items: &[Vec<u8>]) -> Vec<u8> {
-    tcl_cmd_core::prefix::choice_list_bytes(items)
-}
-
 /// `tcl::prefix match|all|longest …` — prefix matching against a table
 /// (`Tcl_PrefixMatchObjCmd` / `Tcl_PrefixAllObjCmd` / `Tcl_PrefixLongestObjCmd`).
 fn tcl_prefix(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     if argv.len() < 2 {
         return interp.wrong_args(b"tcl::prefix subcommand ?arg ...?");
     }
-    match obj_bytes(argv[1]).as_slice() {
-        b"match" => tcl_prefix_match(interp, argv),
+    let word = obj_bytes(argv[1]);
+    let canon = match tcl_cmd_core::ensemble::resolve_subcommand(PREFIX_SUBS, &word, true) {
+        Some(index) => PREFIX_SUBS[index],
+        None => {
+            return interp.set_error(&tcl_cmd_core::ensemble::unknown_subcommand_message(
+                PREFIX_SUBS,
+                &word,
+                true,
+                b"::tcl::prefix",
+            ));
+        }
+    };
+    match canon {
         b"all" => tcl_prefix_all(interp, argv),
         b"longest" => tcl_prefix_longest(interp, argv),
-        other => {
-            let subs: Vec<Vec<u8>> = [b"all".as_ref(), b"longest", b"match"]
-                .iter()
-                .map(|s| s.to_vec())
-                .collect();
-            let mut m = b"unknown or ambiguous subcommand \"".to_vec();
-            m.extend_from_slice(other);
-            m.extend_from_slice(b"\": must be ");
-            m.extend_from_slice(&enum_must_be(&subs));
-            interp.set_error(&m)
-        }
+        _ => tcl_prefix_match(interp, argv),
     }
 }
+
+/// `tcl::prefix`'s subcommand set, alphabetical as `TclMakeEnsemble` sorts it.
+const PREFIX_SUBS: &[&[u8]] = &[b"all", b"longest", b"match"];
 
 /// Split `s` as a Tcl list, or set the full list-parse error and return the
 /// failing `Code` (used by the `tcl::prefix` subcommands).
@@ -382,7 +385,12 @@ fn split_list_or_error(interp: &mut Interp, s: &[u8]) -> Result<Vec<Vec<u8>>, Co
     }
 }
 
-const PREFIX_MATCH_OPTIONS: &[&[u8]] = &[b"-error", b"-exact", b"-message"];
+/// `tcl::prefix match`'s own option words, in C table order (`matchOptions[]`,
+/// `tclIndexObj.c`): `Tcl_GetIndexFromObj(…, "option", 0)`, so `-m`
+/// abbreviates `-message` while `-e` prefixes both `-error` and `-exact` and
+/// is `ambiguous option "-e"`.
+const PREFIX_MATCH_OPTIONS: tcl_cmd_core::prefix::OptionTable<'static, &[u8]> =
+    tcl_cmd_core::prefix::OptionTable::abbreviating("option", &[b"-error", b"-exact", b"-message"]);
 
 fn tcl_prefix_match(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     // tcl::prefix match ?options? table string
@@ -399,19 +407,19 @@ fn tcl_prefix_match(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     let mut i = 2;
     while i < opt_end {
         let opt = obj_bytes(argv[i]);
-        match index_lookup(PREFIX_MATCH_OPTIONS, &opt) {
-            Resolution::Exact(1) | Resolution::UniquePrefix(1) => {
+        match PREFIX_MATCH_OPTIONS.index_of(&opt) {
+            Ok(1) => {
                 exact = true;
                 i += 1;
             }
-            Resolution::Exact(2) | Resolution::UniquePrefix(2) => {
+            Ok(2) => {
                 if i + 1 >= opt_end {
                     return interp.set_error(b"missing value for -message");
                 }
                 message = obj_bytes(argv[i + 1]);
                 i += 2;
             }
-            Resolution::Exact(_) | Resolution::UniquePrefix(_) => {
+            Ok(_) => {
                 if i + 1 >= opt_end {
                     return interp.set_error(b"missing value for -error");
                 }
@@ -426,17 +434,7 @@ fn tcl_prefix_match(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
                 error_opts = Some(val);
                 i += 2;
             }
-            bad => {
-                let verb: &[u8] = if matches!(bad, Resolution::Ambiguous) {
-                    b"ambiguous option \""
-                } else {
-                    b"bad option \""
-                };
-                let mut m = verb.to_vec();
-                m.extend_from_slice(&opt);
-                m.extend_from_slice(b"\": must be -error, -exact, or -message");
-                return interp.set_error(&m);
-            }
+            Err(m) => return interp.set_error(&m),
         }
     }
     let table = match split_list_or_error(interp, &obj_bytes(argv[argv.len() - 2])) {
@@ -905,7 +903,10 @@ fn str_map(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
 /// `StringIsCmd`'s `isClasses[]`). The order is significant: it drives the
 /// `bad class`/`ambiguous class` "must be …" diagnostic, and the class is
 /// resolved against this table by exact name or unambiguous prefix.
-const IS_CLASSES: &[&[u8]] = &[
+const IS_CLASSES: tcl_cmd_core::prefix::OptionTable<'static, &[u8]> =
+    tcl_cmd_core::prefix::OptionTable::abbreviating("class", IS_CLASS_NAMES);
+
+const IS_CLASS_NAMES: &[&[u8]] = &[
     b"alnum",
     b"alpha",
     b"ascii",
@@ -930,18 +931,10 @@ const IS_CLASSES: &[&[u8]] = &[
     b"xdigit",
 ];
 
-/// `string is` option table (for the `-strict`/`-failindex` prefix match).
-const IS_OPTIONS: &[&[u8]] = &[b"-strict", b"-failindex"];
-
-/// Resolve `arg` against `table` like `Tcl_GetIndexFromObj` (flags 0): an exact
-/// match wins, else a *unique* prefix; ambiguous and no-match are distinguished
-/// so the caller can emit `bad`/`ambiguous` as C does. An empty `arg` never
-/// abbreviates, but — per C — its miss is worded `ambiguous` when it trivially
-/// prefixes two or more entries (tclsh8.6: `string is "" x` → `ambiguous
-/// class ""…`; the old local matcher said `bad`).
-fn index_lookup(table: &[&[u8]], arg: &[u8]) -> Resolution {
-    tcl_cmd_core::prefix::scan(table, arg, false)
-}
+/// `string is`'s own options (`Tcl_GetIndexFromObj(…, "option", 0)`), in C
+/// table order — the two-entry enumeration has no comma before `or`.
+const IS_OPTIONS: tcl_cmd_core::prefix::OptionTable<'static, &[u8]> =
+    tcl_cmd_core::prefix::OptionTable::abbreviating("option", &[b"-strict", b"-failindex"]);
 
 /// `string is class ?-strict? ?-failindex var? string`. Returns 1/0; with
 /// `-failindex`, stores the first failing character index in `var` — but **only
@@ -953,12 +946,9 @@ fn str_is(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         return interp.wrong_args(USAGE);
     }
     let class_arg = obj_bytes(argv[2]);
-    let class: &[u8] = match index_lookup(IS_CLASSES, &class_arg) {
-        Resolution::Exact(i) | Resolution::UniquePrefix(i) => IS_CLASSES[i],
-        Resolution::Ambiguous => {
-            return interp.set_error(&class_err(b"ambiguous class", &class_arg));
-        }
-        Resolution::NoMatch => return interp.set_error(&class_err(b"bad class", &class_arg)),
+    let class: &[u8] = match IS_CLASSES.index_of(&class_arg) {
+        Ok(i) => IS_CLASSES.names()[i],
+        Err(m) => return interp.set_error(&m),
     };
 
     // The last argument is always the string under test; the args between the
@@ -969,12 +959,12 @@ fn str_is(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     let mut k = 3;
     while k < last {
         let opt = obj_bytes(argv[k]);
-        match index_lookup(IS_OPTIONS, &opt) {
-            Resolution::Exact(0) | Resolution::UniquePrefix(0) => {
+        match IS_OPTIONS.index_of(&opt) {
+            Ok(0) => {
                 strict = true;
                 k += 1;
             }
-            Resolution::Exact(_) | Resolution::UniquePrefix(_) => {
+            Ok(_) => {
                 if k + 1 >= last {
                     // C names the resolved class here (`string is double …`), not
                     // the generic "class" the arg-count check uses.
@@ -986,10 +976,7 @@ fn str_is(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
                 failvar = Some(obj_bytes(argv[k + 1]));
                 k += 2;
             }
-            Resolution::Ambiguous => {
-                return interp.set_error(&option_err(b"ambiguous option", &opt));
-            }
-            Resolution::NoMatch => return interp.set_error(&option_err(b"bad option", &opt)),
+            Err(m) => return interp.set_error(&m),
         }
     }
 
@@ -1016,26 +1003,6 @@ fn str_is(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     }
     interp.set_result_bytes(if ok { b"1" } else { b"0" });
     Code::Ok
-}
-
-/// `bad class "X": must be …` / `ambiguous class "X": must be …`.
-fn class_err(kind: &[u8], arg: &[u8]) -> Vec<u8> {
-    let mut m = kind.to_vec();
-    m.extend_from_slice(b" \"");
-    m.extend_from_slice(arg);
-    m.extend_from_slice(b"\": must be ");
-    let classes: Vec<Vec<u8>> = IS_CLASSES.iter().map(|s| s.to_vec()).collect();
-    m.extend_from_slice(&tcl_cmd_core::ensemble::subcommand_choices(&classes));
-    m
-}
-
-/// `bad option "X": must be -strict or -failindex` (two-item form: no comma).
-fn option_err(kind: &[u8], arg: &[u8]) -> Vec<u8> {
-    let mut m = kind.to_vec();
-    m.extend_from_slice(b" \"");
-    m.extend_from_slice(arg);
-    m.extend_from_slice(b"\": must be -strict or -failindex");
-    m
 }
 
 // `string is` classification now lives in the shared `tcl_cmd_core::string_is`
@@ -1276,6 +1243,63 @@ mod tests {
         );
         assert_eq!(ok(b"tcl::prefix longest {apple apricot banana} ap"), b"ap");
         assert_eq!(ok(b"tcl::prefix match -error {} {apple apricot} xy"), b"");
+    }
+
+    /// Issue #1607: `string` and `tcl::prefix` are `TclMakeEnsemble` commands,
+    /// so both the scan and the whole miss sentence belong to
+    /// `tcl_cmd_core::ensemble`; `tcl::prefix`'s dispatch matched exactly and
+    /// its enumeration came from `prefix::choice_list_bytes` (the wrong owner —
+    /// the same bytes only because the list has three entries).
+    /// `tcl::prefix match`'s own options and `string is`'s class/option words
+    /// are `Tcl_GetIndexFromObj` tables whose sentences were spelled by hand.
+    ///
+    /// tclsh 8.6.16 / 9.0.4:
+    ///   tcl::prefix {} {a} a       -> unknown or ambiguous subcommand "":
+    ///                                 must be all, longest, or match
+    ///   tcl::prefix m {a} a        -> a
+    ///   tcl::prefix match -e {a} a -> ambiguous option "-e": must be -error,
+    ///                                 -exact, or -message
+    ///   tcl::prefix match -x {a} a -> bad option "-x": must be <same>
+    ///   string {} a                -> unknown or ambiguous subcommand "":
+    ///                                 must be cat, compare, …, or wordstart
+    ///   string is {} x             -> ambiguous class "": must be alnum, …
+    ///   string is integer -z x     -> bad option "-z": must be -strict or -failindex
+    #[test]
+    fn string_and_prefix_ensembles_resolve_like_tclsh() {
+        const OPT_MUST: &str = "must be -error, -exact, or -message";
+        const STRING_MUST: &str = "must be cat, compare, equal, first, index, insert, is, last, \
+                                   length, map, match, range, repeat, replace, reverse, tolower, \
+                                   totitle, toupper, trim, trimleft, trimright, wordend, or \
+                                   wordstart";
+        assert_eq!(
+            err(b"tcl::prefix {} {a} a"),
+            b"unknown or ambiguous subcommand \"\": must be all, longest, or match"
+        );
+        assert_eq!(ok(b"tcl::prefix m {a} a"), b"a");
+        assert_eq!(
+            err(b"tcl::prefix match -e {a} a"),
+            format!("ambiguous option \"-e\": {OPT_MUST}").as_bytes()
+        );
+        assert_eq!(
+            err(b"tcl::prefix match -x {a} a"),
+            format!("bad option \"-x\": {OPT_MUST}").as_bytes()
+        );
+        assert_eq!(
+            err(b"string {} a"),
+            format!("unknown or ambiguous subcommand \"\": {STRING_MUST}").as_bytes()
+        );
+        assert_eq!(
+            err(b"string to abc"),
+            format!("unknown or ambiguous subcommand \"to\": {STRING_MUST}").as_bytes()
+        );
+        assert_eq!(ok(b"string le hello"), b"5");
+        // `string is`'s class and option words are plain option tables.
+        assert!(err(b"string is {} x").starts_with(b"ambiguous class \"\": must be alnum, "));
+        assert_eq!(
+            err(b"string is integer -z x"),
+            b"bad option \"-z\": must be -strict or -failindex"
+        );
+        assert_eq!(ok(b"string is int 12"), b"1");
     }
 
     #[test]

--- a/runtime/rust/src/cmd_string.rs
+++ b/runtime/rust/src/cmd_string.rs
@@ -125,20 +125,26 @@ fn string_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     // (`Tcl_GetIndexFromObj`): `string fir` → `first`, `string trim` wins over
     // its `trimleft`/`trimright` prefixes via the exact-match rule.
     let sub = obj_bytes(argv[1]);
-    let canonical: &[u8] =
-        match tcl_cmd_core::ensemble::resolve_subcommand(STRING_SUBCOMMANDS, &sub, true) {
-            Some(index) => STRING_SUBCOMMANDS[index],
-            // The whole sentence — including the ensemble's comma before `or` —
-            // belongs to the owner, not to a literal beside the table.
-            None => {
-                return interp.set_error(&tcl_cmd_core::ensemble::unknown_subcommand_message(
-                    STRING_SUBCOMMANDS,
-                    &sub,
-                    true,
-                    b"::tcl::string",
-                ));
-            }
-        };
+    // `insert` arrives in Tcl 9, so under an earlier pin it must not resolve
+    // and must not make `string in` ambiguous with `index`.
+    let subs = crate::environment::release_subcommands(
+        interp.runtime_version().dialect_profile_name(),
+        "string",
+        STRING_SUBCOMMANDS,
+    );
+    let canonical: &[u8] = match tcl_cmd_core::ensemble::resolve_subcommand(&subs, &sub, true) {
+        Some(index) => subs[index],
+        // The whole sentence — including the ensemble's comma before `or` —
+        // belongs to the owner, not to a literal beside the table.
+        None => {
+            return interp.set_error(&tcl_cmd_core::ensemble::unknown_subcommand_message(
+                &subs,
+                &sub,
+                true,
+                b"::tcl::string",
+            ));
+        }
+    };
     // Portable subcommands now live in the shared command core (`tcl-cmd-core`),
     // driven over this runtime's `*mut TclObj` `ValueOps`. The runtime is a thin
     // adapter: map `Result<*mut TclObj, CmdError>` onto set_result/set_error.

--- a/runtime/rust/src/cmd_zlib.rs
+++ b/runtime/rust/src/cmd_zlib.rs
@@ -35,7 +35,7 @@ use flate2::read::{DeflateDecoder, GzDecoder, ZlibDecoder};
 use flate2::write::{DeflateEncoder, GzEncoder, ZlibEncoder};
 use flate2::Compression;
 use std::io::{Read, Write};
-use tcl_cmd_core::ensemble::{resolve_subcommand, subcommand_choices};
+use tcl_cmd_core::ensemble::resolve_subcommand;
 
 /// Register the `zlib` ensemble.
 pub fn install(interp: &mut Interp) {
@@ -175,11 +175,16 @@ fn zlib_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     let sub = obj_bytes(argv[1]);
     let names: Vec<Vec<u8>> = SUBS.iter().map(|s| s.to_vec()).collect();
     let Some(idx) = resolve_subcommand(&names, &sub, true) else {
-        let mut m = b"unknown or ambiguous subcommand \"".to_vec();
-        m.extend_from_slice(&sub);
-        m.extend_from_slice(b"\": must be ");
-        m.extend_from_slice(&subcommand_choices(&names));
-        return interp.set_error(&m);
+        // The whole sentence, not just its enumeration, is the owner's. 9.0
+        // made `zlib` a real ensemble; 8.6 resolved it with
+        // `Tcl_GetIndexFromObj(…, "command", 0)` and worded its miss
+        // `bad command "x"` / `ambiguous command ""` instead.
+        return interp.set_error(&tcl_cmd_core::ensemble::unknown_subcommand_message(
+            &names,
+            &sub,
+            true,
+            b"::tcl::zlib",
+        ));
     };
     match SUBS[idx] {
         b"crc32" => checksum(interp, argv, false),
@@ -313,8 +318,8 @@ fn gzip(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     let mut i = 3;
     while i < argv.len() {
         let opt = obj_bytes(argv[i]);
-        match opt.as_slice() {
-            b"-level" => {
+        match GZIP_OPTIONS.index_of(&opt) {
+            Ok(1) => {
                 let Some(&val) = argv.get(i + 1) else {
                     return interp.wrong_args(b"zlib gzip data ?-level level? ?-header header?");
                 };
@@ -324,23 +329,30 @@ fn gzip(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
                 };
                 i += 2;
             }
-            b"-header" => {
+            Ok(_) => {
                 return interp.set_error(
                     b"the -header option to zlib gzip is not supported under the WASM runtime",
                 );
             }
-            _ => {
-                let mut m = b"bad option \"".to_vec();
-                m.extend_from_slice(&opt);
-                m.extend_from_slice(b"\": must be -level or -header");
-                return interp.set_error(&m);
-            }
+            Err(m) => return interp.set_error(&m),
         }
     }
     let out = compress_gzip(&data, level);
     interp.set_result_byte_array(&out);
     Code::Ok
 }
+
+/// `zlib gzip`'s option words, in C table order (`tclZlib.c`), resolved with
+/// `Tcl_GetIndexFromObj(…, "option", 0)`: `-l` abbreviates `-level` and the
+/// empty word — a prefix of both — is `ambiguous option ""`. The order matters:
+/// C lists `-header` first, so its enumeration reads `-header or -level`.
+const GZIP_OPTIONS: tcl_cmd_core::prefix::OptionTable<'static, &[u8]> =
+    tcl_cmd_core::prefix::OptionTable::abbreviating("option", &[b"-header", b"-level"]);
+
+/// `zlib gunzip`'s option words, in C table order (`tclZlib.c`). This
+/// advertised only `-headerVar`; C also takes `-buffersize`.
+const GUNZIP_OPTIONS: tcl_cmd_core::prefix::OptionTable<'static, &[u8]> =
+    tcl_cmd_core::prefix::OptionTable::abbreviating("option", &[b"-buffersize", b"-headerVar"]);
 
 /// `zlib gunzip data ?-headerVar varName?` — the header-var readback is not
 /// modelled here.
@@ -350,15 +362,19 @@ fn gunzip(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     }
     if argv.len() > 3 {
         let opt = obj_bytes(argv[3]);
-        if opt == b"-headerVar" {
-            return interp.set_error(
-                b"the -headerVar option to zlib gunzip is not supported under the WASM runtime",
-            );
+        match GUNZIP_OPTIONS.index_of(&opt) {
+            Ok(0) => {
+                return interp.set_error(
+                    b"the -buffersize option to zlib gunzip is not supported under the WASM runtime",
+                );
+            }
+            Ok(_) => {
+                return interp.set_error(
+                    b"the -headerVar option to zlib gunzip is not supported under the WASM runtime",
+                );
+            }
+            Err(m) => return interp.set_error(&m),
         }
-        let mut m = b"bad option \"".to_vec();
-        m.extend_from_slice(&opt);
-        m.extend_from_slice(b"\": must be -headerVar");
-        return interp.set_error(&m);
     }
     let data = match interp.binary_bytes(argv[2]) {
         Ok(data) => data,
@@ -400,6 +416,49 @@ mod tests {
         assert_eq!(adler32(1, b"hello, world"), 492_045_449);
         // Continued (non-default start value).
         assert_eq!(crc32(5, b"abc"), 871_334_697);
+    }
+
+    /// Issue #1607: `zlib gzip`'s and `zlib gunzip`'s option words are
+    /// `Tcl_GetIndexFromObj(…, "option", 0)` tables. Both were matched exactly,
+    /// `gzip`'s enumeration was in the wrong order (C lists `-header` first),
+    /// and `gunzip`'s omitted `-buffersize` entirely. `zlib`'s own dispatch
+    /// borrows the full ensemble sentence now, not just its enumeration.
+    ///
+    /// tclsh 9.0.4:
+    ///   zlib gzip abc -x 1  -> bad option "-x": must be -header or -level
+    ///   zlib gzip abc {} 1  -> ambiguous option "": must be -header or -level
+    ///   zlib gunzip <gz> -x y -> bad option "-x": must be -buffersize or -headerVar
+    ///   zlib co abc         -> compressed bytes  ;  zlib c abc -> ambiguous
+    #[test]
+    fn zlib_option_words_resolve_like_tcl_get_index_from_obj() {
+        let mut i = Interp::new();
+        let err_of = |i: &mut Interp, src: &[u8]| {
+            assert_eq!(i.eval_str(src), Code::Error, "expected an error");
+            String::from_utf8_lossy(&i.result_bytes()).into_owned()
+        };
+        assert_eq!(
+            err_of(&mut i, b"zlib gzip abc -x 1"),
+            "bad option \"-x\": must be -header or -level"
+        );
+        assert_eq!(
+            err_of(&mut i, b"zlib gzip abc {} 1"),
+            "ambiguous option \"\": must be -header or -level"
+        );
+        assert_eq!(
+            err_of(&mut i, b"zlib gunzip abc -x y"),
+            "bad option \"-x\": must be -buffersize or -headerVar"
+        );
+        // `-l` uniquely abbreviates `-level`, so the option is consumed.
+        assert_eq!(i.eval_str(b"zlib gzip abc -l 1"), Code::Ok);
+        // `-b` uniquely abbreviates `-buffersize`, so it resolves and the
+        // error names the *option*, not a bad word.
+        assert_eq!(
+            err_of(&mut i, b"zlib gunzip abc -b 4096"),
+            "the -buffersize option to zlib gunzip is not supported under the WASM runtime"
+        );
+        // The dispatch keeps tclsh 9.0's ensemble wording.
+        assert!(err_of(&mut i, b"zlib c abc")
+            .starts_with("unknown or ambiguous subcommand \"c\": must be adler32, "));
     }
 
     #[test]

--- a/runtime/rust/src/environment.rs
+++ b/runtime/rust/src/environment.rs
@@ -102,3 +102,44 @@ pub(crate) fn known_surface_point_for_dialect(
     tcl_registry::model::resolve_known_environment(name)
         .map(|environment| environment.document_authoring_scope())
 }
+
+/// The subset of an engine ensemble `table` the emulated release actually
+/// has, in the table's own order — the WASM runtime's half of the rule
+/// `tcl-vm`'s `environment::release_subcommands` states.
+///
+/// A `TclMakeEnsemble` table is a *release* fact: `dict getwithdefault`,
+/// `string insert` and `chan isbinary` arrive in Tcl 9 while `string
+/// bytelength` leaves with it, and resolving against one release's table
+/// under every pin both dispatches names the pinned release never had and
+/// changes prefix verdicts for names that have nothing to do with them
+/// (`dict g` is `get` on 8.6, ambiguous on 9.0; `string in` is `index` on
+/// 8.6, ambiguous on 9.0). The names and their gates belong to the registry.
+///
+/// Only *removal* happens: a name the registry does not model (an engine
+/// extra) is kept, so a table stays the engine's own list of what it
+/// dispatches and its enumeration order.
+pub(crate) fn release_subcommands(
+    dialect_name: &str,
+    command: &str,
+    table: &[&'static [u8]],
+) -> Vec<&'static [u8]> {
+    let profile = profile_for_dialect(dialect_name);
+    let point = surface_point(profile);
+    let Some(spec) = store_for_profile(profile).get(command) else {
+        return table.to_vec();
+    };
+    table
+        .iter()
+        .copied()
+        .filter(|name| {
+            spec.subcommands
+                .iter()
+                .find(|sub| sub.name.as_bytes() == *name)
+                .is_none_or(|sub| {
+                    sub.surface
+                        .or(spec.surface)
+                        .is_none_or(|gate| tcl_dialect::model::surface_admits(gate, Some(&point)))
+                })
+        })
+        .collect()
+}

--- a/runtime/rust/src/environment.rs
+++ b/runtime/rust/src/environment.rs
@@ -43,6 +43,8 @@
 //!
 //! [`TclVersion::dialect_profile_name`]: tcl_dialect::TclVersion::dialect_profile_name
 
+use std::sync::{Mutex, OnceLock};
+
 use tcl_dialect::model::SurfaceQuery;
 use tcl_dialect::DialectProfile;
 use tcl_registry::CommandRegistry;
@@ -103,6 +105,10 @@ pub(crate) fn known_surface_point_for_dialect(
         .map(|environment| environment.document_authoring_scope())
 }
 
+/// One memoised answer: `(command, release name, the release's slice of the
+/// engine's table)`.
+type SubcommandCacheEntry = (&'static str, String, &'static [&'static [u8]]);
+
 /// The subset of an engine ensemble `table` the emulated release actually
 /// has, in the table's own order — the WASM runtime's half of the rule
 /// `tcl-vm`'s `environment::release_subcommands` states.
@@ -118,28 +124,53 @@ pub(crate) fn known_surface_point_for_dialect(
 /// Only *removal* happens: a name the registry does not model (an engine
 /// extra) is kept, so a table stays the engine's own list of what it
 /// dispatches and its enumeration order.
+///
+/// Memoised per `(command, release)` for the same reason the VM's is:
+/// resolving the environment by name costs tens of microseconds, which would
+/// dominate a `dict get`. The pair is a closed, tiny set and each command
+/// name has one table, so the leak is bounded by it.
+fn release_subcommand_cache() -> &'static Mutex<Vec<SubcommandCacheEntry>> {
+    static CACHE: OnceLock<Mutex<Vec<SubcommandCacheEntry>>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(Vec::new()))
+}
+
 pub(crate) fn release_subcommands(
     dialect_name: &str,
-    command: &str,
+    command: &'static str,
     table: &[&'static [u8]],
-) -> Vec<&'static [u8]> {
+) -> &'static [&'static [u8]] {
+    let cache = release_subcommand_cache();
+    if let Some((_, _, hit)) = cache
+        .lock()
+        .expect("subcommand cache")
+        .iter()
+        .find(|(cmd, name, _)| *cmd == command && name == dialect_name)
+    {
+        return hit;
+    }
     let profile = profile_for_dialect(dialect_name);
     let point = surface_point(profile);
-    let Some(spec) = store_for_profile(profile).get(command) else {
-        return table.to_vec();
+    let filtered: Vec<&'static [u8]> = match store_for_profile(profile).get(command) {
+        Some(spec) => table
+            .iter()
+            .copied()
+            .filter(|name| {
+                spec.subcommands
+                    .iter()
+                    .find(|sub| sub.name.as_bytes() == *name)
+                    .is_none_or(|sub| {
+                        sub.surface.or(spec.surface).is_none_or(|gate| {
+                            tcl_dialect::model::surface_admits(gate, Some(&point))
+                        })
+                    })
+            })
+            .collect(),
+        None => table.to_vec(),
     };
-    table
-        .iter()
-        .copied()
-        .filter(|name| {
-            spec.subcommands
-                .iter()
-                .find(|sub| sub.name.as_bytes() == *name)
-                .is_none_or(|sub| {
-                    sub.surface
-                        .or(spec.surface)
-                        .is_none_or(|gate| tcl_dialect::model::surface_admits(gate, Some(&point)))
-                })
-        })
-        .collect()
+    let leaked: &'static [&'static [u8]] = Vec::leak(filtered);
+    cache
+        .lock()
+        .expect("subcommand cache")
+        .push((command, dialect_name.to_string(), leaked));
+    leaked
 }

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -6500,13 +6500,52 @@ impl Interp {
             .resolve_fqn(self.current_ns.get(), name)
     }
 
+    /// The child-as-command subcommand words, in C table order (`options[]` in
+    /// `NRChildCmd`, `tclInterp.c`), resolved with
+    /// `Tcl_GetIndexFromObj(…, "option", 0)` — so `ev` abbreviates `eval` and
+    /// the empty word is `ambiguous option ""`. The child command object
+    /// advertises a *shorter* list than `interp` does (no `children`, `create`,
+    /// `delete`, or `exists`: those are only ever spelled `interp <op> path`),
+    /// and this runtime dispatches all thirteen (issue #1412 item 7).
+    pub(crate) const CHILD_OPTIONS: &[&[u8]] = &[
+        b"alias",
+        b"aliases",
+        b"bgerror",
+        b"debug",
+        b"eval",
+        b"expose",
+        b"hide",
+        b"hidden",
+        b"issafe",
+        b"invokehidden",
+        b"limit",
+        b"marktrusted",
+        b"recursionlimit",
+    ];
+
     /// Dispatch a child-interpreter command (`$child subcommand ?arg ...?`): the
     /// child is addressable like the `interp` ensemble restricted to it.
     fn dispatch_child(&mut self, name: &[u8], argv: &[*mut TclObj]) -> Code {
         if argv.len() < 2 {
             return self.error(b"wrong # args: should be \"interp cmd ?arg ...?\"");
         }
-        match obj_bytes(argv[1]).as_slice() {
+        let word = obj_bytes(argv[1]);
+        // `$child delete` is this runtime's own extra — C's child table has no
+        // `delete` (it is only ever spelled `interp delete path`) — so it is
+        // matched exactly, never abbreviates, and stays out of the enumeration.
+        let sub: &[u8] = if word == b"delete" {
+            b"delete"
+        } else {
+            match crate::cmd_alias::resolve_interp_option(
+                Self::CHILD_OPTIONS,
+                Self::CHILD_OPTIONS,
+                &word,
+            ) {
+                Ok(canonical) => canonical,
+                Err(m) => return self.error(&m),
+            }
+        };
+        match sub {
             b"eval" => {
                 let script = join_words(&argv[2..]);
                 self.eval_in_child(name, &script)
@@ -6521,8 +6560,18 @@ impl Interp {
                 self.set_result_bytes(b"");
                 Code::Ok
             }
-            b"hide" | b"expose" if argv.len() == 3 => {
-                let hide = obj_bytes(argv[1]) == b"hide";
+            b"hide" | b"expose" => {
+                let hide = sub == b"hide";
+                if argv.len() < 3 || argv.len() > 4 {
+                    let mut m = b"wrong # args: should be \"".to_vec();
+                    m.extend_from_slice(name);
+                    m.extend_from_slice(if hide {
+                        b" hide cmdName ?hiddenCmdName?\"".as_slice()
+                    } else {
+                        b" expose hiddenCmdName ?cmdName?\"".as_slice()
+                    });
+                    return self.error(&m);
+                }
                 let op = if hide {
                     CommandVisibilityOp::Hide
                 } else {
@@ -6538,15 +6587,24 @@ impl Interp {
                     });
                 }
                 let cmd = obj_bytes(argv[2]);
+                let token = argv.get(3).map_or_else(|| cmd.clone(), |&a| obj_bytes(a));
                 let outcome = self
                     .with_child(name, |c| match op {
-                        CommandVisibilityOp::Hide => c.hide_command(&cmd, &cmd),
-                        CommandVisibilityOp::Expose => c.expose_command(&cmd, &cmd),
+                        CommandVisibilityOp::Hide => c.hide_command(&cmd, &token),
+                        CommandVisibilityOp::Expose => c.expose_command(&cmd, &token),
                     })
                     .unwrap_or(CommandVisibilityOutcome::Missing);
-                self.finish_command_visibility(op, &cmd, &cmd, outcome)
+                self.finish_command_visibility(op, &cmd, &token, outcome)
             }
-            b"invokehidden" if argv.len() >= 3 => {
+            b"invokehidden" => {
+                if argv.len() < 3 {
+                    let mut m = b"wrong # args: should be \"".to_vec();
+                    m.extend_from_slice(name);
+                    m.extend_from_slice(
+                        b" invokehidden ?-namespace ns? ?-global? ?--? cmd ?arg ..?\"",
+                    );
+                    return self.error(&m);
+                }
                 if self.is_safe() {
                     return self
                         .error(b"not allowed to invoke hidden commands from safe interpreter");
@@ -6591,7 +6649,13 @@ impl Interp {
             // `$child alias srcCmd targetCmd ?arg ...?` — a cross-interp alias in
             // the child delegating to `targetCmd` in this (parent) interp. (The
             // target is implicitly the parent, so there is no target-path arg.)
-            b"alias" if argv.len() >= 4 => {
+            b"alias" => {
+                if argv.len() < 4 {
+                    let mut m = b"wrong # args: should be \"".to_vec();
+                    m.extend_from_slice(name);
+                    m.extend_from_slice(b" alias aliasName ?targetName? ?arg ...?\"");
+                    return self.error(&m);
+                }
                 let alias = obj_bytes(argv[2]);
                 let target = obj_bytes(argv[3]);
                 let prefix: Vec<Vec<u8>> = argv[4..].iter().map(|&a| obj_bytes(a)).collect();
@@ -6686,22 +6750,14 @@ impl Interp {
                     None => self.error(b"could not find interpreter"),
                 }
             }
+            // Unreachable: every name in `Self::CHILD_OPTIONS` has an arm above.
             other => {
-                // Same `bad option` shape as the `interp` ensemble's own
-                // fallthrough (`cmd_alias.rs::interp_cmd`) — the child
-                // command object (`NRChildCmd`, tclInterp.c) advertises a
-                // *shorter* list than `interp` does (no `children`,
-                // `create`, `delete`, or `exists`: those are only ever
-                // spelled `interp <op> path`, never `$child <op>`), but the
-                // shape is the same tclsh `bad option` error, not a
-                // runtime-specific message (issue #1412 item 7).
                 let mut m = b"bad option \"".to_vec();
                 m.extend_from_slice(other);
-                m.extend_from_slice(
-                    b"\": must be alias, aliases, bgerror, debug, eval, expose, \
-                      hide, hidden, issafe, invokehidden, limit, marktrusted, \
-                      or recursionlimit",
-                );
+                m.extend_from_slice(b"\": must be ");
+                m.extend_from_slice(&tcl_cmd_core::prefix::choice_list_bytes(
+                    Self::CHILD_OPTIONS,
+                ));
                 self.error(&m)
             }
         }

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -1089,16 +1089,23 @@ fn resolve_limit_opt(arg: &[u8], opts: &[&[u8]]) -> Result<Vec<u8>, Vec<u8>> {
     }
 }
 
-/// Validate an `interp debug` option: it must be a non-empty prefix of `-frame`.
+/// `interp debug`'s one option word (`debugTypes[]`, `tclInterp.c`): C resolves
+/// it with `Tcl_GetIndexFromObj(…, "debug option", 0)`, so `-f`/`-fr`
+/// abbreviate and a miss is `bad debug option "…": must be -frame` — a
+/// one-entry table is never `ambiguous`, not even for the empty word. Shared
+/// with the bytecode VM through the one `tcl-cmd-core::prefix` matcher.
+const DEBUG_OPTIONS: tcl_cmd_core::prefix::OptionTable<'static, &[u8]> =
+    tcl_cmd_core::prefix::OptionTable::abbreviating("debug option", &[b"-frame"]);
+
+/// `interp limit`'s type word (`limitTypes[]`, `tclInterp.c`): the noun is
+/// `limit type` and the flags are `0`, so `c`/`t` abbreviate and the empty
+/// word — a prefix of both entries — is `ambiguous limit type ""`.
+pub(crate) const LIMIT_TYPES: tcl_cmd_core::prefix::OptionTable<'static, &[u8]> =
+    tcl_cmd_core::prefix::OptionTable::abbreviating("limit type", &[b"commands", b"time"]);
+
+/// Validate an `interp debug` option through the shared owner.
 fn check_debug_opt(opt: *mut TclObj) -> Result<(), Vec<u8>> {
-    let o = obj_bytes(opt);
-    if !o.is_empty() && b"-frame".starts_with(o.as_slice()) {
-        return Ok(());
-    }
-    let mut m = b"bad debug option \"".to_vec();
-    m.extend_from_slice(&o);
-    m.extend_from_slice(b"\": must be -frame");
-    Err(m)
+    DEBUG_OPTIONS.index_of(&obj_bytes(opt)).map(|_| ())
 }
 
 /// Parse an `interp limit` integer option value (`expected integer but got "X"`).
@@ -6643,8 +6650,12 @@ impl Interp {
             b"debug" => {
                 let opts: Vec<*mut TclObj> = argv[2..].to_vec();
                 if argv.len() > 4 {
-                    return self
-                        .error(b"wrong # args: should be \"interp debug path ?-frame ?bool??\"");
+                    // C words the arity message with the child's own command
+                    // name here, not the `interp debug path …` spelling.
+                    let mut m = b"wrong # args: should be \"".to_vec();
+                    m.extend_from_slice(name);
+                    m.extend_from_slice(b" debug ?-frame ?bool??\"");
+                    return self.error(&m);
                 }
                 match self.with_child(name, |c| c.debug_apply(&opts)) {
                     Some(Ok(o)) => {
@@ -7242,15 +7253,9 @@ impl Interp {
         ltype: &[u8],
         opts: &[*mut TclObj],
     ) -> Result<*mut TclObj, Vec<u8>> {
-        match ltype {
-            b"commands" => self.limit_commands(opts),
-            b"time" => self.limit_time(opts),
-            other => {
-                let mut m = b"bad limit type \"".to_vec();
-                m.extend_from_slice(other);
-                m.extend_from_slice(b"\": must be commands or time");
-                Err(m)
-            }
+        match LIMIT_TYPES.index_of(ltype)? {
+            0 => self.limit_commands(opts),
+            _ => self.limit_time(opts),
         }
     }
 

--- a/runtime/rust/tests/ensemble_release_surface.rs
+++ b/runtime/rust/tests/ensemble_release_surface.rs
@@ -1,0 +1,245 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! A `TclMakeEnsemble` subcommand table is a **release** fact, and this engine
+//! is release-selectable — so resolving against one release's table under
+//! every pin is wrong twice over. It dispatches names the pinned release never
+//! had (`info cmdtype` under 8.6), and, less visibly, a 9-only name changes
+//! the prefix verdict for a word that has nothing to do with it: `dict g` is
+//! `get` on 8.6 and ambiguous on 9.0, `string in` is `index` on 8.6 and
+//! ambiguous on 9.0, `file te` is `tempfile` on 8.6 and ambiguous on 9.0.
+//!
+//! Every row below is byte-checked against `tmp/tcl8.6.16/unix/tclsh` and
+//! `tmp/tcl9.0.4/unix/tclsh`. Rows the engine deliberately does not implement
+//! are marked `UNIMPLEMENTED:` and assert this engine's documented answer, not
+//! tclsh's.
+
+use tcl_dialect::TclVersion;
+use tcl_runtime::interp::{Code, Interp};
+
+/// An interpreter pinned to `version`.
+fn at(version: TclVersion) -> Interp {
+    let mut interp = Interp::new();
+    interp.set_runtime_version(version);
+    interp
+}
+
+/// Run `src` and return `(code, result)`.
+fn run(interp: &mut Interp, src: &str) -> (Code, String) {
+    let code = interp.eval_str(src.as_bytes());
+    (
+        code,
+        String::from_utf8_lossy(&interp.result_bytes()).into_owned(),
+    )
+}
+
+/// `dict getdef`/`getwithdefault` (TIP 342) are Tcl 9.
+///
+/// tclsh8.6.16:  dict g {a 1} a          -> 1
+///               dict getdef {a 1} z D   -> unknown or ambiguous subcommand
+///                                          "getdef": must be append, …
+/// tclsh9.0.4:   dict g {a 1} a          -> unknown or ambiguous subcommand
+///                                          "g": must be … get, getdef,
+///                                          getwithdefault, …
+///               dict getdef {a 1} z D   -> D
+#[test]
+fn dict_get_prefix_is_unique_before_tcl9() {
+    let mut old = at(TclVersion::V8_6);
+    assert_eq!(run(&mut old, "dict g {a 1} a"), (Code::Ok, "1".to_string()));
+    let (code, message) = run(&mut old, "dict getdef {a 1} z D");
+    assert_eq!(code, Code::Error);
+    assert_eq!(
+        message,
+        "unknown or ambiguous subcommand \"getdef\": must be append, create, exists, filter, \
+         for, get, incr, info, keys, lappend, map, merge, remove, replace, set, size, unset, \
+         update, values, or with"
+    );
+
+    let mut new = at(TclVersion::V9_0);
+    let (code, message) = run(&mut new, "dict g {a 1} a");
+    assert_eq!(code, Code::Error);
+    assert_eq!(
+        message,
+        "unknown or ambiguous subcommand \"g\": must be append, create, exists, filter, for, \
+         get, getdef, getwithdefault, incr, info, keys, lappend, map, merge, remove, replace, \
+         set, size, unset, update, values, or with"
+    );
+    assert_eq!(
+        run(&mut new, "dict getdef {a 1} z D"),
+        (Code::Ok, "D".to_string())
+    );
+}
+
+/// `string insert` is Tcl 9.
+///
+/// tclsh8.6.16:  string in abc 1        -> b   (`index`)
+/// tclsh9.0.4:   string in abc 1        -> unknown or ambiguous subcommand
+///                                         "in": must be … index, insert, is, …
+///               string insert abc 1 X  -> aXbc
+#[test]
+fn string_index_prefix_is_unique_before_tcl9() {
+    let mut old = at(TclVersion::V8_6);
+    assert_eq!(
+        run(&mut old, "string in abc 1"),
+        (Code::Ok, "b".to_string())
+    );
+    let (code, message) = run(&mut old, "string insert abc 1 X");
+    assert_eq!(code, Code::Error);
+    assert!(
+        message.starts_with("unknown or ambiguous subcommand \"insert\": must be cat, compare"),
+        "{message}"
+    );
+
+    let mut new = at(TclVersion::V9_0);
+    let (code, message) = run(&mut new, "string in abc 1");
+    assert_eq!(code, Code::Error);
+    assert!(
+        message.starts_with("unknown or ambiguous subcommand \"in\": must be cat, compare"),
+        "{message}"
+    );
+    assert!(message.contains("index, insert, is,"), "{message}");
+    assert_eq!(
+        run(&mut new, "string insert abc 1 X"),
+        (Code::Ok, "aXbc".to_string())
+    );
+}
+
+/// `info cmdtype`/`constant`/`consts` are Tcl 9. The exact-name row is the one
+/// that shows a *resolution* miss must report rather than fall through: the
+/// dispatch arms match the canonical name, so `info cmdtype` under an 8.6 pin
+/// would otherwise still run.
+///
+/// tclsh8.6.16:  info cm            -> a count   (`cmdcount`)
+///               info cmdtype set   -> unknown or ambiguous subcommand
+///                                     "cmdtype": must be args, body, class, …
+/// tclsh9.0.4:   info cm            -> unknown or ambiguous subcommand "cm":
+///                                     must be … cmdcount, cmdtype, …
+///               info cmdtype set   -> native
+#[test]
+fn info_cmdcount_prefix_is_unique_before_tcl9() {
+    let mut old = at(TclVersion::V8_6);
+    let (code, count) = run(&mut old, "info cm");
+    assert_eq!(code, Code::Ok);
+    assert!(
+        count.bytes().all(|b| b.is_ascii_digit()) && !count.is_empty(),
+        "info cm must be the cmdcount, got {count}"
+    );
+    let (code, message) = run(&mut old, "info cmdtype set");
+    assert_eq!(code, Code::Error);
+    assert_eq!(
+        message,
+        "unknown or ambiguous subcommand \"cmdtype\": must be args, body, class, cmdcount, \
+         commands, complete, coroutine, default, errorstack, exists, frame, functions, globals, \
+         hostname, level, library, loaded, locals, nameofexecutable, object, patchlevel, procs, \
+         script, sharedlibextension, tclversion, or vars"
+    );
+
+    let mut new = at(TclVersion::V9_0);
+    let (code, message) = run(&mut new, "info cm");
+    assert_eq!(code, Code::Error);
+    assert!(
+        message.contains("cmdcount, cmdtype,"),
+        "9.0 must advertise cmdtype: {message}"
+    );
+    assert_eq!(
+        run(&mut new, "info cmdtype set"),
+        (Code::Ok, "native".to_string())
+    );
+}
+
+/// `chan isbinary` is Tcl 9; `pipe`/`pop`/`push` are 8.6.
+///
+/// tclsh8.6.16:  chan isbinary stdin -> unknown or ambiguous subcommand
+///                                      "isbinary": must be blocked, close, …
+/// UNIMPLEMENTED: under 9.0 this engine resolves the name and then declines it
+/// — the release gate is what this test pins, not the missing feature.
+#[test]
+fn chan_isbinary_is_unknown_before_tcl9() {
+    let mut old = at(TclVersion::V8_6);
+    let (code, message) = run(&mut old, "chan isbinary stdin");
+    assert_eq!(code, Code::Error);
+    assert_eq!(
+        message,
+        "unknown or ambiguous subcommand \"isbinary\": must be blocked, close, configure, copy, \
+         create, eof, event, flush, gets, names, pending, pipe, pop, postevent, push, puts, \
+         read, seek, tell, or truncate"
+    );
+
+    let mut new = at(TclVersion::V9_0);
+    let (code, message) = run(&mut new, "chan isbinary stdin");
+    assert_eq!(code, Code::Error);
+    assert_eq!(
+        message,
+        "chan isbinary is not supported under the WASM runtime"
+    );
+}
+
+/// `array default`/`for` are Tcl 9.
+///
+/// tclsh8.6.16:  array f x -> unknown or ambiguous subcommand "f": must be …
+/// tclsh9.0.4:   array f x -> wrong # args: should be "array for {key value}
+///                            arrayName script"   (`for` resolves, then its
+///                            own arity check speaks)
+///
+/// UNIMPLEMENTED: this engine's `array` table advertises only the subcommands
+/// it dispatches, so its enumeration is shorter than tclsh's on both releases;
+/// the release gate is still what decides whether `f` resolves at all.
+#[test]
+fn array_for_is_unknown_before_tcl9() {
+    let mut old = at(TclVersion::V8_6);
+    let (code, message) = run(&mut old, "array f x");
+    assert_eq!(code, Code::Error);
+    assert!(
+        message.starts_with("unknown or ambiguous subcommand \"f\""),
+        "{message}"
+    );
+    assert!(
+        !message.contains("for"),
+        "8.6 must not advertise for: {message}"
+    );
+
+    let mut new = at(TclVersion::V9_0);
+    let (code, message) = run(&mut new, "array f x");
+    assert_eq!(code, Code::Error);
+    assert_eq!(
+        message,
+        "wrong # args: should be \"array for {key value} arrayName script\""
+    );
+}
+
+/// `file home`/`tempdir`/`tildeexpand` are Tcl 9 — the row the VM's own
+/// regression was found on, pinned here for this engine too.
+///
+/// tclsh8.6.16:  file te x -> a channel   (`tempfile`)
+/// tclsh9.0.4:   file te x -> unknown or ambiguous subcommand "te": must be
+///                            … tail, tempdir, tempfile, tildeexpand, …
+#[test]
+fn file_tempfile_prefix_is_unique_before_tcl9() {
+    let mut old = at(TclVersion::V8_6);
+    let (code, channel) = run(&mut old, "file te x");
+    assert_eq!(code, Code::Ok, "{channel}");
+    assert!(channel.starts_with("file"), "a channel name: {channel}");
+
+    let mut new = at(TclVersion::V9_0);
+    let (code, message) = run(&mut new, "file te x");
+    assert_eq!(code, Code::Error);
+    assert!(
+        message.contains("tempdir, tempfile, tildeexpand,"),
+        "{message}"
+    );
+}

--- a/runtime/rust/tests/ensemble_release_surface.rs
+++ b/runtime/rust/tests/ensemble_release_surface.rs
@@ -243,3 +243,47 @@ fn file_tempfile_prefix_is_unique_before_tcl9() {
         "{message}"
     );
 }
+
+/// `binary encode`/`decode` (TIP 317) arrive in 8.6, and `encoding dirs` in
+/// 8.5 — the same rule below the releases the rows above use.
+///
+/// tclsh8.5.19:  binary d base64 QQ== -> bad option "d": must be format or scan
+/// tclsh8.6.16:  binary d base64 QQ== -> A
+/// tclsh8.4.20:  encoding d           -> bad option "d": must be convertfrom,
+///                                       convertto, names, or system
+/// tclsh8.5.19:  encoding d           -> the encoding directory list
+///
+/// The *sentence* differs below 8.6 — C only made these ensembles in 8.6, so
+/// 8.4/8.5 word the miss `bad option` — which this engine does not model; it
+/// speaks the ensemble sentence at every release. What the rows pin is the
+/// resolution and the enumeration, not that older wording.
+#[test]
+fn binary_and_encoding_tables_follow_the_emulated_release() {
+    let mut old = at(TclVersion::V8_5);
+    let (code, message) = run(&mut old, "binary d base64 QQ==");
+    assert_eq!(code, Code::Error);
+    assert_eq!(
+        message,
+        // Two entries still take the ensemble owner's comma before `or`.
+        "unknown or ambiguous subcommand \"d\": must be format, or scan"
+    );
+    assert_eq!(
+        run(&mut old, "encoding d").0,
+        Code::Ok,
+        "`dirs` exists from 8.5"
+    );
+
+    let mut new = at(TclVersion::V8_6);
+    assert_eq!(
+        run(&mut new, "binary d base64 QQ=="),
+        (Code::Ok, "A".to_string())
+    );
+
+    let mut ancient = at(TclVersion::V8_4);
+    let (code, message) = run(&mut ancient, "encoding d");
+    assert_eq!(code, Code::Error);
+    assert_eq!(
+        message,
+        "unknown or ambiguous subcommand \"d\": must be convertfrom, convertto, names, or system"
+    );
+}

--- a/runtime/rust/tests/rename_interp_semantics.rs
+++ b/runtime/rust/tests/rename_interp_semantics.rs
@@ -127,6 +127,19 @@ fn interp_bad_option_list_advertises_only_dispatched_subcommands() {
     // via the fallthrough).
     assert_eq!(interp.eval_str(b"catch {interp cancel} e; set e"), Code::Ok);
     assert!(interp.result_bytes().starts_with(b"bad option \"cancel\""));
+    // Issue #1607: the list is shortened, but it is still resolved by the one
+    // `Tcl_GetIndexFromObj` matcher, so tclsh's abbreviation and ambiguity
+    // verdicts hold over it.
+    //
+    // tclsh9.0.4:
+    //   interp cr j -> j   ;  interp c j -> ambiguous option "c": must be …
+    //   interp {}   -> ambiguous option "": must be …
+    assert_eq!(interp.eval_str(b"interp cr j"), Code::Ok);
+    assert_eq!(interp.result_bytes(), b"j".as_slice());
+    assert_eq!(interp.eval_str(b"catch {interp c j} e; set e"), Code::Ok);
+    assert!(interp.result_bytes().starts_with(b"ambiguous option \"c\""));
+    assert_eq!(interp.eval_str(b"catch {interp {}} e; set e"), Code::Ok);
+    assert!(interp.result_bytes().starts_with(b"ambiguous option \"\""));
 }
 
 /// item 3: `interp target path alias` — the interp-path from this interp to
@@ -222,6 +235,15 @@ fn child_command_bad_option_matches_the_tclsh_shape() {
           or recursionlimit"
             .as_slice()
     );
+    // Issue #1607: the same table now abbreviates, exactly as tclsh's does.
+    //
+    // tclsh9.0.4:
+    //   kid ev {set x 1} -> 1
+    //   kid h            -> ambiguous option "h": must be …
+    assert_eq!(interp.eval_str(b"kid ev {set x 1}"), Code::Ok);
+    assert_eq!(interp.result_bytes(), b"1".as_slice());
+    assert_eq!(interp.eval_str(b"catch {kid h} e; set e"), Code::Ok);
+    assert!(interp.result_bytes().starts_with(b"ambiguous option \"h\""));
 }
 
 /// item 4 (fixed before this lane started, pinned here as a regression

--- a/rust/tcl-cmd-core/src/clock.rs
+++ b/rust/tcl-cmd-core/src/clock.rs
@@ -81,21 +81,45 @@ where
     let Some((sub, rest)) = args.split_first() else {
         return Err(CmdError::wrong_args("clock subcommand ?arg ...?"));
     };
-    let sub = ops.as_str(sub).to_string();
-    match sub.as_str() {
+    let word = ops.as_str(sub).to_string();
+    // `clock` is an ensemble, so an exact name wins and a unique prefix
+    // resolves (`clock se` → `seconds`); the whole miss sentence — including
+    // the ensemble's comma before `or` — belongs to `crate::ensemble`.
+    let Some(index) = crate::ensemble::resolve_subcommand(CLOCK_SUBS, word.as_bytes(), true) else {
+        return Err(CmdError::new(
+            String::from_utf8_lossy(&crate::ensemble::unknown_subcommand_message(
+                CLOCK_SUBS,
+                word.as_bytes(),
+                true,
+                b"::tcl::clock",
+            ))
+            .into_owned(),
+        ));
+    };
+    match CLOCK_SUBS[index] {
         "seconds" => nullary(ops, rest, "seconds", now.secs),
         "milliseconds" => nullary(ops, rest, "milliseconds", now.millis),
         "microseconds" => nullary(ops, rest, "microseconds", now.micros),
         "clicks" => clicks(ops, rest, now),
         "format" => format(ops, rest, local_offset),
         "add" => add(ops, rest, local_offset),
-        "scan" => scan(ops, rest, now, local_offset),
-        other => Err(CmdError::new(format!(
-            "unknown or ambiguous subcommand \"{other}\": must be add, clicks, \
-             format, microseconds, milliseconds, scan, or seconds"
-        ))),
+        // Unreachable: `CLOCK_SUBS` has exactly the seven arms here.
+        _ => scan(ops, rest, now, local_offset),
     }
 }
+
+/// `clock`'s subcommand set, alphabetical as the ensemble sorts it. C also
+/// carries `configure`, `mktime` and the internal `::tcl::clock` helpers behind
+/// its script implementation; this core names only what it dispatches.
+const CLOCK_SUBS: &[&str] = &[
+    "add",
+    "clicks",
+    "format",
+    "microseconds",
+    "milliseconds",
+    "scan",
+    "seconds",
+];
 
 /// A no-argument time readout (`clock seconds`/`milliseconds`/`microseconds`).
 fn nullary<O, V>(ops: &mut O, rest: &[V], name: &str, val: i64) -> Result<V, CmdError>

--- a/rust/tcl-cmd-core/src/dict.rs
+++ b/rust/tcl-cmd-core/src/dict.rs
@@ -322,6 +322,12 @@ pub fn getdef<O: ValueOps>(
 }
 
 /// Dispatch a pure `dict` subcommand. `rest` is the args after the subcommand.
+/// `dict filter`'s type word, in C table order (`filters[]`, `tclDictObj.c`):
+/// `Tcl_GetIndexFromObj(…, "filterType", 0)`, so `k`/`s`/`v` abbreviate and
+/// the empty word — a prefix of all three — is `ambiguous filterType ""`.
+const FILTER_TYPES: crate::prefix::OptionTable<'static> =
+    crate::prefix::OptionTable::abbreviating("filterType", &["key", "script", "value"]);
+
 /// Returns `None` for a not-yet-ported (variable-mutating) subcommand so the
 /// caller falls back to its legacy path.
 pub fn dispatch_canon<O: ValueOps>(
@@ -363,13 +369,11 @@ pub fn dispatch_canon<O: ValueOps>(
         // dict is parsed (tclsh: `dict filter {a b c} bogus` is a bad-filterType
         // error, not a bad-dict one).
         "filter" => match (rest.first(), rest.get(1)) {
-            (Some(dict), Some(ft)) => match ops.as_str(ft).as_ref() {
-                "key" => Some(filter(ops, dict, true, &rest[2..])),
-                "value" => Some(filter(ops, dict, false, &rest[2..])),
-                "script" => None,
-                other => Some(Err(CmdError::new(format!(
-                    "bad filterType \"{other}\": must be key, script, or value"
-                )))),
+            (Some(dict), Some(ft)) => match FILTER_TYPES.index_of_str(ops.as_str(ft).as_ref()) {
+                Ok(0) => Some(filter(ops, dict, true, &rest[2..])),
+                Ok(2) => Some(filter(ops, dict, false, &rest[2..])),
+                Ok(_) => None,
+                Err(e) => Some(Err(e)),
             },
             _ => Some(Err(CmdError::wrong_args(
                 "dict filter dictionary filterType ?arg ...?",

--- a/rust/tcl-cmd-core/src/prefix.rs
+++ b/rust/tcl-cmd-core/src/prefix.rs
@@ -377,6 +377,31 @@ mod tests {
         assert_eq!(lookup(&["apple", ""], b"", false), Lookup::Found(1));
     }
 
+    /// Issue #1607: `dict filter`'s type word is an [`OptionTable`] over C's
+    /// `filters[]` (`tclDictObj.c`) with the noun `filterType`, so the three
+    /// types abbreviate and the empty word is `ambiguous`.
+    ///
+    /// tclsh 8.6.16 / 9.0.4:
+    ///   dict filter {a 1} k *  -> a 1
+    ///   dict filter {a 1} x *  -> bad filterType "x": must be key, script, or value
+    ///   dict filter {a 1} {} * -> ambiguous filterType "": must be key, script, or value
+    #[test]
+    fn dict_filter_type_noun_and_abbreviations() {
+        const TABLE: OptionTable<'static> =
+            OptionTable::abbreviating("filterType", &["key", "script", "value"]);
+        assert_eq!(TABLE.index_of(b"k"), Ok(0));
+        assert_eq!(TABLE.index_of(b"s"), Ok(1));
+        assert_eq!(TABLE.index_of(b"v"), Ok(2));
+        assert_eq!(
+            TABLE.index_of(b"x"),
+            Err(b"bad filterType \"x\": must be key, script, or value".to_vec())
+        );
+        assert_eq!(
+            TABLE.index_of(b""),
+            Err(b"ambiguous filterType \"\": must be key, script, or value".to_vec())
+        );
+    }
+
     #[test]
     fn choice_list_matches_c_join() {
         assert_eq!(choice_list(&["a"]), "a");

--- a/rust/tcl-cmd-core/src/string.rs
+++ b/rust/tcl-cmd-core/src/string.rs
@@ -126,6 +126,16 @@ pub fn compare<O: ValueOps>(
         return Err(CmdError::wrong_args(&usage));
     }
 
+    // A deliberate non-`OptionTable` site (#1607): C's `StringCmpOpts`
+    // hand-rolls `strncmp(…, length > 1)` instead of calling
+    // `Tcl_GetIndexFromObj`, so `""` and a lone `-` are `bad`, never
+    // `ambiguous`, and a one-character word never abbreviates. Routing this
+    // through the shared matcher would change all three verdicts.
+    //
+    // tclsh 8.6.16 / 9.0.4:
+    //   string compare "" a b  -> bad option "": must be -nocase or -length
+    //   string compare -  a b  -> bad option "-": must be -nocase or -length
+    //   string compare -n a A  -> 0
     let mut nocase = false;
     let mut length = None;
     let mut i = 0;

--- a/rust/tcl-vm/src/cmd_array.rs
+++ b/rust/tcl-vm/src/cmd_array.rs
@@ -40,12 +40,39 @@ pub(crate) fn register(vm: &mut Vm) {
     vm.register("::tcl::array::for", |vm, a| array_op(vm, "for", a));
 }
 
+/// `array`'s subcommand set, alphabetical as `TclMakeEnsemble` sorts it.
+/// C's table also carries `anymore`, `donesearch`, `nextelement`,
+/// `startsearch`, `statistics`, and (9.0) `default`; like the rest of this
+/// engine's ensembles it names only what it dispatches, so an advertised name
+/// always works.
+///
+/// tclsh 9.0.4, for contrast:
+///   array x a -> unknown or ambiguous subcommand "x": must be anymore,
+///                default, donesearch, exists, for, get, names, nextelement,
+///                set, size, startsearch, statistics, or unset
+const ARRAY_SUBS: &[&str] = &["exists", "for", "get", "names", "set", "size", "unset"];
+
 /// `array option arrayName ?arg ...?` — dispatch to the subcommand handler.
 fn cmd_array(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     let Some((sub, rest)) = args.split_first() else {
         return err("wrong # args: should be \"array subcommand ?arg ...?\"");
     };
-    array_op(vm, &sub.to_str(), rest)
+    let word = sub.to_str();
+    // `array` is a `TclMakeEnsemble` command: exact match, else a unique
+    // prefix, so `array e a` is `array exists a`.
+    let Some(index) = tcl_cmd_core::ensemble::resolve_subcommand(ARRAY_SUBS, word.as_bytes(), true)
+    else {
+        return err(
+            String::from_utf8_lossy(&tcl_cmd_core::ensemble::unknown_subcommand_message(
+                ARRAY_SUBS,
+                word.as_bytes(),
+                true,
+                b"::tcl::array",
+            ))
+            .into_owned(),
+        );
+    };
+    array_op(vm, ARRAY_SUBS[index], rest)
 }
 
 fn array_op(vm: &mut Vm, sub: &str, rest: &[Value]) -> Completion<Value> {
@@ -126,9 +153,18 @@ fn array_op(vm: &mut Vm, sub: &str, rest: &[Value]) -> Completion<Value> {
             }
             _ => err("wrong # args: should be \"array set arrayName list\""),
         },
-        other => err(format!(
-            "unknown or ambiguous subcommand \"{other}\": must be exists, for, get, names, set, size, or unset"
-        )),
+        // Unreachable from `cmd_array` (every `ARRAY_SUBS` name is handled
+        // above or by the shared core); the registered `::tcl::array::*`
+        // entry points pass canonical names.
+        other => err(
+            String::from_utf8_lossy(&tcl_cmd_core::ensemble::unknown_subcommand_message(
+                ARRAY_SUBS,
+                other.as_bytes(),
+                true,
+                b"::tcl::array",
+            ))
+            .into_owned(),
+        ),
     }
 }
 

--- a/rust/tcl-vm/src/cmd_array.rs
+++ b/rust/tcl-vm/src/cmd_array.rs
@@ -67,11 +67,11 @@ fn cmd_array(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
         "array",
         ARRAY_SUBS,
     );
-    let Some(index) = tcl_cmd_core::ensemble::resolve_subcommand(&subs, word.as_bytes(), true)
+    let Some(index) = tcl_cmd_core::ensemble::resolve_subcommand(subs, word.as_bytes(), true)
     else {
         return err(
             String::from_utf8_lossy(&tcl_cmd_core::ensemble::unknown_subcommand_message(
-                &subs,
+                subs,
                 word.as_bytes(),
                 true,
                 b"::tcl::array",

--- a/rust/tcl-vm/src/cmd_array.rs
+++ b/rust/tcl-vm/src/cmd_array.rs
@@ -60,11 +60,18 @@ fn cmd_array(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     let word = sub.to_str();
     // `array` is a `TclMakeEnsemble` command: exact match, else a unique
     // prefix, so `array e a` is `array exists a`.
-    let Some(index) = tcl_cmd_core::ensemble::resolve_subcommand(ARRAY_SUBS, word.as_bytes(), true)
+    // `for` is Tcl 9 (as is `default`, which this engine does not dispatch),
+    // so under an earlier pin it must neither run nor claim the prefix `f`.
+    let subs = crate::environment::release_subcommands(
+        vm.runtime_version().dialect_profile_name(),
+        "array",
+        ARRAY_SUBS,
+    );
+    let Some(index) = tcl_cmd_core::ensemble::resolve_subcommand(&subs, word.as_bytes(), true)
     else {
         return err(
             String::from_utf8_lossy(&tcl_cmd_core::ensemble::unknown_subcommand_message(
-                ARRAY_SUBS,
+                &subs,
                 word.as_bytes(),
                 true,
                 b"::tcl::array",
@@ -72,7 +79,7 @@ fn cmd_array(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
             .into_owned(),
         );
     };
-    array_op(vm, ARRAY_SUBS[index], rest)
+    array_op(vm, subs[index], rest)
 }
 
 fn array_op(vm: &mut Vm, sub: &str, rest: &[Value]) -> Completion<Value> {

--- a/rust/tcl-vm/src/cmd_binary.rs
+++ b/rust/tcl-vm/src/cmd_binary.rs
@@ -44,18 +44,51 @@ fn value_to_bytes(v: &Value) -> Vec<u8> {
     v.to_str().chars().map(|c| c as u32 as u8).collect()
 }
 
+/// `binary`'s subcommand set, alphabetical as `TclMakeEnsemble` sorts it.
+const BINARY_SUBS: &[&str] = &["decode", "encode", "format", "scan"];
+
+/// `binary encode`/`binary decode`'s format set. These two are ensembles with
+/// **`-prefixes` off** (`TclMakeEnsemble` with `TCL_ENSEMBLE_PREFIX` cleared),
+/// so nothing abbreviates and the miss is worded `unknown subcommand`, never
+/// `unknown or ambiguous` (tclsh: `binary encode h a` → `unknown subcommand
+/// "h": must be base64, hex, or uuencode`).
+const BINARY_FORMATS: &[&str] = &["base64", "hex", "uuencode"];
+
+/// Resolve a `binary` ensemble word, or the ensemble's own miss sentence.
+fn resolve_binary_sub(
+    subs: &'static [&'static str],
+    word: &str,
+    prefixes: bool,
+    ns: &[u8],
+) -> Result<&'static str, String> {
+    match tcl_cmd_core::ensemble::resolve_subcommand(subs, word.as_bytes(), prefixes) {
+        Some(index) => Ok(subs[index]),
+        None => Err(
+            String::from_utf8_lossy(&tcl_cmd_core::ensemble::unknown_subcommand_message(
+                subs,
+                word.as_bytes(),
+                prefixes,
+                ns,
+            ))
+            .into_owned(),
+        ),
+    }
+}
+
 fn cmd_binary(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     let Some((sub, rest)) = args.split_first() else {
         return err("wrong # args: should be \"binary subcommand ?arg ...?\"");
     };
-    match &*sub.to_str() {
+    let canon = match resolve_binary_sub(BINARY_SUBS, &sub.to_str(), true, b"::tcl::binary") {
+        Ok(name) => name,
+        Err(m) => return err(m),
+    };
+    match canon {
         "format" => binary_format(rest),
         "scan" => binary_scan(vm, rest),
         "encode" => binary_encode(rest),
-        "decode" => binary_decode(rest),
-        other => err(format!(
-            "unknown or ambiguous subcommand \"{other}\": must be decode, encode, format, or scan"
-        )),
+        // Unreachable: `BINARY_SUBS` has exactly the four arms here.
+        _ => binary_decode(rest),
     }
 }
 
@@ -66,7 +99,16 @@ fn binary_encode(rest: &[Value]) -> Completion<Value> {
     let Some((fmt, args)) = rest.split_first() else {
         return err("wrong # args: should be \"binary encode format ?options? data\"");
     };
-    match &*fmt.to_str() {
+    let canon = match resolve_binary_sub(
+        BINARY_FORMATS,
+        &fmt.to_str(),
+        false,
+        b"::tcl::binary::encode",
+    ) {
+        Ok(name) => name,
+        Err(m) => return err(m),
+    };
+    match canon {
         "hex" => {
             let [data] = args else {
                 return err("wrong # args: should be \"binary encode hex data\"");
@@ -75,10 +117,8 @@ fn binary_encode(rest: &[Value]) -> Completion<Value> {
             ok(bytes_to_value(&out))
         }
         "base64" => binary_encode_wrapped(args, false),
-        "uuencode" => binary_encode_wrapped(args, true),
-        other => err(format!(
-            "unknown subcommand \"{other}\": must be base64, hex, or uuencode"
-        )),
+        // Unreachable: `BINARY_FORMATS` has exactly the three arms here.
+        _ => binary_encode_wrapped(args, true),
     }
 }
 
@@ -120,7 +160,16 @@ fn binary_decode(rest: &[Value]) -> Completion<Value> {
     let Some((fmt, args)) = rest.split_first() else {
         return err("wrong # args: should be \"binary decode format ?options? data\"");
     };
-    match &*fmt.to_str() {
+    let canon = match resolve_binary_sub(
+        BINARY_FORMATS,
+        &fmt.to_str(),
+        false,
+        b"::tcl::binary::decode",
+    ) {
+        Ok(name) => name,
+        Err(m) => return err(m),
+    };
+    match canon {
         "hex" => {
             let [data] = args else {
                 return err("wrong # args: should be \"binary decode hex data\"");
@@ -137,13 +186,11 @@ fn binary_decode(rest: &[Value]) -> Completion<Value> {
             },
             Err(c) => c,
         },
-        "uuencode" => match decode_args(args) {
+        // Unreachable: `BINARY_FORMATS` has exactly the three arms here.
+        _ => match decode_args(args) {
             Ok((_strict, bytes)) => ok(bytes_to_value(&tcl_cmd_core::binary::uu_decode(&bytes))),
             Err(c) => c,
         },
-        other => err(format!(
-            "unknown subcommand \"{other}\": must be base64, hex, or uuencode"
-        )),
     }
 }
 

--- a/rust/tcl-vm/src/cmd_binary.rs
+++ b/rust/tcl-vm/src/cmd_binary.rs
@@ -79,7 +79,14 @@ fn cmd_binary(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     let Some((sub, rest)) = args.split_first() else {
         return err("wrong # args: should be \"binary subcommand ?arg ...?\"");
     };
-    let canon = match resolve_binary_sub(BINARY_SUBS, &sub.to_str(), true, b"::tcl::binary") {
+    // `encode`/`decode` (TIP 317) arrive in 8.6: under an earlier pin `binary
+    // d` must not resolve to `decode`.
+    let subs = crate::environment::release_subcommands(
+        vm.runtime_version().dialect_profile_name(),
+        "binary",
+        BINARY_SUBS,
+    );
+    let canon = match resolve_binary_sub(subs, &sub.to_str(), true, b"::tcl::binary") {
         Ok(name) => name,
         Err(m) => return err(m),
     };

--- a/rust/tcl-vm/src/cmd_chan.rs
+++ b/rust/tcl-vm/src/cmd_chan.rs
@@ -279,24 +279,28 @@ fn cmd_tell(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     }
 }
 
+/// `seek`'s origin word, in C table order (`originOptions[]`, `tclIOCmd.c`):
+/// `Tcl_GetIndexFromObj(…, "origin", 0)`, so `s`/`c`/`e` abbreviate and the
+/// empty word — a prefix of all three — is `ambiguous origin ""`.
+const SEEK_ORIGINS: tcl_cmd_core::prefix::OptionTable<'static> =
+    tcl_cmd_core::prefix::OptionTable::abbreviating("origin", &["start", "current", "end"]);
+
 fn cmd_seek(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     let (id, offset, origin) = match args {
-        [c, o] => (
-            c.to_str().to_string(),
-            o.as_int().unwrap_or(0),
-            "start".to_string(),
-        ),
-        [c, o, w] => (
-            c.to_str().to_string(),
-            o.as_int().unwrap_or(0),
-            w.to_str().to_string(),
-        ),
+        [c, o] => (c.to_str().to_string(), o.as_int().unwrap_or(0), 0),
+        [c, o, w] => {
+            let index = match SEEK_ORIGINS.index_of_str(&w.to_str()) {
+                Ok(i) => i,
+                Err(e) => return err(e.into_message()),
+            };
+            (c.to_str().to_string(), o.as_int().unwrap_or(0), index)
+        }
         _ => return err("wrong # args: should be \"seek channelId offset ?origin?\""),
     };
     if let Some(Channel::Read { data, pos }) = vm.channel_mut(&id) {
-        let base = match origin.as_str() {
-            "current" => i64::try_from(*pos).unwrap_or(0),
-            "end" => i64::try_from(data.len()).unwrap_or(0),
+        let base = match origin {
+            1 => i64::try_from(*pos).unwrap_or(0),
+            2 => i64::try_from(data.len()).unwrap_or(0),
             _ => 0,
         };
         let np = (base + offset).clamp(0, i64::try_from(data.len()).unwrap_or(i64::MAX));

--- a/rust/tcl-vm/src/cmd_dict.rs
+++ b/rust/tcl-vm/src/cmd_dict.rs
@@ -79,11 +79,19 @@ fn cmd_dict(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     let word = sub.to_str();
     // `dict` is a `TclMakeEnsemble` command: exact match, else a unique
     // prefix, so `dict k` is `dict keys`.
-    let Some(index) = tcl_cmd_core::ensemble::resolve_subcommand(DICT_SUBS, word.as_bytes(), true)
+    // `getdef`/`getwithdefault` are Tcl 9 (TIP 342): under an 8.6 pin they
+    // must not resolve, and — the reason this matters for words that have
+    // nothing to do with them — must not make `dict g` ambiguous either.
+    let subs = crate::environment::release_subcommands(
+        vm.runtime_version().dialect_profile_name(),
+        "dict",
+        DICT_SUBS,
+    );
+    let Some(index) = tcl_cmd_core::ensemble::resolve_subcommand(&subs, word.as_bytes(), true)
     else {
         return err(
             String::from_utf8_lossy(&tcl_cmd_core::ensemble::unknown_subcommand_message(
-                DICT_SUBS,
+                &subs,
                 word.as_bytes(),
                 true,
                 b"::tcl::dict",
@@ -91,7 +99,7 @@ fn cmd_dict(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
             .into_owned(),
         );
     };
-    dict_op(vm, DICT_SUBS[index], rest)
+    dict_op(vm, subs[index], rest)
 }
 
 /// The dict's **canonical** ordered `(key-string, value)` pairs, from the one

--- a/rust/tcl-vm/src/cmd_dict.rs
+++ b/rust/tcl-vm/src/cmd_dict.rs
@@ -87,11 +87,11 @@ fn cmd_dict(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
         "dict",
         DICT_SUBS,
     );
-    let Some(index) = tcl_cmd_core::ensemble::resolve_subcommand(&subs, word.as_bytes(), true)
+    let Some(index) = tcl_cmd_core::ensemble::resolve_subcommand(subs, word.as_bytes(), true)
     else {
         return err(
             String::from_utf8_lossy(&tcl_cmd_core::ensemble::unknown_subcommand_message(
-                &subs,
+                subs,
                 word.as_bytes(),
                 true,
                 b"::tcl::dict",

--- a/rust/tcl-vm/src/cmd_dict.rs
+++ b/rust/tcl-vm/src/cmd_dict.rs
@@ -43,12 +43,55 @@ pub(crate) fn register(vm: &mut Vm) {
     vm.register("::tcl::dict::lappend", |vm, a| dict_op(vm, "lappend", a));
 }
 
+/// `dict`'s subcommand set, alphabetical as `TclMakeEnsemble` sorts it. C's
+/// 9.0 table also carries `info` (per-dict hash statistics), which this engine
+/// does not model; like the rest of its ensembles it names only what it
+/// dispatches.
+const DICT_SUBS: &[&str] = &[
+    "append",
+    "create",
+    "exists",
+    "filter",
+    "for",
+    "get",
+    "getdef",
+    "getwithdefault",
+    "incr",
+    "keys",
+    "lappend",
+    "map",
+    "merge",
+    "remove",
+    "replace",
+    "set",
+    "size",
+    "unset",
+    "update",
+    "values",
+    "with",
+];
+
 /// `dict subcommand ?arg ...?` — dispatch to the subcommand handler.
 fn cmd_dict(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     let Some((sub, rest)) = args.split_first() else {
         return err("wrong # args: should be \"dict subcommand ?arg ...?\"");
     };
-    dict_op(vm, &sub.to_str(), rest)
+    let word = sub.to_str();
+    // `dict` is a `TclMakeEnsemble` command: exact match, else a unique
+    // prefix, so `dict k` is `dict keys`.
+    let Some(index) = tcl_cmd_core::ensemble::resolve_subcommand(DICT_SUBS, word.as_bytes(), true)
+    else {
+        return err(
+            String::from_utf8_lossy(&tcl_cmd_core::ensemble::unknown_subcommand_message(
+                DICT_SUBS,
+                word.as_bytes(),
+                true,
+                b"::tcl::dict",
+            ))
+            .into_owned(),
+        );
+    };
+    dict_op(vm, DICT_SUBS[index], rest)
 }
 
 /// The dict's **canonical** ordered `(key-string, value)` pairs, from the one
@@ -315,7 +358,18 @@ fn dict_op(vm: &mut Vm, sub: &str, rest: &[Value]) -> Completion<Value> {
         "update" => cmd_dict_update(vm, rest),
         "filter" => cmd_dict_filter(vm, rest),
         "with" => cmd_dict_with(vm, rest),
-        other => err(format!("unknown or ambiguous subcommand \"{other}\"")),
+        // Unreachable from `cmd_dict` (every `DICT_SUBS` name is handled above
+        // or by the shared core); the registered `::tcl::dict::*` entry points
+        // pass canonical names.
+        other => err(
+            String::from_utf8_lossy(&tcl_cmd_core::ensemble::unknown_subcommand_message(
+                DICT_SUBS,
+                other.as_bytes(),
+                true,
+                b"::tcl::dict",
+            ))
+            .into_owned(),
+        ),
     }
 }
 

--- a/rust/tcl-vm/src/cmd_event.rs
+++ b/rust/tcl-vm/src/cmd_event.rs
@@ -151,6 +151,18 @@ pub(crate) fn register(vm: &mut Vm) {
     vm.register("update", cmd_update);
 }
 
+/// `after`'s subcommand words, in C table order (`afterSubCmds[]`,
+/// `tclTimer.c`). C scans them at flags `0` with a NULL interp, so
+/// abbreviations resolve (`in` → `info`, `ca` → `cancel`) but the miss is
+/// silent and `after` composes its own sentence.
+const AFTER_SUBCOMMANDS: &[&str] = &["cancel", "idle", "info"];
+
+/// `update`'s one option word (`tclCmdIL.c`): `Tcl_GetIndexFromObj(…,
+/// "option", 0)`, so `i` abbreviates `idletasks` and a one-entry table's miss
+/// is always `bad`, never `ambiguous`.
+const UPDATE_OPTIONS: tcl_cmd_core::prefix::OptionTable<'static> =
+    tcl_cmd_core::prefix::OptionTable::abbreviating("option", &["idletasks"]);
+
 /// `after ms ?script ...?` / `after idle ?script ...?` /
 /// `after cancel id|script` / `after info ?id?`. A bare `after ms` (no script)
 /// processes events until `ms` has elapsed (a blocking delay). Multiple script
@@ -159,7 +171,22 @@ fn cmd_after(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     let Some(first) = args.first() else {
         return err("wrong # args: should be \"after option ?arg ...?\"");
     };
-    match &*first.to_str() {
+    let word = first.to_str();
+    // C composes this one itself: `Tcl_GetIndexFromObj(NULL, …, afterSubCmds,
+    // "", 0, &index)` (`tclTimer.c`) — a *silent* lookup, so a miss falls
+    // through to the integer parse and only then to `after`'s own
+    // `bad argument …, or an integer` sentence. An `OptionTable` message must
+    // never surface here; only the scan is shared. Note `i` is ambiguous
+    // (idle/info) and so lands on the integer path, exactly as in tclsh.
+    let scanned = tcl_cmd_core::prefix::scan(AFTER_SUBCOMMANDS, word.as_bytes(), false);
+    let first = match scanned {
+        tcl_cmd_core::prefix::Resolution::Exact(i)
+        | tcl_cmd_core::prefix::Resolution::UniquePrefix(i) => AFTER_SUBCOMMANDS[i],
+        tcl_cmd_core::prefix::Resolution::Ambiguous | tcl_cmd_core::prefix::Resolution::NoMatch => {
+            ""
+        }
+    };
+    match first {
         "idle" => {
             if args.len() < 2 {
                 return err("wrong # args: should be \"after idle script\"");
@@ -185,10 +212,10 @@ fn cmd_after(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
         // report empty (nothing depends on the detail, and it never lies about
         // scheduling — a cancelled/fired event is simply absent).
         "info" => ok(Value::empty()),
-        other => {
-            let Some(ms) = parse_ms(other) else {
+        _ => {
+            let Some(ms) = parse_ms(&word) else {
                 return err(format!(
-                    "bad argument \"{other}\": must be cancel, idle, info, or an integer"
+                    "bad argument \"{word}\": must be cancel, idle, info, or an integer"
                 ));
             };
             if args.len() == 1 {
@@ -234,10 +261,10 @@ fn cmd_vwait(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
 fn cmd_update(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     let idletasks = match args {
         [] => false,
-        [a] if &*a.to_str() == "idletasks" => true,
-        [a] => {
-            return err(format!("bad option \"{}\": must be idletasks", a.to_str()));
-        }
+        [a] => match UPDATE_OPTIONS.index_of_str(&a.to_str()) {
+            Ok(_) => true,
+            Err(e) => return err(e.into_message()),
+        },
         _ => return err("wrong # args: should be \"update ?idletasks?\""),
     };
     let now = Instant::now();

--- a/rust/tcl-vm/src/cmd_file.rs
+++ b/rust/tcl-vm/src/cmd_file.rs
@@ -83,65 +83,61 @@ fn path_str(bytes: &[u8]) -> Completion<Value> {
     ok(Value::string(std::str::from_utf8(bytes).unwrap_or("")))
 }
 
-/// Resolve a `file` subcommand word to its canonical Tcl 9 name with Tcl's
-/// unambiguous-prefix rule (`Tcl_GetIndexFromObj`): exact match wins, else a
-/// unique prefix — so `file ext` resolves to `extension` (cmdAH.test). The
-/// table is the full Tcl 9 `file` option set so ambiguity matches C even for
-/// subcommands the VM does not yet implement (those resolve then fall through
-/// to the unknown-subcommand arm). `None` ⇒ no match or ambiguous.
+/// `file`'s subcommand set, alphabetical as `TclMakeEnsemble` sorts it — the
+/// full Tcl 9 table, so ambiguity matches C even for subcommands the VM does
+/// not yet implement (those resolve, then fall through to the
+/// unknown-subcommand arm).
+const FILE_SUBS: &[&str] = &[
+    "atime",
+    "attributes",
+    "channels",
+    "copy",
+    "delete",
+    "dirname",
+    "executable",
+    "exists",
+    "extension",
+    "home",
+    "isdirectory",
+    "isfile",
+    "join",
+    "link",
+    "lstat",
+    "mkdir",
+    "mtime",
+    "nativename",
+    "normalize",
+    "owned",
+    "pathtype",
+    "readable",
+    "readlink",
+    "rename",
+    "rootname",
+    "separator",
+    "size",
+    "split",
+    "stat",
+    "system",
+    "tail",
+    "tempdir",
+    "tempfile",
+    "tildeexpand",
+    "type",
+    "volumes",
+    "writable",
+];
+
+/// `file`'s implementation namespace — the `ns_fqn` an empty ensemble's miss
+/// message would name (`TclMakeEnsemble`, `tclFileName.c`).
+const FILE_NS: &[u8] = b"::tcl::file";
+
+/// Resolve a `file` subcommand word to its canonical Tcl 9 name through the
+/// shared ensemble owner: exact match wins, else a unique prefix — so
+/// `file ext` resolves to `extension` (cmdAH.test). `None` ⇒ no match or
+/// ambiguous.
 fn canonical_file_sub(sub: &str) -> Option<&'static str> {
-    const SUBS: &[&str] = &[
-        "atime",
-        "attributes",
-        "channels",
-        "copy",
-        "delete",
-        "dirname",
-        "executable",
-        "exists",
-        "extension",
-        "isdirectory",
-        "isfile",
-        "join",
-        "link",
-        "lstat",
-        "mkdir",
-        "mtime",
-        "nativename",
-        "normalize",
-        "owned",
-        "pathtype",
-        "readable",
-        "readlink",
-        "rename",
-        "rootname",
-        "separator",
-        "size",
-        "split",
-        "stat",
-        "system",
-        "tail",
-        "tempdir",
-        "tempfile",
-        "type",
-        "volumes",
-        "writable",
-    ];
-    if sub.is_empty() {
-        return None;
-    }
-    if let Some(&exact) = SUBS.iter().find(|&&s| s == sub) {
-        return Some(exact);
-    }
-    let mut found = None;
-    let mut count = 0u32;
-    for &s in SUBS {
-        if s.starts_with(sub) {
-            found = Some(s);
-            count += 1;
-        }
-    }
-    if count == 1 { found } else { None }
+    tcl_cmd_core::ensemble::resolve_subcommand(FILE_SUBS, sub.as_bytes(), true)
+        .map(|index| FILE_SUBS[index])
 }
 
 /// The platform-independent path-text subcommands of `file` (no filesystem
@@ -276,7 +272,17 @@ fn cmd_file(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
             }
             ok(Value::empty())
         }
-        other => err(format!("unknown or ambiguous subcommand \"{other}\"")),
+        // Reached by a word that matched nothing, prefixed several entries, or
+        // resolved to a subcommand this engine does not implement.
+        other => err(
+            String::from_utf8_lossy(&tcl_cmd_core::ensemble::unknown_subcommand_message(
+                FILE_SUBS,
+                other.as_bytes(),
+                true,
+                FILE_NS,
+            ))
+            .into_owned(),
+        ),
     }
 }
 

--- a/rust/tcl-vm/src/cmd_file.rs
+++ b/rust/tcl-vm/src/cmd_file.rs
@@ -218,10 +218,10 @@ fn cmd_file(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     // A miss reports here rather than falling through with the raw word: the
     // arms below match on the canonical name, so a word the *pinned release*
     // does not have would otherwise still dispatch.
-    let Some(canon) = canonical_file_sub(&subs, &sub_str) else {
+    let Some(canon) = canonical_file_sub(subs, &sub_str) else {
         return err(
             String::from_utf8_lossy(&tcl_cmd_core::ensemble::unknown_subcommand_message(
-                &subs,
+                subs,
                 sub_str.as_bytes(),
                 true,
                 FILE_NS,
@@ -296,7 +296,7 @@ fn cmd_file(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
         // resolved to a subcommand this engine does not implement.
         other => err(
             String::from_utf8_lossy(&tcl_cmd_core::ensemble::unknown_subcommand_message(
-                &subs,
+                subs,
                 other.as_bytes(),
                 true,
                 FILE_NS,

--- a/rust/tcl-vm/src/cmd_file.rs
+++ b/rust/tcl-vm/src/cmd_file.rs
@@ -355,31 +355,115 @@ fn normalize(p: &str, cwd: &str) -> String {
     format!("/{}", parts.join("/"))
 }
 
-/// `glob ?-nocomplain? ?-directory dir? ?--? pattern ...` — minimal matching
-/// against the directory's entries.
+/// `glob`'s option words, in C table order (`globOptions[]`, `tclFileName.c`),
+/// resolved with `Tcl_GetIndexFromObj(…, "option", 0)`: `-n`/`-d`/`-j`
+/// abbreviate, `-t` prefixes both `-tails` and `-types` and so is
+/// `ambiguous option "-t"`, and the lone `-` prefixes every entry. Only a word
+/// starting with `-` reaches the table, so an empty word is a pattern
+/// (tclsh: `glob {}` → `.`), never a miss.
+///
+/// Issue #1607: this loop used to *skip* an unrecognised `-word` silently, so
+/// `glob -x a` ran and `-types d` leaked its value into the pattern list.
+/// Rejecting an unknown option is a deliberate behaviour change, ruled on for
+/// that sweep; every name the table advertises is honoured below.
+const GLOB_OPTIONS: tcl_cmd_core::prefix::OptionTable<'static> =
+    tcl_cmd_core::prefix::OptionTable::abbreviating(
+        "option",
+        &[
+            "-directory",
+            "-join",
+            "-nocomplain",
+            "-path",
+            "-tails",
+            "-types",
+            "--",
+        ],
+    );
+
+/// Whether the entry at `path` satisfies every `-types` specifier — the same
+/// portable rule the WASM runtime applies (`cmd_fs::entry_matches_types`):
+/// file-kind `d f l` and permission `r w x` over the [`Filesystem`] seam, with
+/// the Unix special-device kinds `p s b c` never matching because the seam
+/// cannot express them. An empty list matches everything.
+fn glob_types_match(filesystem: &dyn Filesystem, path: &str, types: &[char]) -> bool {
+    if types.is_empty() {
+        return true;
+    }
+    // `symlink_metadata` so `l` (and the kind tests) see the link itself.
+    let Ok(meta) = filesystem.symlink_metadata(path) else {
+        return false;
+    };
+    types.iter().all(|&t| match t {
+        'd' => meta.is_dir,
+        'f' => meta.is_file,
+        'l' => meta.is_symlink,
+        'x' => meta.executable,
+        'p' | 's' | 'b' | 'c' => false, // special devices: not portable
+        _ => true, // `r`/`w` are best-effort; an unknown letter does not exclude
+    })
+}
+
+/// `glob ?-nocomplain? ?-directory dir? ?-tails? ?-types list? ?-join? ?--?
+/// pattern ...` — minimal matching against the directory's entries.
 fn cmd_glob(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     // We never error on no match (effectively always `-nocomplain`).
     let mut dir: Option<String> = None;
     let mut join = false;
+    let mut tails = false;
+    let mut types: Vec<char> = Vec::new();
     let mut i = 0;
     while i < args.len() {
-        match &*args[i].to_str() {
-            "-nocomplain" => i += 1,
-            "-join" => {
-                join = true;
-                i += 1;
-            }
-            "-directory" | "-dir" => {
+        let word = args[i].to_str();
+        // Only a `-`-leading word reaches the table, as in C — a bare word
+        // (the empty one included) is the first pattern.
+        if !word.starts_with('-') {
+            break;
+        }
+        match GLOB_OPTIONS.index_of_str(&word) {
+            // `-directory dir` and `-path prefix` are distinct in C; this
+            // engine models both as the search root.
+            Ok(0 | 3) => {
                 dir = args.get(i + 1).map(|v| v.to_str().to_string());
                 i += 2;
             }
-            "--" => {
+            Ok(1) => {
+                join = true;
+                i += 1;
+            }
+            Ok(2) => i += 1,
+            Ok(4) => {
+                tails = true;
+                i += 1;
+            }
+            Ok(5) => {
+                // A list of one-letter type specifiers (`d`, `f`, `r`, …); a
+                // name must satisfy every requested test.
+                types = args
+                    .get(i + 1)
+                    .and_then(|v| v.as_list().ok())
+                    .map(|items| {
+                        items
+                            .iter()
+                            .filter_map(|s| {
+                                let s = s.to_str();
+                                let mut cs = s.chars();
+                                cs.next().filter(|_| cs.next().is_none())
+                            })
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                i += 2;
+            }
+            // `--` ends the option scan.
+            Ok(_) => {
                 i += 1;
                 break;
             }
-            s if s.starts_with('-') => i += 1, // ignore other options
-            _ => break,
+            Err(e) => return err(e.into_message()),
         }
+    }
+    if tails && dir.is_none() {
+        return err("\"-tails\" must be used with either \"-directory\" or \"-path\"");
     }
     let patterns = &args[i..];
     let base = dir.clone().unwrap_or_else(|| ".".to_string());
@@ -402,6 +486,24 @@ fn cmd_glob(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
                     name
                 };
                 results.push(full);
+            }
+        }
+    }
+    // `-types` filters on the entry's real path; `-tails` then reports each hit
+    // relative to the `-directory`/`-path` root, as C does.
+    let prefix = format!("{}/", base.trim_end_matches('/'));
+    results.retain(|r| {
+        let probe = if dir.is_some() {
+            r.clone()
+        } else {
+            file_join(&[Value::string(base.clone()), Value::string(r.clone())])
+        };
+        glob_types_match(filesystem, &probe, &types)
+    });
+    if tails {
+        for r in &mut results {
+            if let Some(rest) = r.strip_prefix(&prefix) {
+                *r = rest.to_owned();
             }
         }
     }

--- a/rust/tcl-vm/src/cmd_file.rs
+++ b/rust/tcl-vm/src/cmd_file.rs
@@ -87,6 +87,12 @@ fn path_str(bytes: &[u8]) -> Completion<Value> {
 /// full Tcl 9 table, so ambiguity matches C even for subcommands the VM does
 /// not yet implement (those resolve, then fall through to the
 /// unknown-subcommand arm).
+///
+/// It is filtered to the emulated release before use
+/// ([`crate::environment::release_subcommands`]): `home`, `tempdir` and
+/// `tildeexpand` are Tcl 9 additions, and under an 8.6 pin they must neither
+/// resolve nor take part in the prefix scan — `file te` is a unique prefix of
+/// `tempfile` on 8.6.16 and ambiguous on 9.0.4.
 const FILE_SUBS: &[&str] = &[
     "atime",
     "attributes",
@@ -131,13 +137,12 @@ const FILE_SUBS: &[&str] = &[
 /// message would name (`TclMakeEnsemble`, `tclFileName.c`).
 const FILE_NS: &[u8] = b"::tcl::file";
 
-/// Resolve a `file` subcommand word to its canonical Tcl 9 name through the
-/// shared ensemble owner: exact match wins, else a unique prefix — so
-/// `file ext` resolves to `extension` (cmdAH.test). `None` ⇒ no match or
-/// ambiguous.
-fn canonical_file_sub(sub: &str) -> Option<&'static str> {
-    tcl_cmd_core::ensemble::resolve_subcommand(FILE_SUBS, sub.as_bytes(), true)
-        .map(|index| FILE_SUBS[index])
+/// Resolve a `file` subcommand word to its canonical name through the shared
+/// ensemble owner: exact match wins, else a unique prefix — so `file ext`
+/// resolves to `extension` (cmdAH.test). `subs` is the emulated release's
+/// table ([`file_subcommands`]). `None` ⇒ no match or ambiguous.
+fn canonical_file_sub<'a>(subs: &[&'a str], sub: &str) -> Option<&'a str> {
+    tcl_cmd_core::ensemble::resolve_subcommand(subs, sub.as_bytes(), true).map(|index| subs[index])
 }
 
 /// The platform-independent path-text subcommands of `file` (no filesystem
@@ -205,9 +210,24 @@ fn cmd_file(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     };
     let s = |v: &Value| v.to_str().to_string();
     let sub_str = sub.to_str();
-    let canon: &str = match canonical_file_sub(&sub_str) {
-        Some(c) => c,
-        None => &sub_str,
+    let subs = crate::environment::release_subcommands(
+        vm.runtime_version().dialect_profile_name(),
+        "file",
+        FILE_SUBS,
+    );
+    // A miss reports here rather than falling through with the raw word: the
+    // arms below match on the canonical name, so a word the *pinned release*
+    // does not have would otherwise still dispatch.
+    let Some(canon) = canonical_file_sub(&subs, &sub_str) else {
+        return err(
+            String::from_utf8_lossy(&tcl_cmd_core::ensemble::unknown_subcommand_message(
+                &subs,
+                sub_str.as_bytes(),
+                true,
+                FILE_NS,
+            ))
+            .into_owned(),
+        );
     };
     // Pure path-text subcommands (no filesystem access) are handled first; the
     // rest fall through to the filesystem-backed ops below.
@@ -276,7 +296,7 @@ fn cmd_file(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
         // resolved to a subcommand this engine does not implement.
         other => err(
             String::from_utf8_lossy(&tcl_cmd_core::ensemble::unknown_subcommand_message(
-                FILE_SUBS,
+                &subs,
                 other.as_bytes(),
                 true,
                 FILE_NS,

--- a/rust/tcl-vm/src/cmd_info.rs
+++ b/rust/tcl-vm/src/cmd_info.rs
@@ -98,10 +98,10 @@ fn cmd_info(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     // A miss reports here rather than falling through with the raw word: the
     // arms below match on the canonical name, so a word the *pinned release*
     // does not have (`info cmdtype` under 8.6) would otherwise still dispatch.
-    let Some(canon) = canonical_info_sub(&subs, &sub_str) else {
+    let Some(canon) = canonical_info_sub(subs, &sub_str) else {
         return err(
             String::from_utf8_lossy(&tcl_cmd_core::ensemble::unknown_subcommand_message(
-                &subs,
+                subs,
                 sub_str.as_bytes(),
                 true,
                 INFO_NS,
@@ -271,7 +271,7 @@ fn cmd_info(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
         // resolved to a subcommand this engine does not implement.
         other => err(
             String::from_utf8_lossy(&tcl_cmd_core::ensemble::unknown_subcommand_message(
-                &subs,
+                subs,
                 other.as_bytes(),
                 true,
                 INFO_NS,

--- a/rust/tcl-vm/src/cmd_info.rs
+++ b/rust/tcl-vm/src/cmd_info.rs
@@ -32,60 +32,53 @@ pub(crate) fn register(vm: &mut Vm) {
     vm.register("info", cmd_info);
 }
 
-/// Resolve an `info` subcommand word to its canonical Tcl 9 name with Tcl's
-/// unambiguous-prefix rule (`Tcl_GetIndexFromObj`): an exact match wins,
-/// otherwise a unique prefix — so `info command` resolves to `commands`
-/// (cmdAH.test). Returns `None` when the word matches nothing or is an
-/// ambiguous prefix of several; the caller then reports the error. The table is
-/// the full Tcl 9 `info` option set so ambiguity matches C even for
-/// subcommands the VM does not yet implement (those resolve then fall through
-/// to the unknown-subcommand arm).
+/// `info`'s subcommand set, alphabetical as `TclMakeEnsemble` sorts it — the
+/// full Tcl 9 table, so ambiguity matches C even for subcommands the VM does
+/// not yet implement (those resolve, then fall through to the
+/// unknown-subcommand arm).
+const INFO_SUBS: &[&str] = &[
+    "args",
+    "body",
+    "class",
+    "cmdcount",
+    "cmdtype",
+    "commands",
+    "complete",
+    "constant",
+    "consts",
+    "coroutine",
+    "default",
+    "errorstack",
+    "exists",
+    "frame",
+    "functions",
+    "globals",
+    "hostname",
+    "level",
+    "library",
+    "loaded",
+    "locals",
+    "nameofexecutable",
+    "object",
+    "patchlevel",
+    "procs",
+    "script",
+    "sharedlibextension",
+    "tclversion",
+    "vars",
+];
+
+/// `info`'s implementation namespace — the `ns_fqn` an empty ensemble's miss
+/// message would name (`TclMakeEnsemble`, `tclBasic.c`).
+const INFO_NS: &[u8] = b"::tcl::info";
+
+/// Resolve an `info` subcommand word to its canonical Tcl 9 name through the
+/// shared ensemble owner: an exact match wins, otherwise a unique prefix — so
+/// `info command` resolves to `commands` (cmdAH.test). `None` when the word
+/// matches nothing or prefixes several; the caller then reports the miss.
 fn canonical_info_sub(sub: &str) -> Option<&'static str> {
-    const SUBS: &[&str] = &[
-        "args",
-        "body",
-        "cmdcount",
-        "cmdtype",
-        "commands",
-        "complete",
-        "constant",
-        "consts",
-        "coroutine",
-        "default",
-        "errorstack",
-        "exists",
-        "frame",
-        "functions",
-        "globals",
-        "hostname",
-        "level",
-        "library",
-        "loaded",
-        "locals",
-        "nameofexecutable",
-        "object",
-        "patchlevel",
-        "procs",
-        "script",
-        "sharedlibextension",
-        "tclversion",
-        "vars",
-    ];
-    if sub.is_empty() {
-        return None;
-    }
-    if let Some(&exact) = SUBS.iter().find(|&&s| s == sub) {
-        return Some(exact);
-    }
-    let mut found = None;
-    let mut count = 0u32;
-    for &s in SUBS {
-        if s.starts_with(sub) {
-            found = Some(s);
-            count += 1;
-        }
-    }
-    if count == 1 { found } else { None }
+    tcl_cmd_core::ensemble::resolve_subcommand(INFO_SUBS, sub.as_bytes(), true)
+        .map(|index| INFO_SUBS[index])
 }
 
 #[allow(clippy::too_many_lines)] // One subcommand-dispatch match; splitting obscures it.
@@ -256,7 +249,17 @@ fn cmd_info(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
             [] => ok(crate::cmd_coro::current_coroutine(vm)),
             _ => err("wrong # args: should be \"info coroutine\""),
         },
-        other => err(format!("unknown or ambiguous subcommand \"{other}\"")),
+        // Reached by a word that matched nothing, prefixed several entries, or
+        // resolved to a subcommand this engine does not implement.
+        other => err(
+            String::from_utf8_lossy(&tcl_cmd_core::ensemble::unknown_subcommand_message(
+                INFO_SUBS,
+                other.as_bytes(),
+                true,
+                INFO_NS,
+            ))
+            .into_owned(),
+        ),
     }
 }
 

--- a/rust/tcl-vm/src/cmd_info.rs
+++ b/rust/tcl-vm/src/cmd_info.rs
@@ -76,9 +76,8 @@ const INFO_NS: &[u8] = b"::tcl::info";
 /// shared ensemble owner: an exact match wins, otherwise a unique prefix — so
 /// `info command` resolves to `commands` (cmdAH.test). `None` when the word
 /// matches nothing or prefixes several; the caller then reports the miss.
-fn canonical_info_sub(sub: &str) -> Option<&'static str> {
-    tcl_cmd_core::ensemble::resolve_subcommand(INFO_SUBS, sub.as_bytes(), true)
-        .map(|index| INFO_SUBS[index])
+fn canonical_info_sub<'a>(subs: &[&'a str], sub: &str) -> Option<&'a str> {
+    tcl_cmd_core::ensemble::resolve_subcommand(subs, sub.as_bytes(), true).map(|index| subs[index])
 }
 
 #[allow(clippy::too_many_lines)] // One subcommand-dispatch match; splitting obscures it.
@@ -87,9 +86,28 @@ fn cmd_info(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
         return err("wrong # args: should be \"info subcommand ?arg ...?\"");
     };
     let sub_str = sub.to_str();
-    let canon: &str = match canonical_info_sub(&sub_str) {
-        Some(c) => c,
-        None => &sub_str,
+    // `cmdtype`, `constant` and `consts` are Tcl 9 (`class`, `coroutine`,
+    // `errorstack` and `object` 8.6, `frame` 8.5), so the table is filtered to
+    // the emulated release before the scan: on 8.6 `info cm` is `cmdcount`,
+    // on 9.0 it is ambiguous with `cmdtype`.
+    let subs = crate::environment::release_subcommands(
+        vm.runtime_version().dialect_profile_name(),
+        "info",
+        INFO_SUBS,
+    );
+    // A miss reports here rather than falling through with the raw word: the
+    // arms below match on the canonical name, so a word the *pinned release*
+    // does not have (`info cmdtype` under 8.6) would otherwise still dispatch.
+    let Some(canon) = canonical_info_sub(&subs, &sub_str) else {
+        return err(
+            String::from_utf8_lossy(&tcl_cmd_core::ensemble::unknown_subcommand_message(
+                &subs,
+                sub_str.as_bytes(),
+                true,
+                INFO_NS,
+            ))
+            .into_owned(),
+        );
     };
     match canon {
         // `info exists varName` — the shared Family-B core over `VarStore::exists`.
@@ -253,7 +271,7 @@ fn cmd_info(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
         // resolved to a subcommand this engine does not implement.
         other => err(
             String::from_utf8_lossy(&tcl_cmd_core::ensemble::unknown_subcommand_message(
-                INFO_SUBS,
+                &subs,
                 other.as_bytes(),
                 true,
                 INFO_NS,

--- a/rust/tcl-vm/src/cmd_namespace.rs
+++ b/rust/tcl-vm/src/cmd_namespace.rs
@@ -110,14 +110,18 @@ fn cmd_namespace(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
             })
             .map(|candidate| candidate.name)
             .collect();
-        let choices = match available.as_slice() {
-            [] => String::new(),
-            [only] => (*only).to_string(),
-            [head @ .., last] => format!("{}, or {last}", head.join(", ")),
-        };
-        return err(format!(
-            "unknown or ambiguous subcommand \"{sub_word}\": must be {choices}"
-        ));
+        // The sentence — including the ensemble's comma before `or`, even for
+        // two entries — belongs to `tcl_cmd_core::ensemble`, not to a local
+        // join beside it.
+        return err(
+            String::from_utf8_lossy(&tcl_cmd_core::ensemble::unknown_subcommand_message(
+                &available,
+                sub_word.as_bytes(),
+                true,
+                b"::tcl::namespace",
+            ))
+            .into_owned(),
+        );
     };
     match subcommand.name {
         "eval" => ns_eval(vm, rest),

--- a/rust/tcl-vm/src/cmd_oo.rs
+++ b/rust/tcl-vm/src/cmd_oo.rs
@@ -2274,13 +2274,32 @@ const ISA_CATEGORIES: tcl_cmd_core::prefix::OptionTable<'static> =
 
 /// `info object isa category object ?arg?`.
 fn info_object_isa(vm: &mut Vm, rest: &[Value]) -> Completion<Value> {
+    // C checks the arity in two stages (`InfoObjectIsACmd`, tclOOInfo.c).
+    // First, `category objName` must both be present — *before* the category
+    // word is resolved, so `info object isa object` is this message and not a
+    // category error.
     let (Some(kind), Some(obj_arg)) = (rest.first(), rest.get(1)) else {
-        return err("wrong # args: should be \"info object isa category object ?arg ...?\"");
+        return err("wrong # args: should be \"info object isa category objName ?arg ...?\"");
     };
     let kind = match ISA_CATEGORIES.index_of_str(&kind.to_str()) {
         Ok(i) => ISA_CATEGORIES.names()[i],
         Err(e) => return err(e.into_message()),
     };
+    // Then each category pins an *exact* count — C's second stage,
+    // `Tcl_WrongNumArgs(interp, 2, objv, …)`, whose noun carries the resolved
+    // category word (an index-typed argument prints as its table entry). So
+    // `info object isa t o` is `"info object isa typeof objName className"`,
+    // and a trailing extra word is an error rather than being ignored.
+    let (want, tail) = match kind {
+        "mixin" | "typeof" => (3, " objName className"),
+        // class / metaclass / object.
+        _ => (2, " objName"),
+    };
+    if rest.len() != want {
+        return err(format!(
+            "wrong # args: should be \"info object isa {kind}{tail}\""
+        ));
+    }
     let obj = vm.qualify_name(&obj_arg.to_str());
     // `isa object` on a non-object is a plain false, not an error — the same
     // test the `tclooIsObject` opcode this form compiles to performs.

--- a/rust/tcl-vm/src/cmd_oo.rs
+++ b/rust/tcl-vm/src/cmd_oo.rs
@@ -226,15 +226,13 @@ fn exported_by_default(name: &str) -> bool {
     name.as_bytes().first().is_some_and(u8::is_ascii_lowercase)
 }
 
-/// Format a sorted method-name set as `must be a, b or c` (`TclOO`'s list style
-/// — no Oxford comma before the final `or`).
+/// Format a sorted method-name set as `must be a, b or c` — `TclOO`'s own list
+/// style, which drops the Oxford comma `Tcl_GetIndexFromObj` keeps. The rule
+/// lives in `tcl_cmd_core::prefix::tcloo_choice_list_bytes`; this is the
+/// `String` adapter over it.
 fn oxford_or(names: &BTreeSet<String>) -> String {
     let v: Vec<&str> = names.iter().map(String::as_str).collect();
-    match v.as_slice() {
-        [] => String::new(),
-        [a] => (*a).to_string(),
-        [rest @ .., last] => format!("{} or {last}", rest.join(", ")),
-    }
+    String::from_utf8_lossy(&tcl_cmd_core::prefix::tcloo_choice_list_bytes(&v)).into_owned()
 }
 
 pub(crate) fn register(vm: &mut Vm) {
@@ -362,17 +360,6 @@ fn err_code(message: impl Into<String>, code: &[&str]) -> Completion<Value> {
     );
     let opts = Value::list(vec![Value::string("-errorcode"), ec]);
     Completion::new(Code::Error, Value::string(message.into()), opts)
-}
-
-/// Format a sorted name list `Tcl_GetIndexFromObj`-style: `a`, `a or b`, or
-/// `a, b, or c` (with the Oxford comma, unlike `TclOO`'s method-name [`oxford_or`]).
-fn index_or(names: &[String]) -> String {
-    match names {
-        [] => String::new(),
-        [a] => a.clone(),
-        [a, b] => format!("{a} or {b}"),
-        [rest @ .., last] => format!("{}, or {last}", rest.join(", ")),
-    }
 }
 
 /// The readable (`writable == false`) or writable property names visible to
@@ -628,10 +615,10 @@ fn configure_method(vm: &mut Vm, obj_key: &str, args: &[Value]) -> Completion<Va
             ok(Value::list(out))
         }
         1 => {
-            let dashed = args[0].to_str().to_string();
-            if let Err(e) = gate_property(vm, obj_key, &dashed, false) {
-                return e;
-            }
+            let dashed = match gate_property(vm, obj_key, &args[0].to_str(), false) {
+                Ok(name) => name,
+                Err(e) => return e,
+            };
             match read_property(vm, obj_key, &dashed) {
                 Ok(v) => ok(v),
                 Err(e) => e,
@@ -640,10 +627,10 @@ fn configure_method(vm: &mut Vm, obj_key: &str, args: &[Value]) -> Completion<Va
         n if n % 2 == 0 => {
             let mut i = 0;
             while i < n {
-                let dashed = args[i].to_str().to_string();
-                if let Err(e) = gate_property(vm, obj_key, &dashed, true) {
-                    return e;
-                }
+                let dashed = match gate_property(vm, obj_key, &args[i].to_str(), true) {
+                    Ok(name) => name,
+                    Err(e) => return e,
+                };
                 if let Err(e) = write_property(vm, obj_key, &dashed, args[i + 1].clone()) {
                     return e;
                 }
@@ -661,26 +648,39 @@ fn configure_method(vm: &mut Vm, obj_key: &str, args: &[Value]) -> Completion<Va
     }
 }
 
-/// Check that `dashed` is a valid property for the requested access, producing
-/// the `bad property`/`is write only`/`is read only` errors otherwise.
+/// Resolve `dashed` to a property valid for the requested access, producing
+/// the `bad`/`ambiguous property`/`is write only`/`is read only` errors
+/// otherwise.
+///
+/// C's `oo::configuresupport` reaches this through
+/// `tcl::prefix match -message property`, so an abbreviation resolves
+/// (`-ye` → `-yellow`) and a word prefixing several — `""` and a lone `-`
+/// included — is `ambiguous property`. The resolved *canonical* name is what
+/// the accessor then reads or writes.
 fn gate_property(
     vm: &Vm,
     obj_key: &str,
     dashed: &str,
     for_write: bool,
-) -> Result<(), Completion<Value>> {
+) -> Result<String, Completion<Value>> {
     let wanted = configure_props(vm, obj_key, for_write);
-    if wanted.iter().any(|p| p == dashed) {
-        return Ok(());
-    }
+    let miss = match tcl_cmd_core::prefix::OptionTable::abbreviating("property", &wanted)
+        .index_of(dashed.as_bytes())
+    {
+        Ok(index) => return Ok(wanted[index].clone()),
+        Err(message) => message,
+    };
     // Present but in the opposite slot → a directionality error.
     let other = configure_props(vm, obj_key, !for_write);
-    if other.iter().any(|p| p == dashed) {
+    if tcl_cmd_core::prefix::OptionTable::abbreviating("property", &other)
+        .index_of(dashed.as_bytes())
+        .is_ok()
+    {
         let why = if for_write { "read only" } else { "write only" };
         return Err(err(format!("property \"{dashed}\" is {why}")));
     }
     Err(err_code(
-        format!("bad property \"{dashed}\": must be {}", index_or(&wanted)),
+        String::from_utf8_lossy(&miss).into_owned(),
         &["TCL", "LOOKUP", "INDEX", "property", dashed],
     ))
 }
@@ -2261,12 +2261,26 @@ fn info_object_properties(vm: &mut Vm, obj: &str, extra: &[Value]) -> Completion
     ok(Value::list(names.into_iter().map(Value::string).collect()))
 }
 
+/// `info object isa`'s category word, in C table order (`categories[]`,
+/// `tclOOInfo.c`): `Tcl_GetIndexFromObj(…, "category", 0)`, so `cl`/`ob`/`t`
+/// abbreviate, `m` is ambiguous (metaclass/mixin), and the empty word — a
+/// prefix of all five — is `ambiguous category ""`. The Oxford comma before
+/// `or` is `Tcl_GetIndexFromObj`'s, not `TclOO`'s method-list style.
+const ISA_CATEGORIES: tcl_cmd_core::prefix::OptionTable<'static> =
+    tcl_cmd_core::prefix::OptionTable::abbreviating(
+        "category",
+        &["class", "metaclass", "mixin", "object", "typeof"],
+    );
+
 /// `info object isa category object ?arg?`.
 fn info_object_isa(vm: &mut Vm, rest: &[Value]) -> Completion<Value> {
     let (Some(kind), Some(obj_arg)) = (rest.first(), rest.get(1)) else {
         return err("wrong # args: should be \"info object isa category object ?arg ...?\"");
     };
-    let kind = kind.to_str().to_string();
+    let kind = match ISA_CATEGORIES.index_of_str(&kind.to_str()) {
+        Ok(i) => ISA_CATEGORIES.names()[i],
+        Err(e) => return err(e.into_message()),
+    };
     let obj = vm.qualify_name(&obj_arg.to_str());
     // `isa object` on a non-object is a plain false, not an error — the same
     // test the `tclooIsObject` opcode this form compiles to performs.
@@ -2276,7 +2290,7 @@ fn info_object_isa(vm: &mut Vm, rest: &[Value]) -> Completion<Value> {
     if !vm.oo.objects.contains_key(&obj) {
         return ok(Value::bool(false));
     }
-    let res = match kind.as_str() {
+    let res = match kind {
         "class" => vm.oo.classes.contains_key(&obj),
         "metaclass" => vm.oo.is_metaclass(&obj),
         "typeof" => rest
@@ -2286,11 +2300,8 @@ fn info_object_isa(vm: &mut Vm, rest: &[Value]) -> Completion<Value> {
             let ck = vm.qualify_name(&c.to_str());
             vm.oo.objects[&obj].mixins.contains(&ck)
         }),
-        _ => {
-            return err(format!(
-                "bad category \"{kind}\": must be class, metaclass, mixin, object or typeof"
-            ));
-        }
+        // Unreachable: `ISA_CATEGORIES` has exactly these five names.
+        _ => false,
     };
     ok(Value::bool(res))
 }

--- a/rust/tcl-vm/src/cmd_package.rs
+++ b/rust/tcl-vm/src/cmd_package.rs
@@ -62,11 +62,79 @@ pub(crate) fn provide_core_packages(vm: &mut Vm) {
     }
 }
 
+/// `package`'s subcommand words, in C table order (`pkgOptions[]`,
+/// `tclPkg.c`). C resolves them with `Tcl_GetIndexFromObj(…, "option", 0)`,
+/// so `n` resolves to `names` while `v` and `pr` are ambiguous, and the empty
+/// word — a prefix of every entry — is `ambiguous option ""`. 9.0 added
+/// `files` at the head of the table.
+const PACKAGE_OPTIONS_8X: &[&str] = &[
+    "forget",
+    "ifneeded",
+    "names",
+    "prefer",
+    "present",
+    "provide",
+    "require",
+    "unknown",
+    "vcompare",
+    "versions",
+    "vsatisfies",
+];
+
+/// [`PACKAGE_OPTIONS_8X`] as 8.4 spells it: `prefer` is TIP 268, which 8.5
+/// brought in (tclsh8.4.20: `bad option "prefer": must be forget, ifneeded,
+/// names, present, provide, …`).
+const PACKAGE_OPTIONS_8_4: &[&str] = &[
+    "forget",
+    "ifneeded",
+    "names",
+    "present",
+    "provide",
+    "require",
+    "unknown",
+    "vcompare",
+    "versions",
+    "vsatisfies",
+];
+
+/// [`PACKAGE_OPTIONS_8X`] as 9.0 spells it.
+const PACKAGE_OPTIONS_9X: &[&str] = &[
+    "files",
+    "forget",
+    "ifneeded",
+    "names",
+    "prefer",
+    "present",
+    "provide",
+    "require",
+    "unknown",
+    "vcompare",
+    "versions",
+    "vsatisfies",
+];
+
 fn cmd_package(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     let Some((sub, rest)) = args.split_first() else {
         return err("wrong # args: should be \"package option ?arg ...?\"");
     };
-    match &*sub.to_str() {
+    let options = match vm.runtime_version() {
+        tcl_dialect::TclVersion::V8_4 => PACKAGE_OPTIONS_8_4,
+        tcl_dialect::TclVersion::V8_5 | tcl_dialect::TclVersion::V8_6 => PACKAGE_OPTIONS_8X,
+        _ => PACKAGE_OPTIONS_9X,
+    };
+    let word = sub.to_str();
+    let sub = match tcl_cmd_core::prefix::OptionTable::abbreviating("option", options)
+        .index_of(word.as_bytes())
+    {
+        Ok(i) => options[i],
+        Err(message) => {
+            return err_with_code(
+                String::from_utf8_lossy(&message).into_owned(),
+                &tcl_syntax::list::join_list(["TCL", "LOOKUP", "INDEX", "option", &word]),
+            );
+        }
+    };
+    match sub {
         "provide" => match rest {
             [name] => ok(vm
                 .package_version(&name.to_str())
@@ -130,7 +198,19 @@ fn cmd_package(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
             ok(Value::empty())
         }
         "prefer" => pkg_prefer(vm, rest),
-        other => err(format!("unknown or ambiguous subcommand \"{other}\"")),
+        // `package files package` (9.0). C reports the files a *loader*
+        // recorded for the package; nothing here loads through one, so the
+        // answer is the empty list — as it is in tclsh for a package provided
+        // by script (`package provide foo 1.0; package files foo` → {}).
+        "files" => match rest {
+            [_name] => ok(Value::empty()),
+            _ => err("wrong # args: should be \"package files package\""),
+        },
+        // Unreachable: every name in the release's table has an arm above.
+        other => err(format!(
+            "bad option \"{other}\": must be {}",
+            tcl_cmd_core::prefix::choice_list(options)
+        )),
     }
 }
 
@@ -161,22 +241,31 @@ fn pkg_unknown(vm: &mut Vm, rest: &[Value]) -> Completion<Value> {
     }
 }
 
+/// `package prefer`'s preference word (`tclPkg.c`): C resolves it with
+/// `Tcl_GetIndexFromObj(…, "preference", 0)`, so `l`/`s` abbreviate and the
+/// empty word — a prefix of both entries — is `ambiguous preference ""`.
+const PACKAGE_PREFERENCES: tcl_cmd_core::prefix::OptionTable<'static> =
+    tcl_cmd_core::prefix::OptionTable::abbreviating("preference", &["latest", "stable"]);
+
 fn pkg_prefer(vm: &mut Vm, rest: &[Value]) -> Completion<Value> {
     match rest {
         [] => ok(Value::string(preference_name(vm.package_prefer()))),
-        [preference] => match &*preference.to_str() {
-            "latest" => {
-                vm.prefer_latest_packages();
-                ok(Value::string(preference_name(vm.package_prefer())))
+        [preference] => {
+            let word = preference.to_str();
+            match PACKAGE_PREFERENCES.index_of(word.as_bytes()) {
+                Ok(0) => {
+                    vm.prefer_latest_packages();
+                    ok(Value::string(preference_name(vm.package_prefer())))
+                }
+                // The preference is a monotone Tcl latch: once raised to
+                // latest, asking for stable succeeds but leaves it at latest.
+                Ok(_) => ok(Value::string(preference_name(vm.package_prefer()))),
+                Err(message) => err_with_code(
+                    String::from_utf8_lossy(&message).into_owned(),
+                    &tcl_syntax::list::join_list(["TCL", "LOOKUP", "INDEX", "preference", &word]),
+                ),
             }
-            // The preference is a monotone Tcl latch: once raised to latest,
-            // asking for stable succeeds but leaves it at latest.
-            "stable" => ok(Value::string(preference_name(vm.package_prefer()))),
-            other => err_with_code(
-                format!("bad preference \"{other}\": must be latest or stable"),
-                &format!("TCL LOOKUP INDEX preference {other}"),
-            ),
-        },
+        }
         _ => err("wrong # args: should be \"package prefer ?preference?\""),
     }
 }

--- a/rust/tcl-vm/src/cmd_prefix.rs
+++ b/rust/tcl-vm/src/cmd_prefix.rs
@@ -37,15 +37,31 @@ fn cmd_prefix(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     let Some((sub, rest)) = args.split_first() else {
         return err("wrong # args: should be \"tcl::prefix subcommand ?arg ...?\"");
     };
-    match &*sub.to_str() {
+    let word = sub.to_str();
+    let canon = match tcl_cmd_core::ensemble::resolve_subcommand(PREFIX_SUBS, word.as_bytes(), true)
+    {
+        Some(index) => PREFIX_SUBS[index],
+        None => {
+            return err(String::from_utf8_lossy(
+                &tcl_cmd_core::ensemble::unknown_subcommand_message(
+                    PREFIX_SUBS,
+                    word.as_bytes(),
+                    true,
+                    b"::tcl::prefix",
+                ),
+            )
+            .into_owned());
+        }
+    };
+    match canon {
         "all" => prefix_all(rest),
         "longest" => prefix_longest(rest),
-        "match" => prefix_match(vm, rest),
-        other => err(format!(
-            "unknown or ambiguous subcommand \"{other}\": must be all, longest, or match"
-        )),
+        _ => prefix_match(vm, rest),
     }
 }
+
+/// `tcl::prefix`'s subcommand set, alphabetical as `TclMakeEnsemble` sorts it.
+const PREFIX_SUBS: &[&str] = &["all", "longest", "match"];
 
 /// Split a list value, surfacing a parse error as a completion.
 fn entries(v: &Value) -> Result<Vec<String>, Completion<Value>> {
@@ -100,6 +116,13 @@ fn prefix_longest(rest: &[Value]) -> Completion<Value> {
     ok(Value::string(first.chars().take(len).collect::<String>()))
 }
 
+/// `tcl::prefix match`'s own option words, in C table order (`matchOptions[]`,
+/// `tclIndexObj.c`): `Tcl_GetIndexFromObj(…, "option", 0)`, so `-m`
+/// abbreviates `-message` while `-e` prefixes both `-error` and `-exact` and
+/// is `ambiguous option "-e"`.
+const MATCH_OPTIONS: tcl_cmd_core::prefix::OptionTable<'static> =
+    tcl_cmd_core::prefix::OptionTable::abbreviating("option", &["-error", "-exact", "-message"]);
+
 /// `tcl::prefix match ?-exact? ?-message s? ?-error opts? table string`.
 fn prefix_match(_vm: &mut Vm, rest: &[Value]) -> Completion<Value> {
     let mut exact = false;
@@ -118,30 +141,29 @@ fn prefix_match(_vm: &mut Vm, rest: &[Value]) -> Completion<Value> {
     };
     let mut i = 0;
     while i < opts.len() {
-        match &*opts[i].to_str() {
-            "-exact" => {
-                exact = true;
-                i += 1;
-            }
-            "-message" => {
-                let Some(v) = opts.get(i + 1) else {
-                    return err("missing value for -message");
-                };
-                message = v.to_str().to_string();
-                i += 2;
-            }
-            "-error" => {
+        // C's `matchOptions[]` (`tclIndexObj.c`), resolved with
+        // `Tcl_GetIndexFromObj(…, "option", 0)`: `-m` abbreviates `-message`,
+        // while `-e` prefixes both `-error` and `-exact` and is `ambiguous`.
+        match MATCH_OPTIONS.index_of_str(&opts[i].to_str()) {
+            Ok(0) => {
                 let Some(v) = opts.get(i + 1) else {
                     return err("missing value for -error");
                 };
                 error_opts = Some(v.clone());
                 i += 2;
             }
-            other => {
-                return err(format!(
-                    "bad option \"{other}\": must be -error, -exact, or -message"
-                ));
+            Ok(1) => {
+                exact = true;
+                i += 1;
             }
+            Ok(_) => {
+                let Some(v) = opts.get(i + 1) else {
+                    return err("missing value for -message");
+                };
+                message = v.to_str().to_string();
+                i += 2;
+            }
+            Err(e) => return err(e.into_message()),
         }
     }
     let table = match entries(table) {

--- a/rust/tcl-vm/src/cmd_string.rs
+++ b/rust/tcl-vm/src/cmd_string.rs
@@ -114,31 +114,22 @@ const STRING_SUBS: &[&str] = &[
     "wordstart",
 ];
 
-/// Resolve a (possibly abbreviated) `string` subcommand to its canonical name,
-/// honouring Tcl's unique-prefix matching. Returns the standard error message on
-/// no/ambiguous match.
+/// Resolve a (possibly abbreviated) `string` subcommand to its canonical name
+/// through the shared ensemble owner (`string` is a `TclMakeEnsemble` command),
+/// or the ensemble's own miss sentence — including its comma before `or`, which
+/// `prefix::choice_list` words differently.
 fn resolve_string_sub(input: &str) -> Result<&'static str, String> {
-    if let Some(&s) = STRING_SUBS.iter().find(|&&s| s == input) {
-        return Ok(s);
-    }
-    let mut hits = STRING_SUBS.iter().filter(|&&s| s.starts_with(input));
-    match (hits.next(), hits.next()) {
-        (Some(&s), None) if !input.is_empty() => Ok(s),
-        _ => {
-            let mut list = String::new();
-            for (i, s) in STRING_SUBS.iter().enumerate() {
-                if i > 0 {
-                    list.push_str(", ");
-                }
-                if i == STRING_SUBS.len() - 1 {
-                    list.push_str("or ");
-                }
-                list.push_str(s);
-            }
-            Err(format!(
-                "unknown or ambiguous subcommand \"{input}\": must be {list}"
+    match tcl_cmd_core::ensemble::resolve_subcommand(STRING_SUBS, input.as_bytes(), true) {
+        Some(index) => Ok(STRING_SUBS[index]),
+        None => Err(
+            String::from_utf8_lossy(&tcl_cmd_core::ensemble::unknown_subcommand_message(
+                STRING_SUBS,
+                input.as_bytes(),
+                true,
+                b"::tcl::string",
             ))
-        }
+            .into_owned(),
+        ),
     }
 }
 

--- a/rust/tcl-vm/src/cmd_string.rs
+++ b/rust/tcl-vm/src/cmd_string.rs
@@ -145,7 +145,7 @@ fn cmd_string(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
         "string",
         STRING_SUBS,
     );
-    let canon = match resolve_string_sub(&subs, &sub.to_str()) {
+    let canon = match resolve_string_sub(subs, &sub.to_str()) {
         Ok(c) => c,
         Err(e) => return err(e),
     };

--- a/rust/tcl-vm/src/cmd_string.rs
+++ b/rust/tcl-vm/src/cmd_string.rs
@@ -118,12 +118,12 @@ const STRING_SUBS: &[&str] = &[
 /// through the shared ensemble owner (`string` is a `TclMakeEnsemble` command),
 /// or the ensemble's own miss sentence — including its comma before `or`, which
 /// `prefix::choice_list` words differently.
-fn resolve_string_sub(input: &str) -> Result<&'static str, String> {
-    match tcl_cmd_core::ensemble::resolve_subcommand(STRING_SUBS, input.as_bytes(), true) {
-        Some(index) => Ok(STRING_SUBS[index]),
+fn resolve_string_sub<'a>(subs: &[&'a str], input: &str) -> Result<&'a str, String> {
+    match tcl_cmd_core::ensemble::resolve_subcommand(subs, input.as_bytes(), true) {
+        Some(index) => Ok(subs[index]),
         None => Err(
             String::from_utf8_lossy(&tcl_cmd_core::ensemble::unknown_subcommand_message(
-                STRING_SUBS,
+                subs,
                 input.as_bytes(),
                 true,
                 b"::tcl::string",
@@ -137,7 +137,15 @@ fn cmd_string(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     let Some((sub, rest)) = args.split_first() else {
         return err_wrong_args("string subcommand ?arg ...?");
     };
-    let canon = match resolve_string_sub(&sub.to_str()) {
+    // `insert` arrives in Tcl 9 and `bytelength` leaves with it, so the table
+    // is the emulated release's: on 8.6 `string in` is `index`, on 9.0 it is
+    // ambiguous with `insert`.
+    let subs = crate::environment::release_subcommands(
+        vm.runtime_version().dialect_profile_name(),
+        "string",
+        STRING_SUBS,
+    );
+    let canon = match resolve_string_sub(&subs, &sub.to_str()) {
         Ok(c) => c,
         Err(e) => return err(e),
     };
@@ -519,7 +527,14 @@ fn cmd_append(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
 
 #[cfg(test)]
 mod tests {
-    use super::{is_nocase, resolve_string_sub};
+    use super::{STRING_SUBS, is_nocase};
+
+    /// The unit tests below exercise the resolver over the engine's full
+    /// (Tcl 9) table; the release filter that narrows it per pin is covered
+    /// end-to-end in `tests/cmd_info_prefix_e2e.rs`.
+    fn resolve_string_sub(input: &str) -> Result<&'static str, String> {
+        super::resolve_string_sub(STRING_SUBS, input)
+    }
 
     #[test]
     fn resolve_string_sub_prefers_exact_over_prefix() {

--- a/rust/tcl-vm/src/cmd_try.rs
+++ b/rust/tcl-vm/src/cmd_try.rs
@@ -201,6 +201,14 @@ fn bind_handler_vars(
     Ok(())
 }
 
+/// `try`'s handler-type words, in C table order (`TryObjCmd`'s `handlerNames`,
+/// `tclCmdMZ.c`): `Tcl_GetIndexFromObj(…, "handler type", 0)`, so `f`/`o`/`t`
+/// abbreviate and the empty word — a prefix of all three — is
+/// `ambiguous handler type ""`. The type is resolved before the clause's
+/// arity, as it is in C (`try {} x` → `bad handler type "x"`).
+const HANDLER_TYPES: tcl_cmd_core::prefix::OptionTable<'static> =
+    tcl_cmd_core::prefix::OptionTable::abbreviating("handler type", &["finally", "on", "trap"]);
+
 /// Parse a `try`'s handler (`on`/`trap`) and `finally` clauses, validating the
 /// grammar (a bad clause errors before the body runs). Returns the handlers and
 /// the optional `finally` script.
@@ -209,7 +217,12 @@ fn parse_clauses(rest: &[Value]) -> Result<(Vec<Handler>, Option<Value>), Comple
     let mut finally: Option<Value> = None;
     let mut j = 0;
     while j < rest.len() {
-        match &*rest[j].to_str() {
+        let word = rest[j].to_str();
+        let handler_type = match HANDLER_TYPES.index_of_str(&word) {
+            Ok(i) => HANDLER_TYPES.names()[i],
+            Err(e) => return Err(err(e.into_message())),
+        };
+        match handler_type {
             "finally" => {
                 if j + 2 < rest.len() {
                     return Err(err("finally clause must be last"));
@@ -256,9 +269,11 @@ fn parse_clauses(rest: &[Value]) -> Result<(Vec<Handler>, Option<Value>), Comple
                 });
                 j += 4;
             }
+            // Unreachable: `HANDLER_TYPES` has exactly the three arms above.
             other => {
                 return Err(err(format!(
-                    "bad handler type \"{other}\": must be finally, on, or trap"
+                    "bad handler type \"{other}\": must be {}",
+                    tcl_cmd_core::prefix::choice_list(HANDLER_TYPES.names())
                 )));
             }
         }

--- a/rust/tcl-vm/src/command.rs
+++ b/rust/tcl-vm/src/command.rs
@@ -586,6 +586,13 @@ fn cmd_rename(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     ok(Value::empty())
 }
 
+/// `interp create`'s option words (`createOptions[]`, `tclInterp.c`), resolved
+/// with `Tcl_GetIndexFromObj(…, "option", 0)`: `-s` abbreviates `-safe` and the
+/// lone `-` — a prefix of both entries — is `ambiguous option "-"`. Only a word
+/// starting with `-` reaches the table, so the empty word is a path, not a miss.
+const CREATE_OPTIONS: tcl_cmd_core::prefix::OptionTable<'static> =
+    tcl_cmd_core::prefix::OptionTable::abbreviating("option", &["-safe", "--"]);
+
 /// `interp create ?-safe? ?--? ?name?` — make a child interpreter.
 fn interp_create_cmd(vm: &mut Vm, rest: &[Value]) -> Completion<Value> {
     // C's "weird historical rule": `-safe` is accepted anywhere before `--`
@@ -598,17 +605,17 @@ fn interp_create_cmd(vm: &mut Vm, rest: &[Value]) -> Completion<Value> {
     while i < rest.len() {
         let a = rest[i].to_str();
         if !last && a.starts_with('-') {
-            match &*a {
-                "-safe" => {
+            match CREATE_OPTIONS.index_of_str(&a) {
+                Ok(0) => {
                     safe = true;
                     i += 1;
                     continue;
                 }
-                "--" => {
+                Ok(_) => {
                     i += 1;
                     last = true;
                 }
-                s => return err(format!("bad option \"{s}\": must be -safe or --")),
+                Err(e) => return err(e.into_message()),
             }
         }
         if name.is_some() {
@@ -845,11 +852,50 @@ fn interp_hidectl_cmd(vm: &mut Vm, hide: bool, rest: &[Value]) -> Completion<Val
     }
 }
 
-/// `interp invokehidden path ?-namespace ns? ?--? cmd ?arg ...?` — invoke a
-/// hidden command in the named child.
+/// `interp invokehidden`'s leading option words (`hiddenOptions[]`,
+/// `tclInterp.c`), resolved with `Tcl_GetIndexFromObj(…, "option", 0)`: `-g`
+/// and `-n` abbreviate, and the lone `-` is `ambiguous option "-"`. Only a word
+/// starting with `-` reaches the table, so an empty word is the command name.
+const HIDDEN_OPTIONS: tcl_cmd_core::prefix::OptionTable<'static> =
+    tcl_cmd_core::prefix::OptionTable::abbreviating("option", &["-global", "-namespace", "--"]);
+
+/// Consume `interp invokehidden`'s leading options from `tail`, returning the
+/// index of the command word. Mirrors C's loop: a word not starting with `-`
+/// ends the scan, `-namespace` swallows the following word, and `--` ends it.
+/// `-namespace`/`-global` select the invocation namespace, which this engine
+/// does not model.
+pub(crate) fn skip_hidden_options(tail: &[Value]) -> Result<usize, String> {
+    let mut i = 0;
+    while i < tail.len() {
+        let word = tail[i].to_str();
+        if !word.starts_with('-') {
+            break;
+        }
+        match HIDDEN_OPTIONS.index_of_str(&word) {
+            Ok(1) => {
+                // `-namespace ns` — the namespace word, when there is one.
+                i += 1;
+                if i == tail.len() {
+                    break;
+                }
+                i += 1;
+            }
+            Ok(2) => {
+                i += 1;
+                break;
+            }
+            Ok(_) => i += 1,
+            Err(e) => return Err(e.into_message()),
+        }
+    }
+    Ok(i)
+}
+
+/// `interp invokehidden path ?-namespace ns? ?-global? ?--? cmd ?arg ...?` —
+/// invoke a hidden command in the named child.
 fn interp_invokehidden_cmd(vm: &mut Vm, rest: &[Value]) -> Completion<Value> {
-    let usage =
-        "wrong # args: should be \"interp invokehidden path ?-namespace ns? ?--? cmd ?arg ..?\"";
+    let usage = "wrong # args: should be \"interp invokehidden path \
+                 ?-namespace ns? ?-global? ?--? cmd ?arg ..?\"";
     let [path, tail @ ..] = rest else {
         return err(usage);
     };
@@ -859,25 +905,94 @@ fn interp_invokehidden_cmd(vm: &mut Vm, rest: &[Value]) -> Completion<Value> {
     if vm.is_safe() {
         return err("not allowed to invoke hidden commands from safe interpreter");
     }
-    // Skip the option flags we don't model (`-namespace ns`, `--`).
-    let mut i = 0;
-    while i < tail.len() {
-        match &*tail[i].to_str() {
-            "-namespace" => i += 2,
-            "--" => {
-                i += 1;
-                break;
-            }
-            s if s.starts_with('-') => i += 1,
-            _ => break,
-        }
-    }
+    let i = match skip_hidden_options(tail) {
+        Ok(i) => i,
+        Err(m) => return err(m),
+    };
     let Some(cmd) = tail.get(i) else {
         return err(usage);
     };
     let p = path.to_str();
     vm.invoke_hidden_in_child(&p, &cmd.to_str(), &tail[i + 1..])
         .unwrap_or_else(|| err(format!("could not find interpreter \"{p}\"")))
+}
+
+/// `interp`'s subcommand words, in C table order (`options[]`, `tclInterp.c`).
+/// C resolves them with `Tcl_GetIndexFromObj(…, "option", 0)`, so `cr`
+/// abbreviates `create` and the empty word — a prefix of every entry — is
+/// `ambiguous option ""`.
+///
+/// Like the WASM runtime (#1412 item 3), the table names only the subcommands
+/// this engine dispatches: `aliases`, `cancel`, and `target` need
+/// infrastructure the VM has none of, so they are dropped rather than left
+/// advertised-but-undispatchable. `slaves` is 8.x's deprecated spelling of
+/// `children`: it still resolves at 9.0 (as it does in C, whose `options[]`
+/// keeps it) but [`interp_option_choices`] drops it from the enumeration.
+///
+/// tclsh 9.0.4, for contrast:
+///   bad option "x": must be alias, aliases, bgerror, cancel, children,
+///   create, debug, delete, eval, exists, expose, hide, hidden, issafe,
+///   invokehidden, limit, marktrusted, recursionlimit, share, target, or
+///   transfer
+pub(crate) const INTERP_OPTIONS: &[&str] = &[
+    "alias",
+    "bgerror",
+    "children",
+    "create",
+    "debug",
+    "delete",
+    "eval",
+    "exists",
+    "expose",
+    "hide",
+    "hidden",
+    "issafe",
+    "invokehidden",
+    "limit",
+    "marktrusted",
+    "recursionlimit",
+    "slaves",
+    "share",
+    "transfer",
+];
+
+/// The `interp` subcommands the miss message enumerates for the emulated
+/// release: 9.0 retired `slaves` from the advertised list (C reports the miss
+/// against its own `optionsNoSlaves[]`) while still dispatching it.
+fn interp_option_choices(vm: &Vm) -> Vec<&'static str> {
+    if vm.runtime_version() >= tcl_dialect::TclVersion::V9_0 {
+        INTERP_OPTIONS
+            .iter()
+            .copied()
+            .filter(|name| *name != "slaves")
+            .collect()
+    } else {
+        INTERP_OPTIONS.to_vec()
+    }
+}
+
+/// Resolve an `interp`-family subcommand word through the shared owner:
+/// `dispatch` is the table the word may resolve against, `advertised` the
+/// (possibly shorter) table the miss message enumerates — C splits the two the
+/// same way for `slaves`.
+pub(crate) fn resolve_interp_option(
+    dispatch: &'static [&'static str],
+    advertised: &[&'static str],
+    word: &str,
+) -> Result<&'static str, String> {
+    match tcl_cmd_core::prefix::scan(dispatch, word.as_bytes(), false) {
+        tcl_cmd_core::prefix::Resolution::Exact(i)
+        | tcl_cmd_core::prefix::Resolution::UniquePrefix(i) => Ok(dispatch[i]),
+        miss => Err(
+            String::from_utf8_lossy(&tcl_cmd_core::prefix::bad_key_message(
+                advertised,
+                b"option",
+                word.as_bytes(),
+                matches!(miss, tcl_cmd_core::prefix::Resolution::Ambiguous),
+            ))
+            .into_owned(),
+        ),
+    }
 }
 
 /// `interp` — child-interpreter creation, evaluation, and the single-interp
@@ -888,7 +1003,12 @@ fn cmd_interp(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     let Some((sub, rest)) = args.split_first() else {
         return err("wrong # args: should be \"interp cmd ?arg ...?\"");
     };
-    match &*sub.to_str() {
+    let choices = interp_option_choices(vm);
+    let sub = match resolve_interp_option(INTERP_OPTIONS, &choices, &sub.to_str()) {
+        Ok(name) => name,
+        Err(m) => return err(m),
+    };
+    match sub {
         "create" => interp_create_cmd(vm, rest),
         // interp alias srcPath srcCmd targetPath targetCmd ?arg ...?
         "alias" => match rest {
@@ -943,7 +1063,7 @@ fn cmd_interp(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
         "slaves" | "children" => interp_children_cmd(vm, rest),
         "recursionlimit" => interp_recursionlimit_cmd(vm, rest),
         // interp hide path cmd / interp expose path cmd
-        "hide" | "expose" => interp_hidectl_cmd(vm, &*sub.to_str() == "hide", rest),
+        "hide" | "expose" => interp_hidectl_cmd(vm, sub == "hide", rest),
         "hidden" => interp_hidden_cmd(vm, rest),
         "invokehidden" => interp_invokehidden_cmd(vm, rest),
         "debug" => interp_debug_cmd(vm, rest),
@@ -966,11 +1086,10 @@ fn cmd_interp(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
         // channels at top level runs to completion (the dependent reads are
         // covered by the per-interp channel table, not a global one).
         "share" | "transfer" => ok(Value::empty()),
+        // Unreachable: every name in `INTERP_OPTIONS` has an arm above.
         other => err(format!(
-            "bad option \"{other}\": must be alias, aliases, bgerror, cancel, \
-             children, create, debug, delete, eval, exists, expose, hide, \
-             hidden, issafe, invokehidden, limit, marktrusted, recursionlimit, \
-             share, slaves, target, or transfer"
+            "bad option \"{other}\": must be {}",
+            tcl_cmd_core::prefix::choice_list(&choices)
         )),
     }
 }

--- a/rust/tcl-vm/src/command.rs
+++ b/rust/tcl-vm/src/command.rs
@@ -1691,23 +1691,45 @@ fn cmd_time(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
 /// reports `utf-8`, `names` lists the supported set, and `dirs` is accepted and
 /// ignored (no encoding-file search). This is a documented simplification — real
 /// codepage conversion (cp1252, shiftjis, …) is not implemented on either side.
+/// `encoding`'s subcommand set, alphabetical as `TclMakeEnsemble` sorts it.
+/// 9.0's table also carries `profiles` and `user`, which need the encoding
+/// machinery this engine does not model; like its other ensembles it names
+/// only what it dispatches.
+const ENCODING_SUBS: &[&str] = &["convertfrom", "convertto", "dirs", "names", "system"];
+
 fn cmd_encoding(_vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     let Some(sub) = args.first() else {
         return err("wrong # args: should be \"encoding subcommand ?arg ...?\"");
     };
-    match &*sub.to_str() {
+    let canon = match tcl_cmd_core::ensemble::resolve_subcommand(
+        ENCODING_SUBS,
+        sub.to_str().as_bytes(),
+        true,
+    ) {
+        Some(index) => ENCODING_SUBS[index],
+        None => {
+            return err(String::from_utf8_lossy(
+                &tcl_cmd_core::ensemble::unknown_subcommand_message(
+                    ENCODING_SUBS,
+                    sub.to_str().as_bytes(),
+                    true,
+                    b"::tcl::encoding",
+                ),
+            )
+            .into_owned());
+        }
+    };
+    match canon {
         "dirs" => ok(Value::empty()),
         "system" => ok(Value::string("utf-8")),
         "names" => ok(Value::string("utf-8 unicode ascii iso8859-1")),
-        "convertto" | "convertfrom" => {
+        // Unreachable: `ENCODING_SUBS` has exactly these five names.
+        _ => {
             if args.len() < 2 {
                 return err("wrong # args: should be \"encoding convertto ?encoding? data\"");
             }
             ok(args.last().expect("len >= 2").clone())
         }
-        other => err(format!(
-            "unknown or ambiguous subcommand \"{other}\": must be convertfrom, convertto, dirs, names, or system"
-        )),
     }
 }
 

--- a/rust/tcl-vm/src/command.rs
+++ b/rust/tcl-vm/src/command.rs
@@ -661,10 +661,8 @@ fn interp_limit_cmd(vm: &mut Vm, rest: &[Value]) -> Completion<Value> {
     };
     // Validate the limit type before the current-interp guard so that a bad
     // type is reported ahead of the inaccessibility error (interp-35.3 vs .23).
-    if &*ltype != "commands" && &*ltype != "time" {
-        return err(format!(
-            "bad limit type \"{ltype}\": must be commands or time"
-        ));
+    if let Err(e) = crate::interp::LIMIT_TYPES.index_of_str(&ltype) {
+        return err(e.into_message());
     }
     if path.is_empty() {
         return err("limits on current interpreter inaccessible");
@@ -763,17 +761,18 @@ fn interp_bgerror_cmd(vm: &mut Vm, rest: &[Value]) -> Completion<Value> {
 
 /// `interp debug path ?-frame ?bool??` — the per-interp frame-debug switch.
 fn interp_debug_cmd(vm: &mut Vm, rest: &[Value]) -> Completion<Value> {
+    const USAGE: &str = "interp debug path ?-frame ?bool??";
     let Some((path, dargs)) = rest.split_first() else {
-        return err("wrong # args: should be \"interp debug path ?-frame ?bool??\"");
+        return err(format!("wrong # args: should be \"{USAGE}\""));
     };
     let p = path.to_str();
     let res = if p.is_empty() {
-        vm.debug_apply(dargs)
+        vm.debug_apply(dargs, USAGE)
     } else {
         match vm.resolve_interp_path(&p) {
             Ok(id) => {
                 let dargs = dargs.to_vec();
-                vm.in_interp(id, |vm| vm.debug_apply(&dargs))
+                vm.in_interp(id, |vm| vm.debug_apply(&dargs, USAGE))
             }
             Err(c) => return c,
         }

--- a/rust/tcl-vm/src/command.rs
+++ b/rust/tcl-vm/src/command.rs
@@ -1702,28 +1702,31 @@ fn cmd_time(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
 /// only what it dispatches.
 const ENCODING_SUBS: &[&str] = &["convertfrom", "convertto", "dirs", "names", "system"];
 
-fn cmd_encoding(_vm: &mut Vm, args: &[Value]) -> Completion<Value> {
+fn cmd_encoding(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     let Some(sub) = args.first() else {
         return err("wrong # args: should be \"encoding subcommand ?arg ...?\"");
     };
-    let canon = match tcl_cmd_core::ensemble::resolve_subcommand(
+    // `dirs` arrives in 8.5, so the table follows the emulated release.
+    let subs = crate::environment::release_subcommands(
+        vm.runtime_version().dialect_profile_name(),
+        "encoding",
         ENCODING_SUBS,
-        sub.to_str().as_bytes(),
-        true,
-    ) {
-        Some(index) => ENCODING_SUBS[index],
-        None => {
-            return err(String::from_utf8_lossy(
-                &tcl_cmd_core::ensemble::unknown_subcommand_message(
-                    ENCODING_SUBS,
-                    sub.to_str().as_bytes(),
-                    true,
-                    b"::tcl::encoding",
-                ),
-            )
-            .into_owned());
-        }
-    };
+    );
+    let canon =
+        match tcl_cmd_core::ensemble::resolve_subcommand(subs, sub.to_str().as_bytes(), true) {
+            Some(index) => subs[index],
+            None => {
+                return err(String::from_utf8_lossy(
+                    &tcl_cmd_core::ensemble::unknown_subcommand_message(
+                        subs,
+                        sub.to_str().as_bytes(),
+                        true,
+                        b"::tcl::encoding",
+                    ),
+                )
+                .into_owned());
+            }
+        };
     match canon {
         "dirs" => ok(Value::empty()),
         "system" => ok(Value::string("utf-8")),

--- a/rust/tcl-vm/src/environment.rs
+++ b/rust/tcl-vm/src/environment.rs
@@ -59,6 +59,8 @@
 //! [`TclVersion`]: tcl_dialect::TclVersion
 //! [`TclVersion::dialect_name`]: tcl_dialect::TclVersion::dialect_name
 
+use std::sync::{Mutex, OnceLock};
+
 use tcl_dialect::DialectProfile;
 use tcl_dialect::model::SurfaceQuery;
 use tcl_dialect::model::surface_admits;
@@ -121,6 +123,10 @@ pub(crate) fn surface_point_for_dialect(name: &str) -> SurfaceQuery<'static> {
     tcl_registry::model::static_document_context_for(name).authoring_query()
 }
 
+/// One memoised answer: `(command, release name, the release's slice of the
+/// engine's table)`.
+type SubcommandCacheEntry = (&'static str, String, &'static [&'static str]);
+
 /// The subset of an engine ensemble `table` the emulated release actually
 /// has, in the table's own order.
 ///
@@ -137,28 +143,54 @@ pub(crate) fn surface_point_for_dialect(name: &str) -> SurfaceQuery<'static> {
 /// Only *removal* happens: a name the registry does not model (an engine
 /// extra) is kept, so a table stays the engine's own list of what it
 /// dispatches and its enumeration order.
-pub(crate) fn release_subcommands<'a>(
+///
+/// This sits on the dispatch path of the hottest ensembles (`dict`, `string`,
+/// `info`), and resolving the environment by name costs tens of microseconds
+/// — 6x the whole cost of a `dict get` — so the answer is memoised per
+/// `(command, release)`. That pair is a closed, tiny set, and each engine has
+/// exactly one table per command name, so the leak is bounded by it.
+fn release_subcommand_cache() -> &'static Mutex<Vec<SubcommandCacheEntry>> {
+    static CACHE: OnceLock<Mutex<Vec<SubcommandCacheEntry>>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+pub(crate) fn release_subcommands(
     dialect_name: &str,
-    command: &str,
-    table: &[&'a str],
-) -> Vec<&'a str> {
+    command: &'static str,
+    table: &[&'static str],
+) -> &'static [&'static str] {
+    let cache = release_subcommand_cache();
+    if let Some((_, _, hit)) = cache
+        .lock()
+        .expect("subcommand cache")
+        .iter()
+        .find(|(cmd, name, _)| *cmd == command && name == dialect_name)
+    {
+        return hit;
+    }
     let profile = profile_for_dialect(dialect_name);
     let point = surface_point(profile);
-    let Some(spec) = store_for_profile(profile).get(command) else {
-        return table.to_vec();
+    let filtered: Vec<&'static str> = match store_for_profile(profile).get(command) {
+        Some(spec) => table
+            .iter()
+            .copied()
+            .filter(|name| {
+                spec.subcommands
+                    .iter()
+                    .find(|sub| sub.name == *name)
+                    .is_none_or(|sub| {
+                        sub.surface
+                            .or(spec.surface)
+                            .is_none_or(|gate| surface_admits(gate, Some(&point)))
+                    })
+            })
+            .collect(),
+        None => table.to_vec(),
     };
-    table
-        .iter()
-        .copied()
-        .filter(|name| {
-            spec.subcommands
-                .iter()
-                .find(|sub| sub.name == *name)
-                .is_none_or(|sub| {
-                    sub.surface
-                        .or(spec.surface)
-                        .is_none_or(|gate| surface_admits(gate, Some(&point)))
-                })
-        })
-        .collect()
+    let leaked: &'static [&'static str] = Vec::leak(filtered);
+    cache
+        .lock()
+        .expect("subcommand cache")
+        .push((command, dialect_name.to_string(), leaked));
+    leaked
 }

--- a/rust/tcl-vm/src/environment.rs
+++ b/rust/tcl-vm/src/environment.rs
@@ -61,6 +61,7 @@
 
 use tcl_dialect::DialectProfile;
 use tcl_dialect::model::SurfaceQuery;
+use tcl_dialect::model::surface_admits;
 use tcl_registry::CommandRegistry;
 
 /// Resolve a dialect **name** to the profile this VM pins.
@@ -118,4 +119,46 @@ pub(crate) fn surface_point(profile: &'static DialectProfile) -> SurfaceQuery<'s
 /// [`TclVersion::dialect_profile_name`]: tcl_dialect::TclVersion::dialect_profile_name
 pub(crate) fn surface_point_for_dialect(name: &str) -> SurfaceQuery<'static> {
     tcl_registry::model::static_document_context_for(name).authoring_query()
+}
+
+/// The subset of an engine ensemble `table` the emulated release actually
+/// has, in the table's own order.
+///
+/// A `TclMakeEnsemble` table is a *release* fact: `dict getwithdefault`,
+/// `array for`, `file tempdir` and `info cmdtype` arrive in Tcl 9, and a
+/// handler that resolves against one release's table under every pin gets
+/// two things wrong at once — it dispatches a subcommand the pinned release
+/// never had, and, worse, a 9-only name silently changes an 8.x prefix
+/// verdict for a name that has nothing to do with it (`dict g` is `get` on
+/// 8.6 and ambiguous on 9.0). The names and their gates belong to the
+/// registry, so this filters the engine's table through the selected
+/// release's surface rather than duplicating the release facts here.
+///
+/// Only *removal* happens: a name the registry does not model (an engine
+/// extra) is kept, so a table stays the engine's own list of what it
+/// dispatches and its enumeration order.
+pub(crate) fn release_subcommands<'a>(
+    dialect_name: &str,
+    command: &str,
+    table: &[&'a str],
+) -> Vec<&'a str> {
+    let profile = profile_for_dialect(dialect_name);
+    let point = surface_point(profile);
+    let Some(spec) = store_for_profile(profile).get(command) else {
+        return table.to_vec();
+    };
+    table
+        .iter()
+        .copied()
+        .filter(|name| {
+            spec.subcommands
+                .iter()
+                .find(|sub| sub.name == *name)
+                .is_none_or(|sub| {
+                    sub.surface
+                        .or(spec.surface)
+                        .is_none_or(|gate| surface_admits(gate, Some(&point)))
+                })
+        })
+        .collect()
 }

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -247,6 +247,19 @@ fn parse_recursion_limit(s: &str) -> Result<i64, String> {
     Err(format!("expected integer but got \"{s}\""))
 }
 
+/// `interp debug`'s one option word (`debugTypes[]`, `tclInterp.c`): C resolves
+/// it with `Tcl_GetIndexFromObj(…, "debug option", 0)`, so `-f`/`-fr`
+/// abbreviate and a miss is `bad debug option "…": must be -frame` — a
+/// one-entry table is never `ambiguous`, not even for the empty word.
+const DEBUG_OPTIONS: tcl_cmd_core::prefix::OptionTable<'static> =
+    tcl_cmd_core::prefix::OptionTable::abbreviating("debug option", &["-frame"]);
+
+/// `interp limit`'s type word (`limitTypes[]`, `tclInterp.c`): the noun is
+/// `limit type` and the flags are `0`, so `c`/`t` abbreviate and the empty
+/// word — a prefix of both entries — is `ambiguous limit type ""`.
+pub(crate) const LIMIT_TYPES: tcl_cmd_core::prefix::OptionTable<'static> =
+    tcl_cmd_core::prefix::OptionTable::abbreviating("limit type", &["commands", "time"]);
+
 /// Resolve an `interp limit` option by unambiguous prefix against `opts`,
 /// matching C's `Tcl_GetIndexFromObj` — through the one shared owner.
 ///
@@ -2944,26 +2957,31 @@ impl Vm {
 
     /// `interp debug ?-frame ?bool??` on this interp. `-frame` is a one-way
     /// switch (once on, stays on); returns the settings list / the frame bool.
-    pub(crate) fn debug_apply(&mut self, args: &[Value]) -> Result<Value, String> {
-        match args {
-            [] => Ok(Value::list(vec![
-                Value::string("-frame"),
-                Value::int(i64::from(self.debug_frame)),
-            ])),
-            [opt] if &*opt.to_str() == "-frame" => Ok(Value::int(i64::from(self.debug_frame))),
-            [opt, val] if &*opt.to_str() == "-frame" => {
-                if val.as_bool().unwrap_or(false) {
-                    self.debug_frame = true;
-                }
-                Ok(Value::int(i64::from(self.debug_frame)))
+    ///
+    /// C checks the argument count before the option word, so
+    /// `interp debug i -x 1 2` is `wrong # args`, not `bad debug option`;
+    /// `usage` is the caller's own `should be` text, which differs between the
+    /// `interp debug path …` and `$child debug …` spellings.
+    pub(crate) fn debug_apply(&mut self, args: &[Value], usage: &str) -> Result<Value, String> {
+        let (opt, rest) = match args {
+            [] => {
+                return Ok(Value::list(vec![
+                    Value::string("-frame"),
+                    Value::int(i64::from(self.debug_frame)),
+                ]));
             }
-            _ => Err(format!(
-                "bad option \"{}\": must be -frame",
-                args.first()
-                    .map(|v| v.to_str().to_string())
-                    .unwrap_or_default()
-            )),
+            [opt, rest @ ..] if rest.len() <= 1 => (opt, rest),
+            _ => return Err(format!("wrong # args: should be \"{usage}\"")),
+        };
+        DEBUG_OPTIONS
+            .index_of_str(&opt.to_str())
+            .map_err(tcl_cmd_core::CmdError::into_message)?;
+        if let [val] = rest
+            && val.as_bool().unwrap_or(false)
+        {
+            self.debug_frame = true;
         }
+        Ok(Value::int(i64::from(self.debug_frame)))
     }
 
     /// `interp bgerror ?cmdPrefix?` on this interp — get/set the background-error
@@ -3116,12 +3134,12 @@ impl Vm {
     /// `interp limit limitType ?-option value …?` on this interp (query / set;
     /// enforced for `time`).
     pub(crate) fn limit_apply(&mut self, ltype: &str, args: &[Value]) -> Result<Value, String> {
-        match ltype {
-            "commands" => self.limit_commands(args),
-            "time" => self.limit_time(args),
-            other => Err(format!(
-                "bad limit type \"{other}\": must be commands or time"
-            )),
+        match LIMIT_TYPES
+            .index_of_str(ltype)
+            .map_err(tcl_cmd_core::CmdError::into_message)?
+        {
+            0 => self.limit_commands(args),
+            _ => self.limit_time(args),
         }
     }
 
@@ -4030,6 +4048,16 @@ impl Vm {
             "recursionlimit" => err(format!(
                 "wrong # args: should be \"{name} recursionlimit ?newlimit?\""
             )),
+            // `$child debug ?-frame ?bool??` — the same switch `interp debug
+            // path …` reaches, with the child spelling in the arity message.
+            "debug" => {
+                let dargs = rest.to_vec();
+                let usage = format!("{name} debug ?-frame ?bool??");
+                match self.in_interp(id, |vm| vm.debug_apply(&dargs, &usage)) {
+                    Ok(v) => ok(v),
+                    Err(m) => err(m),
+                }
+            }
             "limit" => self.dispatch_child_limit(name, id, rest),
             other => err(format!(
                 "bad option \"{other}\": must be alias, aliases, bgerror, eval, \

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -254,6 +254,28 @@ fn parse_recursion_limit(s: &str) -> Result<i64, String> {
 const DEBUG_OPTIONS: tcl_cmd_core::prefix::OptionTable<'static> =
     tcl_cmd_core::prefix::OptionTable::abbreviating("debug option", &["-frame"]);
 
+/// The child-as-command (`$child sub …`) subcommand words, in C table order
+/// (`options[]` in `NRChildCmd`, `tclInterp.c`), resolved with
+/// `Tcl_GetIndexFromObj(…, "option", 0)` — so `ev` abbreviates `eval` and the
+/// empty word is `ambiguous option ""`.
+///
+/// C's table is `alias, aliases, bgerror, debug, eval, expose, hide, hidden,
+/// issafe, invokehidden, limit, marktrusted, recursionlimit`; like the
+/// `interp` ensemble's own table this engine names only what it dispatches
+/// (#1412 item 3), dropping `alias`, `aliases`, and `bgerror`.
+pub(crate) const CHILD_OPTIONS: &[&str] = &[
+    "debug",
+    "eval",
+    "expose",
+    "hide",
+    "hidden",
+    "issafe",
+    "invokehidden",
+    "limit",
+    "marktrusted",
+    "recursionlimit",
+];
+
 /// `interp limit`'s type word (`limitTypes[]`, `tclInterp.c`): the noun is
 /// `limit type` and the flags are `0`, so `c`/`t` abbreviate and the empty
 /// word — a prefix of both entries — is `ambiguous limit type ""`.
@@ -3998,7 +4020,19 @@ impl Vm {
         let Some((sub, rest)) = argv.split_first() else {
             return err(format!("wrong # args: should be \"{name} cmd ?arg ...?\""));
         };
-        match &*sub.to_str() {
+        let word = sub.to_str();
+        // `$child delete` is this engine's own extra — C's child table has no
+        // `delete` (it is only ever spelled `interp delete path`) — so it is
+        // matched exactly, never abbreviates, and stays out of the enumeration.
+        let sub = if &*word == "delete" {
+            "delete"
+        } else {
+            match crate::command::resolve_interp_option(CHILD_OPTIONS, CHILD_OPTIONS, &word) {
+                Ok(canonical) => canonical,
+                Err(m) => return err(m),
+            }
+        };
+        match sub {
             "eval" => {
                 let script = rest
                     .iter()
@@ -4020,16 +4054,29 @@ impl Vm {
                 names.sort();
                 ok(Value::list(names.into_iter().map(Value::string).collect()))
             }
-            "hide" | "expose" if rest.len() == 1 => {
-                let hide = &*sub.to_str() == "hide";
+            "hide" | "expose" => {
+                let hide = sub == "hide";
+                // `$child hide   cmdName    ?hiddenCmdName?`
+                // `$child expose hiddenName ?cmdName?`
+                let (cmd, token) = match rest {
+                    [cmd] => (cmd.to_str(), cmd.to_str()),
+                    [cmd, token] => (cmd.to_str(), token.to_str()),
+                    _ => {
+                        let form = if hide {
+                            "hide cmdName ?hiddenCmdName?"
+                        } else {
+                            "expose hiddenCmdName ?cmdName?"
+                        };
+                        return err(format!("wrong # args: should be \"{name} {form}\""));
+                    }
+                };
                 if self.is_safe() {
                     let verb = if hide { "hide" } else { "expose" };
                     return err(format!(
                         "permission denied: safe interpreter cannot {verb} commands"
                     ));
                 }
-                let c = rest[0].to_str();
-                match self.child_hide_by_id(id, &c, &c, hide) {
+                match self.child_hide_by_id(id, &cmd, &token, hide) {
                     Ok(()) => ok(Value::empty()),
                     Err(problem) => problem.into_completion(),
                 }
@@ -4041,7 +4088,7 @@ impl Vm {
                 self.mark_interp_trusted(id);
                 ok(Value::empty())
             }
-            "invokehidden" if !rest.is_empty() => self.dispatch_child_invokehidden(name, id, rest),
+            "invokehidden" => self.dispatch_child_invokehidden(name, id, rest),
             "recursionlimit" if rest.len() <= 1 => {
                 self.dispatch_child_recursionlimit(name, id, rest)
             }
@@ -4059,10 +4106,10 @@ impl Vm {
                 }
             }
             "limit" => self.dispatch_child_limit(name, id, rest),
+            // Unreachable: every name in `CHILD_OPTIONS` has an arm above.
             other => err(format!(
-                "bad option \"{other}\": must be alias, aliases, bgerror, eval, \
-                 expose, hide, hidden, issafe, invokehidden, limit, marktrusted, \
-                 recursionlimit, or transfer"
+                "bad option \"{other}\": must be {}",
+                tcl_cmd_core::prefix::choice_list(CHILD_OPTIONS)
             )),
         }
     }
@@ -4077,25 +4124,17 @@ impl Vm {
         if self.is_safe() {
             return err("not allowed to invoke hidden commands from safe interpreter");
         }
-        // Skip unmodelled `-namespace ns` / `--` flags.
-        let mut i = 0;
-        while i < rest.len() {
-            match &*rest[i].to_str() {
-                "-namespace" => i += 2,
-                "--" => {
-                    i += 1;
-                    break;
-                }
-                s if s.starts_with('-') => i += 1,
-                _ => break,
-            }
-        }
+        let i = match crate::command::skip_hidden_options(rest) {
+            Ok(i) => i,
+            Err(m) => return err(m),
+        };
         match rest.get(i) {
             Some(cmd) => self
                 .invoke_hidden_by_id(id, &cmd.to_str(), &rest[i + 1..])
                 .unwrap_or_else(|| err(format!("could not find interpreter \"{name}\""))),
             None => err(format!(
-                "wrong # args: should be \"{name} invokehidden ?-namespace ns? ?--? cmd ?arg ..?\""
+                "wrong # args: should be \"{name} invokehidden ?-namespace ns? \
+                 ?-global? ?--? cmd ?arg ..?\""
             )),
         }
     }

--- a/rust/tcl-vm/tests/builtins_e2e.rs
+++ b/rust/tcl-vm/tests/builtins_e2e.rs
@@ -1842,6 +1842,55 @@ fn channel_io() {
     );
 }
 
+/// Issue #1607: `seek`'s origin word is a `Tcl_GetIndexFromObj(…, "origin", 0)`
+/// table (`originOptions[]`, `tclIOCmd.c`). This engine silently treated any
+/// unknown origin as `start`; C rejects it, abbreviates `s`/`c`/`e`, and words
+/// the empty origin — a prefix of all three — `ambiguous`.
+///
+/// tclsh 8.6.16 / 9.0.4:
+///   seek $f 0 x  -> bad origin "x": must be start, current, or end
+///   seek $f 0 {} -> ambiguous origin "": must be start, current, or end
+///   seek $f 0 s / c / e -> {}
+#[test]
+fn seek_origin_resolves_like_tcl_get_index_from_obj() {
+    const MUST: &str = "must be start, current, or end";
+    const SETUP: &str = "set p /tmp/zz_tcltest_seek_test.txt\n\
+                         set f [open $p w]\nputs $f abcdef\nclose $f\n\
+                         set r [open $p r]\n";
+    let msg = |tail: &str| {
+        let (ok, result, _) = run(&format!("{SETUP}catch {{{tail}}} e\nclose $r\nset e\n"));
+        assert!(ok, "expected the catch to succeed for {tail}");
+        result
+    };
+    assert_eq!(msg("seek $r 0 x"), format!("bad origin \"x\": {MUST}"));
+    assert_eq!(
+        msg("seek $r 0 {}"),
+        format!("ambiguous origin \"\": {MUST}")
+    );
+    // Abbreviations resolve, and `e` seeks to the end.
+    assert_eq!(
+        run(&format!(
+            "{SETUP}seek $r 0 e\nset n [tell $r]\nclose $r\nfile delete $p\nset n\n"
+        ))
+        .1,
+        "7"
+    );
+    assert_eq!(
+        run(&format!(
+            "{SETUP}seek $r 2 s\nset n [tell $r]\nclose $r\nset n\n"
+        ))
+        .1,
+        "2"
+    );
+    assert_eq!(
+        run(&format!(
+            "{SETUP}seek $r 2 s\nseek $r 1 c\nset n [tell $r]\nclose $r\nfile delete $p\nset n\n"
+        ))
+        .1,
+        "3"
+    );
+}
+
 /// `-failindex` must be written. The inline `string is` codegen gates on arity
 /// alone, so it used to accept `CLASS -failindex var value`, take the last word
 /// as the value, and silently drop the option — the class answer was right and

--- a/rust/tcl-vm/tests/builtins_e2e.rs
+++ b/rust/tcl-vm/tests/builtins_e2e.rs
@@ -730,6 +730,72 @@ fn interp_debug_option_uses_c_noun_and_abbreviates() {
     );
 }
 
+/// Issue #1607: `package`'s subcommand word is a `Tcl_GetIndexFromObj(…,
+/// "option", 0)` table (`pkgOptions[]`, `tclPkg.c`) — both engines said
+/// `unknown or ambiguous subcommand "x"` with no list, which is the *ensemble*
+/// wording; `package` is not an ensemble. `package prefer`'s word is a second
+/// table with the noun `preference`.
+///
+/// tclsh 9.0.4 (the VM's default release):
+///   package x  -> bad option "x": must be files, forget, ifneeded, names,
+///                 prefer, present, provide, require, unknown, vcompare,
+///                 versions, or vsatisfies       [TCL LOOKUP INDEX option x]
+///   package {} -> ambiguous option "": must be <same>
+///   package pr -> ambiguous option "pr": must be <same>   (prefer/present/provide)
+///   package v  -> ambiguous option "v": must be <same>    (vcompare/versions/vsatisfies)
+///   package n  -> the names list
+///   package prefer {} -> ambiguous preference "": must be latest or stable
+///   package prefer x  -> bad preference "x": must be latest or stable
+///   package prefer s  -> stable
+#[test]
+fn package_option_words_resolve_like_tcl_get_index_from_obj() {
+    const MUST: &str = "must be files, forget, ifneeded, names, prefer, present, provide, \
+                        require, unknown, vcompare, versions, or vsatisfies";
+    const PREFER_MUST: &str = "must be latest or stable";
+    let msg = |src: &str| {
+        let (ok, result, _) = run(src);
+        assert!(!ok, "expected an error for {src}, got ok");
+        result
+    };
+    assert_eq!(msg("package x\n"), format!("bad option \"x\": {MUST}"));
+    assert_eq!(
+        msg("package {}\n"),
+        format!("ambiguous option \"\": {MUST}")
+    );
+    assert_eq!(
+        msg("package pr\n"),
+        format!("ambiguous option \"pr\": {MUST}")
+    );
+    assert_eq!(
+        msg("package v\n"),
+        format!("ambiguous option \"v\": {MUST}")
+    );
+    assert_eq!(
+        run("package provide foo 1.0\nllength [lsearch -all -exact [package n] foo]\n").1,
+        "1"
+    );
+    // C's lookup error code travels with the message.
+    assert_eq!(
+        run("catch {package x} e opts\nreturn [dict get $opts -errorcode]\n").1,
+        "TCL LOOKUP INDEX option x"
+    );
+    // `package prefer`'s own table.
+    assert_eq!(
+        msg("package prefer {}\n"),
+        format!("ambiguous preference \"\": {PREFER_MUST}")
+    );
+    assert_eq!(
+        msg("package prefer x\n"),
+        format!("bad preference \"x\": {PREFER_MUST}")
+    );
+    assert_eq!(run("package prefer s\n").1, "stable");
+    assert_eq!(run("package prefer l\n").1, "latest");
+    // 9.0's `files`: nothing here loads through a package loader, so the
+    // answer is the empty list, as it is in tclsh for a script-provided
+    // package (`package provide foo 1.0; package files foo` → {}).
+    assert_eq!(run("package provide foo 1.0\npackage files foo\n").1, "");
+}
+
 /// Issue #1607: the `interp` ensemble and the child-as-command dispatch are
 /// `Tcl_GetIndexFromObj(…, "option", 0)` tables (`options[]` in `Tcl_InterpObjCmd`
 /// and `NRChildCmd`, `tclInterp.c`), so subcommands abbreviate and the empty

--- a/rust/tcl-vm/tests/builtins_e2e.rs
+++ b/rust/tcl-vm/tests/builtins_e2e.rs
@@ -1921,6 +1921,58 @@ fn channel_io() {
     );
 }
 
+/// Issue #1607: `glob`'s option words are a
+/// `Tcl_GetIndexFromObj(…, "option", 0)` table (`globOptions[]`,
+/// `tclFileName.c`). This engine used to *skip* an unrecognised `-word`
+/// silently — `glob -x a` ran, and `-types d` leaked its value into the
+/// pattern list. Rejecting an unknown option is a deliberate behaviour change,
+/// ruled on for this sweep, so the new rejection is pinned byte for byte.
+///
+/// tclsh 8.6.16 and 9.0.4 agree on every row (no dialect split):
+///   glob -x a  -> bad option "-x": must be -directory, -join, -nocomplain,
+///                 -path, -tails, -types, or --
+///   glob - a   -> ambiguous option "-": must be <same>
+///   glob -t d a-> ambiguous option "-t": must be <same>   (-tails/-types)
+///   glob -tails <pat>
+///              -> "-tails" must be used with either "-directory" or "-path"
+///   glob {}    -> .    (the empty word is a pattern, not an option)
+///   -n/-d/-j/-ta/-ty all resolve as unique prefixes.
+#[test]
+fn glob_option_words_resolve_like_tcl_get_index_from_obj() {
+    const MUST: &str = "must be -directory, -join, -nocomplain, -path, -tails, -types, or --";
+    const SETUP: &str = "set d /tmp/zz_tcltest_glob\n\
+                         file delete -force $d\n\
+                         file mkdir $d/sub\n\
+                         set f [open $d/a.tcl w]\nclose $f\n";
+    let msg = |tail: &str| {
+        let (ok, result, _) = run(&format!("{SETUP}catch {{{tail}}} e\nset e\n"));
+        assert!(ok, "expected the catch to succeed for {tail}");
+        result
+    };
+    // Unique prefixes resolve, and each advertised name is honoured.
+    assert_eq!(run(&format!("{SETUP}glob -d $d -ta *.tcl")).1, "a.tcl");
+    assert_eq!(run(&format!("{SETUP}glob -n -d $d -ta -ty f *")).1, "a.tcl");
+    assert_eq!(run(&format!("{SETUP}glob -n -d $d -ta -ty d *")).1, "sub");
+    // The new rejection.
+    assert_eq!(msg("glob -x a"), format!("bad option \"-x\": {MUST}"));
+    assert_eq!(msg("glob - a"), format!("ambiguous option \"-\": {MUST}"));
+    assert_eq!(
+        msg("glob -t d a"),
+        format!("ambiguous option \"-t\": {MUST}")
+    );
+    assert_eq!(
+        msg("glob -tails *.tcl"),
+        "\"-tails\" must be used with either \"-directory\" or \"-path\""
+    );
+    assert_eq!(
+        run(&format!(
+            "{SETUP}set r [glob -j -d $d -- sub]\nfile delete -force $d\nset r"
+        ))
+        .1,
+        "/tmp/zz_tcltest_glob/sub"
+    );
+}
+
 /// Issue #1607: `seek`'s origin word is a `Tcl_GetIndexFromObj(…, "origin", 0)`
 /// table (`originOptions[]`, `tclIOCmd.c`). This engine silently treated any
 /// unknown origin as `start`; C rejects it, abbreviates `s`/`c`/`e`, and words

--- a/rust/tcl-vm/tests/builtins_e2e.rs
+++ b/rust/tcl-vm/tests/builtins_e2e.rs
@@ -730,6 +730,122 @@ fn interp_debug_option_uses_c_noun_and_abbreviates() {
     );
 }
 
+/// Issue #1607: the `interp` ensemble and the child-as-command dispatch are
+/// `Tcl_GetIndexFromObj(…, "option", 0)` tables (`options[]` in `Tcl_InterpObjCmd`
+/// and `NRChildCmd`, `tclInterp.c`), so subcommands abbreviate and the empty
+/// word — a prefix of every entry — is `ambiguous option ""`.
+///
+/// Both lists name only what this engine dispatches (`aliases`, `cancel`, and
+/// `target` need infrastructure the VM has none of), so the enumeration is
+/// shorter than tclsh's. tclsh 9.0.4, for contrast:
+///   interp x  -> bad option "x": must be alias, aliases, bgerror, cancel,
+///                children, create, debug, delete, eval, exists, expose, hide,
+///                hidden, issafe, invokehidden, limit, marktrusted,
+///                recursionlimit, share, target, or transfer
+///   i x       -> bad option "x": must be alias, aliases, bgerror, debug, eval,
+///                expose, hide, hidden, issafe, invokehidden, limit,
+///                marktrusted, or recursionlimit
+///
+/// The abbreviation verdicts are tclsh's exactly (8.6.16 / 9.0.4 agree):
+///   interp cr j        -> j
+///   interp c j         -> ambiguous option "c"
+///   interp ev {set x 1} -> 1   ;  interp e {set x 1} -> ambiguous option "e"
+///   i ev {set x 1}     -> 1    ;  i h / i hi -> ambiguous option "h" / "hi"
+#[test]
+fn interp_subcommand_words_resolve_like_tcl_get_index_from_obj() {
+    const MUST: &str = "must be alias, bgerror, children, create, debug, delete, eval, \
+                        exists, expose, hide, hidden, issafe, invokehidden, limit, \
+                        marktrusted, recursionlimit, share, or transfer";
+    const CHILD_MUST: &str = "must be debug, eval, expose, hide, hidden, issafe, \
+                              invokehidden, limit, marktrusted, or recursionlimit";
+    let msg = |src: &str| {
+        let (ok, result, _) = run(src);
+        assert!(!ok, "expected an error for {src}, got ok");
+        result
+    };
+    assert_eq!(msg("interp x\n"), format!("bad option \"x\": {MUST}"));
+    assert_eq!(msg("interp {}\n"), format!("ambiguous option \"\": {MUST}"));
+    assert_eq!(
+        msg("interp c j\n"),
+        format!("ambiguous option \"c\": {MUST}")
+    );
+    assert_eq!(run("interp cr j\n").1, "j");
+    assert_eq!(
+        msg("interp e {set x 1}\n"),
+        format!("ambiguous option \"e\": {MUST}")
+    );
+    assert_eq!(run("interp ev {} {set x 1}\n").1, "1");
+    // The 8.x-only `slaves` spelling still resolves, and still dispatches.
+    assert_eq!(run("interp create i\nllength [interp sl]\n").1, "1");
+    // The child-as-command table.
+    assert_eq!(
+        msg("interp create i\ni x\n"),
+        format!("bad option \"x\": {CHILD_MUST}")
+    );
+    assert_eq!(
+        msg("interp create i\ni {}\n"),
+        format!("ambiguous option \"\": {CHILD_MUST}")
+    );
+    assert_eq!(
+        msg("interp create i\ni e {set x 1}\n"),
+        format!("ambiguous option \"e\": {CHILD_MUST}")
+    );
+    assert_eq!(run("interp create i\ni ev {set x 1}\n").1, "1");
+    assert_eq!(
+        msg("interp create i\ni h\n"),
+        format!("ambiguous option \"h\": {CHILD_MUST}")
+    );
+    assert_eq!(
+        msg("interp create i\ni hi\n"),
+        format!("ambiguous option \"hi\": {CHILD_MUST}")
+    );
+}
+
+/// Issue #1607: `interp create`'s and `interp invokehidden`'s leading options
+/// are `Tcl_GetIndexFromObj(…, "option", 0)` tables (`createOptions[]` /
+/// `hiddenOptions[]`, `tclInterp.c`), so they abbreviate and the lone `-` —
+/// a prefix of every entry — is `ambiguous`, not `bad`.
+///
+/// tclsh 8.6.16 / 9.0.4:
+///   interp create -x k          -> bad option "-x": must be -safe or --
+///   interp create - k           -> ambiguous option "-": must be -safe or --
+///   interp create -s k          -> k        ;  interp create -- k -> k
+///   interp invokehidden i -x f  -> bad option "-x": must be -global, -namespace, or --
+///   interp invokehidden i - f   -> ambiguous option "-": must be -global, -namespace, or --
+///   i invokehidden -x f         -> bad option "-x": must be -global, -namespace, or --
+#[test]
+fn interp_create_and_invokehidden_options_resolve_like_tcl_get_index_from_obj() {
+    const CREATE_MUST: &str = "must be -safe or --";
+    const HIDDEN_MUST: &str = "must be -global, -namespace, or --";
+    let msg = |src: &str| {
+        let (ok, result, _) = run(src);
+        assert!(!ok, "expected an error for {src}, got ok");
+        result
+    };
+    assert_eq!(
+        msg("interp create -x k\n"),
+        format!("bad option \"-x\": {CREATE_MUST}")
+    );
+    assert_eq!(
+        msg("interp create - k\n"),
+        format!("ambiguous option \"-\": {CREATE_MUST}")
+    );
+    assert_eq!(run("interp create -s k\n").1, "k");
+    assert_eq!(run("interp create -- k\n").1, "k");
+    assert_eq!(
+        msg("interp create i\ninterp invokehidden i -x foo\n"),
+        format!("bad option \"-x\": {HIDDEN_MUST}")
+    );
+    assert_eq!(
+        msg("interp create i\ninterp invokehidden i - foo\n"),
+        format!("ambiguous option \"-\": {HIDDEN_MUST}")
+    );
+    assert_eq!(
+        msg("interp create i\ni invokehidden -x foo\n"),
+        format!("bad option \"-x\": {HIDDEN_MUST}")
+    );
+}
+
 /// Issue #1607: `interp limit`'s type word is `Tcl_GetIndexFromObj(…,
 /// "limit type", 0)` (`limitTypes[]`, `tclInterp.c`), so `c`/`t` abbreviate
 /// and the empty word — a prefix of both entries — is `ambiguous`.

--- a/rust/tcl-vm/tests/builtins_e2e.rs
+++ b/rust/tcl-vm/tests/builtins_e2e.rs
@@ -730,6 +730,70 @@ fn interp_debug_option_uses_c_noun_and_abbreviates() {
     );
 }
 
+/// Issue #1607: `binary`, `binary encode`/`decode`, `encoding` and `namespace`
+/// are `TclMakeEnsemble` commands. `binary encode`/`decode` run with
+/// **`-prefixes` off**, so nothing abbreviates there and the miss is worded
+/// `unknown subcommand`, never `unknown or ambiguous`.
+///
+/// tclsh 8.6.16 / 9.0.4:
+///   binary e hex a       -> 61     ;  binary en hex a -> 61
+///   binary {}            -> unknown or ambiguous subcommand "": must be
+///                           decode, encode, format, or scan
+///   binary encode h a    -> unknown subcommand "h": must be base64, hex, or uuencode
+///   binary encode {} a   -> unknown subcommand "": must be <same>
+///   binary decode b YQ== -> unknown subcommand "b": must be <same>
+///   encoding s           -> the system encoding
+///   encoding c           -> unknown or ambiguous subcommand "c": must be …
+///   namespace cu         -> ::
+#[test]
+fn ensemble_subcommand_words_resolve_like_tclsh() {
+    const FORMATS: &str = "must be base64, hex, or uuencode";
+    const ENC_MUST: &str = "must be convertfrom, convertto, dirs, names, or system";
+    let msg = |src: &str| {
+        let (ok, result, _) = run(src);
+        assert!(!ok, "expected an error for {src}, got ok");
+        result
+    };
+    // `binary` abbreviates; its encode/decode format tables do not.
+    assert_eq!(run("binary e hex a").1, "61");
+    assert_eq!(run("binary en hex a").1, "61");
+    assert_eq!(
+        msg("binary {}"),
+        "unknown or ambiguous subcommand \"\": must be decode, encode, format, or scan"
+    );
+    assert_eq!(
+        msg("binary encode h a"),
+        format!("unknown subcommand \"h\": {FORMATS}")
+    );
+    assert_eq!(
+        msg("binary encode {} a"),
+        format!("unknown subcommand \"\": {FORMATS}")
+    );
+    assert_eq!(
+        msg("binary decode b YQ=="),
+        format!("unknown subcommand \"b\": {FORMATS}")
+    );
+    // `encoding`: this engine advertises only what it implements (9.0 also has
+    // `profiles` and `user`), but the verdicts are tclsh's.
+    assert_eq!(run("encoding s").1, "utf-8");
+    assert_eq!(
+        msg("encoding c"),
+        format!("unknown or ambiguous subcommand \"c\": {ENC_MUST}")
+    );
+    assert_eq!(
+        msg("encoding {}"),
+        format!("unknown or ambiguous subcommand \"\": {ENC_MUST}")
+    );
+    // `namespace`'s miss sentence now comes from the same owner.
+    assert_eq!(run("namespace cu").1, "::");
+    assert_eq!(
+        msg("namespace {}"),
+        "unknown or ambiguous subcommand \"\": must be children, code, current, delete, \
+         ensemble, eval, exists, export, forget, import, inscope, origin, parent, path, \
+         qualifiers, tail, unknown, upvar, or which"
+    );
+}
+
 /// Issue #1607: `package`'s subcommand word is a `Tcl_GetIndexFromObj(…,
 /// "option", 0)` table (`pkgOptions[]`, `tclPkg.c`) — both engines said
 /// `unknown or ambiguous subcommand "x"` with no list, which is the *ensemble*

--- a/rust/tcl-vm/tests/builtins_e2e.rs
+++ b/rust/tcl-vm/tests/builtins_e2e.rs
@@ -747,6 +747,8 @@ fn interp_debug_option_uses_c_noun_and_abbreviates() {
 ///   namespace cu         -> ::
 #[test]
 fn ensemble_subcommand_words_resolve_like_tclsh() {
+    const CLOCK_MUST: &str = "must be add, clicks, format, microseconds, milliseconds, \
+                              scan, or seconds";
     const FORMATS: &str = "must be base64, hex, or uuencode";
     const ENC_MUST: &str = "must be convertfrom, convertto, dirs, names, or system";
     let msg = |src: &str| {
@@ -783,6 +785,19 @@ fn ensemble_subcommand_words_resolve_like_tclsh() {
     assert_eq!(
         msg("encoding {}"),
         format!("unknown or ambiguous subcommand \"\": {ENC_MUST}")
+    );
+    // `clock` is an ensemble too: `se` resolves, `m`/`mi` are ambiguous.
+    assert!(
+        run("clock se").0,
+        "`clock se` must resolve to `clock seconds`"
+    );
+    assert_eq!(
+        msg("clock m"),
+        format!("unknown or ambiguous subcommand \"m\": {CLOCK_MUST}")
+    );
+    assert_eq!(
+        msg("clock {}"),
+        format!("unknown or ambiguous subcommand \"\": {CLOCK_MUST}")
     );
     // `namespace`'s miss sentence now comes from the same owner.
     assert_eq!(run("namespace cu").1, "::");

--- a/rust/tcl-vm/tests/builtins_e2e.rs
+++ b/rust/tcl-vm/tests/builtins_e2e.rs
@@ -685,6 +685,96 @@ fn interp_limit_option_words_resolve_like_tcl_get_index_from_obj() {
     assert!(ok);
 }
 
+/// Issue #1607: `interp debug`'s option word is a `Tcl_GetIndexFromObj` table
+/// whose noun is `debug option` (`debugTypes[]`, `tclInterp.c`), so `-f`/`-fr`
+/// abbreviate and the one-entry table never says `ambiguous`. The arity check
+/// runs first, as it does in C.
+///
+/// tclsh 8.6.16 / 9.0.4:
+///   interp debug i {}      -> bad debug option "": must be -frame
+///   interp debug i -x      -> bad debug option "-x": must be -frame
+///   interp debug i -f      -> 0
+///   interp debug i -fr 1   -> 1
+///   i debug -f             -> 1   (after the latch)
+///   interp debug i -x 1 2  -> wrong # args: should be "interp debug path ?-frame ?bool??"
+///   i debug -x 1 2         -> wrong # args: should be "i debug ?-frame ?bool??"
+#[test]
+fn interp_debug_option_uses_c_noun_and_abbreviates() {
+    let msg = |src: &str| {
+        let (ok, result, _) = run(src);
+        assert!(!ok, "expected an error for {src}, got ok");
+        result
+    };
+    assert_eq!(
+        msg("interp create i\ninterp debug i {}\n"),
+        "bad debug option \"\": must be -frame"
+    );
+    assert_eq!(
+        msg("interp create i\ninterp debug i -x\n"),
+        "bad debug option \"-x\": must be -frame"
+    );
+    assert_eq!(run("interp create i\ninterp debug i -f\n").1, "0");
+    assert_eq!(run("interp create i\ninterp debug i -fr 1\n").1, "1");
+    // The child-as-command spelling reaches the same switch.
+    assert_eq!(
+        run("interp create i\ninterp debug i -fr 1\ni debug -f\n").1,
+        "1"
+    );
+    assert_eq!(
+        msg("interp create i\ninterp debug i -x 1 2\n"),
+        "wrong # args: should be \"interp debug path ?-frame ?bool??\""
+    );
+    assert_eq!(
+        msg("interp create i\ni debug -x 1 2\n"),
+        "wrong # args: should be \"i debug ?-frame ?bool??\""
+    );
+}
+
+/// Issue #1607: `interp limit`'s type word is `Tcl_GetIndexFromObj(…,
+/// "limit type", 0)` (`limitTypes[]`, `tclInterp.c`), so `c`/`t` abbreviate
+/// and the empty word — a prefix of both entries — is `ambiguous`.
+///
+/// tclsh 8.6.16 / 9.0.4:
+///   interp limit i {}  -> ambiguous limit type "": must be commands or time
+///   interp limit i x   -> bad limit type "x": must be commands or time
+///   interp limit i c   -> -command {} -granularity 1 -value {}
+///   interp limit i t   -> -command {} -granularity 10 -milliseconds {} -seconds {}
+///   i limit {}         -> ambiguous limit type "": must be commands or time
+#[test]
+fn interp_limit_type_word_resolves_like_tcl_get_index_from_obj() {
+    const MUST: &str = "must be commands or time";
+    let msg = |src: &str| {
+        let (ok, result, _) = run(src);
+        assert!(!ok, "expected an error for {src}, got ok");
+        result
+    };
+    assert_eq!(
+        msg("interp create i\ninterp limit i {}\n"),
+        format!("ambiguous limit type \"\": {MUST}")
+    );
+    assert_eq!(
+        msg("interp create i\ninterp limit i x\n"),
+        format!("bad limit type \"x\": {MUST}")
+    );
+    assert_eq!(
+        run("interp create i\ninterp limit i c\n").1,
+        "-command {} -granularity 1 -value {}"
+    );
+    assert_eq!(
+        run("interp create i\ninterp limit i t\n").1,
+        "-command {} -granularity 10 -milliseconds {} -seconds {}"
+    );
+    // The child-as-command spelling shares the resolver.
+    assert_eq!(
+        msg("interp create i\ni limit {}\n"),
+        format!("ambiguous limit type \"\": {MUST}")
+    );
+    assert_eq!(
+        run("interp create i\ni limit c\n").1,
+        "-command {} -granularity 1 -value {}"
+    );
+}
+
 #[test]
 fn regexp_regsub() {
     out_eq("puts [regexp {[0-9]+} abc123]\n", "1\n");

--- a/rust/tcl-vm/tests/cmd_collections_e2e.rs
+++ b/rust/tcl-vm/tests/cmd_collections_e2e.rs
@@ -192,14 +192,39 @@ fn array_arity_errors() {
 /// An unknown `array` subcommand reports the VM's bad-subcommand message (the
 /// VM's supported set is exists/for/get/names/set/size/unset — narrower than C's
 /// full ensemble, so the message text is the VM's own).
+///
+/// Issue #1607: the sentence and the exact-then-unique-prefix scan are
+/// `tcl_cmd_core::ensemble`'s, so `array e a` abbreviates as it does in tclsh.
+///
+/// tclsh 9.0.4 (the verdicts, not the shortened list):
+///   array e a  -> 1     ;  array ex a -> 1
+///   array s a  -> unknown or ambiguous subcommand "s": must be …
+///                        (set/size both start with `s`)
+///   array {} a -> unknown or ambiguous subcommand "": must be …
 #[test]
 fn array_bad_subcommand() {
-    let (ok, msg, _) = run("array badcmd a");
-    assert!(!ok);
+    const MUST: &str = "must be exists, for, get, names, set, size, or unset";
+    let msg = |src: &str| {
+        let (ok, result, _) = run(src);
+        assert!(!ok, "expected an error for {src}, got ok");
+        result
+    };
     assert_eq!(
-        msg,
-        "unknown or ambiguous subcommand \"badcmd\": must be exists, for, get, names, set, size, or unset"
+        msg("array badcmd a"),
+        format!("unknown or ambiguous subcommand \"badcmd\": {MUST}")
     );
+    assert_eq!(
+        msg("array s a"),
+        format!("unknown or ambiguous subcommand \"s\": {MUST}")
+    );
+    assert_eq!(
+        msg("array {} a"),
+        format!("unknown or ambiguous subcommand \"\": {MUST}")
+    );
+    // Unique prefixes resolve.
+    assert_eq!(run("set a(x) 1\narray e a").1, "1");
+    assert_eq!(run("set a(x) 1\narray ex a").1, "1");
+    assert_eq!(run("set a(x) 1\narray n a").1, "x");
 }
 
 /// `array for {k v} arrayName body` iterates the element pairs (Tcl 9.0). The
@@ -610,13 +635,55 @@ fn dict_with() {
 }
 
 /// An unknown `dict` subcommand reports the VM's bad-subcommand message.
+///
+/// Issue #1607: `dict` is a `TclMakeEnsemble` command, so the whole sentence
+/// — which this used to emit without any `must be` clause — and the
+/// exact-then-unique-prefix scan come from `tcl_cmd_core::ensemble`. The list
+/// is C's 9.0 table minus `info` (per-dict hash statistics), which this engine
+/// does not model.
+///
+/// tclsh 9.0.4 (the verdicts, not the shortened list):
+///   dict k {a 1}         -> a      (keys)
+///   dict g {a 1} a       -> unknown or ambiguous subcommand "g": must be …
+///                                  (get/getdef/getwithdefault)
+///   dict {} {a 1}        -> unknown or ambiguous subcommand "": must be …
+///   dict filter {a 1} k *  -> a 1
+///   dict filter {a 1} x *  -> bad filterType "x": must be key, script, or value
+///   dict filter {a 1} {} * -> ambiguous filterType "": must be key, script, or value
 #[test]
 fn dict_bad_subcommand() {
-    let (ok, msg, _) = run("dict no_such_sub x");
-    assert!(!ok);
-    assert!(
-        msg.starts_with("unknown or ambiguous subcommand \"no_such_sub\""),
-        "got: {msg}"
+    const MUST: &str = "must be append, create, exists, filter, for, get, getdef, \
+                        getwithdefault, incr, keys, lappend, map, merge, remove, replace, \
+                        set, size, unset, update, values, or with";
+    let msg = |src: &str| {
+        let (ok, result, _) = run(src);
+        assert!(!ok, "expected an error for {src}, got ok");
+        result
+    };
+    assert_eq!(
+        msg("dict no_such_sub x"),
+        format!("unknown or ambiguous subcommand \"no_such_sub\": {MUST}")
+    );
+    assert_eq!(
+        msg("dict g {a 1} a"),
+        format!("unknown or ambiguous subcommand \"g\": {MUST}")
+    );
+    assert_eq!(
+        msg("dict {} {a 1}"),
+        format!("unknown or ambiguous subcommand \"\": {MUST}")
+    );
+    // Unique prefixes resolve.
+    assert_eq!(run("dict k {a 1}").1, "a");
+    assert_eq!(run("dict si {a 1}").1, "1");
+    // `dict filter`'s type word is its own `Tcl_GetIndexFromObj` table.
+    assert_eq!(run("dict filter {a 1} k *").1, "a 1");
+    assert_eq!(
+        msg("dict filter {a 1} x *"),
+        "bad filterType \"x\": must be key, script, or value"
+    );
+    assert_eq!(
+        msg("dict filter {a 1} {} *"),
+        "ambiguous filterType \"\": must be key, script, or value"
     );
 }
 

--- a/rust/tcl-vm/tests/cmd_control_e2e.rs
+++ b/rust/tcl-vm/tests/cmd_control_e2e.rs
@@ -264,6 +264,35 @@ fn try_dash_fallthrough() {
     );
 }
 
+/// Issue #1607: `try`'s handler-type word is a `Tcl_GetIndexFromObj(…,
+/// "handler type", 0)` table, so the three types abbreviate and the empty word
+/// — a prefix of all three — is `ambiguous handler type ""`, not `bad`.
+///
+/// tclsh 8.6.16 / 9.0.4:
+///   try {} o error {} {}  -> {}       ;  try {} f {}      -> {}
+///   try {} t {} {} {}     -> {}
+///   try {} {} error {} {} -> ambiguous handler type "": must be finally, on, or trap
+///   try {} x error {} {}  -> bad handler type "x": must be finally, on, or trap
+///   try {} x              -> bad handler type "x": … (the type precedes the arity)
+#[test]
+fn try_handler_type_resolves_like_tcl_get_index_from_obj() {
+    const MUST: &str = "must be finally, on, or trap";
+    // Unique prefixes resolve to their clause grammar.
+    assert_eq!(run("set t try; $t {set x ok} o error {} {set x h}").1, "ok");
+    assert_eq!(run("set t try; $t {set x ok} f {set y 1}").1, "ok");
+    assert_eq!(run("set t try; $t {set x ok} t {} {} {set x h}").1, "ok");
+    // The empty word prefixes all three ⇒ ambiguous.
+    assert_eq!(
+        run("set t try; catch {$t good {} error {} {x}} e; set e").1,
+        format!("ambiguous handler type \"\": {MUST}"),
+    );
+    // The type is resolved before the clause's arity.
+    assert_eq!(
+        run("set t try; catch {$t good x} e; set e").1,
+        format!("bad handler type \"x\": {MUST}"),
+    );
+}
+
 /// `try` grammar errors are raised before the body runs (validated by
 /// `parse_clauses`).
 #[test]

--- a/rust/tcl-vm/tests/cmd_event_e2e.rs
+++ b/rust/tcl-vm/tests/cmd_event_e2e.rs
@@ -198,6 +198,47 @@ fn after_bad_argument() {
     );
 }
 
+/// Issue #1607: `update`'s option and `after`'s subcommand word both resolve
+/// through the one `Tcl_GetIndexFromObj` matcher. `update`'s is an ordinary
+/// one-entry table, so a miss is always `bad` — never `ambiguous`, not even
+/// for the empty word. `after`'s scan is *silent* in C (`Tcl_GetIndexFromObj`
+/// with a NULL interp), so a miss falls through to the integer parse and
+/// `after` composes its own sentence — including for the ambiguous `i`.
+///
+/// tclsh 8.6.16 / 9.0.4:
+///   update {}   -> bad option "": must be idletasks
+///   update i    -> {}     (abbreviation accepted)
+///   after in    -> {}     (info)      ;  after ca 1 -> {}   (cancel)
+///   after i     -> bad argument "i": must be cancel, idle, info, or an integer
+///   after {}    -> bad argument "": must be cancel, idle, info, or an integer
+#[test]
+fn update_and_after_words_resolve_like_tcl_get_index_from_obj() {
+    let msg = |src: &str| {
+        let (ok, result, _) = run(src);
+        assert!(ok, "expected the catch to succeed for {src}");
+        result
+    };
+    assert_eq!(
+        msg("catch {update {}} e; set e"),
+        "bad option \"\": must be idletasks"
+    );
+    // A unique prefix resolves.
+    let (ok, _msg, _) = run("update i");
+    assert!(ok, "`update i` must resolve to idletasks");
+    // `after`'s silent scan: `in` and `ca` resolve, `i` is ambiguous and so
+    // reaches the integer parse, where `after` words its own miss.
+    assert_eq!(msg("catch {after in} e; set e"), "");
+    assert_eq!(msg("catch {after ca 1} e; set e"), "");
+    assert_eq!(
+        msg("catch {after i} e; set e"),
+        "bad argument \"i\": must be cancel, idle, info, or an integer"
+    );
+    assert_eq!(
+        msg("catch {after {}} e; set e"),
+        "bad argument \"\": must be cancel, idle, info, or an integer"
+    );
+}
+
 // The coroutine driver: after 0 $coro
 
 #[test]

--- a/rust/tcl-vm/tests/cmd_info_prefix_e2e.rs
+++ b/rust/tcl-vm/tests/cmd_info_prefix_e2e.rs
@@ -63,6 +63,27 @@ impl CompileService for CompilerSvc {
         let cfg = build_cfg_codegen(&ir, false);
         Ok(codegen_module(&cfg, &ir, &self.registry))
     }
+
+    fn compile_for_profile(
+        &self,
+        src: &str,
+        profile: &'static tcl_dialect::DialectProfile,
+    ) -> Result<tcl_bytecode::ModuleAsm, CompileError> {
+        let registry = tcl_registry::model::ingress::static_context_for_profile(profile).commands();
+        let config = tcl_lexer::LexerConfig::from_grammar(profile.grammar);
+        if let Some(msg) = tcl_compiler::lowering::first_fatal_parse_error_with_config(src, config)
+        {
+            return Err(CompileError(msg));
+        }
+        let ir = tcl_compiler::lowering::lower_to_ir_for_bytecode_with_dialect(
+            src,
+            registry,
+            config,
+            Some(profile),
+        );
+        let cfg = build_cfg_codegen(&ir, false);
+        Ok(codegen_module(&cfg, &ir, registry))
+    }
 }
 
 /// A `Write` sink backed by a shared buffer the test can read afterwards.
@@ -95,6 +116,33 @@ const FILE_MUST: &str = "must be atime, attributes, channels, copy, delete, dirn
                          readable, readlink, rename, rootname, separator, size, split, stat, \
                          system, tail, tempdir, tempfile, tildeexpand, type, volumes, or \
                          writable";
+
+/// [`run`] under an explicit release pin — one resolved profile drives both
+/// the compile service and the VM's runtime version, as `tclvm --tcl-version`
+/// does.
+fn run_for_version(src: &str, version: tcl_dialect::TclVersion) -> (bool, String, String) {
+    let profile = tcl_registry::model::ingress::resolve_environment(version.dialect_name())
+        .analyser_profile();
+    let service = CompilerSvc {
+        registry: CommandRegistry::build_default(),
+    };
+    let asm = service
+        .compile_for_profile(src, profile)
+        .expect("test script compiles for its selected profile");
+
+    let buf = Rc::new(RefCell::new(Vec::new()));
+    let mut vm = Vm::with_output(Box::new(Capture(Rc::clone(&buf))));
+    vm.set_runtime_version(version);
+    vm.set_compiler(Box::new(service));
+    let completion = vm.run_module(&asm);
+
+    let out = String::from_utf8(buf.borrow().clone()).expect("utf-8 output");
+    (
+        completion.code.is_ok(),
+        completion.result.to_str().to_string(),
+        out,
+    )
+}
 
 fn run(src: &str) -> (bool, String, String) {
     let registry = CommandRegistry::build_default();
@@ -1417,4 +1465,147 @@ fn info_and_file_ensemble_misses_carry_the_full_option_list() {
         msg("file ex /"),
         format!("unknown or ambiguous subcommand \"ex\": {FILE_MUST}")
     );
+}
+
+/// Issue #1607 follow-up: `file`'s table is the *selected release's* surface,
+/// not a pinned Tcl 9 list. `home`, `tempdir` and `tildeexpand` arrive in 9.0,
+/// and their presence changes the verdict for words that have nothing to do
+/// with them — `file te` is a unique prefix of `tempfile` under 8.6 and
+/// ambiguous under 9.0. The names and their gates come from the registry
+/// through the one environment ingress seam, as the WASM runtime's `file`
+/// already did.
+///
+/// tclsh8.6.16:
+///   catch {file te x} m -> 0, a channel   (tempfile)
+///   catch {file h} m    -> 1 unknown or ambiguous subcommand "h": must be
+///                          … tail, tempfile, type, volumes, or writable
+/// tclsh9.0.4:
+///   catch {file te x} m -> 1 unknown or ambiguous subcommand "te": must be
+///                          … tempdir, tempfile, tildeexpand, …
+///   catch {file h} m    -> 0 /root        (home)
+///
+/// UNIMPLEMENTED: the VM implements neither `tempfile` nor `home`, so a word
+/// that resolves to one still lands on the unknown-subcommand arm — under the
+/// *canonical* name, which is exactly what shows the resolution happened, and
+/// with the release's own enumeration.
+#[test]
+fn file_subcommand_table_follows_the_emulated_release() {
+    const FILE_MUST_86: &str = "must be atime, attributes, channels, copy, delete, dirname, \
+                                executable, exists, extension, isdirectory, isfile, join, \
+                                link, lstat, mkdir, mtime, nativename, normalize, owned, \
+                                pathtype, readable, readlink, rename, rootname, separator, \
+                                size, split, stat, system, tail, tempfile, type, volumes, \
+                                or writable";
+
+    // 8.6: `te` is unique (no `tempdir`), so it resolves to `tempfile`; `h`
+    // matches nothing, and the enumeration has no 9.0 names in it.
+    let (ok, msg, _) = run_for_version("file te x", tcl_dialect::TclVersion::V8_6);
+    assert!(!ok);
+    assert_eq!(
+        msg,
+        format!("unknown or ambiguous subcommand \"tempfile\": {FILE_MUST_86}")
+    );
+    let (ok, msg, _) = run_for_version("file h", tcl_dialect::TclVersion::V8_6);
+    assert!(!ok);
+    assert_eq!(
+        msg,
+        format!("unknown or ambiguous subcommand \"h\": {FILE_MUST_86}")
+    );
+
+    // 9.0: `tempdir` makes `te` ambiguous, and `h` now resolves to `home`.
+    let (ok, msg, _) = run_for_version("file te x", tcl_dialect::TclVersion::V9_0);
+    assert!(!ok);
+    assert_eq!(
+        msg,
+        format!("unknown or ambiguous subcommand \"te\": {FILE_MUST}")
+    );
+    let (ok, msg, _) = run_for_version("file h", tcl_dialect::TclVersion::V9_0);
+    assert!(!ok);
+    assert_eq!(
+        msg,
+        format!("unknown or ambiguous subcommand \"home\": {FILE_MUST}")
+    );
+
+    // A prefix that is unique in both releases still resolves in both.
+    assert_eq!(
+        run_for_version("file ext /a.b", tcl_dialect::TclVersion::V8_6).1,
+        ".b"
+    );
+    assert_eq!(
+        run_for_version("file ext /a.b", tcl_dialect::TclVersion::V9_0).1,
+        ".b"
+    );
+}
+
+/// Issue #1607 follow-up, the rest of the class: every `TclMakeEnsemble`
+/// table this engine resolves against is a *release* fact, and the VM is
+/// release-selectable. A 9-only name must not dispatch under an earlier pin,
+/// and — the half that hides — must not change the prefix verdict for a word
+/// that has nothing to do with it.
+///
+/// tclsh8.6.16 / tclsh9.0.4:
+///   dict g {a 1} a     -> 1                    / ambiguous (getdef, getwithdefault)
+///   string in abc 1    -> b                    / ambiguous (index, insert)
+///   info cm            -> the cmdcount         / ambiguous (cmdcount, cmdtype)
+///   info cmdtype set   -> unknown "cmdtype"    / native
+///   array f x          -> unknown "f"          / `array for`'s own arity error
+#[test]
+fn ensemble_tables_follow_the_emulated_release() {
+    let v86 = tcl_dialect::TclVersion::V8_6;
+    let v90 = tcl_dialect::TclVersion::V9_0;
+
+    // dict: `getdef`/`getwithdefault` are TIP 342 (Tcl 9).
+    assert_eq!(run_for_version("dict g {a 1} a", v86).1, "1");
+    let (ok, msg, _) = run_for_version("dict g {a 1} a", v90);
+    assert!(!ok);
+    assert!(
+        msg.contains("get, getdef, getwithdefault,"),
+        "9.0 must advertise both spellings: {msg}"
+    );
+
+    // string: `insert` is Tcl 9.
+    assert_eq!(run_for_version("string in abc 1", v86).1, "b");
+    let (ok, msg, _) = run_for_version("string in abc 1", v90);
+    assert!(!ok);
+    assert!(msg.contains("index, insert, is,"), "{msg}");
+
+    // info: `cmdtype` is Tcl 9. The exact-name row shows that a resolution
+    // miss must report rather than fall through — the dispatch arms match on
+    // the canonical name, so `info cmdtype` would otherwise still run.
+    // UNIMPLEMENTED: the VM has no `info cmdcount`, so the *resolved* word is
+    // what the miss quotes — which is exactly the evidence that `cm` resolved
+    // uniquely under 8.6 and did not under 9.0.
+    let (ok, msg, _) = run_for_version("info cm", v86);
+    assert!(!ok);
+    assert!(
+        msg.starts_with("unknown or ambiguous subcommand \"cmdcount\""),
+        "8.6 must resolve `cm` to cmdcount: {msg}"
+    );
+    let (ok, msg, _) = run_for_version("info cmdtype set", v86);
+    assert!(!ok);
+    assert!(
+        msg.starts_with("unknown or ambiguous subcommand \"cmdtype\": must be args, body, class,"),
+        "{msg}"
+    );
+    let (ok, msg, _) = run_for_version("info cm", v90);
+    assert!(!ok);
+    assert!(
+        msg.starts_with("unknown or ambiguous subcommand \"cm\""),
+        "9.0 must leave `cm` ambiguous: {msg}"
+    );
+    assert!(msg.contains("cmdcount, cmdtype,"), "{msg}");
+
+    // array: `for` is Tcl 9 (so is `default`, which this engine does not
+    // dispatch). UNIMPLEMENTED: the enumeration is this engine's own
+    // dispatched set, shorter than tclsh's, on both releases.
+    let (ok, msg, _) = run_for_version("array f x", v86);
+    assert!(!ok);
+    assert!(
+        msg.starts_with("unknown or ambiguous subcommand \"f\""),
+        "{msg}"
+    );
+    assert!(!msg.contains("for"), "8.6 must not advertise for: {msg}");
+    let (ok, msg, _) = run_for_version("array f x", v90);
+    assert!(!ok);
+    assert!(msg.contains("wrong # args"), "9.0 resolves `for`: {msg}");
 }

--- a/rust/tcl-vm/tests/cmd_info_prefix_e2e.rs
+++ b/rust/tcl-vm/tests/cmd_info_prefix_e2e.rs
@@ -224,6 +224,50 @@ fn prefix_match_ambiguous_and_bad() {
     assert_eq!(msg, r#"bad option "z": no valid options"#);
 }
 
+/// Issue #1607: `tcl::prefix` is itself a `TclMakeEnsemble` command, and
+/// `tcl::prefix match`'s own options are a `Tcl_GetIndexFromObj(…, "option", 0)`
+/// table (`matchOptions[]`, `tclIndexObj.c`) — both were matched exactly here.
+///
+/// tclsh 8.6.16 / 9.0.4:
+/// ```text
+/// tcl::prefix {} {a} a         -> unknown or ambiguous subcommand "":
+///                                 must be all, longest, or match
+/// tcl::prefix m {a} a          -> a
+/// tcl::prefix match -e {a} a   -> ambiguous option "-e": must be -error,
+///                                 -exact, or -message
+/// tcl::prefix match -x {a} a   -> bad option "-x": must be -error, -exact,
+///                                 or -message
+/// tcl::prefix match -m noun {a} b -> bad noun "b": must be a
+/// ```
+#[test]
+fn prefix_ensemble_and_match_options_resolve_like_tclsh() {
+    const OPT_MUST: &str = "must be -error, -exact, or -message";
+    let msg = |src: &str| {
+        let (ok, result, _) = run(src);
+        assert!(!ok, "expected an error for {src}, got ok");
+        result
+    };
+    assert_eq!(
+        msg("tcl::prefix {} {a} a"),
+        "unknown or ambiguous subcommand \"\": must be all, longest, or match"
+    );
+    assert_eq!(run("tcl::prefix m {a} a").1, "a");
+    assert_eq!(run("tcl::prefix l {apple applet} ap").1, "apple");
+    assert_eq!(
+        msg("tcl::prefix match -e {a} a"),
+        format!("ambiguous option \"-e\": {OPT_MUST}")
+    );
+    assert_eq!(
+        msg("tcl::prefix match -x {a} a"),
+        format!("bad option \"-x\": {OPT_MUST}")
+    );
+    // `-m` uniquely abbreviates `-message`, whose value becomes the noun.
+    assert_eq!(
+        msg("tcl::prefix match -m noun {a} b"),
+        "bad noun \"b\": must be a"
+    );
+}
+
 /// The empty word never abbreviation-matches: one entry reports `bad`, two or
 /// more report `ambiguous` — C's `Tcl_GetIndexFromObjStruct` rejects the empty
 /// key before the abbreviation count is consulted. (Previously the VM resolved

--- a/rust/tcl-vm/tests/cmd_info_prefix_e2e.rs
+++ b/rust/tcl-vm/tests/cmd_info_prefix_e2e.rs
@@ -1609,3 +1609,42 @@ fn ensemble_tables_follow_the_emulated_release() {
     assert!(!ok);
     assert!(msg.contains("wrong # args"), "9.0 resolves `for`: {msg}");
 }
+
+/// The same rule below 8.6: `binary encode`/`decode` (TIP 317) arrive in 8.6
+/// and `encoding dirs` in 8.5.
+///
+/// tclsh8.5.19: binary d base64 QQ== -> bad option "d": must be format or scan
+/// tclsh8.6.16: binary d base64 QQ== -> A
+/// tclsh8.4.20: encoding d           -> bad option "d": must be convertfrom,
+///                                      convertto, names, or system
+/// tclsh8.5.19: encoding d           -> the encoding directory list
+///
+/// The *sentence* below 8.6 is C's pre-ensemble `bad option` wording, which
+/// this engine does not model — it speaks the ensemble sentence at every
+/// release. The rows pin the resolution and the enumeration, not that wording.
+#[test]
+fn binary_and_encoding_tables_follow_the_emulated_release() {
+    let v84 = tcl_dialect::TclVersion::V8_4;
+    let v85 = tcl_dialect::TclVersion::V8_5;
+    let v86 = tcl_dialect::TclVersion::V8_6;
+
+    let (ok, msg, _) = run_for_version("binary d base64 QQ==", v85);
+    assert!(!ok);
+    // Two entries still take the ensemble owner's comma before `or`.
+    assert_eq!(
+        msg,
+        "unknown or ambiguous subcommand \"d\": must be format, or scan"
+    );
+    assert_eq!(run_for_version("binary d base64 QQ==", v86).1, "A");
+
+    let (ok, msg, _) = run_for_version("encoding d", v84);
+    assert!(!ok);
+    assert_eq!(
+        msg,
+        "unknown or ambiguous subcommand \"d\": must be convertfrom, convertto, names, or system"
+    );
+    assert!(
+        run_for_version("encoding d", v85).0,
+        "`dirs` exists from 8.5"
+    );
+}

--- a/rust/tcl-vm/tests/cmd_info_prefix_e2e.rs
+++ b/rust/tcl-vm/tests/cmd_info_prefix_e2e.rs
@@ -80,6 +80,22 @@ impl Write for Capture {
 }
 
 /// Compile and run `src`; return `(ok, result-string, captured-stdout)`.
+/// tclsh9.0.4's `info` ensemble enumeration (`info {}` → `unknown or ambiguous
+/// subcommand "": must be …`).
+const INFO_MUST: &str = "must be args, body, class, cmdcount, cmdtype, commands, complete, \
+                         constant, consts, coroutine, default, errorstack, exists, frame, \
+                         functions, globals, hostname, level, library, loaded, locals, \
+                         nameofexecutable, object, patchlevel, procs, script, \
+                         sharedlibextension, tclversion, or vars";
+
+/// tclsh9.0.4's `file` ensemble enumeration.
+const FILE_MUST: &str = "must be atime, attributes, channels, copy, delete, dirname, \
+                         executable, exists, extension, home, isdirectory, isfile, join, \
+                         link, lstat, mkdir, mtime, nativename, normalize, owned, pathtype, \
+                         readable, readlink, rename, rootname, separator, size, split, stat, \
+                         system, tail, tempdir, tempfile, tildeexpand, type, volumes, or \
+                         writable";
+
 fn run(src: &str) -> (bool, String, String) {
     let registry = CommandRegistry::build_default();
     let ir = lower_to_ir(src, &registry);
@@ -519,6 +535,11 @@ fn info_dispatch_and_abbreviation() {
 /// The list is exactly the `info` subcommands the VM's dispatch table lacks;
 /// every other subcommand this suite exercises is implemented and covered
 /// above.
+///
+/// Since #1607 the miss is composed by `tcl_cmd_core::ensemble`, so it carries
+/// tclsh9.0.4's full `must be` clause — the name itself still appears there,
+/// because the word *resolved* against the ensemble table and only then found
+/// no implementation.
 #[test]
 fn info_unimplemented_subcommands_error() {
     for sub in ["cmdcount", "hostname", "frame"] {
@@ -526,7 +547,7 @@ fn info_unimplemented_subcommands_error() {
         assert!(!ok, "VM unexpectedly implemented `info {sub}`: {msg}");
         assert_eq!(
             msg,
-            format!("unknown or ambiguous subcommand \"{sub}\""),
+            format!("unknown or ambiguous subcommand \"{sub}\": {INFO_MUST}"),
             "`info {sub}` should report the VM's unknown-subcommand error",
         );
     }
@@ -1301,15 +1322,55 @@ fn namespace_inscope_zero_args() {
     );
 }
 
-/// An empty `info` subcommand is rejected (the `canonical_info_sub` empty-input
-/// guard, then the unknown-subcommand arm). The VM's message is shorter than
-/// tclsh9.0's, which appends the full option list.
-/// Divergence (error text only):
-///   tclsh9.0: `unknown or ambiguous subcommand "": must be args, body, ...`
-///   VM:       `unknown or ambiguous subcommand ""`
+/// Issue #1607: `info` and `file` are `TclMakeEnsemble` commands, so both the
+/// prefix scan and the miss message belong to `tcl_cmd_core::ensemble`. The VM
+/// used to emit the sentence without its `must be` clause.
+///
+/// tclsh 9.0.4:
+///   info {}   -> unknown or ambiguous subcommand "": must be args, body,
+///                class, cmdcount, cmdtype, commands, complete, constant,
+///                consts, coroutine, default, errorstack, exists, frame,
+///                functions, globals, hostname, level, library, loaded,
+///                locals, nameofexecutable, object, patchlevel, procs, script,
+///                sharedlibextension, tclversion, or vars
+///   info e /  -> unknown or ambiguous subcommand "e": must be <same>
+///   info ex x -> 0        (a unique prefix still resolves)
+///   file {}   -> unknown or ambiguous subcommand "": must be atime,
+///                attributes, channels, copy, delete, dirname, executable,
+///                exists, extension, home, isdirectory, isfile, join, link,
+///                lstat, mkdir, mtime, nativename, normalize, owned, pathtype,
+///                readable, readlink, rename, rootname, separator, size,
+///                split, stat, system, tail, tempdir, tempfile, tildeexpand,
+///                type, volumes, or writable
+///   file e /  -> unknown or ambiguous subcommand "e": must be <same>
+///   file ex / -> unknown or ambiguous subcommand "ex": must be <same>
+///                (exists/executable/extension all start with `ex`)
 #[test]
-fn info_empty_subcommand() {
-    let (ok, msg, _) = run("info \"\"");
-    assert!(!ok);
-    assert_eq!(msg, r#"unknown or ambiguous subcommand """#);
+fn info_and_file_ensemble_misses_carry_the_full_option_list() {
+    let msg = |src: &str| {
+        let (ok, result, _) = run(src);
+        assert!(!ok, "expected an error for {src}, got ok");
+        result
+    };
+    assert_eq!(
+        msg("info \"\""),
+        format!("unknown or ambiguous subcommand \"\": {INFO_MUST}")
+    );
+    assert_eq!(
+        msg("info e x"),
+        format!("unknown or ambiguous subcommand \"e\": {INFO_MUST}")
+    );
+    assert_eq!(run("set x 1; info ex x").1, "1");
+    assert_eq!(
+        msg("file \"\""),
+        format!("unknown or ambiguous subcommand \"\": {FILE_MUST}")
+    );
+    assert_eq!(
+        msg("file e /"),
+        format!("unknown or ambiguous subcommand \"e\": {FILE_MUST}")
+    );
+    assert_eq!(
+        msg("file ex /"),
+        format!("unknown or ambiguous subcommand \"ex\": {FILE_MUST}")
+    );
 }

--- a/rust/tcl-vm/tests/cmd_oo_e2e.rs
+++ b/rust/tcl-vm/tests/cmd_oo_e2e.rs
@@ -305,6 +305,66 @@ fn tip558_configurable_property_abbreviates() {
     );
 }
 
+/// The other half of `info object isa`'s dispatch: once the category
+/// resolves, C checks an **exact** argument count per category
+/// (`InfoObjectIsACmd`, tclOOInfo.c) — two trailing words for
+/// `class`/`metaclass`/`object`, three for `mixin`/`typeof`. Resolving the
+/// category by prefix without that second stage answers `0` for
+/// `info object isa t $obj` (a missing class name) and `1` for
+/// `info object isa ob $obj extra` (a word C refuses).
+///
+/// The noun is C's `Tcl_WrongNumArgs(interp, 2, objv, …)`, so it carries the
+/// *resolved* category word — an index-typed argument prints as its table
+/// entry, which is why `isa t o` reports `typeof`. The two-words-missing case
+/// is checked before the category is resolved, so `info object isa object` is
+/// the generic message.
+///
+/// tclsh 8.6.16 and 9.0.4, byte-identical:
+///   info object isa               -> wrong # args: should be "info object isa
+///                                    category objName ?arg ...?"
+///   info object isa object        -> <same>
+///   info object isa t o           -> wrong # args: should be "info object isa
+///                                    typeof objName className"
+///   info object isa ob o extra    -> … "info object isa object objName"
+///   info object isa cl o extra    -> … "info object isa class objName"
+///   info object isa metaclass o e -> … "info object isa metaclass objName"
+///   info object isa mi o          -> … "info object isa mixin objName className"
+///   info object isa mixin o C x   -> <same>
+///   info object isa ty o C x      -> … "info object isa typeof objName className"
+#[test]
+fn info_object_isa_enforces_the_per_category_arity() {
+    const SETUP: &str = "oo::class create C { method m {} {return 1} }\nC create o\n";
+    let msg = |tail: &str| {
+        let (ok, result, _) = run(&format!("{SETUP}{tail}"));
+        assert!(!ok, "expected an error for {tail}");
+        result
+    };
+    const GENERIC: &str = "wrong # args: should be \"info object isa category objName ?arg ...?\"";
+    assert_eq!(msg("info object isa"), GENERIC);
+    assert_eq!(msg("info object isa object"), GENERIC);
+    for (tail, want) in [
+        ("info object isa t o", "typeof objName className"),
+        ("info object isa mi o", "mixin objName className"),
+        ("info object isa mixin o C extra", "mixin objName className"),
+        ("info object isa ty o C extra", "typeof objName className"),
+        ("info object isa ob o extra", "object objName"),
+        ("info object isa cl o extra", "class objName"),
+        ("info object isa metaclass o extra", "metaclass objName"),
+    ] {
+        assert_eq!(
+            msg(tail),
+            format!("wrong # args: should be \"info object isa {want}\"")
+        );
+    }
+    // The exact counts still answer.
+    assert_eq!(
+        run(&format!("{SETUP}info object isa object nosuchobj")).1,
+        "0"
+    );
+    assert_eq!(run(&format!("{SETUP}info object isa typeof o C")).1, "1");
+    assert_eq!(run(&format!("{SETUP}info object isa mixin o C")).1, "0");
+}
+
 /// Issue #1607: `info object isa`'s category is a
 /// `Tcl_GetIndexFromObj(…, "category", 0)` table (`tclOOInfo.c`), so `cl`/`ob`/
 /// `t` abbreviate, `m` is ambiguous (metaclass/mixin), and the enumeration

--- a/rust/tcl-vm/tests/cmd_oo_e2e.rs
+++ b/rust/tcl-vm/tests/cmd_oo_e2e.rs
@@ -269,6 +269,94 @@ fn tip558_configurable_bad_property() {
     assert_eq!(msg, "bad property \"gorp\": must be -x, -y, or -z");
 }
 
+/// Issue #1607: `configure`'s property word is resolved by C's
+/// `oo::configuresupport` through `tcl::prefix match -message property`, so an
+/// abbreviation resolves and a word prefixing several — `""` and a lone `-`
+/// included — is `ambiguous property`. This matched exactly and hand-joined
+/// the enumeration.
+///
+/// tclsh 9.0.4 (`oo::configurable create Q { property yellow zed }`):
+///   q configure -zz   -> bad property "-zz": must be -yellow or -zed
+///   q configure {}    -> ambiguous property "": must be -yellow or -zed
+///   q configure -     -> ambiguous property "-": must be -yellow or -zed
+///   q configure -ye 1 -> {}      ;  q configure -ye -> 1
+#[test]
+fn tip558_configurable_property_abbreviates() {
+    const MUST: &str = "must be -yellow or -zed";
+    let setup = "oo::configurable create Q { property yellow zed\n\
+                     constructor {} { my configure -yellow 0 -zed 0 } }\n\
+                 set q [Q new]\n";
+    let msg = |tail: &str| {
+        let (ok, result, _) = run(&format!("{setup}$q configure {tail}"));
+        assert!(!ok, "expected an error for `configure {tail}`");
+        result
+    };
+    assert_eq!(msg("-zz"), format!("bad property \"-zz\": {MUST}"));
+    assert_eq!(msg("{}"), format!("ambiguous property \"\": {MUST}"));
+    assert_eq!(msg("-"), format!("ambiguous property \"-\": {MUST}"));
+    // A unique prefix resolves — and the *canonical* property is written.
+    assert_eq!(
+        run(&format!("{setup}$q configure -ye 1\n$q configure -yellow")).1,
+        "1"
+    );
+    assert_eq!(
+        run(&format!("{setup}$q configure -ye 1\n$q configure -ye")).1,
+        "1"
+    );
+}
+
+/// Issue #1607: `info object isa`'s category is a
+/// `Tcl_GetIndexFromObj(…, "category", 0)` table (`tclOOInfo.c`), so `cl`/`ob`/
+/// `t` abbreviate, `m` is ambiguous (metaclass/mixin), and the enumeration
+/// keeps the Oxford comma the *method* lists drop.
+///
+/// tclsh 8.6.16 / 9.0.4:
+///   info object isa x o  -> bad category "x": must be class, metaclass,
+///                           mixin, object, or typeof
+///   info object isa {} o -> ambiguous category "": must be <same>
+///   info object isa m o  -> ambiguous category "m": must be <same>
+///   info object isa cl o -> 0 ; ob o -> 1 ; me o -> 0 ; t o C -> 1
+///   o x                  -> unknown method "x": must be destroy or m
+#[test]
+fn info_object_isa_category_resolves_like_tcl_get_index_from_obj() {
+    const MUST: &str = "must be class, metaclass, mixin, object, or typeof";
+    const SETUP: &str = "oo::class create C { method m {} {return 1} }\nC create o\n";
+    let msg = |tail: &str| {
+        let (ok, result, _) = run(&format!("{SETUP}{tail}"));
+        assert!(!ok, "expected an error for {tail}");
+        result
+    };
+    assert_eq!(
+        msg("info object isa x o"),
+        format!("bad category \"x\": {MUST}")
+    );
+    assert_eq!(
+        msg("info object isa {} o"),
+        format!("ambiguous category \"\": {MUST}")
+    );
+    assert_eq!(
+        msg("info object isa m o"),
+        format!("ambiguous category \"m\": {MUST}")
+    );
+    assert_eq!(run(&format!("{SETUP}info object isa cl o")).1, "0");
+    assert_eq!(run(&format!("{SETUP}info object isa ob o")).1, "1");
+    assert_eq!(run(&format!("{SETUP}info object isa me o")).1, "0");
+    assert_eq!(run(&format!("{SETUP}info object isa t o C")).1, "1");
+    // The method list keeps TclOO's own join, which drops the Oxford comma the
+    // option tables above keep.
+    //
+    // tclsh 8.6.16 / 9.0.4:
+    //   o3 zz -> unknown method "zz": must be a, b, c or destroy
+    assert_eq!(msg("o x"), "unknown method \"x\": must be destroy or m");
+    assert_eq!(msg("o {}"), "unknown method \"\": must be destroy or m");
+    let (ok, four, _) = run(
+        "oo::class create C3 { method a {} {}; method b {} {}; method c {} {} }\n\
+         C3 create o3\no3 zz",
+    );
+    assert!(!ok);
+    assert_eq!(four, "unknown method \"zz\": must be a, b, c or destroy");
+}
+
 #[test]
 fn tip558_configurable_custom_get_set() {
     // ooProp-3.1: custom `-get`/`-set` bodies run as accessor methods over the

--- a/rust/tcl-vm/tests/cmd_oo_e2e.rs
+++ b/rust/tcl-vm/tests/cmd_oo_e2e.rs
@@ -334,12 +334,12 @@ fn tip558_configurable_property_abbreviates() {
 #[test]
 fn info_object_isa_enforces_the_per_category_arity() {
     const SETUP: &str = "oo::class create C { method m {} {return 1} }\nC create o\n";
+    const GENERIC: &str = "wrong # args: should be \"info object isa category objName ?arg ...?\"";
     let msg = |tail: &str| {
         let (ok, result, _) = run(&format!("{SETUP}{tail}"));
         assert!(!ok, "expected an error for {tail}");
         result
     };
-    const GENERIC: &str = "wrong # args: should be \"info object isa category objName ?arg ...?\"";
     assert_eq!(msg("info object isa"), GENERIC);
     assert_eq!(msg("info object isa object"), GENERIC);
     for (tail, want) in [

--- a/rust/tcl-vm/tests/cmd_string_e2e.rs
+++ b/rust/tcl-vm/tests/cmd_string_e2e.rs
@@ -564,29 +564,42 @@ fn string_insert_command() {
 /// ambiguous/unknown error, and the no-subcommand error.
 #[test]
 fn string_subcommand_dispatch() {
+    const MUST: &str = "must be cat, compare, equal, first, index, insert, is, last, length, \
+                        map, match, range, repeat, replace, reverse, tolower, totitle, \
+                        toupper, trim, trimleft, trimright, wordend, or wordstart";
     // tclsh: unique prefixes resolve
     res_eq("string le hello", "5"); // le -> length
     res_eq("string rev hello", "olleh"); // rev -> reverse
     res_eq("string eq abc abc", "1"); // eq -> equal
-    // tclsh: an unknown subcommand lists the canonical set.
+    // tclsh9.0.4: an unknown subcommand lists the canonical set, joined by the
+    // ensemble's rule (a comma before `or`) — since #1607 the whole sentence is
+    // `tcl_cmd_core::ensemble`'s, so it is pinned byte for byte.
+    //
+    // tclsh9.0.4:
+    //   string bogus x -> unknown or ambiguous subcommand "bogus": must be cat,
+    //                     compare, equal, first, index, insert, is, last,
+    //                     length, map, match, range, repeat, replace, reverse,
+    //                     tolower, totitle, toupper, trim, trimleft, trimright,
+    //                     wordend, or wordstart
+    //   string to abc  -> unknown or ambiguous subcommand "to": must be <same>
+    //   string {} a    -> unknown or ambiguous subcommand "": must be <same>
     let (ok, msg, _) = run("string bogus x");
     assert!(!ok);
-    assert!(
-        msg.starts_with("unknown or ambiguous subcommand \"bogus\": must be "),
-        "got: {msg}"
+    assert_eq!(
+        msg,
+        format!("unknown or ambiguous subcommand \"bogus\": {MUST}")
     );
-    assert!(
-        msg.contains("cat, compare, equal, first, index"),
-        "got: {msg}"
-    );
-    assert!(msg.contains("or wordstart"), "got: {msg}");
     // tclsh: an ambiguous prefix (`to` -> tolower/totitle/toupper) errors too.
     let (ok, msg, _) = run("string to abc");
     assert!(!ok);
-    assert!(
-        msg.starts_with("unknown or ambiguous subcommand \"to\""),
-        "got: {msg}"
+    assert_eq!(
+        msg,
+        format!("unknown or ambiguous subcommand \"to\": {MUST}")
     );
+    // The empty word prefixes every entry, so it lands on the same sentence.
+    let (ok, msg, _) = run("string {} a");
+    assert!(!ok);
+    assert_eq!(msg, format!("unknown or ambiguous subcommand \"\": {MUST}"));
     // tclsh: no subcommand at all.
     err_eq(
         "string",

--- a/rust/tcl-vm/tests/cross_version_command_surface_e2e.rs
+++ b/rust/tcl-vm/tests/cross_version_command_surface_e2e.rs
@@ -590,8 +590,8 @@ fn version_mutation_rechecks_an_existing_imports_source_identity() {
     );
     let probe = vm
         .eval_source(
-            "catch {namespace eval imported {set cmd [string cat imported_ lass ign]; $cmd {a b} x}} imported; \\
-             catch {set cmd [string cat es caped]; $cmd {a b} x} escaped; \\
+            "catch {namespace eval imported {set cmd imported_; append cmd lass ign; $cmd {a b} x}} imported; \\
+             catch {set cmd es; append cmd caped; $cmd {a b} x} escaped; \\
              list $imported $escaped\n",
         )
         .expect("8.4 probe compiles");
@@ -1126,7 +1126,11 @@ fn empty_rename_destination_deletes_commands_across_indirections() {
         "rename ::imported::imported {}\n",
         "puts \"owned=[info commands owned] alias=[info commands alias] target=[info commands set] imported=[info commands ::imported::imported] source=[info commands ::source::imported]\"\n",
         "rename lassign {}\n",
-        "set builtin [string cat las sign]\n",
+        // `append`, not `string cat`: the name is still built at runtime (so
+        // the call cannot be folded), but `string cat` is 8.6+ and this vector
+        // runs from 8.5.
+        "set builtin las\n",
+        "append builtin sign\n",
         "puts \"builtin=[catch {$builtin {a b} x} message];$message\"\n",
     );
     let want = concat!(

--- a/rust/tcl-vm/tests/cross_version_command_surface_e2e.rs
+++ b/rust/tcl-vm/tests/cross_version_command_surface_e2e.rs
@@ -372,6 +372,22 @@ const VECTORS: &[Vector] = &[
         want_86: "1",
         want_90: "1",
     },
+    // -- #1607: `package`'s option table follows the release --
+    // `prefer` is TIP 268 (8.5); `files` is 9.0's. Byte-checked against
+    // tclsh8.4.20 / 8.5.19 / 8.6.16 / 9.0.4, which this suite also re-runs
+    // against any installed tclsh.
+    Vector {
+        name: "package's option list follows the release",
+        script: "puts [catch {package zz} m]$m\n",
+        want_84: "1bad option \"zz\": must be forget, ifneeded, names, present, \
+                  provide, require, unknown, vcompare, versions, or vsatisfies",
+        want_85: "1bad option \"zz\": must be forget, ifneeded, names, prefer, present, \
+                  provide, require, unknown, vcompare, versions, or vsatisfies",
+        want_86: "1bad option \"zz\": must be forget, ifneeded, names, prefer, present, \
+                  provide, require, unknown, vcompare, versions, or vsatisfies",
+        want_90: "1bad option \"zz\": must be files, forget, ifneeded, names, prefer, \
+                  present, provide, require, unknown, vcompare, versions, or vsatisfies",
+    },
     // -- the polyfill pattern: a user proc always wins over a hidden builtin --
     Vector {
         name: "a user-defined proc is callable at every release",


### PR DESCRIPTION
## Summary

- Closes #1607. **70 of 70 in-scope sites converted**, plus 3 of 4 adjacent ones, across 12 commits — one per command family.
- The hand-spelled `bad option` / `ambiguous option` strings and the duplicated subcommand tables now resolve through `tcl_cmd_core::prefix::OptionTable` and `tcl_cmd_core::ensemble`, so the message wording, the abbreviation rule, and the enumeration all have one owner per question instead of ~78 independent spellings.
- Families, in landing order: `interp` debug/limit → `interp` ensemble/child/create/invokehidden → `package` → `event`/`try`/`seek` → `info`/`file` → `string`/`tcl::prefix` → `dict`/`array` → `binary`/`encoding`/`chan`/`zlib`/`namespace` → `oo` → contract note → `clock` → `glob`.

### ⚠️ One deliberate behaviour change: `glob` in tcl-vm

Every other site in this sweep reshapes messages without moving an accept/reject decision. `glob` is the exception and was landed only after an explicit ruling:

- **Before**, tcl-vm's `glob` loop *skipped* any unrecognised `-word`, so `glob -x a` ran happily and `-types d` leaked its value into the pattern list.
- **After**, it rejects with C's text, matching the runtime (which already rejected correctly and here only gains abbreviation, plus `-` moving `bad` → `ambiguous`).
- Because the table now **advertises** `-tails` and `-types`, tcl-vm also **honours** them rather than accepting-and-ignoring: `-tails` reports each hit relative to the `-directory`/`-path` root, and `-types` filters through the same portable `Filesystem` rule the runtime already uses (kinds `d f l`; `x` from the executable bit; `r`/`w` best-effort; Unix `p s b c` are inexpressible through the seam and so never match). Advertising an option the engine silently mis-answers is the one thing the rest of this sweep refuses to do.

Scripts that pass an option tcl-vm previously ignored will now fail. A survey of every `glob -option` use across `samples/ tests/ specs/ rust/ runtime/ editors/ ai/ docs/` found nothing in-tree relying on the old permissiveness: the only `-types`/`-tails`/`-path` uses are an analysed-never-executed sample, analyser fixtures, the tclsh probe scripts in `xtask::audit-option-dialects`, and the runtime's existing `glob_finds_files`. Everything else uses `-directory`/`-nocomplain`/`--`, still accepted. (Apparent hits like `-regexp`/`-inline`/`-matchvar`/`-nocase` are `switch -glob` options, not this command.)

### Oracle-pinned, not written from memory

The new `glob` rejection text was taken from `tmp/tcl8.6.16/unix/tclsh` and `tmp/tcl9.0.4/unix/tclsh` with `TCL_LIBRARY` set to each `library/`. 8.6 and 9.0 agree on every row, so there is no dialect split and both engines pin identical bytes:

```
glob -x a      bad option "-x": must be -directory, -join, -nocomplain, -path, -tails, -types, or --
glob - a       ambiguous option "-": must be <same>
glob -t d a    ambiguous option "-t": must be <same>        (-tails / -types)
glob -tails p  "-tails" must be used with either "-directory" or "-path"
```

### Verified by mutation, not by inspection

Every converted site was mutation-checked in both engines: flipping the table to `exact_only` / `prefixes=false` must fail an abbreviation row, and swapping the noun must fail a message row. That caught real gaps rather than confirming expectations — two mutations initially survived, exposing a missing abbreviation row in the `zlib gunzip` table and a TclOO join test that needed a **four**-entry method list (with two entries both join styles agree, so the test proved nothing). Both were closed. For `glob` the resolving rows had to be reordered ahead of the ambiguity row, which was otherwise absorbing the signal.

### Corrections to the inventory found while converting

- `clock` was listed as mechanical but is behavioural — `clock se` failed the abbreviation row.
- The runtime's `update` option was missing from the inventory entirely (it reported `wrong # args` for a bad option).
- tcl-vm's `info` table was missing `class`; `file`'s was missing `home` and `tildeexpand`.
- Where an engine advertises only what it dispatches, the family's pinned policy was kept (`scan` + `bad_key_message` over the shorter table), the way C hides `slaves` from 9.0's enumeration.

`docs/design/contracts/` records the sites deliberately left alone, and now the `glob` decision and its reasoning, so the next reader finds a decision rather than an unexplained gap. `R34`/`R35` (`oo::define` body-command loops) were marked optional and left.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

| Command | Result |
|---|---|
| `cargo test -p tcl-cmd-core` | ok — 99 passed, 0 failed |
| `cargo test -p tcl-vm` | ok — 45 binaries, 0 failed |
| `cargo test --manifest-path runtime/rust/Cargo.toml` | ok — 9 binaries, 0 failed |
| `make runtime-rust-test-no-tommath` | exit 0 — 9 ok, 0 failed |
| `make rust-check` | exit 0 |
| `cargo xtask audit-option-dialects --check` | OK — 114 probed options, 0 tracked gaps, `KNOWN_UNSPECIFIED` still empty |

## Compiler / diagnostics checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? — No compiler fact contract changed; this is command-dispatch behaviour in tcl-vm and runtime/rust.
- [x] If yes, I updated the owning design doc — the contract note under `docs/design/contracts/` was updated for the deliberate non-OptionTable sites and the `glob` ruling.
- [x] If I added or changed a diagnostic or optimisation code, I updated its page — no diagnostic or optimisation code added or changed.
- [x] If I added a design doc, I linked it from `docs/design/README.md` — no new design doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XV29AoTSsaCBgsJuf2EvEK

---
_Generated by [Claude Code](https://claude.ai/code/session_01XV29AoTSsaCBgsJuf2EvEK)_