### PR TITLE
feat(runtime): dispatch a proc body through a native entry, and export a growable function table

### DIFF
--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -29,7 +29,7 @@ flowchart LR
 
 ## Alphabetic index
 
-[AST](#ast) · [Barrier](#barrier) · [Basic block](#basic-block) · [C extension shim](#c-extension-shim) · [CFG](#cfg) · [Codegen](#codegen) · [Command walk](#command-walk) · [CommandSpec](#commandspec) · [Compilation unit](#compilation-unit) · [Constant folding](#constant-folding) · [CSE](#cse) · [Data-flow graph](#data-flow-graph) · [DCE](#dce) · [Def-use chains](#def-use-chains) · [dialect](#dialect) · [Dispatch-stability proof](#dispatch-stability-proof) · [Dominance frontier](#dominance-frontier) · [Dominator / idom](#dominator--idom) · [Escape tag](#escape-tag) · [FormSpec](#formspec) · [Frame-only var](#frame-only-var) · [GVN](#gvn) · [ICIP](#icip) · [InstCombine](#instcombine) · [Interpreter domain](#interpreter-domain) · [IPA](#ipa) · [IR](#ir) · [Lattice](#lattice) · [LCP](#lcp) · [Lexing](#lexing) · [LICM](#licm) · [Lifecycle (registry)](#lifecycle-registry) · [Liveness](#liveness) · [Lowering](#lowering) · [LVT](#lvt) · [Memory-SSA](#memory-ssa) · [Pattern recognition](#pattern-recognition) · [Phi node (φ)](#phi-node-φ) · [Rendered-value properties](#rendered-value-properties) · [Requirement straddle](#requirement-straddle) · [salsa](#salsa) · [SCCP](#sccp) · [Shimmer](#shimmer) · [Side-effects](#side-effects) · [Source edge](#source-edge) · [Special variable](#special-variable) · [SSA](#ssa) · [SSA value key](#ssa-value-key) · [Strength reduction](#strength-reduction) · [SubCommand](#subcommand) · [Symbol-definer command](#symbol-definer-command) · [Tail position](#tail-position) · [Tail-call optimisation](#tail-call-optimisation) · [Taint analysis](#taint-analysis) · [Taint colour](#taint-colour) · [Taint sink](#taint-sink) · [Taint source](#taint-source) · [Trace](#trace) · [Type inference](#type-inference) · [Unused procs elimination](#unused-procs-elimination) · [Value provenance](#value-provenance) · [ValueOps](#valueops) · [Var-escape analysis](#var-escape-analysis) · [Version floor](#version-floor) · [World-state contents lattice](#world-state-contents-lattice)
+[AST](#ast) · [Barrier](#barrier) · [Basic block](#basic-block) · [C extension shim](#c-extension-shim) · [CFG](#cfg) · [Codegen](#codegen) · [Command walk](#command-walk) · [CommandSpec](#commandspec) · [Compilation unit](#compilation-unit) · [Constant folding](#constant-folding) · [CSE](#cse) · [Data-flow graph](#data-flow-graph) · [DCE](#dce) · [Def-use chains](#def-use-chains) · [dialect](#dialect) · [Dispatch-stability proof](#dispatch-stability-proof) · [Dominance frontier](#dominance-frontier) · [Dominator / idom](#dominator--idom) · [Escape tag](#escape-tag) · [FormSpec](#formspec) · [Frame-only var](#frame-only-var) · [GVN](#gvn) · [ICIP](#icip) · [InstCombine](#instcombine) · [Interpreter domain](#interpreter-domain) · [IPA](#ipa) · [IR](#ir) · [Lattice](#lattice) · [LCP](#lcp) · [Lexing](#lexing) · [LICM](#licm) · [Lifecycle (registry)](#lifecycle-registry) · [Liveness](#liveness) · [Lowering](#lowering) · [LVT](#lvt) · [Memory-SSA](#memory-ssa) · [Native proc entry](#native-proc-entry) · [Pattern recognition](#pattern-recognition) · [Phi node (φ)](#phi-node-φ) · [Rendered-value properties](#rendered-value-properties) · [Requirement straddle](#requirement-straddle) · [salsa](#salsa) · [SCCP](#sccp) · [Shimmer](#shimmer) · [Side-effects](#side-effects) · [Source edge](#source-edge) · [Special variable](#special-variable) · [SSA](#ssa) · [SSA value key](#ssa-value-key) · [Strength reduction](#strength-reduction) · [SubCommand](#subcommand) · [Symbol-definer command](#symbol-definer-command) · [Tail position](#tail-position) · [Tail-call optimisation](#tail-call-optimisation) · [Taint analysis](#taint-analysis) · [Taint colour](#taint-colour) · [Taint sink](#taint-sink) · [Taint source](#taint-source) · [Trace](#trace) · [Type inference](#type-inference) · [Unused procs elimination](#unused-procs-elimination) · [Value provenance](#value-provenance) · [ValueOps](#valueops) · [Var-escape analysis](#var-escape-analysis) · [Version floor](#version-floor) · [World-state contents lattice](#world-state-contents-lattice)
 
 ---
 
@@ -1366,6 +1366,33 @@ the group name for the four the native tier enables.
 See also: [WASM explorer view](design/contracts/wasm-explorer-view.md)
 § *Optimisation passes*.
 KCS tag: `codegen-passes`.
+
+### Native proc entry
+
+The compiled body of a Tcl `proc`: a function an emitted WASM module defines
+and installs into the runtime's shared indirect function table, so the runtime
+calls it instead of interpreting the proc's source body. A wasm32 function
+pointer *is* an index into that table, so "the entry" is just that index
+travelling across the ABI — `tcl_codegen_proc_define_native`'s last argument,
+and `ProcDef.native` on the runtime side.
+
+It lives on the proc's definition rather than in a side table, so redefining
+the proc drops it, `rename` carries it, and deleting the proc frees it, with
+nothing to invalidate.
+
+The runtime keeps the whole call protocol: arity checking and `wrong # args`,
+the call frame in the proc's namespace, `info level`'s words and the formal
+binding all happen before the entry runs, and the return boundary, the
+procedure error frame and frame teardown all happen after. The entry supplies
+only the body, and pushes neither a frame nor an activation of its own. It may
+also **decline** — before any observable effect — and the runtime then runs the
+source body in the frame it already prepared. A live step trace forces the
+source body too, since a natively lowered command never reaches the dispatcher
+and so would fire no `enterstep`.
+
+See also: [WASM codegen](design/compiler/wasm-codegen.md)
+§ *The shared function table*.
+KCS tag: `codegen`.
 
 ### LVT
 

--- a/docs/design/compiler/wasm-codegen.md
+++ b/docs/design/compiler/wasm-codegen.md
@@ -385,6 +385,26 @@ the completion output. It retains outbound result and options before releasing
 its private completion, argv values, and frame. ABI constants and layout live
 in `tcl-runtime-api`; compiler and runtime do not maintain copies.
 
+### The shared function table
+
+Calls in the other direction — the runtime calling a function an emitted
+module defines — go through one wasm table the **runtime** owns.
+`runtime/rust/build.rs` links every wasm target with `--export-table` and
+`--growable-table`, so `tcl_runtime.wasm` publishes `wasm-ld`'s indirect
+function table as `__indirect_function_table` (the name
+`WASM32_FUNCTION_TABLE_IMPORT` owns) with no maximum. A module that wants the
+runtime to call one of its functions imports that table, `table.grow`s room
+for its own entries, `ref.func`s them into the new slots, and passes the slot
+index across the ABI — a wasm32 function pointer *is* such an index, so the
+runtime calls it with an ordinary indirect call.
+
+Two link-time failures are worth naming because their symptoms are far apart.
+A runtime linked without `--export-table` fails *instantiation* of any module
+that imports the table (`unknown import`), so a module imports it only when it
+actually installs an entry; one linked without `--growable-table` keeps
+`min == max` and `table.grow` answers `-1`, which the installing module must
+treat as a build error rather than proceeding with a bogus base.
+
 General lowering's generated values are `i32` pointers to owned
 `TclObj` values in shared linear memory. Compiled variables keep an indexed
 slot and their Tcl-visible named cell as two ports onto the same object, so

--- a/docs/design/lanes/wasm-native-lowering.md
+++ b/docs/design/lanes/wasm-native-lowering.md
@@ -1333,3 +1333,37 @@ with the site logged, a compiled body's `-errorinfo` *and* `-errorstack` are
 byte-identical to the interpreted body's, which is tclsh 9.0.4's and
 8.6.16's. So step 6 is now a call site in the emitter, not an open question.
 
+### WASM IR (delivered)
+
+`WasmModule` gains `import_table: bool`, `globals: Vec<WasmGlobal>` and
+`elem_declared: Vec<u32>`, plus the reference-type ops `ref.null`, `ref.func`,
+`table.set` and `table.grow`. All three fields default off, so a module that
+binds no native proc emits byte-identical output — pinned by
+`a_module_that_installs_nothing_keeps_its_previous_shape`, and confirmed by
+`budgets.tsv` being unchanged.
+
+Three details worth carrying into PR-B:
+
+- **`ref.null func` was missing from the plan's op list.** `table.grow` takes
+  an init *reference* and a delta, so the module cannot grow the table without
+  it. It is `WasmOp::RefNull` (`0xD0`) with the `funcref` heap type as its
+  operand byte.
+- **`table.grow` is `0xFC`-prefixed** and `WasmOp` is `repr(u8)`, so the
+  discriminant is the prefix alone and the operand bytes carry the sub-opcode
+  `0x0F` ahead of the table index. `WasmInstruction::table_grow` is the only
+  constructor, so no caller has to know that.
+- **Function imports stay in `imports`.** A table import occupies the table
+  index space, not the function one, so `top_idx = wasm.imports.len()` and the
+  budgets walker are untouched.
+
+The table import declares `(table 0 funcref)` — minimum 0, no maximum — so it
+matches whatever size the runtime actually linked.
+
+`wasm_execute.rs::an_emitted_module_installs_a_function_into_the_hosts_table`
+runs the encoded module under wasmtime: it grows a host table, keeps the base
+in a global, installs a function of its own and has the host call it back
+through the table, answering 42. The installed function is deliberately **not**
+exported, so the declarative element segment is the only thing making its
+`ref.func` legal — removing the segment fails validation, and a fixed-size host
+table traps, so neither half of the case is decorative.
+

--- a/docs/design/lanes/wasm-native-lowering.md
+++ b/docs/design/lanes/wasm-native-lowering.md
@@ -16,6 +16,7 @@ Branch: `claude/wasm-codegen-architecture-5exvpu`.
 | `p1-runtime-abi` | P1 runtime ABI v2 groundwork | `runtime/rust/src/{codegen_abi,frame,vars,interp,obj,bignum,builtins,expr}.rs`, `rust/tcl-runtime-api/src/codegen_abi.rs` | open |
 | `p2-executable-ir` | P2 executable IR total | `rust/tcl-compiler/src/executable_ir.rs` and its consumers | landed (see below) |
 | `p3-native-lowering` | P3 NLIR + native T0/T1 | `rust/tcl-registry/src/native_lowering.rs`, `rust/tcl-compiler/src/native_lowering/`, `codegen/wasm/{native_emit,ir,pipeline,backend}.rs`, `runtime/rust/src/codegen_native.rs` | landed (see below) |
+| `p5-native-procs` | P5-lite native proc dispatch (#1774) | `runtime/rust/{build.rs,src/{interp,codegen_abi}.rs}`, `rust/tcl-runtime-api/src/codegen_abi.rs`, `rust/tcl-compiler/src/codegen/wasm/ir.rs` | in flight — PR-A (runtime + transport) below |
 
 ## Decisions
 
@@ -1202,3 +1203,30 @@ is the design: no emitter reads a compatibility string.
   `puts` sites survive it.
 - Type hints (`LoweringInput::type_hints`) are threaded but unused; the
   interval proofs come from literals and `incr` deltas only.
+
+## p5-native-procs
+
+Issue #1774, phase P5-lite. Split in two: **PR-A** (this section) is the
+runtime and transport half — the runtime can define, dispatch, decline,
+redefine, rename and step-trace a native proc entry, and the WASM IR can
+encode the table plumbing — and emits **no** module change. PR-B is the
+emitter half (proc-entry function shape, `::top` table install, the
+`Definition` lowering, `errorInfo` error-edge logging) and closes the issue.
+
+### Shared vocabulary (delivered)
+
+`rust/tcl-runtime-api/src/codegen_abi.rs` gains three imports and three
+constants, so neither side spells any of them twice:
+
+| Name | Signature | Meaning |
+|---|---|---|
+| `tcl_codegen_proc_define_native` | 7 × i32 → i32 | `proc_register` plus a trailing `entry` (a wasm32 function-table index; `0` = source body only) |
+| `tcl_codegen_log_command` | 3 × i32 → () | one `while executing` / `invoked from within` `errorInfo` frame for a compiled statement: body-relative line, source ptr/len |
+| `tcl_codegen_native_proc_dispatches` | () → i32 | test counter, like `tcl_codegen_call_frame_outstanding` |
+
+`WASM32_FUNCTION_TABLE_IMPORT` is wasm-ld's `__indirect_function_table`;
+`NATIVE_PROC_STATUS_RAN` / `_DECLINED` are the entry's i32 result.
+
+`tcl_codegen_proc_register` stays exactly as it is — `entry = 0` is its
+documented equivalent — because already-emitted legacy-tier modules import it.
+

--- a/docs/design/lanes/wasm-native-lowering.md
+++ b/docs/design/lanes/wasm-native-lowering.md
@@ -1248,3 +1248,69 @@ Neither flag changes an existing module: the runtime's own indirect calls
 index below the initial size, nothing emitted imports the table yet, and
 `wasm-merge` preserves both properties.
 
+### Runtime dispatch (delivered)
+
+`ProcDef` gains `native: Option<NativeProcEntry>` — the compiled body, an
+`unsafe extern "C" fn(argv, argc, out: *mut TclCompletionAbi) -> i32`. The
+nullable-function-pointer ABI is what makes the whole half testable natively:
+wasm sees one i32, and a `cargo test` passes a real Rust function.
+
+**Owner of proc → entry: the `ProcDef` itself**, reached only through
+`define_proc_native`, the single field-by-field construction site (`proc`
+reaches it via `define_proc` with `None`). There is no side table and nothing
+to invalidate — redefinition builds a fresh definition with no entry, `rename`
+clones the definition and carries it, `rename p ""` / `namespace delete` drop
+it with the definition. Each of those is pinned by a test.
+
+`run_proc` is unchanged above and below the body: arity and `wrong # args`,
+the recursion bound, the frame push in `def.ns`, `set_words`, by-name formal
+binding, then teardown, `settle_return`, `make_proc_error` and the TIP 348
+`CALL` entry. Only the single `eval_framed` line becomes a choice, and it
+falls back to the source body in two cases:
+
+- **`traces.step_active` is non-empty.** `dispatch_traced` installs the proc's
+  own `enterstep`/`leavestep` before dispatching, so one read covers both this
+  proc and an outer step trace. A natively lowered `set` never reaches
+  `dispatch`, so it would fire no step trace at all.
+- **the entry returns `DECLINED`**, which it may do only before any observable
+  effect, so the fallback is not a partial re-run.
+
+`run_native_body` is `eval_framed` + `eval_script_mode` minus the parse and
+the command loop: `proc_line_base = line_base`, one `codegen_activation_enter`
+(refusal is `eval_script_mode`'s, verbatim), push the `CmdFrame`, call the
+entry, pop, adopt `out.result` into the result, release `out.options` (a
+snapshot; `settle_return` reads the runtime's own `return_level`/`return_code`),
+`codegen_activation_leave(code)`.
+
+**The double-frame contract, stated in the code so PR-B cannot get it wrong:**
+`run_proc` owns the Tcl variable frame, `info level`'s words and the formal
+binding; `run_native_body` owns the activation and the `CmdFrame`; the entry
+owns **neither**. A native-tier *module function* is not this shape — its
+prologue calls `activation_enter` + `frame_push` (`pushes_frame = !top_level`)
+— so PR-B must give a proc entry its own prologue-free shape rather than reuse
+that one. `info level 0` from inside the entry is the detector, and is pinned.
+
+Measured, not asserted: through the native path a Tcl level costs exactly two
+eval-depth units (`run_native_body` plus the body's own `tcl_invoke_argv`), so
+unbounded recursion refuses at depth **63** with the eval loop's own
+`too many nested evaluations (infinite loop?)`. That number is asserted; a
+level costing more or less moves it.
+
+### Ledgered for PR-B (step 6)
+
+A compiled statement calls no `log_command_info`, and that single absence has
+**two** visible consequences for an error out of a compiled body — the plan
+anticipated one:
+
+- no `while executing "<source text>"` frame, and `error_line` never advances,
+  so `(procedure "boom" line N)` reads the stale `line 1`;
+- **no TIP 348 `CALL` entry either.** `run_proc` does call
+  `error_stack_push_call`, but it deliberately refuses to chain a `CALL` onto
+  an error stack with no inner context yet (`reset_error_stack`,
+  `interp.rs:5497`), so `-errorstack` holds only the caller's own `INNER`.
+
+Both close together when the emitter calls `tcl_codegen_log_command` on a
+statement's error edge. Both are pinned by
+`an_error_from_the_native_body_unwinds_through_the_procedure_frame`, which
+therefore fails in both directions.
+

--- a/docs/design/lanes/wasm-native-lowering.md
+++ b/docs/design/lanes/wasm-native-lowering.md
@@ -1314,3 +1314,22 @@ statement's error edge. Both are pinned by
 `an_error_from_the_native_body_unwinds_through_the_procedure_frame`, which
 therefore fails in both directions.
 
+### The error-edge logger (delivered)
+
+`log_command_info` is split into `log_command_bytes(raw_line, cmd_bytes)`, the
+one implementation of C's `TclLogCommandInfo`, called by the eval loop and by
+`tcl_codegen_log_command`. `error_line` keeps its single writer and both
+callers get the same `already_logged` protocol, error-stack entry and
+150-byte truncation instead of a second, drifting copy.
+
+The ABI's `line` is the statement's 1-based line **within the body it was
+compiled from** — the same raw line the eval loop reads off the script text —
+so the enclosing frame's `line_base`/`proc_line_base` turn it into `errorLine`
+with no special case.
+
+Proved with a stub in the emitter's place
+(`a_logged_statement_site_makes_the_compiled_error_identical_to_the_source_one`):
+with the site logged, a compiled body's `-errorinfo` *and* `-errorstack` are
+byte-identical to the interpreted body's, which is tclsh 9.0.4's and
+8.6.16's. So step 6 is now a call site in the emitter, not an open question.
+

--- a/docs/design/lanes/wasm-native-lowering.md
+++ b/docs/design/lanes/wasm-native-lowering.md
@@ -1230,3 +1230,21 @@ constants, so neither side spells any of them twice:
 `tcl_codegen_proc_register` stays exactly as it is — `entry = 0` is its
 documented equivalent — because already-emitted legacy-tier modules import it.
 
+### The table (delivered)
+
+`runtime/rust/build.rs` adds `--export-table` and `--growable-table` beside
+the existing `--global-base`, for every wasm target. Verified on the linked
+`tcl_runtime.wasm`: `(table $0 814 funcref)` — no maximum — and
+`(export "__indirect_function_table" (table $0))`.
+
+`wasm_real_link.rs::the_runtime_exports_a_growable_indirect_function_table`
+is the gate: a bootstrap imports the table, `table.grow`s one slot,
+`ref.func`s a function of its own into it, and `call_indirect`s it back.
+Checked in both directions — with the two flags removed from `build.rs` the
+case fails (wasmtime cannot even instantiate the bootstrap), so it is not
+vacuous.
+
+Neither flag changes an existing module: the runtime's own indirect calls
+index below the initial size, nothing emitted imports the table yet, and
+`wasm-merge` preserves both properties.
+

--- a/runtime/rust/build.rs
+++ b/runtime/rust/build.rs
@@ -70,6 +70,26 @@ fn main() {
     // cost is ~1 MiB more zero-init linear memory in the wasm module.
     if is_wasm {
         println!("cargo:rustc-link-arg=--global-base=2097152"); // 0x20_0000
+        // Export the wasm indirect function table, and let it grow.
+        //
+        // A wasm32 function pointer *is* an index into this table, so an
+        // emitted module that wants the runtime to call one of its functions
+        // (issue #1774's native proc entries) has to install a `ref.func` into
+        // a table the runtime can `call_indirect` over. `wasm-ld` links the
+        // table private and fixed-size by default (`(table 2 2 funcref)`),
+        // which makes both halves impossible: the module cannot import it, and
+        // `table.grow` on a table at its maximum returns `-1`.
+        //
+        // `--export-table` publishes it as `__indirect_function_table` (the
+        // name `WASM32_FUNCTION_TABLE_IMPORT` in `tcl-runtime-api` owns) and
+        // `--growable-table` drops the maximum so a module can `table.grow`
+        // room for its own entries. Both are inert for a module that never
+        // touches the table: the runtime's own indirect calls index below the
+        // initial size, and an emitted module imports the table only when it
+        // actually binds a native proc, so an older module against this
+        // runtime is unaffected.
+        println!("cargo:rustc-link-arg=--export-table");
+        println!("cargo:rustc-link-arg=--growable-table");
     }
 
     let Some(ltm) = locate_libtommath() else {

--- a/runtime/rust/build.rs
+++ b/runtime/rust/build.rs
@@ -70,6 +70,7 @@ fn main() {
     // cost is ~1 MiB more zero-init linear memory in the wasm module.
     if is_wasm {
         println!("cargo:rustc-link-arg=--global-base=2097152"); // 0x20_0000
+
         // Export the wasm indirect function table, and let it grow.
         //
         // A wasm32 function pointer *is* an index into this table, so an

--- a/runtime/rust/src/cmd_oo.rs
+++ b/runtime/rust/src/cmd_oo.rs
@@ -5830,6 +5830,9 @@ impl Interp {
                 usage_prefix,
                 level_words,
                 quote_name: false,
+                // A method body is never compiled: only `proc` definitions
+                // carry a native entry.
+                native: None,
             },
         );
         self.oo.borrow_mut().filter_handling = saved_fh;

--- a/runtime/rust/src/cmd_proc.rs
+++ b/runtime/rust/src/cmd_proc.rs
@@ -163,6 +163,8 @@ fn apply_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             usage_prefix: None,
             level_words: Some(level_words),
             quote_name: false,
+            // A lambda has no definition to carry a compiled body on.
+            native: None,
         },
     )
 }

--- a/runtime/rust/src/codegen_abi.rs
+++ b/runtime/rust/src/codegen_abi.rs
@@ -1416,6 +1416,42 @@ pub unsafe extern "C" fn tcl_codegen_proc_define_native(
     0
 }
 
+/// Log one `while executing` / `invoked from within` `errorInfo` frame for a
+/// compiled statement that completed with an error.
+///
+/// Generated code has no eval loop, so nothing calls `log_command_info` for
+/// it: a compiled statement that fails leaves no `while executing "<source>"`
+/// frame and does not advance `errorLine`, which surfaces as a stale line in
+/// the enclosing `(procedure "p" line N)` and as a missing TIP 348 `CALL`
+/// entry. This is the emitter's way to close both, on a statement's error
+/// edge.
+///
+/// `line` is the statement's 1-based line **within the body it was compiled
+/// from** — the same raw line the eval loop reads off the script text — so the
+/// enclosing frame's `line_base`/`proc_line_base` turn it into `errorLine`
+/// exactly as they do for an interpreted command. `src` is the statement's
+/// exact source text; the runtime applies C's 150-byte truncation to it.
+///
+/// The runtime owns the `already_logged` protocol, so a statement whose error
+/// was already logged deeper in the same body is a no-op here and the emitter
+/// has no decision to make. Hence no result.
+///
+/// # Safety
+/// `src_ptr`/`src_len` must be a readable range of shared linear memory.
+#[no_mangle]
+pub unsafe extern "C" fn tcl_codegen_log_command(line: i32, src_ptr: *const u8, src_len: i32) {
+    let interp = current_interp();
+    if interp.is_null() {
+        return;
+    }
+    let src = unsafe { input_bytes(src_ptr, src_len) };
+    // Lines are 1-based; a caller that has no line still gets a logged frame
+    // rather than a silently dropped one.
+    let line = u32::try_from(line).unwrap_or(1).max(1);
+    // SAFETY: the bootstrap installed a live current interpreter.
+    unsafe { (*interp).log_command_bytes(line, src) };
+}
+
 /// The number of proc bodies the current interpreter has run through a native
 /// entry rather than their source body; `-1` with no current interpreter.
 ///
@@ -3598,6 +3634,9 @@ mod tests {
         /// The argv [`stub_body`] dispatches, and how many times a stub ran.
         static STUB_ARGV: RefCell<Vec<Vec<u8>>> = const { RefCell::new(Vec::new()) };
         static STUB_CALLS: Cell<u32> = const { Cell::new(0) };
+        /// `(line, source text)` [`stub_body`] logs on an error completion, as
+        /// the emitter will on a statement's error edge. `None` logs nothing.
+        static STUB_LOG: RefCell<Option<(i32, Vec<u8>)>> = const { RefCell::new(None) };
     }
 
     /// Arm the stub with the one command its body runs, and reset the counter.
@@ -3605,7 +3644,13 @@ mod tests {
         STUB_ARGV.with(|argv| {
             *argv.borrow_mut() = words.iter().map(|word| word.to_vec()).collect();
         });
+        STUB_LOG.with(|log| *log.borrow_mut() = None);
         STUB_CALLS.with(|calls| calls.set(0));
+    }
+
+    /// Give the armed stub the statement site it logs when its command fails.
+    fn stub_logs(line: i32, source: &[u8]) {
+        STUB_LOG.with(|log| *log.borrow_mut() = Some((line, source.to_vec())));
     }
 
     fn stub_calls() -> u32 {
@@ -3644,6 +3689,21 @@ mod tests {
         assert_eq!(status, TCL_INVOKE_ABI_OK);
         // SAFETY: balances `owned_word`'s reference on each word.
         unsafe { release_words(&boxed) };
+        // The statement's error edge: an emitted body logs its own source site
+        // here, because nothing else will.
+        // SAFETY: `out` was written by the invoke above.
+        if unsafe { (*out).code } == 1 {
+            if let Some((line, source)) = STUB_LOG.with(|log| log.borrow().clone()) {
+                // SAFETY: `source` is a live readable slice.
+                unsafe {
+                    tcl_codegen_log_command(
+                        line,
+                        source.as_ptr(),
+                        i32::try_from(source.len()).expect("source fits i32"),
+                    );
+                }
+            }
+        }
         NATIVE_PROC_STATUS_RAN
     }
 
@@ -4018,6 +4078,66 @@ mod tests {
                     String::from_utf8_lossy(&info)
                 );
                 assert_eq!(eval(interp, "dict get $o -errorstack").1, b"INNER {boom Q}");
+            });
+        });
+    }
+
+    /// With the statement's site logged, a compiled body's error is
+    /// indistinguishable from the interpreted one — the whole point of
+    /// `tcl_codegen_log_command`, proved here with a stub standing in for the
+    /// emitter so the emitter has a target rather than a guess.
+    #[test]
+    fn a_logged_statement_site_makes_the_compiled_error_identical_to_the_source_one() {
+        leak_free(|| unsafe {
+            with_current_interp(|interp| {
+                define_native(b"boom", b"a", BOOM_BODY, None);
+                assert_eq!(eval(interp, "catch {boom Q} m o").1, b"1");
+                let source_info = eval(interp, "dict get $o -errorinfo").1;
+                let source_stack = eval(interp, "dict get $o -errorstack").1;
+
+                // `error "bad $a"` is the third line of the body and the exact
+                // text of the failing statement — what the emitter carries.
+                stub_argv(&[b"error", b"bad Q"]);
+                stub_logs(3, b"error \"bad $a\"");
+                define_native(b"boom", b"a", BOOM_BODY, Some(stub_body));
+                assert_eq!(eval(interp, "catch {boom Q} m o").1, b"1");
+                assert_eq!(tcl_codegen_native_proc_dispatches(), 1);
+
+                assert_eq!(eval(interp, "dict get $o -errorinfo").1, source_info);
+                assert_eq!(eval(interp, "dict get $o -errorstack").1, source_stack);
+                assert_eq!(
+                    String::from_utf8_lossy(&source_info),
+                    "bad Q\n    while executing\n\"error \"bad $a\"\"\n    \
+                     (procedure \"boom\" line 3)\n    invoked from within\n\"boom Q\"",
+                    "and that shared answer is tclsh 9.0.4's and 8.6.16's"
+                );
+            });
+        });
+    }
+
+    #[test]
+    fn a_logged_command_is_truncated_and_deduplicated_like_an_interpreted_one() {
+        leak_free(|| unsafe {
+            with_current_interp(|interp| {
+                // One `log_command_bytes` protocol for both callers: the first
+                // frame seeds errorInfo from the message and truncates the
+                // command at 150 bytes with `...`; a second call for the same
+                // error is a no-op (`already_logged`).
+                let long = format!("error nope ;# {}", "x".repeat(200));
+                stub_argv(&[b"error", b"nope"]);
+                stub_logs(1, long.as_bytes());
+                define_native(b"long", b"", b"error nope", Some(stub_body));
+                assert_eq!(eval(interp, "catch {long} m o").1, b"1");
+                let info = eval(interp, "dict get $o -errorinfo").1;
+                let expected = format!(
+                    "nope\n    while executing\n\"{}...\"\n    (procedure \"long\" line 1)",
+                    &long[..150]
+                );
+                assert!(
+                    info.starts_with(expected.as_bytes()),
+                    "{}",
+                    String::from_utf8_lossy(&info)
+                );
             });
         });
     }

--- a/runtime/rust/src/codegen_abi.rs
+++ b/runtime/rust/src/codegen_abi.rs
@@ -101,7 +101,7 @@ use tcl_dialect::model::SurfaceQuery;
 use tcl_registry::{CommandRegistry, IntrinsicId, SemanticOperationId};
 use tcl_runtime_api::guard::{GuardDomains, GuardIdentity, GuardToken};
 
-use crate::interp::{drop_fresh, obj_bytes, Interp};
+use crate::interp::{drop_fresh, obj_bytes, Interp, NativeProcEntry};
 use crate::obj::{self, new_string_bytes, TclObj};
 #[cfg(target_arch = "wasm32")]
 use tcl_runtime_api::codegen_abi::{
@@ -1345,6 +1345,9 @@ pub unsafe extern "C" fn tcl_codegen_puts(value: *mut TclObj) -> i32 {
 
 /// Register source metadata for a generated procedure without evaluating `proc`.
 ///
+/// Exactly [`tcl_codegen_proc_define_native`] with no entry. It stays because
+/// already-emitted legacy-tier modules import this spelling.
+///
 /// # Safety
 /// All three pointer/length ranges must be readable shared linear memory.
 #[no_mangle]
@@ -1355,6 +1358,43 @@ pub unsafe extern "C" fn tcl_codegen_proc_register(
     params_len: i32,
     body_ptr: *const u8,
     body_len: i32,
+) -> i32 {
+    // SAFETY: the pointer/length ranges are forwarded under this function's
+    // own contract, which is the callee's.
+    unsafe {
+        tcl_codegen_proc_define_native(
+            name_ptr, name_len, params_ptr, params_len, body_ptr, body_len, None,
+        )
+    }
+}
+
+/// Define a Tcl procedure, optionally binding a compiled body to it.
+///
+/// `entry` is the compiled body: a wasm32 function-table index on the emitted
+/// side, a nullable function pointer here — which is why the runtime types it
+/// as `Option<NativeProcEntry>`, so `0` is `None` on wasm and a native test
+/// can pass an ordinary Rust `extern "C"` function. A `None` entry defines an
+/// ordinary source-body proc and is exactly [`tcl_codegen_proc_register`].
+///
+/// The `body` source is always recorded, entry or not: it is what a step trace
+/// forces, what a declining entry falls back to, and what `info body` reports.
+///
+/// The entry binds to *this* definition. Anything that replaces the definition
+/// — re-running `proc`, `rename p ""`, `namespace delete` — drops it with the
+/// definition, so there is nothing to invalidate.
+///
+/// # Safety
+/// All three pointer/length ranges must be readable shared linear memory, and
+/// `entry`, when present, must satisfy [`NativeProcEntry`]'s whole contract.
+#[no_mangle]
+pub unsafe extern "C" fn tcl_codegen_proc_define_native(
+    name_ptr: *const u8,
+    name_len: i32,
+    params_ptr: *const u8,
+    params_len: i32,
+    body_ptr: *const u8,
+    body_len: i32,
+    entry: Option<NativeProcEntry>,
 ) -> i32 {
     let interp = current_interp();
     if interp.is_null() {
@@ -1370,10 +1410,29 @@ pub unsafe extern "C" fn tcl_codegen_proc_register(
         Err(message) => return i32::try_from(interp.set_error(&message).as_int()).unwrap_or(1),
     };
     let body_obj = new_string_bytes(body);
-    interp.define_proc(name, params, body_obj);
+    interp.define_proc_native(name, params, body_obj, entry);
     drop_fresh(body_obj);
     interp.set_result_bytes(b"");
     0
+}
+
+/// The number of proc bodies the current interpreter has run through a native
+/// entry rather than their source body; `-1` with no current interpreter.
+///
+/// A diagnostic/test boundary, like [`tcl_codegen_call_frame_outstanding`].
+/// The compiled and interpreted bodies of one proc produce the same Tcl result
+/// by construction, so without this counter no test can tell which one ran,
+/// and a binding that silently stopped taking effect would keep every
+/// behavioural assertion green.
+#[no_mangle]
+pub extern "C" fn tcl_codegen_native_proc_dispatches() -> i32 {
+    let interp = current_interp();
+    if interp.is_null() {
+        return -1;
+    }
+    // SAFETY: the bootstrap installed a live current interpreter.
+    let dispatches = unsafe { (*interp).native_proc_dispatches() };
+    i32::try_from(dispatches).unwrap_or(i32::MAX)
 }
 
 /// `tcl_obj_new_string_owned(ptr, len) -> obj` — copy a string from shared
@@ -2010,6 +2069,9 @@ mod tests {
     use super::*;
     use crate::capi::{tcl_runtime_create_interp, tcl_runtime_delete_interp};
     use crate::counters;
+    use crate::interp::Code;
+    use std::cell::RefCell;
+    use tcl_runtime_api::codegen_abi::{NATIVE_PROC_STATUS_DECLINED, NATIVE_PROC_STATUS_RAN};
     use tcl_runtime_api::guard::GuardDomain;
 
     /// Run `body` under the alloc/free counters and assert zero residual — the
@@ -3528,5 +3590,470 @@ mod tests {
             assert_eq!(obj_bytes(word), b"word");
             tcl_obj_release(word);
         });
+    }
+
+    // ---- native proc entries (issue #1774) ---------------------------------
+
+    thread_local! {
+        /// The argv [`stub_body`] dispatches, and how many times a stub ran.
+        static STUB_ARGV: RefCell<Vec<Vec<u8>>> = const { RefCell::new(Vec::new()) };
+        static STUB_CALLS: Cell<u32> = const { Cell::new(0) };
+    }
+
+    /// Arm the stub with the one command its body runs, and reset the counter.
+    fn stub_argv(words: &[&[u8]]) {
+        STUB_ARGV.with(|argv| {
+            *argv.borrow_mut() = words.iter().map(|word| word.to_vec()).collect();
+        });
+        STUB_CALLS.with(|calls| calls.set(0));
+    }
+
+    fn stub_calls() -> u32 {
+        STUB_CALLS.with(Cell::get)
+    }
+
+    /// A stub compiled proc body.
+    ///
+    /// It dispatches one prebuilt argv through the same [`tcl_invoke_argv`] an
+    /// emitted body uses for a statement it could not lower, and forwards that
+    /// completion as its own. Nothing here is test-shaped: the completion
+    /// protocol, the borrowed argv, and the absent frame/activation prologue
+    /// are exactly what `native_emit` must emit for a proc entry.
+    unsafe extern "C" fn stub_body(
+        _argv: *const *mut TclObj,
+        _argc: i32,
+        out: *mut TclCompletionAbi,
+    ) -> i32 {
+        STUB_CALLS.with(|calls| calls.set(calls.get() + 1));
+        let words = STUB_ARGV.with(|argv| argv.borrow().clone());
+        // SAFETY: each word is a valid readable slice; `owned_word` boxes it
+        // and takes the caller-owned reference the borrowed-argv ABI needs.
+        let boxed: Vec<*mut TclObj> = words
+            .iter()
+            .map(|word| unsafe { owned_word(word) })
+            .collect();
+        // SAFETY: `boxed` are live caller-owned words and `out` is the
+        // runtime's own zeroed completion storage.
+        let status = unsafe {
+            tcl_invoke_argv(
+                boxed.as_ptr(),
+                i32::try_from(boxed.len()).expect("stub argv fits i32"),
+                out,
+            )
+        };
+        assert_eq!(status, TCL_INVOKE_ABI_OK);
+        // SAFETY: balances `owned_word`'s reference on each word.
+        unsafe { release_words(&boxed) };
+        NATIVE_PROC_STATUS_RAN
+    }
+
+    /// A stub that declines before doing anything at all — the only shape a
+    /// decline may take, since the runtime then runs the source body in the
+    /// frame it already prepared.
+    unsafe extern "C" fn stub_declines(
+        _argv: *const *mut TclObj,
+        _argc: i32,
+        _out: *mut TclCompletionAbi,
+    ) -> i32 {
+        STUB_CALLS.with(|calls| calls.set(calls.get() + 1));
+        NATIVE_PROC_STATUS_DECLINED
+    }
+
+    /// The call an emitted module makes for a `proc` statement.
+    unsafe fn define_native(
+        name: &[u8],
+        params: &[u8],
+        body: &[u8],
+        entry: Option<NativeProcEntry>,
+    ) {
+        // SAFETY: all three ranges are live readable slices.
+        let code = unsafe {
+            tcl_codegen_proc_define_native(
+                name.as_ptr(),
+                i32::try_from(name.len()).expect("name fits i32"),
+                params.as_ptr(),
+                i32::try_from(params.len()).expect("params fit i32"),
+                body.as_ptr(),
+                i32::try_from(body.len()).expect("body fits i32"),
+                entry,
+            )
+        };
+        assert_eq!(code, 0, "defining {}", String::from_utf8_lossy(name));
+    }
+
+    /// Evaluate `script` and return its completion code and result text.
+    unsafe fn eval(interp: *mut Interp, script: &str) -> (Code, Vec<u8>) {
+        // SAFETY: the caller holds a live interpreter.
+        unsafe {
+            (
+                (*interp).eval_str(script.as_bytes()),
+                (*interp).result_bytes(),
+            )
+        }
+    }
+
+    /// A fresh interpreter, installed as the current one for the codegen ABI.
+    unsafe fn with_current_interp(body: impl FnOnce(*mut Interp)) {
+        let interp = tcl_runtime_create_interp();
+        // SAFETY: a live interpreter this helper owns for the call's duration.
+        unsafe {
+            tcl_runtime_set_current_interp(interp);
+            body(interp);
+            tcl_runtime_set_current_interp(ptr::null_mut());
+            tcl_runtime_delete_interp(interp);
+        }
+    }
+
+    #[test]
+    fn a_native_entry_runs_instead_of_the_source_body_and_is_counted() {
+        leak_free(|| unsafe {
+            with_current_interp(|interp| {
+                assert_eq!(tcl_codegen_native_proc_dispatches(), 0);
+                stub_argv(&[b"return", b"native"]);
+                define_native(b"p", b"a", b"return source", Some(stub_body));
+
+                assert_eq!(eval(interp, "p x"), (Code::Ok, b"native".to_vec()));
+                assert_eq!(stub_calls(), 1);
+                assert_eq!(tcl_codegen_native_proc_dispatches(), 1);
+
+                // The source body is still the proc's body: it is what a step
+                // trace forces, what a decline falls back to, and what
+                // introspection reports.
+                assert_eq!(eval(interp, "info body p").1, b"return source");
+                assert_eq!(eval(interp, "info args p").1, b"a");
+            });
+        });
+    }
+
+    #[test]
+    fn proc_register_is_proc_define_native_with_no_entry() {
+        leak_free(|| unsafe {
+            with_current_interp(|interp| {
+                let (name, params, body) = (b"only", b"a", b"return source");
+                assert_eq!(
+                    tcl_codegen_proc_register(
+                        name.as_ptr(),
+                        i32::try_from(name.len()).unwrap(),
+                        params.as_ptr(),
+                        i32::try_from(params.len()).unwrap(),
+                        body.as_ptr(),
+                        i32::try_from(body.len()).unwrap(),
+                    ),
+                    0
+                );
+                assert_eq!(eval(interp, "only x"), (Code::Ok, b"source".to_vec()));
+                assert_eq!(tcl_codegen_native_proc_dispatches(), 0);
+            });
+        });
+    }
+
+    #[test]
+    fn the_native_entry_runs_in_the_call_frame_run_proc_prepared() {
+        leak_free(|| unsafe {
+            with_current_interp(|interp| {
+                // `info level 0` is the double-frame detector: it reads the
+                // *current* frame's recorded invocation words, and only the
+                // frame `run_proc` pushed has any. An entry that pushed its
+                // own would report the wrong level and have no words at all.
+                stub_argv(&[b"info", b"level", b"0"]);
+                define_native(b"lvl", b"a b", b"return source", Some(stub_body));
+                assert_eq!(eval(interp, "lvl 7 8").1, b"lvl 7 8");
+
+                stub_argv(&[b"info", b"level"]);
+                define_native(b"depth", b"", b"return source", Some(stub_body));
+                assert_eq!(eval(interp, "depth").1, b"1");
+
+                // Formals are bound by name before the entry runs, so the body
+                // reads them as ordinary cells.
+                stub_argv(&[b"set", b"b"]);
+                define_native(b"second", b"a b", b"return source", Some(stub_body));
+                assert_eq!(eval(interp, "second 7 8").1, b"8");
+
+                // The body runs in the proc's defining namespace.
+                assert_eq!(eval(interp, "namespace eval ns {}").0, Code::Ok);
+                stub_argv(&[b"namespace", b"current"]);
+                define_native(b"ns::inner", b"", b"return source", Some(stub_body));
+                assert_eq!(eval(interp, "ns::inner").1, b"::ns");
+            });
+        });
+    }
+
+    #[test]
+    fn wrong_number_of_arguments_never_reaches_the_native_entry() {
+        // The message is `run_proc`'s, produced before any body runs, so the
+        // native and source paths cannot differ. tclsh 9.0.4 and 8.6.16 both
+        // print `wrong # args: should be "greet name"`.
+        leak_free(|| unsafe {
+            with_current_interp(|interp| {
+                stub_argv(&[b"return", b"native"]);
+                define_native(b"greet", b"name", b"return source", Some(stub_body));
+
+                assert_eq!(
+                    eval(interp, "greet"),
+                    (
+                        Code::Error,
+                        b"wrong # args: should be \"greet name\"".to_vec()
+                    )
+                );
+                assert_eq!(
+                    eval(interp, "greet a b"),
+                    (
+                        Code::Error,
+                        b"wrong # args: should be \"greet name\"".to_vec()
+                    )
+                );
+                assert_eq!(stub_calls(), 0, "the entry must never see a bad arity");
+                assert_eq!(tcl_codegen_native_proc_dispatches(), 0);
+            });
+        });
+    }
+
+    /// A multi-line body whose error carries a `(procedure ... line N)` frame.
+    const BOOM_BODY: &[u8] = b"\n    set b 1\n    error \"bad $a\"\n";
+
+    #[test]
+    fn a_declining_entry_falls_back_to_the_source_body_observably_unchanged() {
+        leak_free(|| unsafe {
+            with_current_interp(|interp| {
+                // The same proc, same name, same body — once with a
+                // declining entry and once with none. Comparing under one name
+                // is what makes the comparison total: the proc name appears in
+                // the `(procedure ...)` frame and in the caller's own.
+                stub_argv(&[]);
+                define_native(b"boom", b"a", BOOM_BODY, Some(stub_declines));
+                assert_eq!(eval(interp, "catch {boom Q} m o").1, b"1");
+                let declined_msg = eval(interp, "set m").1;
+                let declined_info = eval(interp, "dict get $o -errorinfo").1;
+                let declined_stack = eval(interp, "dict get $o -errorstack").1;
+                let declined_code = eval(interp, "dict get $o -errorcode").1;
+                assert_eq!(stub_calls(), 1, "the entry was asked, and declined");
+                assert_eq!(
+                    tcl_codegen_native_proc_dispatches(),
+                    0,
+                    "a decline is not a native run"
+                );
+
+                define_native(b"boom", b"a", BOOM_BODY, None);
+                assert_eq!(eval(interp, "catch {boom Q} m o").1, b"1");
+                assert_eq!(eval(interp, "set m").1, declined_msg);
+                assert_eq!(eval(interp, "dict get $o -errorinfo").1, declined_info);
+                assert_eq!(eval(interp, "dict get $o -errorstack").1, declined_stack);
+                assert_eq!(eval(interp, "dict get $o -errorcode").1, declined_code);
+
+                // And that shared answer is the interpreted one: tclsh 9.0.4
+                // and 8.6.16 print exactly these five lines.
+                assert_eq!(declined_msg, b"bad Q");
+                assert_eq!(
+                    String::from_utf8_lossy(&declined_info),
+                    "bad Q\n    while executing\n\"error \"bad $a\"\"\n    \
+                     (procedure \"boom\" line 3)\n    invoked from within\n\"boom Q\""
+                );
+            });
+        });
+    }
+
+    #[test]
+    fn redefining_the_proc_drops_the_native_entry() {
+        leak_free(|| unsafe {
+            with_current_interp(|interp| {
+                stub_argv(&[b"return", b"native"]);
+                define_native(b"twice", b"x", b"return source", Some(stub_body));
+                assert_eq!(eval(interp, "twice 4").1, b"native");
+                assert_eq!(tcl_codegen_native_proc_dispatches(), 1);
+
+                // The `proc` command builds a definition with no entry, so the
+                // new source body runs interpreted. Nothing invalidates
+                // anything: the entry lived on the definition that just went.
+                assert_eq!(
+                    eval(interp, "proc twice {x} {return redefined}").0,
+                    Code::Ok
+                );
+                assert_eq!(eval(interp, "twice 4").1, b"redefined");
+                assert_eq!(tcl_codegen_native_proc_dispatches(), 1);
+                assert_eq!(stub_calls(), 1);
+            });
+        });
+    }
+
+    #[test]
+    fn rename_carries_the_native_entry_and_deleting_the_proc_drops_it() {
+        leak_free(|| unsafe {
+            with_current_interp(|interp| {
+                stub_argv(&[b"return", b"native"]);
+                define_native(b"twice", b"x", b"return source", Some(stub_body));
+
+                assert_eq!(eval(interp, "rename twice thrice").0, Code::Ok);
+                assert_eq!(eval(interp, "thrice 4").1, b"native");
+                assert_eq!(tcl_codegen_native_proc_dispatches(), 1);
+                assert_eq!(eval(interp, "catch {twice 4} m"), (Code::Ok, b"1".to_vec()));
+                assert_eq!(eval(interp, "set m").1, b"invalid command name \"twice\"");
+
+                assert_eq!(eval(interp, "rename thrice {}").0, Code::Ok);
+                assert_eq!(eval(interp, "catch {thrice 4} m").1, b"1");
+                assert_eq!(eval(interp, "set m").1, b"invalid command name \"thrice\"");
+
+                // A whole namespace going away takes its definitions, and the
+                // entries on them, with it.
+                assert_eq!(eval(interp, "namespace eval ns {}").0, Code::Ok);
+                define_native(b"ns::inner", b"", b"return source", Some(stub_body));
+                assert_eq!(eval(interp, "ns::inner").1, b"native");
+                assert_eq!(eval(interp, "namespace delete ns").0, Code::Ok);
+                assert_eq!(eval(interp, "catch {ns::inner} m").1, b"1");
+                assert_eq!(
+                    eval(interp, "set m").1,
+                    b"invalid command name \"ns::inner\""
+                );
+                assert_eq!(tcl_codegen_native_proc_dispatches(), 2);
+            });
+        });
+    }
+
+    #[test]
+    fn a_live_step_trace_forces_the_source_body() {
+        // A natively lowered `set`/`list`/`return` never reaches `dispatch`,
+        // so it would fire no `enterstep` and the transcript would silently
+        // lose lines. `dispatch_traced` installs the proc's own step traces
+        // before dispatching, so one read of `step_active` in `run_proc`
+        // covers both this proc's traces and an outer one's.
+        //
+        // Transcript pinned against tclsh 9.0.4 and 8.6.16: step traces fire
+        // on the *substituted* command, after its `[...]` words have run.
+        leak_free(|| unsafe {
+            with_current_interp(|interp| {
+                stub_argv(&[b"return", b"NATIVE"]);
+                define_native(
+                    b"stepped",
+                    b"x",
+                    b"set y $x; return [list $y $y]",
+                    Some(stub_body),
+                );
+                assert_eq!(eval(interp, "stepped ab").1, b"NATIVE");
+                assert_eq!(tcl_codegen_native_proc_dispatches(), 1);
+
+                assert_eq!(
+                    eval(
+                        interp,
+                        "trace add execution stepped enterstep \
+                         {apply {{cmd op} {lappend ::steps $cmd}}}"
+                    )
+                    .0,
+                    Code::Ok
+                );
+                assert_eq!(
+                    eval(interp, "stepped ab").1,
+                    b"ab ab",
+                    "the traced call must run the source body"
+                );
+                assert_eq!(
+                    eval(interp, "set ::steps").1,
+                    b"{set y ab} {list ab ab} {return {ab ab}}"
+                );
+                assert_eq!(
+                    tcl_codegen_native_proc_dispatches(),
+                    1,
+                    "the traced call must have run the source body"
+                );
+                assert_eq!(stub_calls(), 1);
+
+                // Removing the trace restores the compiled body.
+                assert_eq!(
+                    eval(
+                        interp,
+                        "trace remove execution stepped enterstep \
+                         {apply {{cmd op} {lappend ::steps $cmd}}}"
+                    )
+                    .0,
+                    Code::Ok
+                );
+                assert_eq!(eval(interp, "stepped ab").1, b"NATIVE");
+                assert_eq!(tcl_codegen_native_proc_dispatches(), 2);
+            });
+        });
+    }
+
+    /// An error out of a compiled body takes `run_proc`'s ordinary error tail
+    /// — with the two gaps a compiled statement's missing `log_command_info`
+    /// leaves, both pinned here so PR-B's fix has a gate that fails in both
+    /// directions.
+    #[test]
+    fn an_error_from_the_native_body_unwinds_through_the_procedure_frame() {
+        leak_free(|| unsafe {
+            with_current_interp(|interp| {
+                stub_argv(&[b"error", b"bad Q"]);
+                define_native(b"boom", b"a", BOOM_BODY, Some(stub_body));
+
+                assert_eq!(eval(interp, "catch {boom Q} m o").1, b"1");
+                assert_eq!(eval(interp, "set m").1, b"bad Q");
+                // `run_proc`'s error tail is shared by both bodies: the
+                // `(procedure ...)` frame and the TIP 348 `CALL` entry are
+                // appended exactly as they are for the source body.
+                let info = eval(interp, "dict get $o -errorinfo").1;
+                assert!(
+                    info.starts_with(b"bad Q"),
+                    "errorInfo seeds from the message: {}",
+                    String::from_utf8_lossy(&info)
+                );
+                assert!(
+                    info.windows(26)
+                        .any(|w| w == b"(procedure \"boom\" line 1)\n"),
+                    "errorInfo must carry the procedure frame: {}",
+                    String::from_utf8_lossy(&info)
+                );
+                // LEDGERED (#1774 step 6, PR-B). A compiled statement calls
+                // no `log_command_info`, and that one absence has two visible
+                // consequences here, both closed by `tcl_codegen_log_command`
+                // once the emitter calls it on a statement's error edge:
+                //
+                //  - no `while executing "<source text>"` frame, and
+                //    `error_line` never advances, so the procedure frame reads
+                //    `line 1` where the interpreted body reads `line 3`;
+                //  - no TIP 348 `CALL` entry either. `error_stack_push_call`
+                //    still runs, but it deliberately refuses to chain a `CALL`
+                //    onto an error stack with no inner context yet
+                //    (`reset_error_stack`), so the errorstack holds only the
+                //    caller's own `INNER`.
+                assert!(
+                    !info.windows(16).any(|w| w == b"while executing "),
+                    "unexpected `while executing` frame: {}",
+                    String::from_utf8_lossy(&info)
+                );
+                assert_eq!(eval(interp, "dict get $o -errorstack").1, b"INNER {boom Q}");
+            });
+        });
+    }
+
+    #[test]
+    fn the_native_path_holds_one_activation_per_level_and_refuses_at_the_bound() {
+        // `run_native_body` holds the activation the eval loop would hold, and
+        // the body's own `tcl_invoke_argv` holds one more: two eval-depth
+        // units per Tcl level, the same as the interpreted plain-recursion
+        // shape. A level that cost more would fail sooner and one that cost
+        // less would fail later, so the reached depth pins the accounting.
+        leak_free(|| unsafe {
+            with_current_interp(|interp| {
+                stub_argv(&[b"recur"]);
+                define_native(b"recur", b"", b"return source", Some(stub_body));
+
+                assert_eq!(eval(interp, "catch {recur} m").1, b"1");
+                assert_eq!(
+                    eval(interp, "set m").1,
+                    b"too many nested evaluations (infinite loop?)",
+                    "the refusal is the eval loop's own message"
+                );
+                assert_eq!(
+                    tcl_codegen_native_proc_dispatches(),
+                    63,
+                    "the outermost script and the `catch` body cost one \
+                     eval-depth unit each, leaving 126 of the native bound's \
+                     128 for 63 levels at two apiece"
+                );
+            });
+        });
+    }
+
+    #[test]
+    fn the_dispatch_counter_reports_a_missing_interpreter_distinctly() {
+        tcl_runtime_set_current_interp(ptr::null_mut());
+        assert_eq!(tcl_codegen_native_proc_dispatches(), -1);
     }
 }

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -5098,6 +5098,24 @@ impl Interp {
     /// the first frame, truncates the command to 150 bytes (`...` on overflow),
     /// and sets `already_logged`.
     fn log_command_info(&mut self, src: &[u8], cmd: &parse::Command) {
+        // The same guard [`log_command_bytes`] applies. Repeated here so the
+        // already-logged path — the common one on a deep unwind — skips the
+        // newline scan `line_of` costs.
+        if self.exc.borrow().already_logged {
+            return;
+        }
+        self.log_command_bytes(line_of(src, cmd.start), &src[cmd.start..cmd.end]);
+    }
+
+    /// [`log_command_info`](Self::log_command_info) over the command's bytes
+    /// and its 1-based line within the enclosing script.
+    ///
+    /// The one implementation of C's `TclLogCommandInfo`, shared by the eval
+    /// loop and by `tcl_codegen_log_command` — so `error_line` keeps its
+    /// single writer, and a compiled statement gets the identical
+    /// `already_logged` protocol, error-stack entry, and 150-byte truncation
+    /// rather than a second, drifting copy of them.
+    pub(crate) fn log_command_bytes(&mut self, raw_line: u32, cmd_bytes: &[u8]) {
         // Already logged deeper in the same script (e.g. an inner `[cmd]` subst,
         // or an inline `if`/`while` body): the enclosing command is the same C
         // bytecode frame, so it is *not* re-logged. The flag stays set and is
@@ -5108,16 +5126,17 @@ impl Interp {
         }
         // TIP 348: record this frame's inner context / uplevel boundary into the
         // error stack (the errorStack half of C's `Tcl_LogCommandInfo`).
-        self.error_stack_log(&src[cmd.start..cmd.end]);
+        self.error_stack_log(cmd_bytes);
         // errorLine, measured against the enclosing `codePtr->source` (C's
         // `TclLogCommandInfo`): the command's file-absolute line
         // (`line_base + 1 + count('\n')`) minus the proc/eval body's base, so an
         // inline `catch`/`if` body's commands still report their proc-body line.
         // This is the *only* writer of `error_line`; it persists across `catch`
         // and a subsequent `error msg info`.
-        let raw = line_of(src, cmd.start);
-        let line = self.cmd_frames.borrow().last().map_or(raw, |f| {
-            (f.line_base + raw).saturating_sub(f.proc_line_base).max(1)
+        let line = self.cmd_frames.borrow().last().map_or(raw_line, |f| {
+            (f.line_base + raw_line)
+                .saturating_sub(f.proc_line_base)
+                .max(1)
         });
         self.error_line.set(line);
         let started = self.exc.borrow().info.is_some();
@@ -5131,7 +5150,6 @@ impl Interp {
         } else {
             b"while executing"
         };
-        let cmd_bytes = &src[cmd.start..cmd.end];
         let overflow = cmd_bytes.len() > 150;
         let slice = if overflow {
             &cmd_bytes[..150]

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -41,6 +41,7 @@ use std::cell::{Cell, RefCell};
 use std::rc::{Rc, Weak};
 
 use tcl_core_types::RecursionLimit;
+use tcl_runtime_api::codegen_abi::NATIVE_PROC_STATUS_DECLINED;
 use tcl_runtime_api::guard::{
     GuardDomain, GuardDomains, GuardError, GuardIdentity, GuardManager, GuardToken,
 };
@@ -213,6 +214,10 @@ pub(crate) struct CallMeta<'a> {
     /// `apply`/TclOO whose `usage_called`/`usage_prefix` is a pre-joined
     /// multi-word string (`apply lambdaExpr`, `obj method`) that must stay raw.
     pub quote_name: bool,
+    /// The compiled body to run instead of the source one, from
+    /// [`ProcDef::native`]. `None` for `apply` and every TclOO method: only a
+    /// `proc` definition can carry a compiled body.
+    pub native: Option<NativeProcEntry>,
 }
 
 /// One entry of the source-location stack (`cmdFramePtr`; PC-5) — the runtime
@@ -657,7 +662,56 @@ pub struct ProcDef {
     /// an eval-defined proc, or the defining file line minus one for one defined
     /// in a `source`d file (so its commands report file-absolute lines).
     pub body_line_base: u32,
+    /// The compiled body, when a generated module supplied one
+    /// (`tcl_codegen_proc_define_native`). `None` — the only value the `proc`
+    /// command ever produces — means the source `body` is the only body.
+    ///
+    /// It lives *on the definition*, not in a side table, so every existing
+    /// lifecycle rule already covers it: redefining the proc builds a fresh
+    /// `ProcDef` with `native: None` and the new source body runs interpreted;
+    /// `rename` clones the definition and carries the entry with it;
+    /// `rename p ""` / `namespace delete` drop it with the definition. Nothing
+    /// has to remember to invalidate anything.
+    pub native: Option<NativeProcEntry>,
 }
+
+/// The entry point of a natively lowered proc body — a wasm32 function-table
+/// index on the emitted side, an ordinary function pointer here.
+///
+/// `argv`/`argc` are the bound call arguments. P5-lite bodies do not read them
+/// (they read their formals as named cells, which `run_proc` has already
+/// bound); they are the reserved seam for P5's native formal binder. `out` is
+/// caller-provided, zeroed completion storage — the same [`TclCompletionAbi`]
+/// layout `tcl_invoke_argv` writes in the other direction.
+///
+/// # The frame contract, which only this comment can settle
+///
+/// A native proc entry pushes **neither** an activation **nor** a Tcl call
+/// frame. [`Interp::run_proc`] has already pushed the variable frame in the
+/// proc's own namespace, recorded `info level`'s words and bound the formals
+/// by name, and [`Interp::run_native_body`] holds the compiled activation and
+/// the `CmdFrame` for the body. This is *not* the shape a native-tier function
+/// has when it is emitted as a stand-alone module function: that shape opens
+/// with `tcl_codegen_activation_enter` + `tcl_codegen_frame_push`
+/// (`pushes_frame = !top_level`), and reusing it here would push a second,
+/// nameless frame at the caller's namespace — `namespace current`, `upvar 1`
+/// and `info level` would all be off by one level. The emitter must therefore
+/// give a proc entry its own prologue-free shape; it may not reuse the
+/// module-function one.
+///
+/// Result: [`NATIVE_PROC_STATUS_RAN`] after writing `out` with one owned
+/// reference on each non-null pointer, or [`NATIVE_PROC_STATUS_DECLINED`]
+/// **before any observable effect**, leaving `out` untouched.
+///
+/// # Safety
+/// The implementation must respect the whole contract above: `argv[..argc]`
+/// are borrowed live objects it must not release, and on `RAN` it transfers
+/// one owned reference on `out.result` and `out.options` to the runtime.
+pub type NativeProcEntry = unsafe extern "C" fn(
+    argv: *const *mut TclObj,
+    argc: i32,
+    out: *mut crate::codegen_abi::TclCompletionAbi,
+) -> i32;
 
 /// A `Tcl_Interp` handle. Cheap to clone (an `Rc` bump); all clones share one
 /// [`InterpState`].
@@ -817,6 +871,14 @@ pub struct InterpState {
     var_trace_epoch: Cell<u64>,
     /// Count of commands dispatched (`info cmdcount`).
     cmd_count: Cell<u64>,
+    /// Count of proc bodies run through a native entry
+    /// ([`NativeProcEntry`]) rather than the source body.
+    ///
+    /// A test boundary, like the codegen ABI's outstanding-call-frame ledger:
+    /// the two paths produce identical Tcl results by construction, so without
+    /// a counter no test can tell which one ran, and a binding regression
+    /// would pass every behavioural assertion silently.
+    native_proc_dispatches: Cell<u64>,
     /// The code an `exit` requested, if any. `exit` does **not** terminate the
     /// host process (that would kill the embedding LSP/analysis server); it
     /// records the code here, unwinds uncatchably (`catch` re-propagates while it
@@ -1194,6 +1256,7 @@ impl Interp {
             eval_depth: Cell::new(0),
             var_trace_epoch: Cell::new(1),
             cmd_count: Cell::new(0),
+            native_proc_dispatches: Cell::new(0),
             exit_code: Cell::new(None),
             measure_overhead: Cell::new(0.0),
             bgerror: RefCell::new(Vec::new()),
@@ -2068,6 +2131,25 @@ impl Interp {
     /// `name` lands in — **relative to the current namespace** (so `proc next`
     /// inside `namespace eval counter` binds `::counter::next`, not a global).
     pub(crate) fn define_proc(&mut self, name: &[u8], params: Vec<Param>, body_obj: *mut TclObj) {
+        self.define_proc_native(name, params, body_obj, None);
+    }
+
+    /// [`define_proc`](Self::define_proc) with a compiled body entry.
+    ///
+    /// The one funnel that builds a [`ProcDef`] field by field, so `native` has
+    /// exactly one origin: a generated module's
+    /// `tcl_codegen_proc_define_native`. Every other construction site clones
+    /// an existing definition (`rename`'s re-homing, TclOO's namespace copy)
+    /// and carries the entry along with it; the `proc` command reaches this
+    /// through [`define_proc`](Self::define_proc) with `None`, which is what
+    /// makes a redefinition drop back to the source body.
+    pub(crate) fn define_proc_native(
+        &mut self,
+        name: &[u8],
+        params: Vec<Param>,
+        body_obj: *mut TclObj,
+        native: Option<NativeProcEntry>,
+    ) {
         self.invalidate_command_environment();
         let body = obj_bytes(body_obj);
         let ns = self
@@ -2106,6 +2188,7 @@ impl Interp {
             fqn: fqn.clone(),
             source,
             body_line_base,
+            native,
         });
         self.bind_command_replacement(ns, &tail, Command::Proc(def));
     }
@@ -7575,6 +7658,7 @@ impl Interp {
                 usage_prefix: None,
                 level_words: None,
                 quote_name: true,
+                native: def.native,
             },
         )
     }
@@ -7730,7 +7814,34 @@ impl Interp {
             oo,
             lambda,
         };
-        let code = self.eval_framed(body, proc_frame);
+        // Run the compiled body when there is one, else the source body. The
+        // two are interchangeable here precisely because everything a body can
+        // observe about its call — the variable frame, its namespace, `info
+        // level`'s words, the bound formals, `wrong # args` — was decided
+        // above, and everything about its completion is decided below.
+        //
+        // Two things force the source body even when a compiled one exists:
+        //
+        // - a live step trace. `dispatch_traced` installs this proc's own
+        //   `enterstep`/`leavestep` into `step_active` *before* dispatching, so
+        //   one read covers both "this proc is step-traced" and "an outer step
+        //   trace is running". A natively lowered `set`/`incr`/`expr` never
+        //   reaches `dispatch`, so it would fire no step trace and the
+        //   transcript would silently lose lines. `enter`/`leave` traces need
+        //   nothing: they fire around the whole call either way.
+        // - the entry declining, which it may only do before any observable
+        //   effect, so falling through to the source body is not a partial
+        //   re-run.
+        let native = meta
+            .native
+            .filter(|_| self.traces.borrow().step_active.is_empty());
+        let code = match native {
+            Some(entry) => match self.run_native_body(entry, call_args, proc_frame) {
+                Ok(code) => code,
+                Err(frame) => self.eval_framed(body, *frame),
+            },
+            None => self.eval_framed(body, proc_frame),
+        };
         // The frame's local variables (and any traces on them) die with it.
         let proc_level = self.frames.borrow().current_level();
         // Capture `[info level 0]` (the invocation words) before the frame is
@@ -7792,6 +7903,87 @@ impl Interp {
             }
         }
         settled
+    }
+
+    /// Run a proc's **compiled** body in the call frame
+    /// [`run_proc`](Self::run_proc) has already prepared — the native-tier
+    /// mirror of [`eval_framed`](Self::eval_framed) +
+    /// [`eval_script_mode`](Self::eval_script_mode), minus the parse and the
+    /// command loop.
+    ///
+    /// Ownership, stated here because the emitted side has to match it
+    /// exactly: `run_proc` owns the Tcl variable frame, `info level`'s words
+    /// and the formal binding; this method owns the compiled activation and
+    /// the body's `CmdFrame`; the entry owns **neither** (see
+    /// [`NativeProcEntry`]).
+    ///
+    /// `Ok(code)` is the body's raw completion — `2` for a body-level
+    /// `return`, exactly as the interpreted body reports it, so `run_proc`'s
+    /// `settle_return` cannot tell the two apart. `Err(frame)` is a decline:
+    /// nothing observable happened, and the untouched frame comes back so the
+    /// source body can run in it. Handing the frame back rather than cloning
+    /// it up front keeps the common path allocation-free; the box is what
+    /// keeps a rarely-taken `Err` from widening every return of this function.
+    fn run_native_body(
+        &mut self,
+        entry: NativeProcEntry,
+        call_args: &[*mut TclObj],
+        mut frame: CmdFrame,
+    ) -> Result<Code, Box<CmdFrame>> {
+        // A freshly pushed frame is its own `codePtr->source`, so `errorLine`
+        // is measured from this body's base (`eval_framed`).
+        frame.proc_line_base = frame.line_base;
+        // The activation the eval loop would hold for this body. A refusal is
+        // `eval_script_mode`'s: the error is already set, no activation is
+        // held, and nothing has been pushed, so `run_proc`'s ordinary error
+        // tail is exactly right — including the `(procedure "p" line N)` frame.
+        if !self.codegen_activation_enter() {
+            return Ok(Code::Error);
+        }
+        self.cmd_frames.borrow_mut().push(frame);
+        let mut out = crate::codegen_abi::TclCompletionAbi {
+            code: 0,
+            result: core::ptr::null_mut(),
+            options: core::ptr::null_mut(),
+        };
+        let argc = i32::try_from(call_args.len()).unwrap_or(i32::MAX);
+        // SAFETY: `entry` was supplied by a generated module through
+        // `tcl_codegen_proc_define_native`; `argv[..argc]` are the live bound
+        // call arguments it borrows; `out` is live, zeroed completion storage.
+        let status = unsafe { entry(call_args.as_ptr(), argc, core::ptr::from_mut(&mut out)) };
+        let popped = self.cmd_frames.borrow_mut().pop();
+        if status == NATIVE_PROC_STATUS_DECLINED {
+            self.codegen_activation_leave(Code::Ok);
+            return Err(Box::new(
+                popped.expect("the CmdFrame this method just pushed"),
+            ));
+        }
+        // Counted here, not before the call: a decline is not a native run.
+        self.native_proc_dispatches
+            .set(self.native_proc_dispatches.get().saturating_add(1));
+        let code = Code::from_int(out.code);
+        if !out.result.is_null() {
+            // `set_result` takes the interpreter's own reference, so the
+            // entry's is released after the store rather than transferred.
+            self.set_result(out.result);
+            // SAFETY: the entry transferred one owned reference on `result`.
+            unsafe { obj::decr_ref_count(out.result) };
+        }
+        if !out.options.is_null() {
+            // The options dict is a snapshot of state the runtime already
+            // holds: `return`'s `-code`/`-level` were recorded by the `return`
+            // command when the body invoked it, and `settle_return` below
+            // reads those, not this dict. So it is released, never consulted.
+            // SAFETY: the entry transferred one owned reference on `options`.
+            unsafe { obj::decr_ref_count(out.options) };
+        }
+        self.codegen_activation_leave(code);
+        Ok(code)
+    }
+
+    /// The number of proc bodies dispatched through a [`NativeProcEntry`].
+    pub(crate) fn native_proc_dispatches(&self) -> u64 {
+        self.native_proc_dispatches.get()
     }
 
     /// The ensemble trampoline: resolve `argv[1]` against the subcommand set

--- a/rust/tcl-compiler/src/codegen/wasm/ir.rs
+++ b/rust/tcl-compiler/src/codegen/wasm/ir.rs
@@ -42,6 +42,8 @@ const WASM_MAGIC: [u8; 4] = [0x00, 0x61, 0x73, 0x6D];
 const WASM_VERSION: [u8; 4] = [0x01, 0x00, 0x00, 0x00];
 /// Block type for a structured op that yields no value (`block`/`loop`/`if`).
 const BLOCK_VOID: u8 = 0x40;
+/// The runtime's shared function table, spelled once by `tcl-runtime-api`.
+const FUNCTION_TABLE_IMPORT: &str = tcl_runtime_api::codegen_abi::WASM32_FUNCTION_TABLE_IMPORT;
 
 /// WASM value types (their binary encoding bytes).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -175,7 +177,26 @@ pub enum WasmOp {
     F64Mul = 0xA2,
     F64Div = 0xA3,
     F64ConvertI64S = 0xB9,
+    /// `ref.null <heaptype>` — the operand byte is the heap type
+    /// (`0x70` funcref). Build it with [`WasmInstruction::ref_null_func`].
+    RefNull = 0xD0,
+    /// `ref.func <funcidx>` — a first-class reference to a function, which the
+    /// module installs into the runtime's shared table. The function must be
+    /// *declared*: exported, or listed in [`WasmModule::elem_declared`].
+    RefFunc = 0xD2,
+    /// `table.set <tableidx>`.
+    TableSet = 0x26,
+    /// `table.grow <tableidx>` — a **`0xFC`-prefixed** opcode. `WasmOp` is one
+    /// byte, so the discriminant is the `0xFC` prefix alone and the operand
+    /// bytes carry the sub-opcode (`0x0F`) ahead of the table index. Build it
+    /// with [`WasmInstruction::table_grow`], never by hand.
+    TableGrow = 0xFC,
 }
+
+/// The `0xFC` sub-opcode for `table.grow`.
+const TABLE_GROW_SUBOPCODE: u8 = 0x0F;
+/// The `funcref` heap type, as `ref.null`'s operand and in a table type.
+const HEAPTYPE_FUNCREF: u8 = 0x70;
 
 impl WasmOp {
     /// The WAT mnemonic (`i64.add`, `br_if`, `local.get`, …).
@@ -262,6 +283,10 @@ impl WasmOp {
             Self::F64Mul => "f64.mul",
             Self::F64Div => "f64.div",
             Self::F64ConvertI64S => "f64.convert_i64_s",
+            Self::RefNull => "ref.null",
+            Self::RefFunc => "ref.func",
+            Self::TableSet => "table.set",
+            Self::TableGrow => "table.grow",
         }
     }
 
@@ -308,6 +333,33 @@ impl WasmInstruction {
             range: None,
             label: None,
         }
+    }
+
+    /// `ref.null func` — the null funcref `table.grow` fills new slots with.
+    #[must_use]
+    pub fn ref_null_func() -> Self {
+        Self::with_operands(WasmOp::RefNull, vec![HEAPTYPE_FUNCREF])
+    }
+
+    /// `ref.func <func>` — a reference to a defined function.
+    #[must_use]
+    pub fn ref_func(func: u32) -> Self {
+        Self::with_operands(WasmOp::RefFunc, leb128_unsigned(u64::from(func)))
+    }
+
+    /// `table.set <table>`.
+    #[must_use]
+    pub fn table_set(table: u32) -> Self {
+        Self::with_operands(WasmOp::TableSet, leb128_unsigned(u64::from(table)))
+    }
+
+    /// `table.grow <table>` — the one constructor for the `0xFC`-prefixed
+    /// encoding, so no caller has to know the sub-opcode goes in the operands.
+    #[must_use]
+    pub fn table_grow(table: u32) -> Self {
+        let mut operands = vec![TABLE_GROW_SUBOPCODE];
+        operands.extend(leb128_unsigned(u64::from(table)));
+        Self::with_operands(WasmOp::TableGrow, operands)
     }
 
     /// The opcode byte followed by its operand bytes.
@@ -394,6 +446,61 @@ pub struct WasmImport {
     pub type_idx: usize,
 }
 
+/// A module-level global's constant initialiser.
+///
+/// Only integer globals are representable, which is all this backend emits:
+/// making the initialiser carry its own type is what stops a `ValType` and an
+/// `i64` from disagreeing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GlobalInit {
+    /// `(i32.const n)`.
+    I32(i32),
+    /// `(i64.const n)`.
+    I64(i64),
+}
+
+impl GlobalInit {
+    /// The global's value type.
+    #[must_use]
+    pub fn val_type(self) -> ValType {
+        match self {
+            Self::I32(_) => ValType::I32,
+            Self::I64(_) => ValType::I64,
+        }
+    }
+
+    /// The constant-expression bytes, `end` included.
+    fn encode(self) -> Vec<u8> {
+        let (op, value) = match self {
+            Self::I32(n) => (WasmOp::I32Const, i64::from(n)),
+            Self::I64(n) => (WasmOp::I64Const, n),
+        };
+        let mut out = vec![op as u8];
+        out.extend(leb128_signed(value));
+        out.push(WasmOp::End as u8);
+        out
+    }
+
+    /// The WAT initialiser, e.g. `(i32.const -1)`.
+    fn to_wat(self) -> String {
+        match self {
+            Self::I32(n) => format!("(i32.const {n})"),
+            Self::I64(n) => format!("(i64.const {n})"),
+        }
+    }
+}
+
+/// A module-level global.
+#[derive(Debug, Clone)]
+pub struct WasmGlobal {
+    /// Name, for WAT rendering only (globals are addressed by index).
+    pub name: String,
+    /// Whether `global.set` may write it.
+    pub mutable: bool,
+    /// The constant initialiser, which also fixes the value type.
+    pub init: GlobalInit,
+}
+
 /// A data segment (string constant pool entry).
 #[derive(Debug, Clone)]
 pub struct WasmData {
@@ -416,6 +523,25 @@ pub struct WasmModule {
     pub memory_pages: u64,
     /// Import linear memory from the runtime rather than defining our own.
     pub import_memory: bool,
+    /// Import the runtime's shared function table
+    /// (`WASM32_FUNCTION_TABLE_IMPORT`) rather than defining our own.
+    ///
+    /// Off by default, and deliberately opt-in per module rather than implied
+    /// by `import_memory`: a runtime linked without `--export-table` cannot
+    /// satisfy the import at all, and instantiation fails hard with `unknown
+    /// import`. So a module asks for the table only when it installs something
+    /// in it, and every module that does not keeps loading against an older
+    /// runtime.
+    pub import_table: bool,
+    /// Module-level globals, in index order.
+    pub globals: Vec<WasmGlobal>,
+    /// Function indices declared by a **declarative** element segment, which
+    /// is what makes them legal `ref.func` operands.
+    ///
+    /// An exported function is already declared, so this is belt and braces
+    /// for the table install — but it is the cheap half: un-exporting a
+    /// function later would otherwise silently invalidate the module.
+    pub elem_declared: Vec<u32>,
     /// Interned function signatures `(params, results)`, in type-index order.
     types: Vec<(Vec<ValType>, Vec<ValType>)>,
 }
@@ -547,7 +673,7 @@ impl WasmModule {
         // a module that only needs runtime memory (e.g. for data segments)
         // must still declare it, or it references memory 0 undefined and
         // fails validation.
-        if !self.imports.is_empty() || self.import_memory {
+        if !self.imports.is_empty() || self.import_memory || self.import_table {
             let mut entries: Vec<Vec<u8>> = self
                 .imports
                 .iter()
@@ -565,6 +691,18 @@ impl WasmModule {
                 e.push(0x02); // memory import
                 e.push(0x00); // limits: no maximum
                 e.extend(leb128_unsigned(self.memory_pages));
+                entries.push(e);
+            }
+            if self.import_table {
+                // A minimum of 0 with no maximum, so the import matches any
+                // table the runtime actually links: import matching only needs
+                // the real table to be at least this big.
+                let mut e = encode_string("tcl");
+                e.extend(encode_string(FUNCTION_TABLE_IMPORT));
+                e.push(0x01); // table import
+                e.push(HEAPTYPE_FUNCREF);
+                e.push(0x00); // limits: no maximum
+                e.extend(leb128_unsigned(0));
                 entries.push(e);
             }
             sections.extend(Self::make_section(
@@ -604,6 +742,24 @@ impl WasmModule {
             sections.extend(Self::make_section(SectionId::Memory, &mem));
         }
 
+        // Global section (id 6, so between Memory and Export).
+        if !self.globals.is_empty() {
+            let entries: Vec<Vec<u8>> = self
+                .globals
+                .iter()
+                .map(|global| {
+                    let mut e = vec![global.init.val_type() as u8];
+                    e.push(u8::from(global.mutable));
+                    e.extend(global.init.encode());
+                    e
+                })
+                .collect();
+            sections.extend(Self::make_section(
+                SectionId::Global,
+                &encode_vector(&entries),
+            ));
+        }
+
         // Export section.
         let mut exports: Vec<Vec<u8>> = Vec::new();
         if !self.import_memory {
@@ -625,6 +781,23 @@ impl WasmModule {
             sections.extend(Self::make_section(
                 SectionId::Export,
                 &encode_vector(&exports),
+            ));
+        }
+
+        // Element section (id 9, so between Export and Code): one declarative
+        // segment naming every function a `ref.func` may name.
+        if !self.elem_declared.is_empty() {
+            let indices: Vec<Vec<u8>> = self
+                .elem_declared
+                .iter()
+                .map(|&index| leb128_unsigned(u64::from(index)))
+                .collect();
+            let mut segment = vec![0x03u8]; // declarative, with an elemkind
+            segment.push(0x00); // elemkind: funcref
+            segment.extend(encode_vector(&indices));
+            sections.extend(Self::make_section(
+                SectionId::Element,
+                &encode_vector(&[segment]),
             ));
         }
 
@@ -706,6 +879,31 @@ impl WasmModule {
                 "  (memory (export \"memory\") {})",
                 self.memory_pages
             ));
+        }
+
+        if self.import_table {
+            lines.push(format!(
+                "  (import \"tcl\" \"{FUNCTION_TABLE_IMPORT}\" (table 0 funcref))"
+            ));
+        }
+
+        for global in &self.globals {
+            let ty = global.init.val_type().wat_name();
+            let ty = if global.mutable {
+                format!("(mut {ty})")
+            } else {
+                ty.to_owned()
+            };
+            lines.push(format!(
+                "  (global ${} {ty} {})",
+                global.name,
+                global.init.to_wat()
+            ));
+        }
+
+        if !self.elem_declared.is_empty() {
+            let indices: Vec<String> = self.elem_declared.iter().map(ToString::to_string).collect();
+            lines.push(format!("  (elem declare func {})", indices.join(" ")));
         }
 
         for func in &self.functions {
@@ -804,7 +1002,9 @@ fn format_wat_instr(instr: &WasmInstruction, indent: usize) -> String {
         | WasmOp::GlobalSet
         | WasmOp::Call
         | WasmOp::Br
-        | WasmOp::BrIf => {
+        | WasmOp::BrIf
+        | WasmOp::RefFunc
+        | WasmOp::TableSet => {
             if instr.operands.is_empty() {
                 format!("{prefix}{name}")
             } else {
@@ -839,6 +1039,15 @@ fn format_wat_instr(instr: &WasmInstruction, indent: usize) -> String {
             Some(offset) => format!("{prefix}{name} offset={offset}"),
             None => format!("{prefix}{name}"),
         },
+        // The `0xFC` sub-opcode leads the operands; only the table index
+        // after it carries information.
+        WasmOp::TableGrow => match instr.operands.get(1..) {
+            Some(table) if !table.is_empty() => {
+                format!("{prefix}{name} {}", decode_leb128_unsigned(table))
+            }
+            _ => format!("{prefix}{name}"),
+        },
+        WasmOp::RefNull => format!("{prefix}{name} func"),
         WasmOp::Block | WasmOp::Loop | WasmOp::If => {
             // Only the void block type is emitted by this backend.
             if instr.operands.first() == Some(&BLOCK_VOID) || instr.operands.is_empty() {
@@ -1021,6 +1230,164 @@ mod tests {
         );
         // Idempotent: serialising again neither grows nor reorders the table.
         assert_eq!(m.type_section(), m.types);
+    }
+
+    /// A module shaped like the one issue #1774 emits: it imports the
+    /// runtime's table, keeps the grown base in a global, and declares the
+    /// function it installs.
+    fn table_install_module() -> WasmModule {
+        let mut m = WasmModule::new();
+        m.import_table = true;
+        m.globals.push(WasmGlobal {
+            name: "table_base".into(),
+            mutable: true,
+            init: GlobalInit::I32(-1),
+        });
+        m.functions.push(WasmFunction {
+            name: "::p".into(),
+            params: vec![],
+            results: vec![],
+            locals: vec![],
+            body: vec![
+                WasmInstruction::ref_null_func(),
+                WasmInstruction::with_operands(WasmOp::I32Const, leb128_signed(1)),
+                WasmInstruction::table_grow(0),
+                WasmInstruction::with_operands(WasmOp::GlobalSet, leb128_unsigned(0)),
+                WasmInstruction::with_operands(WasmOp::GlobalGet, leb128_unsigned(0)),
+                WasmInstruction::ref_func(0),
+                WasmInstruction::table_set(0),
+            ],
+            local_names: vec![],
+            // Deliberately *not* exported, so the declarative element segment
+            // is the only thing making `ref.func 0` legal.
+            exported: false,
+            source_range: None,
+            kind: "proc".into(),
+        });
+        m.elem_declared.push(0);
+        m
+    }
+
+    #[test]
+    fn a_table_installing_module_emits_its_sections_in_ascending_id_order() {
+        let mut m = table_install_module();
+        let bytes = m.to_bytes();
+        let mut seen = Vec::new();
+        let mut i = 8;
+        while i < bytes.len() {
+            let id = bytes[i];
+            let (len, adv) = read_uleb(&bytes[i + 1..]);
+            seen.push(id);
+            i += 1 + adv + len as usize;
+        }
+        // Type(1), Import(2), Function(3), Global(6), Element(9), Code(10).
+        // Global must precede Export and Element must precede Code, or the
+        // module is rejected before any of it runs.
+        assert_eq!(seen, vec![1, 2, 3, 6, 9, 10], "section ids: {seen:?}");
+    }
+
+    #[test]
+    fn the_table_import_matches_any_runtime_table() {
+        let mut m = table_install_module();
+        let bytes = m.to_bytes();
+        // module "tcl", name, 0x01 table, 0x70 funcref, 0x00 no-max, min 0.
+        let mut needle = encode_string("tcl");
+        needle.extend(encode_string(FUNCTION_TABLE_IMPORT));
+        needle.extend([0x01, 0x70, 0x00, 0x00]);
+        assert!(
+            bytes.windows(needle.len()).any(|w| w == needle),
+            "table import must declare `funcref`, no maximum, and a minimum of \
+             0 so it matches whatever the runtime linked"
+        );
+        assert!(m.to_wat().contains(&format!(
+            "(import \"tcl\" \"{FUNCTION_TABLE_IMPORT}\" (table 0 funcref))"
+        )));
+    }
+
+    #[test]
+    fn a_mutable_global_carries_its_type_and_constant_initialiser() {
+        let mut m = table_install_module();
+        let bytes = m.to_bytes();
+        // i32 (0x7F), mutable (0x01), i32.const -1 (0x41 0x7F), end (0x0B).
+        let needle = [0x7Fu8, 0x01, 0x41, 0x7F, 0x0B];
+        assert!(
+            bytes.windows(needle.len()).any(|w| w == needle),
+            "global section must carry (mut i32) (i32.const -1)"
+        );
+        assert!(
+            m.to_wat()
+                .contains("(global $table_base (mut i32) (i32.const -1))")
+        );
+
+        // An immutable i64 global takes the other arm of both encoders.
+        let mut other = WasmModule::new();
+        other.globals.push(WasmGlobal {
+            name: "answer".into(),
+            mutable: false,
+            init: GlobalInit::I64(42),
+        });
+        let bytes = other.to_bytes();
+        let needle = [0x7Eu8, 0x00, 0x42, 0x2A, 0x0B];
+        assert!(
+            bytes.windows(needle.len()).any(|w| w == needle),
+            "an immutable i64 global"
+        );
+        assert!(
+            other
+                .to_wat()
+                .contains("(global $answer i64 (i64.const 42))")
+        );
+    }
+
+    #[test]
+    fn a_declarative_element_segment_names_every_ref_func_target() {
+        let mut m = table_install_module();
+        let bytes = m.to_bytes();
+        // One segment: 0x03 declarative, 0x00 funcref elemkind, vec [0].
+        let needle = [0x01u8, 0x03, 0x00, 0x01, 0x00];
+        assert!(
+            bytes.windows(needle.len()).any(|w| w == needle),
+            "one declarative funcref segment naming function 0"
+        );
+        assert!(m.to_wat().contains("(elem declare func 0)"));
+    }
+
+    #[test]
+    fn the_reference_ops_encode_their_prefixes_and_render_their_operands() {
+        // `table.grow` is the only 0xFC-prefixed op here: one byte of opcode,
+        // then the sub-opcode, then the table index.
+        let grow = WasmInstruction::table_grow(0);
+        assert_eq!(grow.encode(), vec![0xFC, 0x0F, 0x00]);
+        assert_eq!(WasmInstruction::ref_func(3).encode(), vec![0xD2, 0x03]);
+        assert_eq!(WasmInstruction::table_set(0).encode(), vec![0x26, 0x00]);
+        assert_eq!(WasmInstruction::ref_null_func().encode(), vec![0xD0, 0x70]);
+
+        let wat = table_install_module().to_wat();
+        for expected in ["ref.null func", "table.grow 0", "ref.func 0", "table.set 0"] {
+            assert!(wat.contains(expected), "{expected} missing from:\n{wat}");
+        }
+    }
+
+    #[test]
+    fn a_module_that_installs_nothing_keeps_its_previous_shape() {
+        // The three new fields default off, so a module that binds no native
+        // proc emits exactly the bytes it emitted before — which is what lets
+        // it keep loading against a runtime with no exported table.
+        let mut plain = sample_module();
+        assert!(!plain.import_table);
+        assert!(plain.globals.is_empty());
+        assert!(plain.elem_declared.is_empty());
+        let bytes = plain.to_bytes();
+        let mut seen = Vec::new();
+        let mut i = 8;
+        while i < bytes.len() {
+            let id = bytes[i];
+            let (len, adv) = read_uleb(&bytes[i + 1..]);
+            seen.push(id);
+            i += 1 + adv + len as usize;
+        }
+        assert_eq!(seen, vec![1, 2, 3, 7, 10]);
+        assert!(!plain.to_wat().contains(FUNCTION_TABLE_IMPORT));
     }
 
     #[test]

--- a/rust/tcl-compiler/src/codegen/wasm/mod.rs
+++ b/rust/tcl-compiler/src/codegen/wasm/mod.rs
@@ -36,7 +36,8 @@ mod semantic_plan;
 pub use crate::semantic_optimisation::{SemanticOptimisationConfig, SemanticOptimisationPassId};
 pub use backend::RESERVED_DATA_BASE;
 pub use ir::{
-    SectionId, ValType, WasmData, WasmFunction, WasmImport, WasmInstruction, WasmModule, WasmOp,
+    GlobalInit, SectionId, ValType, WasmData, WasmFunction, WasmGlobal, WasmImport,
+    WasmInstruction, WasmModule, WasmOp,
 };
 pub use pipeline::WasmSemanticDecline;
 pub use pipeline::{

--- a/rust/tcl-compiler/tests/wasm_execute.rs
+++ b/rust/tcl-compiler/tests/wasm_execute.rs
@@ -55,7 +55,8 @@
 //! link (`__memory_base` relocation) — both later increments.
 
 use tcl_compiler::codegen::wasm::{
-    ValType, WasmCompileOptions, WasmFunction, WasmInstruction, WasmModule, WasmOp, compile_wasm,
+    GlobalInit, ValType, WasmCompileOptions, WasmFunction, WasmGlobal, WasmInstruction, WasmModule,
+    WasmOp, compile_wasm,
 };
 use tcl_compiler::compilation_unit::CompilationUnit;
 use tcl_registry::CommandRegistry;
@@ -353,5 +354,117 @@ fn emitted_completion_codes_propagate() {
     assert_eq!(
         run_capture_code("while {1} {puts body}\nputs after\n", 1, 3, "brkLoop"),
         "puts body\nputs after\n"
+    );
+}
+
+/// A host stub standing in for the linked runtime's table half: it exports a
+/// **growable** function table and one function that calls back through it.
+const TABLE_HOST_WAT: &str = r#"(module
+  (memory (export "memory") 1)
+  (table (export "__indirect_function_table") 1 funcref)
+  (type $slot_t (func (result i32)))
+  (func (export "tcl_call_slot") (param $slot i32) (result i32)
+    (call_indirect (type $slot_t) (local.get $slot))))
+"#;
+
+/// A module in the shape issue #1774 emits: import the runtime's table, grow
+/// it, keep the base in a global, install a function of its own, and have the
+/// host call it back through the table.
+///
+/// The installed function is deliberately **not** exported, so the declarative
+/// element segment is the only thing making its `ref.func` legal — which is
+/// what the segment is there to guarantee once a later change stops exporting
+/// generated functions.
+fn table_install_module() -> WasmModule {
+    let mut m = WasmModule::new();
+    let call_slot = m.add_import("tcl", "tcl_call_slot", &[ValType::I32], &[ValType::I32]);
+    m.import_table = true;
+    m.globals.push(WasmGlobal {
+        name: "table_base".into(),
+        mutable: true,
+        init: GlobalInit::I32(-1),
+    });
+    let answer_index = u32::try_from(m.imports.len()).expect("import count fits u32");
+    m.elem_declared.push(answer_index);
+    m.functions.push(WasmFunction {
+        name: "answer".into(),
+        params: vec![],
+        results: vec![ValType::I32],
+        locals: vec![],
+        body: vec![WasmInstruction::with_operands(WasmOp::I32Const, vec![42])],
+        local_names: vec![],
+        exported: false,
+        source_range: None,
+        kind: "proc".into(),
+    });
+    m.functions.push(WasmFunction {
+        name: "::top".into(),
+        params: vec![],
+        results: vec![ValType::I32],
+        locals: vec![],
+        body: vec![
+            // base = table.grow(null, 1); traps below if the host's table is
+            // not growable, because table.set at -1 is out of bounds.
+            WasmInstruction::ref_null_func(),
+            WasmInstruction::with_operands(WasmOp::I32Const, vec![0x01]),
+            WasmInstruction::table_grow(0),
+            WasmInstruction::with_operands(WasmOp::GlobalSet, vec![0x00]),
+            // table[base] = ref.func $answer
+            WasmInstruction::with_operands(WasmOp::GlobalGet, vec![0x00]),
+            WasmInstruction::ref_func(answer_index),
+            WasmInstruction::table_set(0),
+            // return host(base)
+            WasmInstruction::with_operands(WasmOp::GlobalGet, vec![0x00]),
+            WasmInstruction::with_operands(
+                WasmOp::Call,
+                vec![u8::try_from(call_slot).expect("import index fits a byte")],
+            ),
+        ],
+        local_names: vec![],
+        exported: true,
+        source_range: None,
+        kind: "top".into(),
+    });
+    m
+}
+
+/// The IR's table, global and element encodings are accepted by a real engine,
+/// and the installed function is reachable through the shared table.
+///
+/// The unit tests in `ir.rs` pin the bytes; this proves the bytes are a module
+/// wasmtime will validate, instantiate and run — the half a byte assertion
+/// cannot reach.
+#[test]
+fn an_emitted_module_installs_a_function_into_the_hosts_table() {
+    if !have_wasmtime() {
+        eprintln!("wasmtime CLI unavailable; skipping the table-install execution");
+        return;
+    }
+    let tmp = std::env::temp_dir();
+    let host = tmp.join("tcl_e2e_host_table.wat");
+    let user = tmp.join("tcl_e2e_user_table.wasm");
+    std::fs::write(&host, TABLE_HOST_WAT).expect("write table host");
+    std::fs::write(&user, table_install_module().to_bytes()).expect("write user module");
+    let out = std::process::Command::new("wasmtime")
+        .arg("run")
+        .arg("--preload")
+        .arg(format!("tcl={}", host.display()))
+        .arg("--invoke")
+        .arg("::top")
+        .arg(&user)
+        .output()
+        .expect("run wasmtime");
+    let _ = std::fs::remove_file(&host);
+    let _ = std::fs::remove_file(&user);
+    assert!(
+        out.status.success(),
+        "the table-installing module did not run:\n--- stdout ---\n{}\n--- stderr ---\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stdout).contains("42"),
+        "the host must reach the installed function through the table, got {:?}",
+        String::from_utf8_lossy(&out.stdout)
     );
 }

--- a/rust/tcl-compiler/tests/wasm_real_link.rs
+++ b/rust/tcl-compiler/tests/wasm_real_link.rs
@@ -110,6 +110,7 @@ use tcl_runtime_api::codegen_abi::CodegenAbiImportId;
 
 mod common;
 use common::wasm_link::{real_link_runtime, scratch};
+use tcl_runtime_api::codegen_abi::WASM32_FUNCTION_TABLE_IMPORT;
 
 /// The bootstrap WASI command (see the module docs): create + select an interp,
 /// run the emitted `::top`, then evaluate `query` against the same interp and
@@ -919,4 +920,91 @@ fn sealed_native_i64_add_runs_and_trace_registration_falls_back() {
         ),
         "6\n2"
     );
+}
+
+/// A bootstrap that installs a function of its own into the **runtime's**
+/// indirect function table and calls it back through that table.
+///
+/// This is the whole of issue #1774's transport, minus the emitter: a wasm32
+/// function pointer *is* an index into this table, so a module can only hand
+/// the runtime a callable body by growing the table, `ref.func`-ing its
+/// function into the new slot, and passing the index across the ABI. Every
+/// step is a linker property of `tcl_runtime.wasm`, not of anything we emit,
+/// which is why it is proved here before any codegen depends on it.
+///
+/// Each failure is distinct and loud:
+///
+/// - the runtime linked without `--export-table` ⇒ wasmtime refuses to
+///   instantiate this module, naming the missing import;
+/// - linked without `--growable-table` ⇒ the table keeps `wasm-ld`'s
+///   `min == max`, `table.grow` returns `-1`, and the `unreachable` traps;
+/// - a slot that does not hold the installed function ⇒ the `call_indirect`
+///   result is not 42 and the second `unreachable` traps.
+fn function_table_bootstrap_wat() -> String {
+    format!(
+        r#"(module
+  (import "tcl" "memory" (memory 1))
+  (import "tcl" "{WASM32_FUNCTION_TABLE_IMPORT}" (table $fns 0 funcref))
+  (import "wasi_snapshot_preview1" "fd_write" (func $fd_write (param i32 i32 i32 i32) (result i32)))
+  (export "memory" (memory 0))
+  (type $answer_t (func (result i32)))
+  (elem declare func $answer)
+  (func $answer (type $answer_t) (i32.const 42))
+  (func (export "_start")
+    (local $slot i32)
+    (local.set $slot (table.grow $fns (ref.null func) (i32.const 1)))
+    (if (i32.lt_s (local.get $slot) (i32.const 0)) (then unreachable))
+    (table.set $fns (local.get $slot) (ref.func $answer))
+    (if (i32.ne (call_indirect $fns (type $answer_t) (local.get $slot)) (i32.const 42))
+      (then unreachable))
+    (i32.store (i32.const 0x190008) (i32.const 0x180000))
+    (i32.store (i32.const 0x19000C) (i32.const 3))
+    (drop (call $fd_write (i32.const 1) (i32.const 0x190008) (i32.const 1) (i32.const 0x190010))))
+  (data (i32.const 0x180000) "ok\n"))
+"#
+    )
+}
+
+/// Run a bootstrap against the runtime alone — no emitted `user` module.
+fn run_boot_only(runtime: &Path, tag: &str, wat: &str) -> Result<String, String> {
+    let boot = scratch(&format!("tcl_real_link_boot_{tag}.wat"));
+    std::fs::write(&boot, wat).expect("write bootstrap");
+    let out = Command::new("wasmtime")
+        .arg("run")
+        .arg("--preload")
+        .arg(format!("tcl={}", runtime.display()))
+        .arg(&boot)
+        .output()
+        .expect("run wasmtime");
+    let _ = std::fs::remove_file(&boot);
+    if out.status.success() {
+        Ok(String::from_utf8(out.stdout).expect("stdout is utf-8"))
+    } else {
+        Err(format!(
+            "--- stdout ---\n{}\n--- stderr ---\n{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr),
+        ))
+    }
+}
+
+/// The runtime exports its indirect function table, and that table grows.
+///
+/// `runtime/rust/build.rs` passes `--export-table --growable-table` for every
+/// wasm target. Without the first there is no table to import; without the
+/// second `wasm-ld` fixes `max == min` and nothing can ever be installed. Both
+/// are inert for a module that does not touch the table, so no already-emitted
+/// module changes — but a native proc entry is impossible without them.
+#[test]
+fn the_runtime_exports_a_growable_indirect_function_table() {
+    let Some(runtime) = real_link_runtime() else {
+        return;
+    };
+    match run_boot_only(&runtime, "function_table", &function_table_bootstrap_wat()) {
+        Ok(stdout) => assert_eq!(stdout, "ok\n"),
+        Err(report) => panic!(
+            "a module could not install a function into the runtime's table.\n             Check that runtime/rust/build.rs still passes --export-table and \
+             --growable-table for wasm targets.\n{report}"
+        ),
+    }
 }

--- a/rust/tcl-runtime-api/src/codegen_abi.rs
+++ b/rust/tcl-runtime-api/src/codegen_abi.rs
@@ -55,6 +55,7 @@ const I32_I32_I32: &[CodegenAbiValueType] = &[CodegenAbiValueType::I32; 3];
 const I32_I32_I32_I32: &[CodegenAbiValueType] = &[CodegenAbiValueType::I32; 4];
 const I32_I32_I32_I32_I32: &[CodegenAbiValueType] = &[CodegenAbiValueType::I32; 5];
 const I32_I32_I32_I32_I32_I32: &[CodegenAbiValueType] = &[CodegenAbiValueType::I32; 6];
+const I32_I32_I32_I32_I32_I32_I32: &[CodegenAbiValueType] = &[CodegenAbiValueType::I32; 7];
 const I32_I32_I32_I32_I64_I32: &[CodegenAbiValueType] = &[
     CodegenAbiValueType::I32,
     CodegenAbiValueType::I32,
@@ -258,6 +259,32 @@ pub enum CodegenAbiImportId {
     /// ordinary command dispatch over `argc` borrowed arguments (an argv
     /// pointer), writing the completion triple.
     MathFunc,
+    /// Define a Tcl procedure whose body may run natively.
+    ///
+    /// Parameters are the name pointer and length, the formal-parameter text
+    /// pointer and length, the body-source pointer and length, and `entry` —
+    /// a wasm32 function-table index for the compiled body, or `0` for none.
+    /// The i32 result is a Tcl completion code.
+    ///
+    /// `entry = 0` is exactly [`Self::ProcRegister`]: a source-only proc. The
+    /// two spellings define the same proc, and this one subsumes the older,
+    /// which stays for already-emitted legacy-tier modules.
+    ProcDefineNative,
+    /// Log one `while executing` / `invoked from within` `errorInfo` frame for
+    /// a compiled statement that completed with an error.
+    ///
+    /// Parameters are the statement's 1-based line relative to the enclosing
+    /// body and the statement's exact source text (pointer and length). No
+    /// result: the runtime owns the `already_logged` protocol, so a statement
+    /// already logged deeper in the same body is a no-op.
+    LogCommand,
+    /// The number of proc bodies dispatched through a native entry.
+    ///
+    /// A test boundary, like [`Self::CallFrameAlloc`]'s outstanding-frame
+    /// counter: it lets a linked test prove the native entry actually ran
+    /// rather than the source body, which is otherwise unobservable because
+    /// both produce the same Tcl result.
+    NativeProcDispatches,
 }
 
 impl CodegenAbiImportId {
@@ -339,9 +366,43 @@ impl CodegenAbiImportId {
             Self::ExprEval => tcl_import("tcl_codegen_expr_eval", I32_I32, I32),
             Self::MathOp => tcl_import("tcl_codegen_mathop", I32_I32_I32_I32_I32, I32),
             Self::MathFunc => tcl_import("tcl_codegen_mathfunc", I32_I32_I32_I32_I32, I32),
+            Self::ProcDefineNative => tcl_import(
+                "tcl_codegen_proc_define_native",
+                I32_I32_I32_I32_I32_I32_I32,
+                I32,
+            ),
+            Self::LogCommand => tcl_import("tcl_codegen_log_command", I32_I32_I32, NONE),
+            Self::NativeProcDispatches => {
+                tcl_import("tcl_codegen_native_proc_dispatches", NONE, I32)
+            }
         }
     }
 }
+
+/// The runtime's exported wasm32 indirect function table.
+///
+/// A wasm32 function pointer is an index into this table, so a module that
+/// wants the runtime to call one of its own functions installs a `ref.func`
+/// here and hands the runtime the index. `wasm-ld` picks the name; the runtime
+/// publishes it with `--export-table` (`runtime/rust/build.rs`). This constant
+/// is the single spelling both sides use, so a toolchain rename is one edit.
+pub const WASM32_FUNCTION_TABLE_IMPORT: &str = "__indirect_function_table";
+
+/// A native proc entry ran and wrote its completion output.
+///
+/// The body's own Tcl error is reported as `code == 1` in that completion, not
+/// through this status.
+pub const NATIVE_PROC_STATUS_RAN: i32 = 0;
+
+/// A native proc entry declined, **before any observable effect**, and left
+/// its completion output untouched.
+///
+/// The runtime then runs the proc's source body in the call frame it has
+/// already prepared. That is only observationally identical because nothing
+/// happened yet, so an entry must decline before its first ABI call that
+/// writes a cell, dispatches a command, or sets a result — never part-way
+/// through a body.
+pub const NATIVE_PROC_STATUS_DECLINED: i32 = 1;
 
 /// wasm32 linear-memory pointer width.
 pub const WASM32_POINTER_BYTES: i32 = 4;
@@ -384,12 +445,13 @@ pub const WASM32_GUARD_IDENTITY_ALIGN: i32 = 8;
 #[cfg(test)]
 mod tests {
     use super::{
-        CodegenAbiImportId, CodegenAbiValueType, I32, I64, WASM32_COMPLETION_ALIGN,
-        WASM32_COMPLETION_CODE_OFFSET, WASM32_COMPLETION_OPTIONS_OFFSET,
-        WASM32_COMPLETION_RESULT_OFFSET, WASM32_COMPLETION_SIZE, WASM32_GUARD_DOMAINS_SIZE,
-        WASM32_GUARD_IDENTITY_ALIGN, WASM32_GUARD_IDENTITY_NAMESPACE_OFFSET,
-        WASM32_GUARD_IDENTITY_SIZE, WASM32_GUARD_IDENTITY_VALUE_OFFSET, WASM32_GUARD_TOKEN_ALIGN,
-        WASM32_GUARD_TOKEN_SIZE, WASM32_INTRINSIC_ID_SIZE,
+        CodegenAbiImportId, CodegenAbiValueType, I32, I64, NATIVE_PROC_STATUS_DECLINED,
+        NATIVE_PROC_STATUS_RAN, WASM32_COMPLETION_ALIGN, WASM32_COMPLETION_CODE_OFFSET,
+        WASM32_COMPLETION_OPTIONS_OFFSET, WASM32_COMPLETION_RESULT_OFFSET, WASM32_COMPLETION_SIZE,
+        WASM32_FUNCTION_TABLE_IMPORT, WASM32_GUARD_DOMAINS_SIZE, WASM32_GUARD_IDENTITY_ALIGN,
+        WASM32_GUARD_IDENTITY_NAMESPACE_OFFSET, WASM32_GUARD_IDENTITY_SIZE,
+        WASM32_GUARD_IDENTITY_VALUE_OFFSET, WASM32_GUARD_TOKEN_ALIGN, WASM32_GUARD_TOKEN_SIZE,
+        WASM32_INTRINSIC_ID_SIZE,
     };
 
     #[test]
@@ -681,6 +743,52 @@ mod tests {
             assert!(descriptor.parameters.iter().all(|value| *value == I32));
             assert_eq!(descriptor.results, &[I32][..], "{id:?}");
         }
+    }
+
+    #[test]
+    fn native_proc_dispatch_imports_carry_the_entry_index_and_a_test_counter() {
+        use CodegenAbiValueType::I32;
+
+        // The definition import is `proc_register` plus one trailing entry
+        // index, so a module that binds a native body and one that does not
+        // emit the same call with `entry = 0`.
+        let define = CodegenAbiImportId::ProcDefineNative.descriptor();
+        assert_eq!(define.module, "tcl");
+        assert_eq!(define.name, "tcl_codegen_proc_define_native");
+        assert_eq!(define.parameters, &[I32; 7][..]);
+        assert_eq!(define.results, &[I32][..]);
+        let register = CodegenAbiImportId::ProcRegister.descriptor();
+        assert_eq!(
+            define.parameters.len(),
+            register.parameters.len() + 1,
+            "proc_define_native is proc_register plus the entry index"
+        );
+        assert_eq!(define.results, register.results);
+
+        // The error-edge logger returns nothing: the runtime owns the
+        // `already_logged` protocol, so the emitter has no decision to make.
+        let log = CodegenAbiImportId::LogCommand.descriptor();
+        assert_eq!(log.module, "tcl");
+        assert_eq!(log.name, "tcl_codegen_log_command");
+        assert_eq!(log.parameters, &[I32; 3][..]);
+        assert!(log.results.is_empty());
+
+        let dispatches = CodegenAbiImportId::NativeProcDispatches.descriptor();
+        assert_eq!(dispatches.module, "tcl");
+        assert_eq!(dispatches.name, "tcl_codegen_native_proc_dispatches");
+        assert!(dispatches.parameters.is_empty());
+        assert_eq!(dispatches.results, &[I32][..]);
+    }
+
+    #[test]
+    fn native_proc_entry_statuses_and_the_table_import_name_have_one_spelling() {
+        // `0` is "ran" so a zeroed status word is never mistaken for a
+        // decline, matching every other ABI status in this file.
+        assert_eq!(NATIVE_PROC_STATUS_RAN, 0);
+        assert_eq!(NATIVE_PROC_STATUS_DECLINED, 1);
+        assert_ne!(NATIVE_PROC_STATUS_RAN, NATIVE_PROC_STATUS_DECLINED);
+        // wasm-ld's name for the table `--export-table` publishes.
+        assert_eq!(WASM32_FUNCTION_TABLE_IMPORT, "__indirect_function_table");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- The runtime half of #1774 (phase P5-lite of `docs/design/compiler/wasm-native-lowering-plan.md`). **Progresses #1774; does not close it** — the compiler half (proc-entry function shape, `::top` install, `Definition` lowering, error-edge logging call sites, samples) follows as a second PR.
- **This PR changes no emitted WASM module.** `budgets.tsv` is unchanged across every sample, and that is asserted rather than assumed. It is fully exercisable through native `cargo test` with Rust `extern "C"` stubs standing in for a compiled entry, which is the point of the split: the toolchain risk is retired before any codegen change depends on it.

| Commit | What |
|---|---|
| `cc45dd8` | ABI vocabulary in `tcl-runtime-api`: `ProcDefineNative` (7×i32→i32), `LogCommand`, `NativeProcDispatches`, `WASM32_FUNCTION_TABLE_IMPORT`, `NATIVE_PROC_STATUS_RAN`/`_DECLINED` |
| `259b2c6` | `runtime/rust/build.rs` links with `--export-table --growable-table`; real-link gate + docs |
| `34124b0` | `ProcDef.native`, `define_proc_native`, `CallMeta.native`, `run_native_body`, dispatch counter, `tcl_codegen_proc_define_native` |
| `1bf7a65` | `log_command_info` → `log_command_bytes` split + `tcl_codegen_log_command` |
| `5dd163a` | WASM IR gains `import_table`, `globals`, `elem_declared`, `ref.null`/`ref.func`/`table.set`/`table.grow`, Global + Element sections, WAT |
| `7a01e96` | GLOSSARY entry for a native proc entry |

### Ownership

**Proc → entry is the `ProcDef` itself**, reached only through `define_proc_native`, the single field-by-field construction site (`define_proc` delegates with `None`). There is deliberately **no side table**, so nothing can go stale: redefinition builds a definition with no entry, `rename` clones and carries it, `rename p ""` and `namespace delete` drop it. Each of those is pinned by a test. Table *slot* → proc remains `ProcedurePlan`'s question and is untouched here — no second map was added.

### What `DECLINED` means

`NATIVE_PROC_STATUS_DECLINED = 1`, returned before the entry's first ABI call that writes a cell, dispatches a command, or sets a result, with `out` untouched.

"Before any effect" is a **contract on the entry, not something the runtime can enforce** — stated as such on `NativeProcEntry` and on the constant, rather than implied. What the runtime *does* guarantee is that a decline costs nothing observable on its side: `run_native_body` pops its `CmdFrame`, leaves the activation `Ok`, does not bump the counter, and hands the untouched frame back so `eval_framed` runs the source body in it. `a_declining_entry_falls_back_to_the_source_body_observably_unchanged` compares result, `-errorinfo`, `-errorstack` and `-errorcode` for the same proc name with and without a declining entry, and against tclsh.

### The two risks, settled in code rather than prose

**Double frame.** Native-tier *module* functions are not frame-less — their prologue already calls `tcl_codegen_activation_enter` and `tcl_codegen_frame_push` (`pushes_frame = !top_level`). Reusing that shape for a proc entry would push twice, at the wrong namespace, and double-count eval depth. `NativeProcEntry` and `run_native_body` both document the split — `run_proc` owns the variable frame, `info level` words and formals; `run_native_body` owns the activation and `CmdFrame`; the entry owns **neither** — with an explicit warning against reusing the module-function shape. `info level 0` read from inside a stub is the detector and is asserted: a second frame has no recorded words. Relatedly, a Tcl level costs exactly **two** eval-depth units through the native path, so unbounded recursion refuses at depth **63** with the eval loop's own message; that number is asserted, so an activation held twice or dropped moves it.

**Version skew.** A newer module against an older runtime fails instantiation hard with `unknown import`, so the table is imported only when a module actually binds a native proc. The other direction — old module, new runtime — is unchanged and asserted: `a_module_that_installs_nothing_keeps_its_previous_shape` pins that `import_table`/`globals`/`elem_declared` all default off so byte output is identical, and the unchanged `budgets.tsv` confirms it across every sample.

### Corrections to the plan found while implementing

1. **`ref.null func` was missing from the op list.** `table.grow` takes an init reference plus a delta, so a module cannot grow the table without it. Added as `WasmOp::RefNull` (0xD0).
2. **The `-errorstack` `CALL` entry is missing too, not just the `while executing` frame** — same root cause. `run_proc` does call `error_stack_push_call`, but it refuses to chain a `CALL` onto an error stack with no inner context, and a compiled statement calls no `log_command_info` to give it one. So the ledger is two lines, not one, and both close together: with the statement site logged through `tcl_codegen_log_command`, a compiled body's `-errorinfo` **and** `-errorstack` are byte-identical to the interpreted body's, which is byte-identical to tclsh 9.0.4 and 8.6.16.
3. `--global-base` is documented in `wasm-target-surfaces.md`, not `wasm-codegen.md`, so the table documentation went under *Runtime ABI and ownership* instead of the anchor the plan named.
4. `Result<Code, CmdFrame>` trips `clippy::result_large_err` (192-byte `CmdFrame`) and no new `#[allow]` is permitted, so the `Err` is boxed — the allocation happens only on a decline.
5. The dispatch counter is incremented *after* the status check; a decline is not a native run.

Step 2 was also landed before step 1, since step 1's test cites `WASM32_FUNCTION_TABLE_IMPORT`, whose owner is step 2.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

| Command | Result |
|---|---|
| `cargo test -p tcl-vm` | exit 0 |
| `TCL_TOMMATH_DIR=… make runtime-rust-test` | exit 0 — 622 lib tests |
| `make runtime-rust-test-no-tommath` | exit 0 — 526 lib tests; all 13 new tests run in this config |
| `make rust-check` | exit 0 |
| `cargo test -p tcl-compiler --tests` | all green |
| `TCL_REQUIRE_WASM_LINK=1` `wasm_real_link` / `wasm_tiers` | 10/10 and 6/6, `budgets.tsv` unchanged |

**Neither new gate is vacuous, and that was checked by breaking them**: `wasm-opt --print` on the linked artefact shows `(table $0 814 funcref)` with no maximum and `(export "__indirect_function_table" (table $0))`; removing the two link flags makes the real-link case fail to instantiate under wasmtime, and removing `elem_declared` makes the `wasm_execute` case fail validation.

## Compiler / diagnostics checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? — No. No emitted module changes; `budgets.tsv` is unchanged.
- [x] If yes, I updated the owning design doc — a *The shared function table* subsection was added under *Runtime ABI and ownership* in `docs/design/compiler/wasm-target-surfaces.md`.
- [x] If I added or changed a diagnostic or optimisation code, I updated its page — none added or changed.
- [x] If I added a design doc, I linked it from `docs/design/README.md` — no new design doc; a GLOSSARY entry was added for a native proc entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XV29AoTSsaCBgsJuf2EvEK

---
_Generated by [Claude Code](https://claude.ai/code/session_01XV29AoTSsaCBgsJuf2EvEK)_