### PR TITLE
fix(trace): C's rename window, its interp-trace gate, and a coroutine that survives a rename

### DIFF
--- a/docs/design/runtime/rename-alias.md
+++ b/docs/design/runtime/rename-alias.md
@@ -100,7 +100,7 @@ Two consequences differ from a flags-and-payload layout:
 
 | Form                              | Behaviour                                                                                     |
 |-----------------------------------|-----------------------------------------------------------------------------------------------|
-| ``rename old new``                | Move the `Command` out of the namespace where ``old`` *resolves* and insert it under ``new`` (relative to the current namespace, absolute when ``::``-led). |
+| ``rename old new``                | Move the `Command` out of the namespace where ``old`` *resolves* and insert it under ``new`` (relative to the current namespace, absolute when ``::``-led). Everything keyed by the command's name follows it: its traces, the imports that redirect to it, its TclOO object, and a live coroutine (C hangs all of these off the command *token*, which the move carries). |
 | ``rename old ""``                 | Delete ``old``: drop the table entry, tear down a suspended coroutine of that name, remove the command's traces. |
 | ``rename foo foo``                | Refused — ``can't rename to "foo": command already exists`` (`TCL OPERATION RENAME TARGET_EXISTS`); the source still occupies the slot when the destination is checked, so a self-rename is *not* a no-op. |
 | ``rename a b`` with ``b`` bound   | Refused with the same message and errorcode; **both** commands survive intact.                |

--- a/docs/design/runtime/trace-implementation.md
+++ b/docs/design/runtime/trace-implementation.md
@@ -107,7 +107,9 @@ destination command:
   `Namespaces::rehome_command` re-points the identity our `Command` variants
   carry in its stead);
 - `trace info command <old>` and `… <new>` answer the same list, and a
-  `trace add` or `trace remove` through either name edits it;
+  `trace add` or `trace remove` through either name edits it — and dispatching
+  through either name fires the command's one set of `enter`/`leave` traces,
+  with the callback receiving the spelling the caller actually invoked;
 - a `rename` or a delete through *either* name moves or destroys that one
   command — and C's `CMD_TRACE_ACTIVE` keeps the pass's remaining callbacks
   from re-firing when it does.

--- a/docs/design/runtime/trace-implementation.md
+++ b/docs/design/runtime/trace-implementation.md
@@ -98,42 +98,53 @@ Both entries reference the one `Command`, and the traces hang off that, not
 off either entry. So for the callbacks' duration the vacating name **is** the
 destination command:
 
-- both names resolve and are callable;
+- both names resolve and are callable, and the command is already re-homed
+  (`cmdPtr->nsPtr = newNsPtr` happens before the firing), so a body invoked
+  through the vacating name reports the *destination's* `namespace current` —
+  and likewise a TclOO object, an ensemble, an import redirect and a live
+  coroutine all still dispatch through the vacating name, because C reaches
+  each of them through the one `Command` (in `runtime/rust`,
+  `Namespaces::rehome_command` re-points the identity our `Command` variants
+  carry in its stead);
 - `trace info command <old>` and `… <new>` answer the same list, and a
   `trace add` or `trace remove` through either name edits it;
 - a `rename` or a delete through *either* name moves or destroys that one
   command — and C's `CMD_TRACE_ACTIVE` keeps the pass's remaining callbacks
   from re-firing when it does.
 
-The VM reproduces that window rather than the naive "mutate, then fire":
-`cmd_rename` registers the destination, `on_command_renamed_traces` moves the
-sidecars to the destination key and fires from there (passing the old
-fully-qualified name for the callback's first word), and only afterwards does
-`retire_renamed_command_source` drop the source entry — the VM's spelling of
-`Tcl_DeleteHashEntry(oldHPtr)`, a plain table removal that fires no `delete`
-trace.
+**Both** runtimes reproduce that window rather than the naive "mutate, then
+fire", by the same three steps: publish the destination, move everything the
+command carries to the destination key and fire from there — passing the old
+fully-qualified name for the callback's first word — and only afterwards drop
+the source's table entry, which is `Tcl_DeleteHashEntry(oldHPtr)`: a plain
+removal that fires no `delete` trace.
 
-The VM has no shared command object to hang that equivalence on, so an open
-window records it as a source→destination pair (`rename_windows`, a stack, one
-frame per nested rename). `renamed_command_key` resolves a key through it —
-used by `trace add`/`remove`/`info` and by `prepare_command_rename`, which is
-what makes a callback's `rename <old> <third>` and `rename <old> {}` act on
-the destination. A nested rename would otherwise strand that state on the key
-it just vacated, so `relocate_rename_state` retargets every enclosing window
-*and* every `firing_cmd_traces` record — the key-addressed stand-in for
+| | publish | fire from | retire the source |
+|---|---|---|---|
+| `runtime/rust` | `Namespaces::publish_rename_destination` (writes the re-homed command into *both* slots) | `Interp::move_bound_command`, after moving the trace list, the import redirects, the TclOO registration and the coroutine | `Namespaces::retire_rename_source` |
+| `rust/tcl-vm` | `cmd_rename` registers the destination | `on_command_renamed_traces`, after moving the sidecars | `retire_renamed_command_source` |
+
+Neither has a shared command object to hang that equivalence on, so an open
+window is recorded as a source→destination pair — `TraceTable::rename_windows`
+in the tree-walker, `rename_windows` in the VM, a stack either way with one
+frame per nested rename. `Interp::renamed_cmd_key` / `renamed_command_key`
+resolves a name through it: used by `trace add`/`remove`/`info`, by the
+tree-walker's execution-trace lookup and coroutine registry, and by
+`Interp::rename_command` / `prepare_command_rename`, which is what makes a
+callback's `rename <old> <third>` and `rename <old> {}` act on the
+destination. A nested rename would otherwise strand that state on the key it
+just vacated, so `relocate_rename_state` retargets every enclosing window
+*and* every `firing_cmd_traces` record — the name-addressed stand-in for
 `CMD_TRACE_ACTIVE`, which C gets for free from the `Command` being one object.
 
-Two residues of that same missing shared identity are not emulated, both
-because C's own behaviour there is a torn-state artefact rather than a
-contract: re-*creating* the vacating name from a callback (`proc <old> {} …`)
-kills the destination in C but not in the VM, and 8.6 and 9.0 disagree with
-each other on what `info commands <old>` reports after a callback deletes the
-command.
+Two residues of that same missing shared identity are not emulated by either
+engine, both because C's own behaviour there is a torn-state artefact rather
+than a contract: re-*creating* the vacating name from a callback
+(`proc <old> {} …`) leaves C deleting a freed hash entry and killing the
+destination with it, where both engines leave the command standing under its
+new name; and 8.6 and 9.0 disagree with each other on what
+`info commands <old>` reports after a callback deletes the command.
 
-**Known gap:** `runtime/rust` fires the `rename` traces *before* any table
-mutation, so a callback there sees the old name but not yet the new one — the
-mirror image of the divergence the VM used to have. Its window has not been
-brought onto C's ordering yet.
 
 ## Callback shape and firing order
 
@@ -290,5 +301,6 @@ not here.
 | `runtime/rust/src/frame.rs` | per-frame variable cells the variable-trace key resolves against |
 | `rust/tcl-vm/src/cmd_trace.rs` | the `trace` command for the bytecode VM |
 | `rust/tcl-vm/src/interp.rs` | VM trace tables, the step-trace epoch, `cmd_trace_entries` |
+| `runtime/rust/tests/trace_semantics.rs` | tclsh-pinned transcripts for the tree-walker, including the `rename` window |
 | `rust/tcl-vm/tests/command_traces_e2e.rs` | tclsh-pinned command/execution/variable trace vectors, including firing order |
 | `rust/tcl-vm/tests/legacy_variable_traces_e2e.rs` | tclsh-pinned cross-version vectors for `trace variable`/`vdelete`/`vinfo` |

--- a/docs/design/runtime/trace-implementation.md
+++ b/docs/design/runtime/trace-implementation.md
@@ -265,11 +265,31 @@ the same variable does not re-fire itself. Command-trace firing is gated the
 way C gates it — **per command**, on the command whose traces are running
 (`CMD_TRACE_ACTIVE`, and `CMD_DYING` for a deletion), not interpreter-wide: a
 callback that deletes a *different* command still fires that command's own
-delete traces, nested inside the first. Execution and step traces keep the
-interpreter-wide gate (`INTERP_TRACE_IN_PROGRESS`), so a callback's own
-dispatches are never step-observed. The interpreter result is preserved across
-every callback (held with an explicit `+1` and restored afterwards), so a trace
-cannot clobber the result of the operation it observed.
+delete traces, nested inside the first. The interpreter result is preserved
+across every callback (held with an explicit `+1` and restored afterwards), so
+a trace cannot clobber the result of the operation it observed.
+
+The interpreter-wide gate (`INTERP_TRACE_IN_PROGRESS`) belongs to **execution
+traces alone**. C sets it in exactly one place — `TraceExecutionProc`
+(`tclTrace.c` 9.0.4:1765), around an `enter`/`leave`/`enterstep`/`leavestep`
+callback — and reads it in exactly one place, `TclCheckInterpTraces` (:1426),
+the step machinery. So an execution callback's own dispatches are never
+step-observed, while `CallCommandTraces` sets nothing at all: a command a
+`rename`/`delete` callback dispatches is traced like any other — its
+`enter`/`leave` traces fire, and an enclosing step scope steps both the
+callback's invocation and the commands its body runs. Both runtimes used to
+raise their stand-in (`TraceTable::exec_firing`, and the VM's
+`trace_in_progress`) for command callbacks too, which silently untraced
+everything such a callback dispatched.
+
+**Known gap:** both stand-ins are still *read* more broadly than C reads its
+flag — at the whole traced-dispatch fast path rather than only in the step
+machinery — so inside an execution callback a **different** command's
+`enter`/`leave` traces do not fire, where C's `TclCheckExecutionTraces`, which
+never consults the flag, fires them. Narrowing the read means first giving
+`runtime/rust` C's per-trace `TCL_TRACE_EXEC_IN_PROGRESS` (:1655), because the
+interp-wide read is currently also supplying that re-entrancy rule; the VM
+already carries it per entry (`CmdTraceEntry::firing`).
 
 A read or write callback that errors reshapes the operation's result
 (`can't read "NAME": …` / `can't set "NAME": …`) and stops further firing —

--- a/docs/design/runtime/trace-implementation.md
+++ b/docs/design/runtime/trace-implementation.md
@@ -282,14 +282,21 @@ raise their stand-in (`TraceTable::exec_firing`, and the VM's
 `trace_in_progress`) for command callbacks too, which silently untraced
 everything such a callback dispatched.
 
-**Known gap:** both stand-ins are still *read* more broadly than C reads its
-flag — at the whole traced-dispatch fast path rather than only in the step
-machinery — so inside an execution callback a **different** command's
-`enter`/`leave` traces do not fire, where C's `TclCheckExecutionTraces`, which
-never consults the flag, fires them. Narrowing the read means first giving
-`runtime/rust` C's per-trace `TCL_TRACE_EXEC_IN_PROGRESS` (:1655), because the
-interp-wide read is currently also supplying that re-entrancy rule; the VM
-already carries it per entry (`CmdTraceEntry::firing`).
+Both stand-ins are *read* exactly where C reads its flag and nowhere else:
+`runtime/rust` gates only the step firing in `Interp::dispatch_traced`, and the
+VM only its `step_scopes_to_fire`. So a command dispatched from inside an
+execution callback fires its own `enter` and `leave` traces, the way
+`TclCheckExecutionTraces` fires them; only an `enterstep`/`leavestep` scope
+goes quiet for the callback's duration. Both engines used to read the gate at
+the whole traced-dispatch fast path instead, and fired neither.
+
+What bounds a callback that invokes the command it traces is C's **per-trace**
+`TCL_TRACE_EXEC_IN_PROGRESS` (:1655), not the interpreter-wide flag — and per
+*trace* is observably different from per command: a second `enter` trace on the
+same command fires for that inner call, and so does a `leave` trace while an
+`enter` one is running. `runtime/rust` carries that as
+`TraceTable::firing_exec_traces` over `CmdTrace::id`; the VM carries it per
+entry as `CmdTraceEntry::firing`.
 
 A read or write callback that errors reshapes the operation's result
 (`can't read "NAME": …` / `can't set "NAME": …`) and stops further firing —

--- a/runtime/rust/src/cmd_coro.rs
+++ b/runtime/rust/src/cmd_coro.rs
@@ -64,7 +64,7 @@ mod imp {
     use std::cell::RefCell;
     use std::panic::AssertUnwindSafe;
     use std::sync::mpsc::{Receiver, Sender};
-    use std::sync::Once;
+    use std::sync::{Arc, Mutex, Once};
     use std::thread::JoinHandle;
 
     /// The panic payload used to unwind a parked worker thread's native stack
@@ -112,6 +112,9 @@ mod imp {
     /// the main-side channel ends and worker join handle.
     pub struct CoroEntry {
         pub(crate) context: CoroContext,
+        /// Shared with the worker thread, so [`rename`] moves the name both
+        /// sides read (see [`CoroName`]).
+        name: CoroName,
         to_coro: Sender<ToCoro>,
         from_coro: Option<Receiver<FromCoro>>,
         join: Option<JoinHandle<()>>,
@@ -125,9 +128,28 @@ mod imp {
     // SAFETY: serialized cooperative handoff — see the module docs.
     unsafe impl Send for SendPtr {}
 
+    /// A coroutine's current command name, shared between the main flow and its
+    /// worker thread so a `rename` is visible on both sides: C ties the
+    /// coroutine to the command *token*, and `[info coroutine]` reports
+    /// whatever that token is called now.
+    pub(crate) type CoroName = Arc<Mutex<Vec<u8>>>;
+
+    /// Read the shared name. Poisoning is ignored — the value is a plain name
+    /// that is never observed half-written, because the lock is only ever held
+    /// across a clone or an assignment, never across anything that can unwind
+    /// (the `CoroTerminate` sentinel included).
+    pub(super) fn read_name(name: &CoroName) -> Vec<u8> {
+        name.lock().unwrap_or_else(|e| e.into_inner()).clone()
+    }
+
+    /// Point the shared name at `value` (a `rename` of the coroutine command).
+    fn write_name(name: &CoroName, value: &[u8]) {
+        value.clone_into(&mut name.lock().unwrap_or_else(|e| e.into_inner()));
+    }
+
     /// The worker thread's own handles + identity (its end of the channels).
     struct CoroTls {
-        name: Vec<u8>,
+        name: CoroName,
         from_coro: Sender<FromCoro>,
         to_coro: Receiver<ToCoro>,
     }
@@ -142,7 +164,7 @@ mod imp {
         TLS.with(|t| {
             t.borrow()
                 .as_ref()
-                .map(|c| c.name.clone())
+                .map(|c| read_name(&c.name))
                 .unwrap_or_default()
         })
     }
@@ -183,7 +205,8 @@ mod imp {
 
         // Hand a clone of the interp to the worker (sound under serialization).
         let send_interp = SendPtr(interp.clone_handle());
-        let worker_name = name.clone();
+        let shared_name: CoroName = Arc::new(Mutex::new(name.clone()));
+        let worker_name = Arc::clone(&shared_name);
         let join = std::thread::Builder::new()
             .stack_size(16 * 1024 * 1024)
             .spawn(move || worker_main(send_interp, cmd_bytes, worker_name, from_tx, to_rx))
@@ -193,6 +216,7 @@ mod imp {
             name.clone(),
             CoroEntry {
                 context,
+                name: shared_name,
                 to_coro: to_tx,
                 from_coro: Some(from_rx),
                 join: Some(join),
@@ -209,14 +233,14 @@ mod imp {
     fn worker_main(
         si: SendPtr,
         cmd_bytes: Vec<Vec<u8>>,
-        name: Vec<u8>,
+        name: CoroName,
         from_tx: Sender<FromCoro>,
         to_rx: Receiver<ToCoro>,
     ) {
         // Install this thread's identity + channel ends.
         TLS.with(|t| {
             *t.borrow_mut() = Some(CoroTls {
-                name: name.clone(),
+                name: Arc::clone(&name),
                 from_coro: from_tx.clone(),
                 to_coro: to_rx,
             });
@@ -247,7 +271,9 @@ mod imp {
         // completion, or in response to a terminate). The main thread is blocked
         // in `resume`/`terminate` recv, so this is race-free.
         let ip = interp;
-        ip.coro_swap_named(&name);
+        // Read the name now, not at spawn: a `rename` while this coroutine was
+        // suspended moved the registry key this swap has to address.
+        ip.coro_swap_named(&read_name(&name));
         let msg = match outcome {
             Ok((code, result)) => FromCoro::Done(code, result),
             Err(_) => FromCoro::Done(Code::Error, Vec::new()),
@@ -359,9 +385,12 @@ mod imp {
             let mut reg = interp.coros_mut();
             let entry = reg.get_mut(name).expect("checked above");
             // (the actual context swap touches other RefCells; do it after)
-            entry.from_coro.take().map(|rx| (entry.to_coro.clone(), rx))
+            entry
+                .from_coro
+                .take()
+                .map(|rx| (entry.to_coro.clone(), rx, Arc::clone(&entry.name)))
         };
-        let Some((to_coro, from_coro)) = chans else {
+        let Some((to_coro, from_coro, shared_name)) = chans else {
             // Already running (re-entrant resume) — C: "coroutine ... is already
             // running".
             let mut m = b"coroutine \"".to_vec();
@@ -374,6 +403,10 @@ mod imp {
             return interp.set_error(b"coroutine is dead");
         }
         let msg = from_coro.recv();
+        // The body may have renamed the coroutine — including itself, `rename
+        // [info coroutine] new` — so address the registry by where it is *now*,
+        // not by the name this resume was called through.
+        let name = &read_name(&shared_name);
         // Put the receiver back for the next resume.
         if let Some(entry) = interp.coros_mut().get_mut(name) {
             entry.from_coro = Some(from_coro);
@@ -394,6 +427,19 @@ mod imp {
                 finish(interp, name);
                 interp.set_error(b"coroutine is dead")
             }
+        }
+    }
+
+    /// `rename $coro $new` moved a live coroutine's command: move its registry
+    /// entry to the new key and point the shared name at it, so the worker's
+    /// own context swaps and `[info coroutine]` address the coroutine where it
+    /// now lives. C needs no equivalent — the coroutine hangs off the command
+    /// token, which a rename moves wholesale.
+    pub(super) fn rename(interp: &mut Interp, old_fqn: &[u8], new_fqn: &[u8]) {
+        let entry = interp.coros_mut().remove(old_fqn);
+        if let Some(entry) = entry {
+            write_name(&entry.name, new_fqn);
+            interp.coros_mut().insert(new_fqn.to_vec(), entry);
         }
     }
 
@@ -421,9 +467,12 @@ mod imp {
         let chans = {
             let mut reg = interp.coros_mut();
             let entry = reg.get_mut(name).expect("checked above");
-            entry.from_coro.take().map(|rx| (entry.to_coro.clone(), rx))
+            entry
+                .from_coro
+                .take()
+                .map(|rx| (entry.to_coro.clone(), rx, Arc::clone(&entry.name)))
         };
-        let Some((to_coro, from_coro)) = chans else {
+        let Some((to_coro, from_coro, shared_name)) = chans else {
             return interp.set_error(b"can only inject a probe command into a suspended coroutine");
         };
         // Swap the coroutine's context in so the probe runs in its frames, hand
@@ -433,6 +482,9 @@ mod imp {
         interp.coro_swap_named(name);
         let sent = to_coro.send(ToCoro::Probe(words)).is_ok();
         let msg = if sent { from_coro.recv().ok() } else { None };
+        // A probe command can rename the coroutine, so swap back and put the
+        // receiver away under the name it answers to now (see `resume`).
+        let name = &read_name(&shared_name);
         interp.coro_swap_named(name);
         if let Some(entry) = interp.coros_mut().get_mut(name) {
             entry.from_coro = Some(from_coro);
@@ -464,15 +516,19 @@ mod imp {
         let chans = {
             let mut reg = interp.coros_mut();
             let entry = reg.get_mut(name).expect("checked above");
-            entry.from_coro.take().map(|rx| (entry.to_coro.clone(), rx))
+            entry
+                .from_coro
+                .take()
+                .map(|rx| (entry.to_coro.clone(), rx, Arc::clone(&entry.name)))
         };
-        let Some((to_coro, from_coro)) = chans else {
+        let Some((to_coro, from_coro, shared_name)) = chans else {
             return interp.set_error(b"can only inject a command into a suspended coroutine");
         };
         // No context swap: the worker only records the command (it runs later, on
         // resume). Send + await the acknowledgement to keep the channel in step.
         let sent = to_coro.send(ToCoro::Inject(words)).is_ok();
         let msg = if sent { from_coro.recv().ok() } else { None };
+        let name = &read_name(&shared_name);
         if let Some(entry) = interp.coros_mut().get_mut(name) {
             entry.from_coro = Some(from_coro);
         }
@@ -502,19 +558,24 @@ mod imp {
         let chans = {
             let mut reg = interp.coros_mut();
             match reg.get_mut(name) {
-                Some(e) => e.from_coro.take().map(|rx| (e.to_coro.clone(), rx)),
+                Some(e) => e
+                    .from_coro
+                    .take()
+                    .map(|rx| (e.to_coro.clone(), rx, Arc::clone(&e.name))),
                 None => return,
             }
         };
-        if let Some((to_coro, from_coro)) = chans {
+        let mut name = name.to_vec();
+        if let Some((to_coro, from_coro, shared_name)) = chans {
             // Install the coroutine's context so its worker unwinds in its own
             // frames, then signal + await the acknowledgement.
-            interp.coro_swap_named(name);
+            interp.coro_swap_named(&name);
             if to_coro.send(ToCoro::Terminate).is_ok() {
                 let _ = from_coro.recv();
             }
+            name = read_name(&shared_name);
         }
-        let entry = interp.coros_mut().remove(name);
+        let entry = interp.coros_mut().remove(&name);
         if let Some(mut e) = entry {
             if let Some(j) = e.join.take() {
                 let _ = j.join();
@@ -547,13 +608,24 @@ fn yieldto_cmd(interp: &mut Interp, _argv: &[*mut TclObj]) -> Code {
     interp.set_error(b"yieldto is not yet implemented")
 }
 
+/// The registry key a written coroutine name addresses: its fully-qualified
+/// name, followed through an open `rename` window. Inside a rename's callbacks
+/// the vacating name still resolves but *is* the destination command (C's two
+/// hash entries reference the one `Command`, and the coroutine hangs off that),
+/// so resuming or probing through either name reaches the one coroutine.
+#[cfg(not(target_arch = "wasm32"))]
+fn coro_key(interp: &Interp, written: &[u8]) -> Vec<u8> {
+    let fqn = interp.fqn_for(written);
+    interp.renamed_cmd_key(&fqn).unwrap_or(fqn)
+}
+
 #[cfg(not(target_arch = "wasm32"))]
 fn coroprobe_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     if argv.len() < 3 {
         return interp
             .set_error(b"wrong # args: should be \"coroprobe coroName cmd ?arg1 arg2 ...?\"");
     }
-    let name = interp.fqn_for(&obj_bytes(argv[1]));
+    let name = coro_key(interp, &obj_bytes(argv[1]));
     let words: Vec<Vec<u8>> = argv[2..].iter().map(|&a| obj_bytes(a)).collect();
     imp::probe(interp, &name, words)
 }
@@ -564,7 +636,7 @@ fn coroinject_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         return interp
             .set_error(b"wrong # args: should be \"coroinject coroName cmd ?arg1 arg2 ...?\"");
     }
-    let name = interp.fqn_for(&obj_bytes(argv[1]));
+    let name = coro_key(interp, &obj_bytes(argv[1]));
     let words: Vec<Vec<u8>> = argv[2..].iter().map(|&a| obj_bytes(a)).collect();
     imp::inject(interp, &name, words)
 }
@@ -579,7 +651,7 @@ fn corotype_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         return interp
             .set_error(b"wrong # args: should be \"::tcl::unsupported::corotype coroName\"");
     }
-    let name = interp.fqn_for(&obj_bytes(argv[1]));
+    let name = coro_key(interp, &obj_bytes(argv[1]));
     if current_coroutine() == name {
         interp.set_result_bytes(b"active");
         return Code::Ok;
@@ -594,7 +666,7 @@ fn corotype_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
 /// Resume the coroutine named by `argv[0]` (its command invocation).
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) fn coro_resume_command(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
-    let name = interp.fqn_for(&obj_bytes(argv[0]));
+    let name = coro_key(interp, &obj_bytes(argv[0]));
     let value = argv.get(1).map(|&a| obj_bytes(a)).unwrap_or_default();
     imp::resume(interp, &name, value)
 }
@@ -603,8 +675,17 @@ pub(crate) fn coro_resume_command(interp: &mut Interp, argv: &[*mut TclObj]) -> 
 /// is a *suspended* coroutine, terminate its worker cleanly first.
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) fn on_command_deleted(interp: &mut Interp, name: &[u8]) {
-    let fqn = interp.fqn_for(name);
+    let fqn = coro_key(interp, name);
     imp::terminate(interp, &fqn);
+}
+
+/// Hook for `rename $coro $new`: move a live coroutine's state to the new name.
+/// C keeps the coroutine on the command *token*, so a rename is transparent to
+/// it — including to `[info coroutine]`, which reports the new name from inside
+/// the coroutine itself (tclsh 8.6/9.0-pinned).
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) fn on_command_renamed(interp: &mut Interp, old_fqn: &[u8], new_fqn: &[u8]) {
+    imp::rename(interp, old_fqn, new_fqn);
 }
 
 /// `info coroutine` — the current coroutine's command name (empty on the main
@@ -672,6 +753,9 @@ pub(crate) fn coro_resume_command(interp: &mut Interp, _argv: &[*mut TclObj]) ->
 
 #[cfg(target_arch = "wasm32")]
 pub(crate) fn on_command_deleted(_interp: &mut Interp, _name: &[u8]) {}
+
+#[cfg(target_arch = "wasm32")]
+pub(crate) fn on_command_renamed(_interp: &mut Interp, _old_fqn: &[u8], _new_fqn: &[u8]) {}
 
 #[cfg(target_arch = "wasm32")]
 pub fn current_coroutine() -> Vec<u8> {
@@ -781,6 +865,58 @@ mod tests {
         run(&mut i, b"namespace delete ::N");
         run(&mut i, b"rename ::co {}");
         assert_eq!(run(&mut i, b"list $log [namespace exists ::N]"), b"{} 0");
+    }
+
+    /// A `rename` carries a live coroutine with its command, as C carries it
+    /// with the command *token*: the new name resumes it, `[info coroutine]`
+    /// reports the new name from inside the body, `corotype` still finds it,
+    /// and the delete side still tears it down — across namespaces too. The
+    /// runtime used to leave the coroutine undispatchable under either name
+    /// (its registry stayed keyed by the vacated name).
+    ///
+    /// tclsh 8.6.16 and 9.0.4 both produce this sequence.
+    #[test]
+    fn a_rename_carries_a_live_coroutine_to_its_new_name() {
+        let mut i = Interp::new();
+        run(
+            &mut i,
+            b"proc body {} { yield; yield [info coroutine]; return B }",
+        );
+        // Creation runs to the first (valueless) yield.
+        assert_eq!(run(&mut i, b"coroutine co body"), b"");
+        run(&mut i, b"rename co c2");
+        assert_eq!(run(&mut i, b"llength [info commands co]"), b"0");
+        assert_eq!(run(&mut i, b"llength [info commands c2]"), b"1");
+        assert_eq!(run(&mut i, b"::tcl::unsupported::corotype c2"), b"yield");
+        // The resume reaches the coroutine, and the body reports the new name.
+        assert_eq!(run(&mut i, b"c2"), b"::c2");
+        assert_eq!(run(&mut i, b"c2"), b"B");
+        assert_eq!(run(&mut i, b"llength [info commands c2]"), b"0");
+        // The same across namespaces, and the delete side still terminates it.
+        run(&mut i, b"namespace eval n {}");
+        run(&mut i, b"coroutine k body");
+        run(&mut i, b"rename k ::n::k");
+        assert_eq!(run(&mut i, b"n::k"), b"::n::k");
+        run(&mut i, b"rename ::n::k {}");
+        assert_eq!(run(&mut i, b"llength [info commands ::n::k]"), b"0");
+    }
+
+    /// The same rule seen from the inside: a coroutine that renames *itself*
+    /// while running keeps going, and its resumer's bookkeeping follows it —
+    /// the next resume must reach it under the name it chose.
+    #[test]
+    fn a_coroutine_can_rename_itself_and_keep_running() {
+        let mut i = Interp::new();
+        run(
+            &mut i,
+            b"proc body {} { yield; rename [info coroutine] self2; \
+              yield [info coroutine]; return B }",
+        );
+        run(&mut i, b"coroutine co body");
+        assert_eq!(run(&mut i, b"co"), b"::self2");
+        assert_eq!(run(&mut i, b"self2"), b"B");
+        assert_eq!(run(&mut i, b"llength [info commands self2]"), b"0");
+        assert_eq!(run(&mut i, b"llength [info commands co]"), b"0");
     }
 
     #[test]

--- a/runtime/rust/src/cmd_trace.rs
+++ b/runtime/rust/src/cmd_trace.rs
@@ -223,15 +223,22 @@ pub struct TraceTable {
     /// **delete** walk holds the dying token's list, so a callback that
     /// re-creates the command under the same name takes the name-keyed table
     /// entry over without cancelling the remaining callbacks; only an explicit
-    /// untrace does. Recorded only while `exec_firing > 0` and cleared when the
-    /// outermost walk ends, so it never grows unbounded.
+    /// untrace does. Recorded only while a walk is in flight
+    /// ([`Self::trace_walk_in_flight`]) and cleared when the outermost one
+    /// ends, so it never grows unbounded.
     pub untraced_cmd_trace_ids: Vec<u64>,
     /// Variable cells whose trace callbacks are currently running. Other
     /// variables remain traceable from within a callback.
     pub active_var_scopes: Vec<VarTraceScope>,
-    /// Non-zero while a command/execution trace callback is running — C's
-    /// `INTERP_TRACE_IN_PROGRESS`. Suppresses re-entrant execution/step firing
-    /// so a callback that invokes the traced command doesn't recurse.
+    /// Non-zero while an **execution** trace callback (`enter`/`leave`/
+    /// `enterstep`/`leavestep`) is running — C's `INTERP_TRACE_IN_PROGRESS`,
+    /// which `TraceExecutionProc` sets around exactly those callbacks
+    /// (tclTrace.c 9.0.4:1765) and nothing else sets. A `rename`/`delete`
+    /// callback does **not** raise it: C's `CallCommandTraces` sets no flag, so
+    /// a command such a callback dispatches is traced like any other. Re-entry
+    /// into a command's own `rename`/`delete` traces is suppressed per command
+    /// by [`Self::firing_cmd_traces`] instead, and that list is also what marks
+    /// such a walk in flight (see [`Self::trace_walk_in_flight`]).
     pub exec_firing: usize,
     /// The commands whose `rename`/`delete` traces are currently firing. C
     /// guards those per `Command` (`CMD_TRACE_ACTIVE`, and `CMD_DYING` for a
@@ -252,6 +259,21 @@ pub struct TraceTable {
     /// the variable access can fail with `can't read/set "name": <msg>` (C's
     /// `TclCallVarTraces` propagation). Taken by the access chokepoint.
     pub pending_err: Option<Vec<u8>>,
+}
+
+impl TraceTable {
+    /// Whether a command or execution trace walk is in flight — the window in
+    /// which a `trace remove` has to be recorded so the walk skips the
+    /// registration it unlinked (see [`Self::untraced_cmd_trace_ids`]).
+    ///
+    /// Two pieces of state, because the two walks are marked differently: an
+    /// execution callback raises [`Self::exec_firing`], C's
+    /// `INTERP_TRACE_IN_PROGRESS`, while a `rename`/`delete` walk deliberately
+    /// raises nothing of the sort — C's `CallCommandTraces` sets no interpreter
+    /// flag — and is marked only by its entry in [`Self::firing_cmd_traces`].
+    pub fn trace_walk_in_flight(&self) -> bool {
+        self.exec_firing > 0 || !self.firing_cmd_traces.is_empty()
+    }
 }
 
 /// Whether `t` belongs to the resolved variable identity. Namespace variables
@@ -501,7 +523,7 @@ fn cmd_trace_add_remove(
             .rposition(|t| t.name == fqn && t.ops == flags && t.command == command);
         if let Some(i) = pos {
             let mut traces = interp.traces.borrow_mut();
-            if traces.exec_firing > 0 {
+            if traces.trace_walk_in_flight() {
                 let id = traces.cmd_traces[i].id;
                 traces.untraced_cmd_trace_ids.push(id);
             }

--- a/runtime/rust/src/cmd_trace.rs
+++ b/runtime/rust/src/cmd_trace.rs
@@ -238,6 +238,16 @@ pub struct TraceTable {
     /// deletion), not interpreter-wide: a callback that deletes a *different*
     /// command still fires that command's own delete traces, nested.
     pub firing_cmd_traces: Vec<Vec<u8>>,
+    /// Source→destination FQN pairs for the `rename` windows currently open,
+    /// innermost last. C creates the destination hash entry, fires the
+    /// `rename` traces and only then deletes the source, and *both* entries
+    /// reference the one `Command` — so for the callbacks' duration the
+    /// vacating name **is** the destination command: it answers `trace info`,
+    /// takes `trace add`/`remove`, and a `rename` or delete through it moves
+    /// or destroys the destination (tclsh 8.6.16 and 9.0.4 identical). Our
+    /// registries are keyed by name, so each open window records that
+    /// equivalence; [`crate::interp::Interp::renamed_cmd_key`] reads it.
+    pub rename_windows: Vec<(Vec<u8>, Vec<u8>)>,
     /// The error message a read/write variable-trace callback left, captured so
     /// the variable access can fail with `can't read/set "name": <msg>` (C's
     /// `TclCallVarTraces` propagation). Taken by the access chokepoint.
@@ -457,6 +467,10 @@ fn cmd_trace_add_remove(
     let Some(fqn) = interp.resolve_cmd_fqn(&name) else {
         return interp.unknown_command(&name);
     };
+    // Inside a rename's callbacks the vacating name reaches the destination's
+    // list: C hangs the traces off the shared `Command`, not off either hash
+    // entry, so both names edit the one list.
+    let fqn = interp.renamed_cmd_key(&fqn).unwrap_or(fqn);
     let command = obj_bytes(argv[5]);
     if is_add {
         // The trace belongs to the token standing at `fqn` now, not to the
@@ -518,6 +532,9 @@ fn cmd_trace_info(interp: &mut Interp, argv: &[*mut TclObj], category: u8) -> Co
     let Some(fqn) = interp.resolve_cmd_fqn(&name) else {
         return interp.unknown_command(&name);
     };
+    // As in `cmd_trace_add_remove`: a rename's vacating name answers with the
+    // destination's list, because C keeps one list on the shared `Command`.
+    let fqn = interp.renamed_cmd_key(&fqn).unwrap_or(fqn);
     // (bit, label) pairs in C's print order for each category.
     let order: &[(u8, &[u8])] = if category == ops::EXEC_ANY {
         &[

--- a/runtime/rust/src/cmd_trace.rs
+++ b/runtime/rust/src/cmd_trace.rs
@@ -128,6 +128,12 @@ pub struct CmdTrace {
     /// untrace can cancel it. A delete walk needs both: it fires the dying
     /// token's list to the end even as a callback rebinds the name, and still
     /// skips whatever that callback untraced.
+    ///
+    /// It is also C's `TraceCommandInfo *` for the purpose its
+    /// `TCL_TRACE_EXEC_IN_PROGRESS` flag hangs off: suppression while a
+    /// callback runs is **per trace**, not per command, so a second trace on
+    /// the same command still fires for a call the first one's callback makes
+    /// (see [`TraceTable::firing_exec_traces`]).
     pub id: u64,
     /// The generation of the command **token** this trace hangs off, or `None`
     /// when the binding had none (a hidden command).
@@ -227,6 +233,16 @@ pub struct TraceTable {
     /// ([`Self::trace_walk_in_flight`]) and cleared when the outermost one
     /// ends, so it never grows unbounded.
     pub untraced_cmd_trace_ids: Vec<u64>,
+    /// The execution traces whose callbacks are currently running — C's
+    /// per-trace `TCL_TRACE_EXEC_IN_PROGRESS` (`tclTrace.c` 9.0.4:1655,
+    /// "Inside any kind of execution trace callback, we do not allow any
+    /// further execution trace callbacks to be called for the same trace").
+    /// This is what bounds a callback that invokes the command it traces;
+    /// [`Self::exec_firing`] deliberately does not, because it gates only the
+    /// step machinery. Distinct from [`Self::untraced_cmd_trace_ids`], which
+    /// records registrations a callback *removed* rather than ones it is
+    /// running.
+    pub firing_exec_traces: Vec<u64>,
     /// Variable cells whose trace callbacks are currently running. Other
     /// variables remain traceable from within a callback.
     pub active_var_scopes: Vec<VarTraceScope>,
@@ -235,10 +251,16 @@ pub struct TraceTable {
     /// which `TraceExecutionProc` sets around exactly those callbacks
     /// (tclTrace.c 9.0.4:1765) and nothing else sets. A `rename`/`delete`
     /// callback does **not** raise it: C's `CallCommandTraces` sets no flag, so
-    /// a command such a callback dispatches is traced like any other. Re-entry
-    /// into a command's own `rename`/`delete` traces is suppressed per command
-    /// by [`Self::firing_cmd_traces`] instead, and that list is also what marks
-    /// such a walk in flight (see [`Self::trace_walk_in_flight`]).
+    /// a command such a callback dispatches is traced like any other.
+    ///
+    /// It is read exactly where C reads its flag — `TclCheckInterpTraces`
+    /// (:1426), the `enterstep`/`leavestep` machinery — and nowhere else:
+    /// `TclCheckExecutionTraces` (:1301) never consults it, so a command
+    /// dispatched from inside a callback still fires its own `enter`/`leave`
+    /// traces. Re-entry into the *same* trace is bounded by
+    /// [`Self::firing_exec_traces`], and into a command's own `rename`/`delete`
+    /// traces by [`Self::firing_cmd_traces`] — which is also what marks such a
+    /// walk in flight (see [`Self::trace_walk_in_flight`]).
     pub exec_firing: usize,
     /// The commands whose `rename`/`delete` traces are currently firing. C
     /// guards those per `Command` (`CMD_TRACE_ACTIVE`, and `CMD_DYING` for a

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -1888,16 +1888,6 @@ impl Interp {
         let Some(old_fqn) = self.resolve_cmd_fqn(old) else {
             return RenameOutcome::NoSuchCommand;
         };
-        // `Namespaces::publish_rename_destination` writes the table entry
-        // directly rather than going through `ns_register`, so clear the
-        // destination's TclOO root marking here too. Today an OO rename is also
-        // re-registered through the funnel by `oo_command_renamed`, which
-        // clears it; doing it here as well makes the invariant — "a root
-        // marking never outlives the entry it described" — hold for the rename
-        // path on its own, rather than by way of a follow-up call that a future
-        // refactor could reorder or drop.
-        let dest = self.fqn_for(new);
-        self.forget_registry_object_root(&dest);
         let Some(publication) = self.namespaces.borrow_mut().publish_rename_destination(
             self.current_ns.get(),
             old,
@@ -1906,6 +1896,15 @@ impl Interp {
             return RenameOutcome::NoSuchCommand;
         };
         let new_fqn = publication.destination_fqn.clone();
+        // `Namespaces::publish_rename_destination` writes the table entry
+        // directly rather than going through `ns_register`, so drop the marking
+        // that described whatever it displaced at the destination. Today an OO
+        // rename is also re-registered through the funnel by
+        // `oo_command_renamed`, which clears it; doing it here as well makes the
+        // invariant — "a root marking never outlives the entry it described" —
+        // hold for the rename path on its own, rather than by way of a
+        // follow-up call that a future refactor could reorder or drop.
+        self.forget_registry_object_root(&new_fqn);
         // The trace list (and any OO object) follows to the new name, and so
         // does every `namespace import` redirect of the old name — C's imports
         // hold the source's command token, so they survive a source rename

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -1805,8 +1805,20 @@ impl Interp {
     }
 
     /// `rename old new` (or `rename old ""` to delete), relative to the current
-    /// namespace. Drives the one command table; see [`Namespaces::rename`].
+    /// namespace. Drives the one command table: the guards C's
+    /// `TclRenameCommand` applies before anything observable happens, then
+    /// [`Self::move_bound_command`] or [`Self::delete_bound_command`].
     pub(crate) fn rename_command(&mut self, old: &[u8], new: &[u8]) -> RenameOutcome {
+        // Inside an open `rename` window the vacating name still resolves, but
+        // it *is* the destination command — C's two hash entries reference the
+        // one `Command` — so a callback's `rename <old> <third>` or `rename
+        // <old> {}` moves or destroys that command rather than a second copy
+        // standing at the vacating name. Resolved up front, because every guard
+        // below and both halves address the binding through this name.
+        let through_window = self
+            .resolve_cmd_fqn(old)
+            .and_then(|fqn| self.renamed_cmd_key(&fqn));
+        let old: &[u8] = through_window.as_deref().unwrap_or(old);
         // C's `TclPreventAliasLoop` guards `rename` too, and refuses before
         // anything observable happens — no rename trace fires for a rename that
         // does not take place.
@@ -1850,6 +1862,83 @@ impl Interp {
         {
             return RenameOutcome::NoSuchCommand;
         }
+        if new.is_empty() {
+            self.delete_bound_command(old)
+        } else {
+            self.move_bound_command(old, new)
+        }
+    }
+
+    /// The `rename old new` half, after [`Self::rename_command`]'s guards.
+    ///
+    /// C's `TclRenameCommand` (`tclBasic.c` 9.0.4) creates the destination hash
+    /// entry, fires the `rename` traces, and only *then* deletes the source
+    /// one; both entries reference the one `Command`, and the traces hang off
+    /// that rather than off either entry. So for the callbacks' duration the
+    /// vacating name **is** the destination command: both names resolve and are
+    /// callable, `trace info` answers the same list through either, a `trace
+    /// add`/`remove` through either edits it, and a `rename` or delete through
+    /// either moves or destroys that one command. Everything the command
+    /// carries therefore moves to the destination *before* the callbacks run,
+    /// and the window
+    /// ([`rename_windows`](crate::cmd_trace::TraceTable::rename_windows))
+    /// records the equivalence our name-keyed registries cannot express.
+    fn move_bound_command(&mut self, old: &[u8], new: &[u8]) -> RenameOutcome {
+        self.invalidate_command_environment();
+        let Some(old_fqn) = self.resolve_cmd_fqn(old) else {
+            return RenameOutcome::NoSuchCommand;
+        };
+        // `Namespaces::publish_rename_destination` writes the table entry
+        // directly rather than going through `ns_register`, so clear the
+        // destination's TclOO root marking here too. Today an OO rename is also
+        // re-registered through the funnel by `oo_command_renamed`, which
+        // clears it; doing it here as well makes the invariant — "a root
+        // marking never outlives the entry it described" — hold for the rename
+        // path on its own, rather than by way of a follow-up call that a future
+        // refactor could reorder or drop.
+        let dest = self.fqn_for(new);
+        self.forget_registry_object_root(&dest);
+        let Some(publication) = self.namespaces.borrow_mut().publish_rename_destination(
+            self.current_ns.get(),
+            old,
+            new,
+        ) else {
+            return RenameOutcome::NoSuchCommand;
+        };
+        let new_fqn = publication.destination_fqn.clone();
+        // The trace list (and any OO object) follows to the new name, and so
+        // does every `namespace import` redirect of the old name — C's imports
+        // hold the source's command token, so they survive a source rename
+        // (tclsh-pinned; see `Namespaces::retarget_imports`). All of it happens
+        // here, before the callbacks, because C had moved its one `Command`
+        // before it fired them.
+        self.move_cmd_traces(&old_fqn, &new_fqn);
+        self.retarget_import_sources(&old_fqn, &new_fqn);
+        if !self.oo_is_empty() {
+            self.oo_command_renamed(&old_fqn, Some(&new_fqn));
+        }
+        self.traces
+            .borrow_mut()
+            .rename_windows
+            .push((old_fqn.clone(), new_fqn.clone()));
+        self.fire_cmd_trace(&new_fqn, &old_fqn, &new_fqn, crate::cmd_trace::ops::RENAME);
+        self.traces.borrow_mut().rename_windows.pop();
+        // C's `Tcl_DeleteHashEntry(oldHPtr)` at the tail of `TclRenameCommand`:
+        // a plain table removal, firing no `delete` trace, after which the
+        // command stands under its new name alone. Whatever occupies the slot
+        // goes — C's captured entry pointer does not care either, and a
+        // callback that rebound the vacating name left C dereferencing freed
+        // memory, so there is no behaviour there to match.
+        self.namespaces
+            .borrow_mut()
+            .retire_rename_source(&publication);
+        RenameOutcome::Renamed
+    }
+
+    /// The `rename old ""` half, after [`Self::rename_command`]'s guards — C's
+    /// `Tcl_DeleteCommandFromToken`, whose `delete` traces fire while the
+    /// command is still bound under its name.
+    fn delete_bound_command(&mut self, old: &[u8]) -> RenameOutcome {
         let (ensemble_token, import_token) =
             match self.namespaces.borrow().resolve(self.current_ns.get(), old) {
                 Some(Command::Ensemble(token)) => (Some(token), None),
@@ -1857,11 +1946,11 @@ impl Interp {
                 _ => (None, None),
             };
         self.invalidate_command_environment();
-        // Command traces fire *before* the table mutation (C's TclRenameCommand:
-        // the command still exists under its old name during the callback), with
-        // the fully-qualified old and new names. C deletes the command *token*
-        // it captured here, not whatever the name holds when the callback
-        // returns — so the binding is captured alongside the name.
+        // Command traces fire *before* the table mutation (the command still
+        // exists under its name during the callback), with the fully-qualified
+        // old name and an empty new one. C deletes the command *token* it
+        // captured here, not whatever the name holds when the callback returns
+        // — so the binding is captured alongside the name.
         let bound_before = self.namespaces.borrow().resolve(self.current_ns.get(), old);
         // The token whose trace list this deletion frees, captured before the
         // callbacks can bind a replacement at the same name.
@@ -1869,43 +1958,21 @@ impl Interp {
         let old_fqn = self.resolve_cmd_fqn(old);
         if let Some(of) = &old_fqn {
             if !self.traces.borrow().cmd_traces.is_empty() {
-                if new.is_empty() {
-                    self.fire_cmd_trace(of, b"", crate::cmd_trace::ops::DELETE);
-                } else {
-                    let nf = self.fqn_for(new);
-                    self.fire_cmd_trace(of, &nf, crate::cmd_trace::ops::RENAME);
-                }
+                self.fire_cmd_trace(of, of, b"", crate::cmd_trace::ops::DELETE);
             }
         }
         let existed = old_fqn.is_some();
         // Deleting a suspended coroutine's command tears down its worker first.
-        if new.is_empty() {
-            if let Some(of) = &old_fqn {
-                crate::cmd_coro::on_command_deleted(self, of);
-            }
-        }
-        // `Namespaces::rename` moves the table entry directly rather than going
-        // through `ns_register`, so clear the destination's TclOO root marking
-        // here too. Today an OO rename is also re-registered through the funnel
-        // by `oo_command_renamed`, which clears it; doing it here as well makes
-        // the invariant — "a root marking never outlives the entry it
-        // described" — hold for the rename path on its own, rather than by way
-        // of a follow-up call that a future refactor could reorder or drop.
-        if !new.is_empty() {
-            let dest = self.fqn_for(new);
-            self.forget_registry_object_root(&dest);
+        if let Some(of) = &old_fqn {
+            crate::cmd_coro::on_command_deleted(self, of);
         }
         // An imported command carries a stable identity. Its delete trace may
         // force-reimport or otherwise replace the same binding; delete the
         // captured old identity wherever it moved, never the callback's fresh
         // command at the old name.
-        let removed_import_fqn = if new.is_empty() {
-            import_token
-                .as_ref()
-                .and_then(|identity| self.remove_import_identity(identity))
-        } else {
-            None
-        };
+        let removed_import_fqn = import_token
+            .as_ref()
+            .and_then(|identity| self.remove_import_identity(identity));
         // A delete-trace callback that re-creates the command (`proc foo {} …`)
         // has bound a *new* command at the old name. C's captured token is
         // `CMD_DYING` and no longer owns the hash entry, so its deletion leaves
@@ -1914,77 +1981,56 @@ impl Interp {
         // "whatever is at the name now" would remove the callback's work
         // instead. This is the command half of the rule the import branch just
         // above already applies to its own identity. Issue #1633.
-        let recreated = new.is_empty()
-            && match (
-                &bound_before,
-                self.namespaces.borrow().resolve(self.current_ns.get(), old),
-            ) {
-                (Some(before), Some(now)) => !before.is_same_binding(&now),
-                _ => false,
-            };
+        let recreated = match (
+            &bound_before,
+            self.namespaces.borrow().resolve(self.current_ns.get(), old),
+        ) {
+            (Some(before), Some(now)) => !before.is_same_binding(&now),
+            _ => false,
+        };
         let raw = if recreated {
             RenameOutcome::Deleted
-        } else if new.is_empty() && import_token.is_some() {
+        } else if import_token.is_some() {
             if removed_import_fqn.is_some() {
                 RenameOutcome::Deleted
             } else {
                 RenameOutcome::NoSuchCommand
             }
+        } else if self
+            .namespaces
+            .borrow_mut()
+            .delete(self.current_ns.get(), old)
+        {
+            RenameOutcome::Deleted
         } else {
-            self.namespaces
-                .borrow_mut()
-                .rename(self.current_ns.get(), old, new)
+            RenameOutcome::NoSuchCommand
         };
         // A delete-trace callback may itself delete the command (e.g. by
         // deleting the object's namespace). C captured the command token before
         // the callback, so the deletion still succeeds — treat "existed at
-        // entry, gone now, `new` empty" as a normal delete (cleanup is
-        // idempotent) rather than reporting "command doesn't exist".
-        let outcome = if existed && matches!(raw, RenameOutcome::NoSuchCommand) && new.is_empty() {
+        // entry, gone now" as a normal delete (cleanup is idempotent) rather
+        // than reporting "command doesn't exist".
+        let outcome = if existed && matches!(raw, RenameOutcome::NoSuchCommand) {
             RenameOutcome::Deleted
         } else {
             raw
         };
-        if let Some(of) = old_fqn {
-            let oo_live = !self.oo_is_empty();
-            match outcome {
-                // The trace list (and any OO object) follows to the new name,
-                // and so does every `namespace import` redirect of the old
-                // name — C's imports hold the source's command token, so they
-                // survive a source rename (tclsh-pinned; see
-                // `Namespaces::retarget_imports`).
-                RenameOutcome::Renamed => {
-                    let nf = self.fqn_for(new);
-                    self.move_cmd_traces(&of, &nf);
-                    self.retarget_import_sources(&of, &nf);
-                    if oo_live {
-                        self.oo_command_renamed(&of, Some(&nf));
-                    }
+        // The command is gone; the dying token's traces and OO registry entry
+        // go with it. A replacement the delete callback bound at the same name
+        // keeps its own traces (C frees only `cmdPtr->tracePtr`).
+        if let (Some(of), RenameOutcome::Deleted) = (old_fqn, outcome) {
+            self.remove_cmd_traces_of_token(&of, dying_token);
+            let tokens: Vec<_> = ensemble_token.into_iter().collect();
+            let mut origins = vec![of.clone()];
+            if let Some(removed_fqn) = removed_import_fqn {
+                if removed_fqn != of {
+                    self.remove_cmd_traces(&removed_fqn);
+                    origins.push(removed_fqn);
                 }
-                // The command is gone; the dying token's traces and OO
-                // registry entry go with it. A replacement the delete callback
-                // bound at the same name keeps its own traces (C frees only
-                // `cmdPtr->tracePtr`).
-                RenameOutcome::Deleted => {
-                    self.remove_cmd_traces_of_token(&of, dying_token);
-                    let tokens: Vec<_> = ensemble_token.into_iter().collect();
-                    let mut origins = vec![of.clone()];
-                    if let Some(removed_fqn) = removed_import_fqn {
-                        if removed_fqn != of {
-                            self.remove_cmd_traces(&removed_fqn);
-                            origins.push(removed_fqn);
-                        }
-                    }
-                    self.remove_imports_for_deleted_origins(origins, &tokens);
-                    if oo_live {
-                        self.oo_command_renamed(&of, None);
-                    }
-                }
-                // `AliasLoop` and `TargetExists` both returned above, before
-                // the table was touched.
-                RenameOutcome::NoSuchCommand
-                | RenameOutcome::AliasLoop
-                | RenameOutcome::TargetExists => {}
+            }
+            self.remove_imports_for_deleted_origins(origins, &tokens);
+            if !self.oo_is_empty() {
+                self.oo_command_renamed(&of, None);
             }
         }
         outcome
@@ -2278,7 +2324,7 @@ impl Interp {
         {
             return;
         }
-        self.fire_cmd_trace_of_token(fqn, b"", crate::cmd_trace::ops::DELETE, dying);
+        self.fire_cmd_trace_of_token(fqn, fqn, b"", crate::cmd_trace::ops::DELETE, dying);
         self.remove_cmd_traces_of_token(fqn, dying);
     }
 
@@ -3846,8 +3892,8 @@ impl Interp {
     /// commands"). Re-entrant firing on *this* command is suppressed (C's
     /// per-`Command` `CMD_TRACE_ACTIVE`/`CMD_DYING`); the interp result is
     /// preserved across the callbacks.
-    fn fire_cmd_trace(&mut self, old_fqn: &[u8], new_fqn: &[u8], op_bit: u8) {
-        self.fire_cmd_trace_of_token(old_fqn, new_fqn, op_bit, None);
+    fn fire_cmd_trace(&mut self, key: &[u8], old_fqn: &[u8], new_fqn: &[u8], op_bit: u8) {
+        self.fire_cmd_trace_of_token(key, old_fqn, new_fqn, op_bit, None);
     }
 
     /// [`fire_cmd_trace`] restricted to one command token's own trace list.
@@ -3857,8 +3903,15 @@ impl Interp {
     /// token being deleted. `dying` is `None` when the caller has no token to
     /// discriminate by, and then the whole name fires (rename, and hidden
     /// commands, which carry no generation).
+    ///
+    /// `key` addresses the trace list and gates re-entry; `old_fqn` only names
+    /// the command in the callback's first word. They differ for a rename,
+    /// which fires from the *destination's* list (see
+    /// [`Self::move_bound_command`]) while still naming the command it is
+    /// leaving.
     fn fire_cmd_trace_of_token(
         &mut self,
+        key: &[u8],
         old_fqn: &[u8],
         new_fqn: &[u8],
         op_bit: u8,
@@ -3869,7 +3922,7 @@ impl Interp {
             .borrow()
             .firing_cmd_traces
             .iter()
-            .any(|firing| firing == old_fqn)
+            .any(|firing| firing == key)
         {
             return;
         }
@@ -3892,7 +3945,7 @@ impl Interp {
             // token under the same name), while the id lets the walk skip a
             // registration an explicit `trace remove` cancelled mid-walk.
             .filter(|t| {
-                t.name == old_fqn && (t.ops & op_bit) != 0 && cmd_trace_owned_by(t.token, dying)
+                t.name == key && (t.ops & op_bit) != 0 && cmd_trace_owned_by(t.token, dying)
             })
             .map(|t| (t.id, t.command.clone()))
             .collect();
@@ -3911,7 +3964,7 @@ impl Interp {
         {
             let mut traces = self.traces.borrow_mut();
             traces.exec_firing += 1;
-            traces.firing_cmd_traces.push(old_fqn.to_vec());
+            traces.firing_cmd_traces.push(key.to_vec());
         }
         for (id, cmd) in entries {
             if self.cmd_trace_untraced(id) {
@@ -4097,10 +4150,47 @@ impl Interp {
         }
     }
 
+    /// The name a command's identity lives under now, following any open
+    /// `rename` window (see [`crate::cmd_trace::TraceTable::rename_windows`]) —
+    /// `None` outside one. Inside a rename's callbacks the vacating name still
+    /// resolves, but it *is* the destination command, so a `trace`, a `rename`
+    /// or a delete through it must reach the destination's state.
+    pub(crate) fn renamed_cmd_key(&self, fqn: &[u8]) -> Option<Vec<u8>> {
+        self.traces
+            .borrow()
+            .rename_windows
+            .iter()
+            .find(|(from, _)| from == fqn)
+            .map(|(_, to)| to.clone())
+    }
+
+    /// A command moved `old_fqn` → `new_fqn`: point every open `rename` window
+    /// and every in-flight firing record that named the old key at the new one.
+    /// C needs no equivalent — both its hash entries reference one `Command`, so
+    /// a nested rename cannot strand them — but our name-keyed state would
+    /// otherwise be left on a name the move just vacated: an enclosing window
+    /// would stop answering through the vacating name, and the
+    /// `firing_cmd_traces` record standing in for `CMD_TRACE_ACTIVE` would stop
+    /// suppressing the command's own remaining callbacks.
+    fn relocate_rename_state(&self, old_fqn: &[u8], new_fqn: &[u8]) {
+        let mut traces = self.traces.borrow_mut();
+        for (_, destination) in &mut traces.rename_windows {
+            if destination == old_fqn {
+                *destination = new_fqn.to_vec();
+            }
+        }
+        for firing in &mut traces.firing_cmd_traces {
+            if firing == old_fqn {
+                *firing = new_fqn.to_vec();
+            }
+        }
+    }
+
     /// Move every command/execution trace on `old_fqn` to `new_fqn` (the trace
     /// follows a renamed command, as C keeps the trace list on the moving
     /// `Command`).
     fn move_cmd_traces(&mut self, old_fqn: &[u8], new_fqn: &[u8]) {
+        self.relocate_rename_state(old_fqn, new_fqn);
         // C moves the `Command` itself, so its trace list travels with the
         // token. Re-stamp to whatever token now stands at the destination, so
         // a later deletion there still tells this list from a replacement's.

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -6511,7 +6511,15 @@ impl Interp {
     fn dispatch_traced(&mut self, argv: &[*mut TclObj]) -> Code {
         use crate::cmd_trace::ops;
         let name = obj_bytes(argv[0]);
-        let fqn = self.resolve_cmd_fqn(&name);
+        // Inside a rename's callbacks the vacating name still resolves, but the
+        // one command's trace list has already moved to the destination key —
+        // so look the traces up there, as C reaches them through the shared
+        // `Command` from either hash entry. Only the *key* is canonicalised:
+        // the callback's own words stay the spelling the caller invoked
+        // (`cmd_word` below), which is what tclsh passes.
+        let fqn = self
+            .resolve_cmd_fqn(&name)
+            .map(|fqn| self.renamed_cmd_key(&fqn).unwrap_or(fqn));
         let (has_enter, has_leave, has_step) = match &fqn {
             Some(f) => {
                 let t = self.traces.borrow();

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -1913,6 +1913,7 @@ impl Interp {
         // before it fired them.
         self.move_cmd_traces(&old_fqn, &new_fqn);
         self.retarget_import_sources(&old_fqn, &new_fqn);
+        crate::cmd_coro::on_command_renamed(self, &old_fqn, &new_fqn);
         if !self.oo_is_empty() {
             self.oo_command_renamed(&old_fqn, Some(&new_fqn));
         }

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -3960,11 +3960,20 @@ impl Interp {
         let saved = self.result.get();
         unsafe { obj::incr_ref_count(saved) };
 
-        {
-            let mut traces = self.traces.borrow_mut();
-            traces.exec_firing += 1;
-            traces.firing_cmd_traces.push(key.to_vec());
-        }
+        // Only `firing_cmd_traces` is raised, never `exec_firing`: C sets
+        // `INTERP_TRACE_IN_PROGRESS` in exactly one place — `TraceExecutionProc`
+        // (tclTrace.c 9.0.4:1765), around an *execution* trace's callback —
+        // and `CallCommandTraces` sets nothing. So a command dispatched from a
+        // `rename`/`delete` callback is traced like any other: its `enter` and
+        // `leave` traces fire, and an enclosing `enterstep`/`leavestep` scope
+        // steps the callback's own commands. Re-entering *this* command's
+        // rename/delete traces is what is suppressed, per command, above.
+        // `firing_cmd_traces` is therefore what marks this walk as in flight
+        // for `TraceTable::trace_walk_in_flight`.
+        self.traces
+            .borrow_mut()
+            .firing_cmd_traces
+            .push(key.to_vec());
         for (id, cmd) in entries {
             if self.cmd_trace_untraced(id) {
                 continue;
@@ -3983,9 +3992,8 @@ impl Interp {
         }
         {
             let mut traces = self.traces.borrow_mut();
-            traces.exec_firing -= 1;
             traces.firing_cmd_traces.pop();
-            if traces.exec_firing == 0 {
+            if !traces.trace_walk_in_flight() {
                 traces.untraced_cmd_trace_ids.clear();
             }
         }

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -4025,6 +4025,16 @@ impl Interp {
             .map(|t| t.command.clone())
     }
 
+    /// Whether execution trace `id` is currently running its own callback —
+    /// C's per-trace `TCL_TRACE_EXEC_IN_PROGRESS` (`tclTrace.c` 9.0.4:1655),
+    /// which is what bounds a callback that invokes the command it traces. Per
+    /// *trace*: a second trace on the same command still fires for that inner
+    /// call, and so does a `leave` trace while an `enter` one is running
+    /// (tclsh 8.6/9.0-pinned).
+    fn exec_trace_is_firing(&self, id: u64) -> bool {
+        self.traces.borrow().firing_exec_traces.contains(&id)
+    }
+
     /// Whether `trace remove` has unlinked command trace `id` since this walk
     /// began. `CallCommandTraces` is handed the dying token's own list
     /// (`tclBasic.c` 9.0.4:3972-3993), so a callback that re-creates the
@@ -4061,6 +4071,11 @@ impl Interp {
         self.traces.borrow_mut().exec_firing += 1;
         let mut abort: Option<Code> = None;
         for id in ids {
+            // A trace whose own callback is running is skipped, per trace
+            // rather than per command (C's `TCL_TRACE_EXEC_IN_PROGRESS`).
+            if self.exec_trace_is_firing(id) {
+                continue;
+            }
             let Some(cmd) = self.live_cmd_trace(id) else {
                 continue;
             };
@@ -4069,7 +4084,9 @@ impl Interp {
             line.push(b' ');
             line.extend_from_slice(&obj_bytes(args));
             drop_fresh(args);
+            self.traces.borrow_mut().firing_exec_traces.push(id);
             let c = self.eval_str(&line);
+            self.traces.borrow_mut().firing_exec_traces.pop();
             if c != Code::Ok {
                 // The callback's result becomes the command's result; abort.
                 abort = Some(c);
@@ -4119,6 +4136,11 @@ impl Interp {
         self.traces.borrow_mut().exec_firing += 1;
         let mut override_code: Option<Code> = None;
         for id in ids {
+            // A trace whose own callback is running is skipped, per trace
+            // rather than per command (C's `TCL_TRACE_EXEC_IN_PROGRESS`).
+            if self.exec_trace_is_firing(id) {
+                continue;
+            }
             let Some(cmd) = self.live_cmd_trace(id) else {
                 continue;
             };
@@ -4133,7 +4155,9 @@ impl Interp {
             line.push(b' ');
             line.extend_from_slice(&obj_bytes(args));
             drop_fresh(args);
+            self.traces.borrow_mut().firing_exec_traces.push(id);
             let c = self.eval_str(&line);
+            self.traces.borrow_mut().firing_exec_traces.pop();
             if c != Code::Ok {
                 override_code = Some(c);
                 break;
@@ -6467,12 +6491,13 @@ impl Interp {
     /// matching C's `TclEvalObjvInternal`.
     pub(crate) fn dispatch(&mut self, argv: &[*mut TclObj]) -> Code {
         self.cmd_count.set(self.cmd_count.get() + 1);
-        // Fast path: no command/execution traces, or we're already inside a
-        // trace callback (C's INTERP_TRACE_IN_PROGRESS) — original dispatch.
-        let traced = {
-            let t = self.traces.borrow();
-            !t.cmd_traces.is_empty() && t.exec_firing == 0
-        };
+        // Fast path: nothing is registered, so nothing can fire. Being inside a
+        // trace callback is *not* a reason to skip: C's
+        // `TclCheckExecutionTraces` never consults `INTERP_TRACE_IN_PROGRESS`,
+        // so a command dispatched from a callback still fires its own
+        // `enter`/`leave` traces. Only the step machinery is gated, in
+        // `dispatch_traced`.
+        let traced = !self.traces.borrow().cmd_traces.is_empty();
         if !traced {
             return self.dispatch_inner(argv);
         }
@@ -6500,7 +6525,13 @@ impl Interp {
             }
             None => (false, false, false),
         };
-        let stepping = !self.traces.borrow().step_active.is_empty();
+        // C's one read of `INTERP_TRACE_IN_PROGRESS`: `TclCheckInterpTraces`
+        // returns immediately while an execution callback is running, so the
+        // callback's own commands are never step-observed.
+        let stepping = {
+            let t = self.traces.borrow();
+            !t.step_active.is_empty() && t.exec_firing == 0
+        };
         if !has_enter && !has_leave && !has_step && !stepping {
             return self.dispatch_inner(argv);
         }

--- a/runtime/rust/src/namespace.rs
+++ b/runtime/rust/src/namespace.rs
@@ -48,7 +48,7 @@ pub type NsId = usize;
 /// The global namespace `::`.
 pub const GLOBAL: NsId = 0;
 
-/// The result of a [`Namespaces::rename`].
+/// The result of a [`crate::interp::Interp::rename_command`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RenameOutcome {
     /// `old` was moved to `new`.
@@ -67,6 +67,18 @@ pub enum RenameOutcome {
     /// that slot at check time); both `old` and the occupant at `new` are
     /// left untouched (issue #1412 item 1).
     TargetExists,
+}
+
+/// The half-finished `rename` a [`Namespaces::publish_rename_destination`]
+/// leaves behind: the command stands under *both* names until
+/// [`Namespaces::retire_rename_source`] drops the source's table entry.
+pub(crate) struct RenamePublication {
+    /// The source table slot — C's `oldHPtr`, which `TclRenameCommand` holds
+    /// across the `rename` traces and deletes at the very end.
+    source: (NsId, Vec<u8>),
+    /// The destination's fully-qualified name: the key the command's traces,
+    /// imports and TclOO registration move to, and the callbacks' second word.
+    pub(crate) destination_fqn: Vec<u8>,
 }
 
 /// One namespace's command table: the `BTreeMap` the resolver looks names up
@@ -151,6 +163,17 @@ impl CommandTable {
     fn restore_slot(&mut self, key: Vec<u8>, slot: (u64, Command)) -> Option<(u64, Command)> {
         self.order.insert(&key);
         self.entries.insert(key, slot)
+    }
+
+    /// Swap `key`'s binding without disturbing its hash entry, so the slot
+    /// keeps its generation and its bucket position. C's `TclRenameCommand`
+    /// never touches the source entry until the very end, but it does re-home
+    /// the one `Command` both entries point at, so the vacating name reports
+    /// the destination's namespace for the callbacks' duration.
+    fn rebind_slot(&mut self, key: &[u8], command: Command) {
+        if let Some((_, bound)) = self.entries.get_mut(key) {
+            *bound = command;
+        }
     }
 
     /// Create `key`'s hash entry ahead of the binding that fills it — C's
@@ -440,46 +463,74 @@ impl Namespaces {
         self.arena[ns].commands.remove(&simple)
     }
 
-    /// `rename old new`: move the command bound to `old` to `new` (both resolved
-    /// relative to `current`, absolute when `::`-led); `new == ""` deletes it.
-    /// Occupancy protection is the caller's job (see
-    /// [`Self::destination_occupant_fqn`]) — a script-visible "already
-    /// exists" refusal needs release-gate context (a TclOO root this release
-    /// hides is not really taken) that this table-only layer does not have,
-    /// so this unconditionally overwrites whatever is at the destination,
-    /// same as [`Self::insert_bound`].
+    /// Publish the destination half of `rename old new` — both names resolved
+    /// relative to `current`, absolute when `::`-led — and leave the source's
+    /// table entry standing. C's `TclRenameCommand` creates the destination
+    /// hash entry, fires the `rename` traces, and only then deletes the source
+    /// one, with *both* entries referencing the one `Command`; the caller
+    /// closes that window with [`Self::retire_rename_source`]. `None` when
+    /// `old` names no command (or `new` has no tail to bind).
     ///
     /// A command moved across namespaces is re-homed: a `Command::Proc`'s
-    /// `ns`/`fqn` are updated to the destination so `namespace current`
-    /// inside its body reports the new namespace, mirroring C's
-    /// `cmdPtr->nsPtr` reassignment.
+    /// `ns`/`fqn` are updated to the destination so `namespace current` inside
+    /// its body reports the new namespace, mirroring C's `cmdPtr->nsPtr`
+    /// reassignment — and because C re-homes the shared `Command` before the
+    /// traces run, the vacating name reports the *destination's* namespace for
+    /// the callbacks' duration too (tclsh 8.6/9.0-pinned).
     ///
-    /// Built-in protection lives in the `rename` builtin, not here — this is the
-    /// pure table operation.
-    pub fn rename(&mut self, current: NsId, old: &[u8], new: &[u8]) -> RenameOutcome {
-        let Some((old_ns, old_simple)) = self.home_of(current, old) else {
-            return RenameOutcome::NoSuchCommand;
-        };
-        if new.is_empty() {
-            // SAFETY of unwrap: `home_of` reported the binding exists.
-            let cmd = self.arena[old_ns].commands.remove(&old_simple).unwrap();
-            Self::mark_command_deleted(&cmd);
-            return RenameOutcome::Deleted;
-        }
-        let Some((ns, simple)) = self.destination_of(current, new) else {
-            // Unreachable for a non-empty, non-separator-terminated name;
-            // nothing has moved yet, so there is nothing to put back.
-            return RenameOutcome::NoSuchCommand;
-        };
+    /// Occupancy protection is the caller's job (see
+    /// [`Self::destination_occupant_fqn`]) — a script-visible "already exists"
+    /// refusal needs release-gate context (a TclOO root this release hides is
+    /// not really taken) that this table-only layer does not have, so this
+    /// unconditionally overwrites whatever is at the destination, same as
+    /// [`Self::insert_bound`].
+    ///
+    /// Built-in protection lives in the `rename` builtin, not here — this is
+    /// the pure table operation, as is the `rename old ""` deletion
+    /// ([`Self::delete`]).
+    pub(crate) fn publish_rename_destination(
+        &mut self,
+        current: NsId,
+        old: &[u8],
+        new: &[u8],
+    ) -> Option<RenamePublication> {
+        let (old_ns, old_simple) = self.home_of(current, old)?;
+        // Unreachable for a non-empty, non-separator-terminated name; nothing
+        // has moved yet, so there is nothing to put back.
+        let (ns, simple) = self.destination_of(current, new)?;
         // C's `TclRenameCommand` creates the destination hash entry *before*
         // deleting the source's, so the transient extra entry can trigger a
         // rebuild a delete-first order would not.
         self.arena[ns].commands.reserve_entry(&simple);
-        // SAFETY of unwrap: `home_of` reported the binding exists.
-        let cmd = self.arena[old_ns].commands.remove(&old_simple).unwrap();
-        let cmd = Self::rehome_proc(cmd, ns, &self.command_fqn(ns, &simple));
+        // SAFETY of expect: `home_of` reported the binding exists.
+        let cmd = self.arena[old_ns]
+            .commands
+            .get(&old_simple)
+            .cloned()
+            .expect("home_of reported a binding at the rename source");
+        let destination_fqn = self.command_fqn(ns, &simple);
+        let cmd = Self::rehome_command(cmd, ns, &destination_fqn);
+        // One command under two names, as C has it: the source slot takes the
+        // re-homed binding too, and an ensemble token is shared outright.
+        self.arena[old_ns]
+            .commands
+            .rebind_slot(&old_simple, cmd.clone());
         self.insert_bound(ns, simple, cmd);
-        RenameOutcome::Renamed
+        Some(RenamePublication {
+            source: (old_ns, old_simple),
+            destination_fqn,
+        })
+    }
+
+    /// Delete the source entry [`Self::publish_rename_destination`] left
+    /// standing — C's `Tcl_DeleteHashEntry(oldHPtr)` at the tail of
+    /// `TclRenameCommand`. A plain table removal: no `delete` trace fires and
+    /// no token dies, because the command lives on under its new name. A
+    /// callback may have removed or rebound the slot itself, so whatever is
+    /// there goes and an already-vacated entry is not an error.
+    pub(crate) fn retire_rename_source(&mut self, publication: &RenamePublication) {
+        let (ns, simple) = &publication.source;
+        self.arena[*ns].commands.remove(simple);
     }
 
     /// The fully-qualified name of whatever is currently bound at the
@@ -508,10 +559,18 @@ impl Namespaces {
             .then(|| self.command_fqn(ns, &simple))
     }
 
-    /// Re-home a `Command::Proc` moved by `rename` to its new binding site.
-    /// Every other `Command` variant carries no namespace of its own and
-    /// passes through unchanged.
-    fn rehome_proc(command: Command, ns: NsId, fqn: &[u8]) -> Command {
+    /// Re-point a command that carries its own binding identity at the site a
+    /// `rename` moved it to — C's `cmdPtr->nsPtr` reassignment, which happens
+    /// to the one shared `Command` and so is visible through *both* names for
+    /// the `rename` traces' duration.
+    ///
+    /// A `Command::Proc` carries its home namespace and FQN, so `namespace
+    /// current` inside its body reports the new namespace. A
+    /// `Command::OoObject` carries the FQN it is registered under in
+    /// [`crate::cmd_oo::OoState`], so dispatch reaches the object the
+    /// accompanying `Interp::oo_command_renamed` moved. Every other variant
+    /// carries no site of its own and passes through unchanged.
+    fn rehome_command(command: Command, ns: NsId, fqn: &[u8]) -> Command {
         match command {
             Command::Proc(def) if def.ns != ns => {
                 let mut def = (*def).clone();
@@ -519,6 +578,7 @@ impl Namespaces {
                 def.fqn = fqn.to_vec();
                 Command::Proc(std::rc::Rc::new(def))
             }
+            Command::OoObject(_) => Command::OoObject(fqn.to_vec()),
             other => other,
         }
     }

--- a/runtime/rust/tests/trace_semantics.rs
+++ b/runtime/rust/tests/trace_semantics.rs
@@ -1019,6 +1019,44 @@ fn the_vacating_name_reports_the_destinations_namespace() {
     );
 }
 
+/// Dispatching through the vacating name reaches the one command's execution
+/// traces too. They have already moved to the destination key by the time the
+/// callbacks run, so the lookup has to follow the window — C reads the one
+/// list off the shared `Command` from either hash entry. The callback's own
+/// words stay the spelling the caller invoked, which is why the first line
+/// says `victim` and the later ones `victim2`.
+#[test]
+fn the_vacating_name_still_fires_the_commands_execution_traces() {
+    let got = transcript(
+        "set ::log {}\n\
+         proc victim {} { return V }\n\
+         proc E args { lappend ::log \"E:[join $args |]\" }\n\
+         proc L args { lappend ::log \"L:[lindex $args 0]\" }\n\
+         trace add execution victim enter E\n\
+         trace add execution victim leave L\n\
+         proc R args {\n\
+         \x20   lappend ::log \"old:[victim]\"\n\
+         \x20   lappend ::log \"new:[victim2]\"\n\
+         }\n\
+         trace add command victim rename R\n\
+         rename victim victim2\n\
+         lappend ::log \"out:[victim2]\"\n\
+         join $::log \\n",
+    );
+    assert_eq!(
+        got,
+        "E:victim|enter\n\
+         L:victim\n\
+         old:V\n\
+         E:victim2|enter\n\
+         L:victim2\n\
+         new:V\n\
+         E:victim2|enter\n\
+         L:victim2\n\
+         out:V"
+    );
+}
+
 /// The window covers the redirect kinds that carry their own binding identity
 /// too: a TclOO object embeds the FQN its registry entry lives under, an
 /// ensemble token its name, and an import its source. C re-homes the one

--- a/runtime/rust/tests/trace_semantics.rs
+++ b/runtime/rust/tests/trace_semantics.rs
@@ -1090,3 +1090,98 @@ fn a_twice_nested_rename_keeps_retargeting_the_enclosing_window() {
          after: 0 0 0 1 V"
     );
 }
+
+// -- `INTERP_TRACE_IN_PROGRESS` belongs to execution traces alone -----------
+//
+// C sets that flag in exactly one place — `TraceExecutionProc` (tclTrace.c
+// 9.0.4:1765), around an `enter`/`leave`/`enterstep`/`leavestep` callback —
+// and reads it in exactly one place, `TclCheckInterpTraces` (:1426), the step
+// machinery. `CallCommandTraces` sets nothing. The runtime used to raise its
+// `exec_firing` stand-in for `rename`/`delete` callbacks too, which silently
+// untraced everything they dispatched.
+
+/// A command invoked from a `rename` or `delete` callback is traced like any
+/// other: its `enter` traces fire, exactly as they do outside one.
+#[test]
+fn a_command_trace_callback_does_not_untrace_what_it_dispatches() {
+    let got = transcript(
+        "set ::log {}\n\
+         proc a {} { return A }\n\
+         proc E args { lappend ::log \"E:[join $args |]\" }\n\
+         trace add execution a enter E\n\
+         proc victim {} {}\n\
+         proc D args { lappend ::log \"D:[a]\" }\n\
+         trace add command victim delete D\n\
+         rename victim {}\n\
+         proc victim2 {} {}\n\
+         proc R args { lappend ::log \"R:[a]\" }\n\
+         trace add command victim2 rename R\n\
+         rename victim2 victim3\n\
+         lappend ::log \"out:[a]\"\n\
+         join $::log \\n",
+    );
+    assert_eq!(got, "E:a|enter\nD:A\nE:a|enter\nR:A\nE:a|enter\nout:A");
+}
+
+/// The step half of the same rule: an enclosing `enterstep` scope observes the
+/// callback's own invocation *and* the commands its body runs, because a
+/// command trace never raises the interp-wide gate.
+#[test]
+fn a_step_scope_steps_a_delete_callbacks_own_commands() {
+    let got = transcript(
+        "set ::log {}\n\
+         proc st args { lappend ::log \"S:[lindex $args 0]\" }\n\
+         proc victim {} {}\n\
+         proc cb args { set q 1 }\n\
+         trace add command victim delete cb\n\
+         proc driver {} { rename victim {} }\n\
+         trace add execution driver enterstep st\n\
+         driver\n\
+         join $::log \\n",
+    );
+    assert_eq!(
+        got,
+        "S:rename victim {}\nS:cb ::victim {} delete\nS:set q 1"
+    );
+}
+
+/// The other side of the gate, which must keep holding: an *execution*
+/// callback does raise it, so the callback's own commands are never
+/// step-observed — while the traced command's body still is.
+#[test]
+fn an_execution_callbacks_own_commands_are_not_step_observed() {
+    let got = transcript(
+        "set ::log {}\n\
+         proc st args { lappend ::log \"S:[lindex $args 0]\" }\n\
+         proc b {} { return B }\n\
+         proc eb args { set z 9; lappend ::log eb }\n\
+         trace add execution b enter eb\n\
+         proc driver {} { b }\n\
+         trace add execution driver enterstep st\n\
+         driver\n\
+         join $::log \\n",
+    );
+    assert_eq!(got, "S:b\neb\nS:return B");
+}
+
+/// And the re-entrancy rule the gate also has to keep: a trace whose callback
+/// invokes the traced command does not fire again for that inner call (C's
+/// per-trace `TCL_TRACE_EXEC_IN_PROGRESS`, tclTrace.c 9.0.4:1655).
+// The sheet guards the inner call with `if`, which only the tower build
+// registers.
+#[cfg(have_tommath)]
+#[test]
+fn an_execution_trace_does_not_re_fire_inside_its_own_callback() {
+    let got = transcript(
+        "set ::log {}\n\
+         proc a {} { return A }\n\
+         proc ea args {\n\
+         \x20   lappend ::log ea\n\
+         \x20   if {![info exists ::d]} { set ::d 1; lappend ::log \"in:[a]\" }\n\
+         }\n\
+         trace add execution a enter ea\n\
+         lappend ::log \"out:[a]\"\n\
+         join $::log \\n",
+    );
+    assert_eq!(got, "ea\nin:A\nout:A");
+}

--- a/runtime/rust/tests/trace_semantics.rs
+++ b/runtime/rust/tests/trace_semantics.rs
@@ -836,3 +836,225 @@ fn a_write_trace_that_mutates_or_unsets_changes_what_set_and_incr_return() {
         assert_eq!(got, "mangled\n|\nmangled\n|", "{version:?}");
     }
 }
+
+// -- The `rename` trace window: one command under two names ------------------
+//
+// C's `TclRenameCommand` (`tclBasic.c` 9.0.4) creates the destination hash
+// entry, fires the `rename` traces, and only *then* deletes the source one —
+// and the traces hang off the shared `Command` rather than off either entry.
+// So for the callbacks' duration the vacating name **is** the destination
+// command. The runtime used to fire before touching the table, so a callback
+// saw the old name but not yet the new one. Every sheet below is identical on
+// tclsh 8.6.16 and 9.0.4.
+
+/// Both names resolve, both are callable, and `trace info command` /
+/// `trace info execution` answer the same list through either of them.
+#[test]
+fn a_rename_callback_sees_the_command_under_both_names() {
+    let got = transcript(
+        "set ::log {}\n\
+         proc victim {} { return V }\n\
+         proc E args {}\n\
+         proc R {old new op} {\n\
+         \x20   lappend ::log [list R $old $new $op]\n\
+         \x20   lappend ::log \"live: [llength [info commands ::victim]] \
+         [llength [info commands ::victim2]]\"\n\
+         \x20   lappend ::log \"call: [victim] [victim2]\"\n\
+         \x20   lappend ::log \"cmd: [trace info command victim] | \
+         [trace info command victim2]\"\n\
+         \x20   lappend ::log \"exec: [trace info execution victim] | \
+         [trace info execution victim2]\"\n\
+         }\n\
+         trace add command victim rename R\n\
+         trace add execution victim enter E\n\
+         rename victim victim2\n\
+         lappend ::log \"after: [llength [info commands ::victim]] \
+         [llength [info commands ::victim2]]\"\n\
+         join $::log \\n",
+    );
+    assert_eq!(
+        got,
+        "R ::victim ::victim2 rename\n\
+         live: 1 1\n\
+         call: V V\n\
+         cmd: {rename R} | {rename R}\n\
+         exec: {enter E} | {enter E}\n\
+         after: 0 1"
+    );
+}
+
+/// There is one trace list, so a callback's `trace remove` through the
+/// vacating name edits the list the rest of the pass — and the surviving
+/// command — is reading.
+#[test]
+fn a_rename_callback_edits_one_trace_list_through_either_name() {
+    let got = transcript(
+        "set ::log {}\n\
+         proc victim {} {}\n\
+         proc C1 {old new op} {\n\
+         \x20   trace remove command victim rename C1\n\
+         \x20   lappend ::log \"C1: [trace info command victim]\"\n\
+         }\n\
+         proc C2 {old new op} { lappend ::log \"C2: [trace info command victim2]\" }\n\
+         trace add command victim rename C2\n\
+         trace add command victim rename C1\n\
+         rename victim victim2\n\
+         lappend ::log \"after: [trace info command victim2]\"\n\
+         join $::log \\n",
+    );
+    assert_eq!(got, "C1: {rename C2}\nC2: {rename C2}\nafter: {rename C2}");
+}
+
+/// The other direction: a `trace add` through the vacating name lands on the
+/// one command, so it is still there under the new name afterwards.
+#[test]
+fn a_trace_added_through_the_vacating_name_follows_the_command() {
+    let got = transcript(
+        "set ::log {}\n\
+         proc victim {} {}\n\
+         proc D {old new op} { lappend ::log [list D $old $new $op] }\n\
+         proc R {old new op} { trace add command victim delete D }\n\
+         trace add command victim rename R\n\
+         rename victim victim2\n\
+         lappend ::log \"info: [trace info command victim2]\"\n\
+         rename victim2 {}\n\
+         join $::log \\n",
+    );
+    assert_eq!(got, "info: {delete D} {rename R}\nD ::victim2 {} delete");
+}
+
+/// A callback that renames *through* the vacating name moves that one command
+/// on again — it does not leave a second copy behind — and C's
+/// `CMD_TRACE_ACTIVE` keeps the pass's remaining callbacks from re-firing when
+/// it does (`C2` runs once, with no nested `C1`/`C2` pass).
+#[test]
+fn a_rename_callback_renaming_the_vacating_name_moves_the_one_command() {
+    let got = transcript(
+        "set ::log {}\n\
+         proc victim {} { return V }\n\
+         proc C1 {old new op} { lappend ::log C1; rename victim victim3 }\n\
+         proc C2 {old new op} { lappend ::log C2 }\n\
+         trace add command victim rename C2\n\
+         trace add command victim rename C1\n\
+         rename victim victim2\n\
+         lappend ::log \"live: [llength [info commands ::victim]] \
+         [llength [info commands ::victim2]] [llength [info commands ::victim3]]\"\n\
+         lappend ::log \"info: [trace info command victim3] | [victim3]\"\n\
+         join $::log \\n",
+    );
+    assert_eq!(
+        got,
+        "C1\nC2\nlive: 0 0 1\ninfo: {rename C1} {rename C2} | V"
+    );
+}
+
+/// And a callback that *deletes* through the vacating name destroys the one
+/// command: neither name is left standing.
+#[test]
+fn a_rename_callback_deleting_the_vacating_name_destroys_the_one_command() {
+    let got = transcript(
+        "set ::log {}\n\
+         proc victim {} {}\n\
+         proc R {old new op} { rename victim {} }\n\
+         trace add command victim rename R\n\
+         rename victim victim2\n\
+         lappend ::log \"live: [llength [info commands ::victim]] \
+         [llength [info commands ::victim2]]\"\n\
+         join $::log \\n",
+    );
+    assert_eq!(got, "live: 0 0");
+}
+
+/// A nested rename must retarget the enclosing window: after the callback
+/// moves the command to a third name, the outermost vacating name still
+/// reaches it, and a `trace add` through that name lands on the survivor.
+#[test]
+fn a_nested_rename_keeps_the_vacating_name_on_the_command() {
+    let got = transcript(
+        "set ::log {}\n\
+         proc victim {} {}\n\
+         proc D {old new op} { lappend ::log [list D $old $new $op] }\n\
+         proc R {old new op} {\n\
+         \x20   rename victim2 victim3\n\
+         \x20   lappend ::log \"in: [trace info command victim] | \
+         [trace info command victim3]\"\n\
+         \x20   trace add command victim delete D\n\
+         }\n\
+         trace add command victim rename R\n\
+         rename victim victim2\n\
+         lappend ::log \"after: [trace info command victim3]\"\n\
+         rename victim3 {}\n\
+         join $::log \\n",
+    );
+    assert_eq!(
+        got,
+        "in: {rename R} | {rename R}\n\
+         after: {delete D} {rename R}\n\
+         D ::victim3 {} delete"
+    );
+}
+
+/// C re-homes the one `Command` (`cmdPtr->nsPtr = newNsPtr`) before it fires,
+/// so a body invoked through the vacating name already reports the
+/// *destination's* namespace.
+#[test]
+fn the_vacating_name_reports_the_destinations_namespace() {
+    let got = transcript(
+        "set ::log {}\n\
+         namespace eval a { proc p {} { return [namespace current] } }\n\
+         namespace eval b {}\n\
+         proc R {old new op} {\n\
+         \x20   lappend ::log [list R $old $new $op]\n\
+         \x20   lappend ::log \"old: [a::p]\"\n\
+         \x20   lappend ::log \"new: [b::q]\"\n\
+         }\n\
+         trace add command a::p rename R\n\
+         rename a::p ::b::q\n\
+         lappend ::log \"after: [b::q]\"\n\
+         join $::log \\n",
+    );
+    assert_eq!(
+        got,
+        "R ::a::p ::b::q rename\nold: ::b\nnew: ::b\nafter: ::b"
+    );
+}
+
+/// The window covers the redirect kinds that carry their own binding identity
+/// too: a TclOO object embeds the FQN its registry entry lives under, an
+/// ensemble token its name, and an import its source. C re-homes the one
+/// `Command` and lets both hash entries reach it, so each is callable under
+/// the vacating name *and* the destination for the callbacks' duration.
+#[test]
+fn the_rename_window_covers_objects_ensembles_and_imports() {
+    let got = transcript(
+        "set ::log {}\n\
+         oo::class create C { method m {} { return M } }\n\
+         C create obj\n\
+         namespace eval e { proc sub {} { return S }; namespace export sub; \
+         namespace ensemble create }\n\
+         namespace eval src { proc f {} { return F }; namespace export f }\n\
+         namespace eval dst { namespace import ::src::f }\n\
+         proc R {old new op} {\n\
+         \x20   lappend ::log [list R $old $new $op]\n\
+         \x20   lappend ::log \"oo: [obj m] [obj2 m]\"\n\
+         }\n\
+         proc RE {old new op} { lappend ::log \"ens: [e sub] [e2 sub]\" }\n\
+         proc RI {old new op} { lappend ::log \"imp: [dst::f] [src::f] [src::g]\" }\n\
+         trace add command obj rename R\n\
+         trace add command e rename RE\n\
+         trace add command src::f rename RI\n\
+         rename obj obj2\n\
+         rename e e2\n\
+         rename ::src::f ::src::g\n\
+         lappend ::log \"after: [obj2 m] [e2 sub] [dst::f]\"\n\
+         join $::log \\n",
+    );
+    assert_eq!(
+        got,
+        "R ::obj ::obj2 rename\n\
+         oo: M M\n\
+         ens: S S\n\
+         imp: F F F\n\
+         after: M S F"
+    );
+}

--- a/runtime/rust/tests/trace_semantics.rs
+++ b/runtime/rust/tests/trace_semantics.rs
@@ -1164,6 +1164,97 @@ fn an_execution_callbacks_own_commands_are_not_step_observed() {
     assert_eq!(got, "S:b\neb\nS:return B");
 }
 
+/// The gate is read only by the step machinery. A command dispatched from
+/// inside an execution callback still fires its **own** `enter` and `leave`
+/// traces, because C's `TclCheckExecutionTraces` (tclTrace.c 9.0.4:1301) never
+/// consults `INTERP_TRACE_IN_PROGRESS` — only `TclCheckInterpTraces` (:1426)
+/// does. Both engines used to read their stand-in at the whole traced-dispatch
+/// fast path and so fired neither.
+#[test]
+fn an_execution_callback_does_not_untrace_what_it_dispatches() {
+    let got = transcript(
+        "set ::log {}\n\
+         proc b {} { return B }\n\
+         proc EB args { lappend ::log EB }\n\
+         proc LB args { lappend ::log \"LB:[lindex $args 1]\" }\n\
+         trace add execution b enter EB\n\
+         trace add execution b leave LB\n\
+         proc a {} { return A }\n\
+         proc ea args { lappend ::log \"in:[b]\" }\n\
+         trace add execution a enter ea\n\
+         lappend ::log \"out:[a]\"\n\
+         join $::log \\n",
+    );
+    assert_eq!(got, "EB\nLB:0\nin:B\nout:A");
+}
+
+/// What bounds that instead is C's **per-trace** flag, not a per-command one:
+/// a *second* `enter` trace on the same command does fire for the inner call
+/// its sibling's callback makes. `E1` (newest, so first) calls `a`; the inner
+/// pass skips `E1` and runs `E2`, and the outer pass then continues to `E2`.
+// The sheet guards the inner call with `if`, which only the tower build
+// registers.
+#[cfg(have_tommath)]
+#[test]
+fn suppression_during_a_callback_is_per_trace_not_per_command() {
+    let got = transcript(
+        "set ::log {}\n\
+         proc a {} { return A }\n\
+         proc E1 args {\n\
+         \x20   lappend ::log E1\n\
+         \x20   if {![info exists ::d]} { set ::d 1; lappend ::log \"in:[a]\" }\n\
+         }\n\
+         proc E2 args { lappend ::log E2 }\n\
+         trace add execution a enter E2\n\
+         trace add execution a enter E1\n\
+         lappend ::log \"out:[a]\"\n\
+         join $::log \\n",
+    );
+    assert_eq!(got, "E1\nE2\nin:A\nE2\nout:A");
+}
+
+/// The same rule across ops: a `leave` trace on the command whose `enter`
+/// callback is running is a different registration, so it fires — once for the
+/// callback's inner call, then again for the outer one.
+// `if` again; tower build only.
+#[cfg(have_tommath)]
+#[test]
+fn a_leave_trace_fires_while_its_commands_enter_callback_runs() {
+    let got = transcript(
+        "set ::log {}\n\
+         proc a {} { return A }\n\
+         proc LA args { lappend ::log LA }\n\
+         trace add execution a leave LA\n\
+         proc EA args {\n\
+         \x20   lappend ::log EA\n\
+         \x20   if {![info exists ::d]} { set ::d 1; lappend ::log \"in:[a]\" }\n\
+         }\n\
+         trace add execution a enter EA\n\
+         lappend ::log \"out:[a]\"\n\
+         join $::log \\n",
+    );
+    assert_eq!(got, "EA\nLA\nin:A\nLA\nout:A");
+}
+
+/// And the step half stays gated: a *step-traced* command invoked from inside
+/// an execution callback runs unstepped, because the flag is still set for the
+/// whole callback evaluation.
+#[test]
+fn a_step_traced_command_called_from_a_callback_is_not_stepped() {
+    let got = transcript(
+        "set ::log {}\n\
+         proc st args { lappend ::log \"S:[lindex $args 0]\" }\n\
+         proc s {} { set q 1; return S }\n\
+         trace add execution s enterstep st\n\
+         proc a {} { return A }\n\
+         proc ea args { lappend ::log \"in:[s]\" }\n\
+         trace add execution a enter ea\n\
+         lappend ::log \"out:[a]\"\n\
+         join $::log \\n",
+    );
+    assert_eq!(got, "in:S\nout:A");
+}
+
 /// And the re-entrancy rule the gate also has to keep: a trace whose callback
 /// invokes the traced command does not fire again for that inner call (C's
 /// per-trace `TCL_TRACE_EXEC_IN_PROGRESS`, tclTrace.c 9.0.4:1655).

--- a/runtime/rust/tests/trace_semantics.rs
+++ b/runtime/rust/tests/trace_semantics.rs
@@ -1058,3 +1058,35 @@ fn the_rename_window_covers_objects_ensembles_and_imports() {
          after: M S F"
     );
 }
+
+/// Two nested renames inside one pass: the enclosing window and the
+/// `CMD_TRACE_ACTIVE` stand-in must both be retargeted each time, so the
+/// outermost vacating name keeps reaching the command wherever it has got to,
+/// and the pass's later callbacks neither re-fire nor lose it.
+#[test]
+fn a_twice_nested_rename_keeps_retargeting_the_enclosing_window() {
+    let got = transcript(
+        "set ::log {}\n\
+         proc victim {} { return V }\n\
+         proc R1 {old new op} { lappend ::log R1; rename victim v3 }\n\
+         proc R2 {old new op} { lappend ::log \"R2: [trace info command victim] | \
+         [trace info command v3]\" }\n\
+         proc R3 {old new op} { lappend ::log \"R3: [catch {rename victim v4}] \
+         [llength [info commands ::v4]]\" }\n\
+         trace add command victim rename R3\n\
+         trace add command victim rename R2\n\
+         trace add command victim rename R1\n\
+         rename victim victim2\n\
+         lappend ::log \"after: [llength [info commands ::victim]] \
+         [llength [info commands ::victim2]] [llength [info commands ::v3]] \
+         [llength [info commands ::v4]] [v4]\"\n\
+         join $::log \\n",
+    );
+    assert_eq!(
+        got,
+        "R1\n\
+         R2: {rename R1} {rename R2} {rename R3} | {rename R1} {rename R2} {rename R3}\n\
+         R3: 0 1\n\
+         after: 0 0 0 1 V"
+    );
+}

--- a/rust/tcl-vm/src/exec.rs
+++ b/rust/tcl-vm/src/exec.rs
@@ -4219,7 +4219,13 @@ impl Vm {
                 }
             }
         }
-        let key = CommandSidecarKey::visible(key);
+        // Inside a rename's callbacks the vacating name still resolves, but the
+        // one command's trace list has already moved to the destination key —
+        // so look the traces up there, as C reaches them through the shared
+        // `Command` from either hash entry. Only the *key* is canonicalised:
+        // the callback's own words stay the spelling the caller invoked
+        // (`cmd_string` above).
+        let key = self.renamed_command_key(CommandSidecarKey::visible(key));
         let sidecar = self.active_sidecar(key.clone());
         let own = self.exec_traces.get(&key).cloned().unwrap_or_default();
         for entry in own.iter().rev() {
@@ -4591,7 +4597,13 @@ impl Vm {
                 }
             }
         }
-        let key = CommandSidecarKey::visible(key);
+        // Inside a rename's callbacks the vacating name still resolves, but the
+        // one command's trace list has already moved to the destination key —
+        // so look the traces up there, as C reaches them through the shared
+        // `Command` from either hash entry. Only the *key* is canonicalised:
+        // the callback's own words stay the spelling the caller invoked
+        // (`cmd_string` above).
+        let key = self.renamed_command_key(CommandSidecarKey::visible(key));
         let sidecar = self.active_sidecar(key.clone());
         let own = self.exec_traces.get(&key).cloned().unwrap_or_default();
         for entry in own.iter().rev() {
@@ -4665,6 +4677,9 @@ impl Vm {
         words.push(Value::string(display_name));
         words.extend_from_slice(argv);
         let cmd_string = Value::list(words).to_str().to_string();
+        // As in `dispatch_words_traced`: a rename window moved the trace list
+        // to the destination key, and both names reach it.
+        let trace_key = self.renamed_command_key(trace_key);
         for scope in self.step_scopes_to_fire() {
             if scope.active_for("enterstep") && self.exec_trace_entry_live(&scope.key, &scope.entry)
             {

--- a/rust/tcl-vm/src/exec.rs
+++ b/rust/tcl-vm/src/exec.rs
@@ -4146,17 +4146,44 @@ impl Vm {
         if let Some(exceeded) = self.charge_command() {
             return Err(exceeded);
         }
-        // M16.3 fast path: no execution traces registered and no step scope
-        // active — dispatch untraced (the common case pays one empty check).
-        // Also untraced while a trace callback is itself running (C's
-        // `INTERP_TRACE_IN_PROGRESS`) — a callback's own commands are never
-        // step-observed, so its `puts`/etc. dispatch here plainly.
-        if self.trace_in_progress.get()
-            || (self.exec_traces.is_empty() && self.exec_step_scopes.is_empty())
-        {
+        // M16.3 fast path: nothing registered that could fire — dispatch
+        // untraced (the common case pays one empty check).  Being inside a
+        // trace callback is *not* a reason to skip: only the step machinery is
+        // gated then, inside `exec_traces_can_fire`.
+        if !self.exec_traces_can_fire() {
             return self.dispatch_words_inner(f, words, None);
         }
         self.dispatch_words_traced(f, words)
+    }
+
+    /// Whether the `enterstep`/`leavestep` machinery may fire right now. This
+    /// is C's one read of `INTERP_TRACE_IN_PROGRESS` — `TclCheckInterpTraces`
+    /// (`tclTrace.c` 9.0.4:1426) returns immediately while an execution
+    /// callback is running, so the callback's own commands are never
+    /// step-observed. Scopes are still *pushed* while one runs, as C still
+    /// installs its interp trace; only the firing is gated.
+    fn step_scopes_can_fire(&self) -> bool {
+        !self.exec_step_scopes.is_empty() && !self.trace_in_progress.get()
+    }
+
+    /// The step scopes to fire for this command — empty while an execution
+    /// callback is running (see [`Self::step_scopes_can_fire`]).
+    fn step_scopes_to_fire(&self) -> Vec<ExecStepScope> {
+        if self.step_scopes_can_fire() {
+            self.exec_step_scopes.clone()
+        } else {
+            Vec::new()
+        }
+    }
+
+    /// Whether this dispatch needs the traced path at all. Being inside a trace
+    /// callback is *not* a reason to skip it: C's `TclCheckExecutionTraces`
+    /// (:1301) never consults the flag, so a command a callback dispatches
+    /// still fires its own `enter`/`leave` traces — only the step machinery is
+    /// gated. Re-entering the *same* trace is bounded per trace instead, by
+    /// `CmdTraceEntry::firing` in [`Vm::run_cmd_trace_callback`].
+    fn exec_traces_can_fire(&self) -> bool {
+        !self.exec_traces.is_empty() || self.step_scopes_can_fire()
     }
 
     /// The traced dispatch path (M16.3): fire `enterstep` for every active
@@ -4177,7 +4204,7 @@ impl Vm {
         // The complete current command, list-merged (tclsh-pinned shape:
         // `p one {t w o}`).
         let cmd_string = Value::list(words.to_vec()).to_str().to_string();
-        for scope in self.exec_step_scopes.clone() {
+        for scope in self.step_scopes_to_fire() {
             if scope.active_for("enterstep") && self.exec_trace_entry_live(&scope.key, &scope.entry)
             {
                 let r = self.run_cmd_trace_callback(
@@ -4322,13 +4349,9 @@ impl Vm {
                 }
             }
         }
-        for scope in self
-            .exec_step_scopes
-            .iter()
-            .rev()
-            .cloned()
-            .collect::<Vec<_>>()
-        {
+        let mut leaving = self.step_scopes_to_fire();
+        leaving.reverse();
+        for scope in leaving {
             if scope.active_for("leavestep") && self.exec_trace_entry_live(&scope.key, &scope.entry)
             {
                 let r = self
@@ -4542,12 +4565,8 @@ impl Vm {
         }
         // M16.3: mirror `dispatch_words`' trace wrapper on this native path —
         // enter/enterstep before, leave/leavestep after (synchronously: the
-        // completion is known when the inner call returns). Also untraced
-        // while a trace callback is itself running (C's
-        // `INTERP_TRACE_IN_PROGRESS`) — see `dispatch_words`.
-        if self.trace_in_progress.get()
-            || (self.exec_traces.is_empty() && self.exec_step_scopes.is_empty())
-        {
+        // completion is known when the inner call returns).
+        if !self.exec_traces_can_fire() {
             return self.invoke_command_inner(name, argv, None);
         }
         let key = self
@@ -4557,7 +4576,7 @@ impl Vm {
         words.push(Value::string(name));
         words.extend_from_slice(argv);
         let cmd_string = Value::list(words).to_str().to_string();
-        for scope in self.exec_step_scopes.clone() {
+        for scope in self.step_scopes_to_fire() {
             if scope.active_for("enterstep") && self.exec_trace_entry_live(&scope.key, &scope.entry)
             {
                 let r = self.run_cmd_trace_callback(
@@ -4633,9 +4652,7 @@ impl Vm {
         if let Some(exceeded) = self.charge_command() {
             return exceeded;
         }
-        if self.trace_in_progress.get()
-            || (self.exec_traces.is_empty() && self.exec_step_scopes.is_empty())
-        {
+        if !self.exec_traces_can_fire() {
             return self.invoke_resolved_command_inner(
                 display_name,
                 command,
@@ -4648,7 +4665,7 @@ impl Vm {
         words.push(Value::string(display_name));
         words.extend_from_slice(argv);
         let cmd_string = Value::list(words).to_str().to_string();
-        for scope in self.exec_step_scopes.clone() {
+        for scope in self.step_scopes_to_fire() {
             if scope.active_for("enterstep") && self.exec_trace_entry_live(&scope.key, &scope.entry)
             {
                 let r = self.run_cmd_trace_callback(

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -1025,12 +1025,15 @@ pub struct InterpState {
     /// entered — see [`Vm::ensure_proc_compiled_for_tracing`].
     trace_deopt_epoch: std::cell::Cell<u64>,
     /// Set for the duration of [`Vm::run_cmd_trace_callback`]'s evaluation:
-    /// C's `INTERP_TRACE_IN_PROGRESS` (`tclTrace.c`) — while any command or
-    /// execution trace callback is running, no further interp-wide trace
-    /// firing happens for commands *inside* that callback (`TclCheckInterpTraces`
-    /// returns immediately). Without this, a step-traced proc's `enterstep`
-    /// callback (e.g. `puts "…"`) would itself be step-observed, and its own
-    /// `puts` dispatch would recurse into firing traces again. A `Cell`, not
+    /// C's `INTERP_TRACE_IN_PROGRESS` (`tclTrace.c` 9.0.4:1765, set only by
+    /// `TraceExecutionProc`) — while an **execution** trace callback is
+    /// running, no further interp-wide trace firing happens for commands
+    /// *inside* that callback (`TclCheckInterpTraces` returns immediately).
+    /// Without this, a step-traced proc's `enterstep` callback (e.g. `puts
+    /// "…"`) would itself be step-observed, and its own `puts` dispatch would
+    /// recurse into firing traces again. A `rename`/`delete` callback does
+    /// **not** raise it — C's `CallCommandTraces` sets no flag — so
+    /// [`Vm::run_command_trace_callback`] leaves it alone. A `Cell`, not
     /// a plain `bool` field, so a read-only dispatch-site check
     /// (`self.trace_in_progress.get()`) doesn't need `&mut self` — and so it
     /// doesn't count toward `clippy::struct_excessive_bools` alongside the
@@ -6673,14 +6676,44 @@ impl Vm {
         ))
     }
 
-    /// Run one trace callback with `args` appended (list-quoted), in the
-    /// current frame — C evaluates trace callbacks in the context where the
-    /// traced operation occurred.  The entry is disabled while its own
-    /// callback runs (C's re-entrancy rule), a nested fire returning ok.
+    /// Run one **execution** trace callback (`enter`/`leave`/`enterstep`/
+    /// `leavestep`) with `args` appended (list-quoted), in the current frame —
+    /// C evaluates trace callbacks in the context where the traced operation
+    /// occurred.  The entry is disabled while its own callback runs (C's
+    /// re-entrancy rule), a nested fire returning ok.
+    ///
+    /// This is the one callback kind C wraps in `INTERP_TRACE_IN_PROGRESS`
+    /// (`TraceExecutionProc`, tclTrace.c 9.0.4:1765), so the callback's own
+    /// commands are not step-observed.
     pub(crate) fn run_cmd_trace_callback(
         &mut self,
         entry: &CmdTraceEntry,
         args: &[Value],
+    ) -> Completion<Value> {
+        self.run_trace_callback(entry, args, true)
+    }
+
+    /// Run one **command** (`rename`/`delete`) trace callback.  C's
+    /// `CallCommandTraces` sets no interpreter flag, so — unlike an execution
+    /// callback — a command this one dispatches is traced like any other: its
+    /// `enter`/`leave` traces fire, and an enclosing step scope steps it.
+    /// Re-entering *this* command's own rename/delete traces is suppressed per
+    /// command by [`Self::firing_cmd_traces`] instead.
+    pub(crate) fn run_command_trace_callback(
+        &mut self,
+        entry: &CmdTraceEntry,
+        args: &[Value],
+    ) -> Completion<Value> {
+        self.run_trace_callback(entry, args, false)
+    }
+
+    /// The shared body of the two above; `interp_trace_in_progress` says
+    /// whether this callback kind raises C's interpreter-wide gate.
+    fn run_trace_callback(
+        &mut self,
+        entry: &CmdTraceEntry,
+        args: &[Value],
+        interp_trace_in_progress: bool,
     ) -> Completion<Value> {
         if entry.firing.get() {
             return ok(Value::empty());
@@ -6691,13 +6724,14 @@ impl Vm {
             script.push(' ');
             script.push_str(&tcl_syntax::list::list_element(&a.to_str()));
         }
-        // C's `INTERP_TRACE_IN_PROGRESS`: no interp-wide trace fires for a
-        // command dispatched *by* this callback (saved/restored, not merely
-        // set — a callback can itself be dispatched from inside another
-        // callback's evaluation only if re-entrant nesting is legitimate, but
-        // the common case is one level; save-restore keeps either correct).
+        // Saved/restored, not merely set — a callback can itself be dispatched
+        // from inside another callback's evaluation only if re-entrant nesting
+        // is legitimate, but the common case is one level; save-restore keeps
+        // either correct, and keeps a command callback nested inside an
+        // execution one from clearing the gate that one raised.
         let saved = self.trace_in_progress.get();
-        self.trace_in_progress.set(true);
+        self.trace_in_progress
+            .set(saved || interp_trace_in_progress);
         let res = match self.eval_source(&script) {
             Ok(c) => c,
             Err(e) => err(e.message),
@@ -6749,7 +6783,7 @@ impl Vm {
             if entry.untraced() {
                 continue;
             }
-            let _ = self.run_cmd_trace_callback(
+            let _ = self.run_command_trace_callback(
                 &entry,
                 &[
                     Value::string(old_display),

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -6893,7 +6893,7 @@ impl Vm {
 
     /// The key a command's state lives under now, following any open rename
     /// window (see [`Self::rename_windows`]). Identity outside one.
-    fn renamed_command_key(&self, key: CommandSidecarKey) -> CommandSidecarKey {
+    pub(crate) fn renamed_command_key(&self, key: CommandSidecarKey) -> CommandSidecarKey {
         match self.rename_windows.iter().find(|(from, _)| *from == key) {
             Some((_, to)) => to.clone(),
             None => key,

--- a/rust/tcl-vm/tests/command_traces_e2e.rs
+++ b/rust/tcl-vm/tests/command_traces_e2e.rs
@@ -328,6 +328,63 @@ const VECTORS: &[Vector] = &[
                  driver\n",
         want: "S:b\neb\nS:return B",
     },
+    // The gate is read only by the step machinery: `TclCheckExecutionTraces`
+    // (tclTrace.c 9.0.4:1301) never consults `INTERP_TRACE_IN_PROGRESS`, only
+    // `TclCheckInterpTraces` (:1426) does. So a command dispatched from inside
+    // an execution callback still fires its own `enter`/`leave` traces, and
+    // what bounds the recursion is C's *per-trace* `TCL_TRACE_EXEC_IN_PROGRESS`
+    // (:1655) — the VM's `CmdTraceEntry::firing`.
+    Vector {
+        name: "an execution callback does not untrace what it dispatches",
+        script: "proc b {} { return B }\n\
+                 proc EB args { puts EB }\n\
+                 proc LB args { puts \"LB:[lindex $args 1]\" }\n\
+                 trace add execution b enter EB\n\
+                 trace add execution b leave LB\n\
+                 proc a {} { return A }\n\
+                 proc ea args { puts \"in:[b]\" }\n\
+                 trace add execution a enter ea\n\
+                 puts \"out:[a]\"\n",
+        want: "EB\nLB:0\nin:B\nout:A",
+    },
+    Vector {
+        name: "suppression during a callback is per trace, not per command",
+        script: "proc a {} { return A }\n\
+                 proc E1 args {\n\
+                     puts E1\n\
+                     if {![info exists ::d]} { set ::d 1; puts \"in:[a]\" }\n\
+                 }\n\
+                 proc E2 args { puts E2 }\n\
+                 trace add execution a enter E2\n\
+                 trace add execution a enter E1\n\
+                 puts \"out:[a]\"\n",
+        want: "E1\nE2\nin:A\nE2\nout:A",
+    },
+    Vector {
+        name: "a leave trace fires while its command's enter callback runs",
+        script: "proc a {} { return A }\n\
+                 proc LA args { puts LA }\n\
+                 trace add execution a leave LA\n\
+                 proc EA args {\n\
+                     puts EA\n\
+                     if {![info exists ::d]} { set ::d 1; puts \"in:[a]\" }\n\
+                 }\n\
+                 trace add execution a enter EA\n\
+                 puts \"out:[a]\"\n",
+        want: "EA\nLA\nin:A\nLA\nout:A",
+    },
+    // The step half stays gated for the whole callback evaluation.
+    Vector {
+        name: "a step-traced command called from a callback is not stepped",
+        script: "proc st args { puts \"S:[lindex $args 0]\" }\n\
+                 proc s {} { set q 1; return S }\n\
+                 trace add execution s enterstep st\n\
+                 proc a {} { return A }\n\
+                 proc ea args { puts \"in:[s]\" }\n\
+                 trace add execution a enter ea\n\
+                 puts \"out:[a]\"\n",
+        want: "in:S\nout:A",
+    },
     Vector {
         name: "namespace-qualified names arrive fully qualified",
         script: "proc tracer args { puts \"T:[join $args |]\" }\n\

--- a/rust/tcl-vm/tests/command_traces_e2e.rs
+++ b/rust/tcl-vm/tests/command_traces_e2e.rs
@@ -282,6 +282,51 @@ const VECTORS: &[Vector] = &[
         want: "in:{rename cb}|{rename cb}\n\
                after:{delete dd} {rename cb}\n\
                D:::victim3||delete",
+    // `INTERP_TRACE_IN_PROGRESS` belongs to execution traces alone. C sets it
+    // in exactly one place — `TraceExecutionProc` (tclTrace.c 9.0.4:1765),
+    // around an `enter`/`leave`/`enterstep`/`leavestep` callback — and reads
+    // it in exactly one place, `TclCheckInterpTraces` (:1426), the step
+    // machinery. `CallCommandTraces` sets nothing, so a command a
+    // `rename`/`delete` callback dispatches is traced like any other.
+    Vector {
+        name: "a command-trace callback does not untrace what it dispatches",
+        script: "proc a {} { return A }\n\
+                 proc E args { puts \"E:[join $args |]\" }\n\
+                 trace add execution a enter E\n\
+                 proc victim {} {}\n\
+                 proc D args { puts \"D:[a]\" }\n\
+                 trace add command victim delete D\n\
+                 rename victim {}\n\
+                 proc victim2 {} {}\n\
+                 proc R args { puts \"R:[a]\" }\n\
+                 trace add command victim2 rename R\n\
+                 rename victim2 victim3\n",
+        want: "E:a|enter\nD:A\nE:a|enter\nR:A",
+    },
+    Vector {
+        name: "a step scope steps a delete callback's own commands",
+        script: "proc st args { puts \"S:[lindex $args 0]\" }\n\
+                 proc victim {} {}\n\
+                 proc cb args { set q 1 }\n\
+                 trace add command victim delete cb\n\
+                 proc driver {} { rename victim {} }\n\
+                 trace add execution driver enterstep st\n\
+                 driver\n",
+        want: "S:rename victim {}\nS:cb ::victim {} delete\nS:set q 1",
+    },
+    // The other side of the same gate, which must keep holding: an execution
+    // callback does raise it, so its own commands are never step-observed —
+    // while the traced command's body still is.
+    Vector {
+        name: "an execution callback's own commands are not step-observed",
+        script: "proc st args { puts \"S:[lindex $args 0]\" }\n\
+                 proc b {} { return B }\n\
+                 proc eb args { set z 9; puts eb }\n\
+                 trace add execution b enter eb\n\
+                 proc driver {} { b }\n\
+                 trace add execution driver enterstep st\n\
+                 driver\n",
+        want: "S:b\neb\nS:return B",
     },
     Vector {
         name: "namespace-qualified names arrive fully qualified",

--- a/rust/tcl-vm/tests/command_traces_e2e.rs
+++ b/rust/tcl-vm/tests/command_traces_e2e.rs
@@ -282,6 +282,7 @@ const VECTORS: &[Vector] = &[
         want: "in:{rename cb}|{rename cb}\n\
                after:{delete dd} {rename cb}\n\
                D:::victim3||delete",
+    },
     // `INTERP_TRACE_IN_PROGRESS` belongs to execution traces alone. C sets it
     // in exactly one place — `TraceExecutionProc` (tclTrace.c 9.0.4:1765),
     // around an `enter`/`leave`/`enterstep`/`leavestep` callback — and reads
@@ -384,6 +385,26 @@ const VECTORS: &[Vector] = &[
                  trace add execution a enter ea\n\
                  puts \"out:[a]\"\n",
         want: "in:S\nout:A",
+    },
+    // Dispatching through the vacating name reaches the one command's
+    // execution traces too: they have already moved to the destination key by
+    // the time the callbacks run, so the lookup follows the window. The
+    // callback's own words stay the spelling the caller invoked, which is why
+    // the first pair says `victim` and the later ones `victim2`.
+    Vector {
+        name: "the vacating name still fires the command's execution traces",
+        script: "proc victim {} { return V }\n\
+                 proc E args { puts \"E:[join $args |]\" }\n\
+                 proc L args { puts \"L:[lindex $args 0]\" }\n\
+                 trace add execution victim enter E\n\
+                 trace add execution victim leave L\n\
+                 proc R args { puts \"old:[victim]\"; puts \"new:[victim2]\" }\n\
+                 trace add command victim rename R\n\
+                 rename victim victim2\n\
+                 puts \"out:[victim2]\"\n",
+        want: "E:victim|enter\nL:victim\nold:V\n\
+               E:victim2|enter\nL:victim2\nnew:V\n\
+               E:victim2|enter\nL:victim2\nout:V",
     },
     Vector {
         name: "namespace-qualified names arrive fully qualified",


### PR DESCRIPTION
Four command-trace divergences from C Tcl in the tree-walking runtime, and the two of them `rust/tcl-vm` shares. Every expectation here was taken from real tclsh 8.6.16 and 9.0.4, which agree on all of it.

## The `rename` trace window (`cafb98431`, `b40e3f668`)

`Interp::rename_command` fired a command's `rename` traces before touching the command table, so a callback resolved the old name but not the new one. C's `TclRenameCommand` (`tclBasic.c` 9.0.4) is the other way round: it creates the destination hash entry, fires, and only then deletes the source — and both entries reference the one `Command`, with the trace list hanging off that. For the callbacks' duration the vacating name *is* the destination command.

`rename_command` splits into its guards plus `move_bound_command` / `delete_bound_command` (the halves shared nothing else), and the move takes C's order: publish the destination leaving the source entry standing, move the trace list / import redirects / TclOO registration, fire from the destination naming the command it is leaving, then `retire_rename_source` — the spelling of `Tcl_DeleteHashEntry(oldHPtr)`, which fires no `delete` trace.

Our registries are keyed by name, so an open window is recorded as a source→destination pair (`TraceTable::rename_windows`, one frame per nested rename). `renamed_cmd_key` resolves through it for `trace add`/`remove`/`info` and for `rename_command` itself; `relocate_rename_state` retargets every enclosing window and every `firing_cmd_traces` record when a nested rename moves the destination on again — the name-addressed stand-in for `CMD_TRACE_ACTIVE`.

`rehome_proc` becomes `rehome_command` and re-points a `Command::OoObject`'s embedded FQN as well as a `Command::Proc`'s home, so an object, an ensemble and an import redirect all still dispatch through the vacating name.

## A `rename`/`delete` callback no longer untraces what it dispatches (`47b7e8105`)

C sets `INTERP_TRACE_IN_PROGRESS` in exactly one place — `TraceExecutionProc` (`tclTrace.c` 9.0.4:1765), around an execution callback — and `CallCommandTraces` sets nothing. Both engines raised their stand-in for command callbacks too, so every command such a callback dispatched ran untraced.

`fire_cmd_trace` no longer bumps `exec_firing`. In the VM, `run_cmd_trace_callback` was the shared runner for both callback kinds, so it splits: execution traces keep raising `trace_in_progress`, and `run_command_trace_callback` leaves it alone.

## Reading that gate where C reads it (`751aba71a`)

C reads the flag only in `TclCheckInterpTraces` (:1426), the step machinery; `TclCheckExecutionTraces` (:1301) never consults it. Both engines read theirs at the whole traced-dispatch fast path, so a command dispatched from inside an execution callback fired neither its `enter` nor its `leave` traces.

The read narrows to the step decision in both engines. That read was also standing in for C's **per-trace** `TCL_TRACE_EXEC_IN_PROGRESS` (:1655), so that rule is now explicit: `CmdTrace` carries an `id` (minted like `VarTrace::id`) and `TraceTable::firing_exec_traces` holds the ids whose callbacks are running. The VM already had it as `CmdTraceEntry::firing`.

Per *trace* is observably different from per command, and both shapes are pinned: a second `enter` trace on the same command fires for the inner call its sibling's callback makes, and a `leave` trace fires while that command's `enter` callback is running.

## A live coroutine survives a rename of its command (`ffd910d0f`)

`rename co co2` left `Interp::coros` keyed by the vacated name, making the coroutine undispatchable under either name. C hangs the coroutine off the command token, so the move is invisible to it; the VM already modelled that, and this is the tree-walker's counterpart.

The worker thread also captured the name at spawn and reaches the registry through it, so the name becomes an `Arc<Mutex<Vec<u8>>>` shared by `CoroEntry` and the worker's TLS — a body that renames *itself* keeps running and reports its new name. For the same reason `resume`/`probe`/`inject`/`terminate` put the reply channel back under the name the coroutine answers to *after* the handoff; a self-rename mid-resume otherwise stranded it and the next resume failed with "already running".

## Testing

- 12 transcripts in `runtime/rust/tests/trace_semantics.rs` and 2 in `cmd_coro`'s own test module, each pinned to tclsh 8.6.16 and 9.0.4.
- 7 `Vector`s in `rust/tcl-vm/tests/command_traces_e2e.rs`; that file's `vectors_match_real_tclsh` verifies the whole table against both tclsh binaries.
- Locally: 62 differential sheets for `runtime/rust` and 17 for the VM, zero diffs against both releases; runtime suite green with and without the bignum tower; full `tcl-vm` suite green; `make prep-pr` green.

## Notes for review

- The `rename`-window section of `docs/design/runtime/trace-implementation.md` **overlaps #1885**, which brings the VM onto the same ordering and adds a section at the same anchor. Whichever of the two merges second needs to fold them into one; the Known-gap paragraph here points at `rust/tcl-vm` and #1885's points at `runtime/rust`.
- Two residues are deliberately not emulated, both because C's own behaviour rests on torn state: re-creating the vacating name from a rename callback leaves C deleting a freed hash entry, and `[info coroutine]` inside a `coroprobe` is empty in C. Both are documented where they bite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
