### PR TITLE
fix(deps): hold TypeScript to 6.0.x, where the eslint peer actually ends

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -67,9 +67,13 @@ updates:
       # Compile against the oldest API declared in engines.vscode. Newer types
       # would allow calls that fail for users on the supported 1.95 floor.
       - dependency-name: "@types/vscode"
-      # typescript-eslint 8.69 supports TypeScript only below 6.1.
+      # typescript-eslint 8.69 supports TypeScript only below 6.1, so the
+      # wall is 6.1.0 and not 7.0.0. Pair this with the `~6.0.3` range in
+      # package.json: the range keeps a plain `npm install` on 6.0.x, and
+      # this keeps Dependabot from proposing the bump the range would
+      # reject. 6.0.x patches still flow.
       - dependency-name: typescript
-        versions: [">=7.0.0"]
+        versions: [">=6.1.0"]
 
   # Every npm project in the tree needs its own entry — Dependabot does not
   # walk sub-directories.  The spec-studio web app was the gap that let four
@@ -89,9 +93,13 @@ updates:
         exclude-patterns:
           - "npm"
     ignore:
-      # typescript-eslint 8.69 supports TypeScript only below 6.1.
+      # typescript-eslint 8.69 supports TypeScript only below 6.1, so the
+      # wall is 6.1.0 and not 7.0.0. Pair this with the `~6.0.3` range in
+      # package.json: the range keeps a plain `npm install` on 6.0.x, and
+      # this keeps Dependabot from proposing the bump the range would
+      # reject. 6.0.x patches still flow.
       - dependency-name: typescript
-        versions: [">=7.0.0"]
+        versions: [">=6.1.0"]
 
   - package-ecosystem: npm
     directory: /rust/bigip-report-gen/frontend
@@ -107,9 +115,13 @@ updates:
         exclude-patterns:
           - "npm"
     ignore:
-      # typescript-eslint 8.69 supports TypeScript only below 6.1.
+      # typescript-eslint 8.69 supports TypeScript only below 6.1, so the
+      # wall is 6.1.0 and not 7.0.0. Pair this with the `~6.0.3` range in
+      # package.json: the range keeps a plain `npm install` on 6.0.x, and
+      # this keeps Dependabot from proposing the bump the range would
+      # reject. 6.0.x patches still flow.
       - dependency-name: typescript
-        versions: [">=7.0.0"]
+        versions: [">=6.1.0"]
 
   # Every cargo root in the tree, not just the workspace at `/`.  The root
   # `[workspace] exclude` list (Cargo.toml) holds each target that cannot

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -31,7 +31,7 @@
         "mocha": "^12.0.0",
         "ovsx": "^1.1.1",
         "prettier": "^3.9.6",
-        "typescript": "^6.0.3",
+        "typescript": "~6.0.3",
         "vscode-oniguruma": "^2.0.1",
         "vscode-textmate": "^9.3.2"
       },

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -9517,7 +9517,7 @@
     "mocha": "^12.0.0",
     "ovsx": "^1.1.1",
     "prettier": "^3.9.6",
-    "typescript": "^6.0.3",
+    "typescript": "~6.0.3",
     "vscode-oniguruma": "^2.0.1",
     "vscode-textmate": "^9.3.2"
   },

--- a/rust/bigip-report-gen/frontend/package-lock.json
+++ b/rust/bigip-report-gen/frontend/package-lock.json
@@ -16,7 +16,7 @@
         "eslint": "^10.10.0",
         "eslint-config-prettier": "^10.1.8",
         "prettier": "^3.9.6",
-        "typescript": "^6.0.3"
+        "typescript": "~6.0.3"
       }
     },
     "node_modules/@cacheable/memory": {

--- a/rust/bigip-report-gen/frontend/package.json
+++ b/rust/bigip-report-gen/frontend/package.json
@@ -20,6 +20,6 @@
     "eslint": "^10.10.0",
     "eslint-config-prettier": "^10.1.8",
     "prettier": "^3.9.6",
-    "typescript": "^6.0.3"
+    "typescript": "~6.0.3"
   }
 }

--- a/rust/tcl-spec-studio/web/package-lock.json
+++ b/rust/tcl-spec-studio/web/package-lock.json
@@ -17,7 +17,7 @@
         "eslint-config-prettier": "^10.1.8",
         "monaco-editor": "^0.56.0",
         "prettier": "^3.9.6",
-        "typescript": "^6.0.3",
+        "typescript": "~6.0.3",
         "vscode-jsonrpc": "^9.0.2",
         "vscode-languageserver-protocol": "^3.18.3",
         "vscode-oniguruma": "^2.0.1",

--- a/rust/tcl-spec-studio/web/package.json
+++ b/rust/tcl-spec-studio/web/package.json
@@ -22,7 +22,7 @@
     "eslint-config-prettier": "^10.1.8",
     "monaco-editor": "^0.56.0",
     "prettier": "^3.9.6",
-    "typescript": "^6.0.3",
+    "typescript": "~6.0.3",
     "vscode-jsonrpc": "^9.0.2",
     "vscode-languageserver-protocol": "^3.18.3",
     "vscode-oniguruma": "^2.0.1",


### PR DESCRIPTION
## Summary

Rebased onto current `rust`. #1884 landed the same core fix while this was queued, so **this PR is now only the part that one leaves open** — the diff is 7 files, 24 insertions.

#1884 set `typescript` back to `^6.0.3` and told Dependabot to ignore `>=7.0.0`. Both bounds stop short of the real wall:

- typescript-eslint 8.69 declares the peer as `typescript >=4.8.4 <6.1.0` — the wall is **6.1.0**, not 7.0.0.
- `^6.0.3` expands to `>=6.0.3 <7.0.0`.

So a TypeScript 6.1.0 release would clear the Dependabot ignore *and* satisfy the declared range, and `npm install` would fail ERESOLVE exactly as it did under 7.0.2 — the fix undoing itself with nobody touching it.

This moves both bounds to where the peer actually ends:

- `~6.0.3` in all three npm roots, so resolution stays on 6.0.x.
- The ignore starts at `>=6.1.0`, so Dependabot stops proposing the bump the range would reject.

`6.0.x` patches still flow. Drop both once typescript-eslint widens the peer range.

Caught by the Codex review on the previous revision of this PR.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

The semver claim, checked rather than asserted:

```
^6.0.3   admits versions the eslint peer rejects: 6.1.0, 6.2.0, 6.9.9
~6.0.3   admits versions the eslint peer rejects: none
```

```
npm ci                          # all three roots: editors/vscode, both front-ends — OK
make lint-ts typecheck-ts
make typecheck-report-ts lint-report-ts
make typecheck-spec-studio-ts lint-spec-studio-ts
make spec-studio-test           # 46 passed
```

## Compiler / diagnostics checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

Not applicable — dependency metadata only, no compiler or diagnostic behaviour touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)