### PR TITLE
fix(compiler): a word's value is resolved exactly once

### DIFF
--- a/docs/design/contracts/shared-utility-contracts-rust.md
+++ b/docs/design/contracts/shared-utility-contracts-rust.md
@@ -37,6 +37,7 @@ entry point, or gate moves without this contract being updated.
 | dicts | `rust/tcl-syntax/src/list.rs`; `rust/tcl-syntax/src/value.rs`; `rust/tcl-cmd-core/src/dict.rs` | `find_element`; `split_list`; `canonical_dict_slots`; `ValueOps::dict_pairs`; `worded_parse_error` | invariant | none |
 | glob matching | `rust/tcl-syntax/src/glob.rs` | `string_match`; `string_match_bytes`; `string_case_match` | invariant | none |
 | switch body grammar | `rust/tcl-syntax/src/switch_body.rs` | `tokenise_switch_body`; `parse_braced_pairs` | invariant | none |
+| word values (brace / list axes, braced-word recognition) | `rust/tcl-syntax/src/word_rules.rs` | `WordValueRules`; `collapse_braced_word`; `split_list`; `split_list_tolerant`; `split_word_names`; `whole_braced_word` | `LexerGrammar::brace_backslash_newline` and `list_parse` per dialect, carried together because a word-shaped list asks both; brace *balance* is release-invariant, so `whole_braced_word` takes no rules | none |
 | numbers | `rust/tcl-syntax/src/number.rs`; `rust/tcl-dialect/src/expr_number.rs`; `rust/tcl-dialect/src/grammar.rs` | `parse`; `parse_whole_with`; `is_expr_number`; `scan_expr_number`; `scan_nan_payload`; `NumberSyntax` | `NumberSyntax` and expression-word grammar per release | `xtask-number-drift` |
 | backslash escapes | `rust/tcl-lexer/src/substitution.rs`; `rust/tcl-syntax/src/backslash.rs`; `rust/tcl-dialect/src/grammar.rs` | `backslash_subst`; `backslash_subst_in`; `decode_bytes_in`; `EscapeSyntax` | `LexerGrammar::escapes` per release | none |
 | boolean words | `rust/tcl-syntax/src/boolean.rs` | `parse_boolean_word`; `truthiness_with` | fixed boolean vocabulary; number axis per release | none |
@@ -184,6 +185,16 @@ entry point, or gate moves without this contract being updated.
   and the first-seed policy are per engine (#1432).
 - `backslash` — the byte-slice convenience over the lexer's decoder
   (see next); deliberately no second decode implementation.
+- `word_rules` — what a *word* means as a value: `WordValueRules` carries
+  the brace-continuation and list-parse axes together (a word-shaped list
+  asks both at once), and `whole_braced_word` answers "is this word a braced
+  literal". That last one is release-invariant and so takes no rules, but it
+  is shared for the same reason the axes are: the VM's `subst_word` strips
+  such a word's braces and suppresses all substitution, and codegen has to
+  decide the identical question about the identical word before it emits.
+  While the two were separate, codegen tested the *necessary* condition only
+  (`{` first, `}` last), so it stripped `{}${z}` to the unbalanced `}${z}`
+  and `switch -- "{}$z" …` refused a script both oracles run.
 
 ### `tcl-dialect` — foundational expression grammar
 

--- a/rust/tcl-compiler/src/codegen/cmd_subst.rs
+++ b/rust/tcl-compiler/src/codegen/cmd_subst.rs
@@ -389,7 +389,9 @@ impl CodegenCtx<'_> {
         {
             for part in &parts {
                 match part {
-                    SubstPart::Lit(text) => self.push_lit(text),
+                    // A decoded fragment is finished text, never source — see
+                    // `push_word_value`, whose fragment rule this is.
+                    SubstPart::Lit(text) => self.push_lit_exact(text),
                     SubstPart::Cmd(cmd) => self.emit_inline_cmd_subst(cmd),
                     SubstPart::Var(name) => self.load_var(name),
                 }
@@ -459,15 +461,23 @@ impl CodegenCtx<'_> {
             // Interpolated string — delegate to emit_value with interpolation
             self.emit_value(arg, true);
         } else if !braced && arg.contains('\\') {
+            // Decoded once here, so the result is the value. The two arms this
+            // replaces both pushed `processed` the same way, so the distinction
+            // their comment drew was written down but never made; the marker
+            // test in `push_word_value` makes it, and only it. A decode that
+            // *re-creates* a `${` / `[` (`"\$\{x}"`) therefore keeps the
+            // substituting push it already had — that vector is wrong on both
+            // sides of this change (the escaped-marker double-decode the VM's
+            // `subst_word` records as living in the compiler's literal
+            // emission), and closing it is not this fix.
             let processed = tcl_lexer::backslash_subst_in(arg, self.escapes);
-            if processed.contains('$') || (processed.contains('[') && processed.contains(']')) {
-                // After backslash processing, still has subst markers — push raw
-                self.push_lit(&processed);
-            } else {
-                self.push_lit(&processed);
-            }
+            self.push_word_value(&processed);
         } else {
-            self.push_lit(arg);
+            // A de-quoted or plain arg is the finished value, so it must not be
+            // re-substituted: `[string index "{}" 0]` answered empty because
+            // the value `{}` was pushed substituting and `subst_word` stripped
+            // the braces a second time (`push_word_value`).
+            self.push_word_value(arg);
         }
     }
 
@@ -543,8 +553,13 @@ impl CodegenCtx<'_> {
             // `be(a:$a)` (set-1.26).
             self.emit_value(word, true);
         } else if !braced && word.contains('\\') {
+            // Decoded here, so the result is this word's value — the same arm,
+            // and the same rule, as `emit_cmd_subst_arg`'s. Left substituting,
+            // the decoded `\{\}` was read back as a braced literal and stripped
+            // to nothing: `set w [dict get [dict create k \{\}] k]` measured 0
+            // where both oracles say 2.
             let processed = tcl_lexer::backslash_subst_in(word, self.escapes);
-            self.push_lit(&processed);
+            self.push_word_value(&processed);
         } else if braced {
             // A braced word is already de-braced here, so its content is the
             // finished value: push it verbatim or the VM's `subst_word` strips
@@ -553,7 +568,10 @@ impl CodegenCtx<'_> {
             // `{loc}` (issue #1602; tclsh 8.6.14 / 9.0.4 return `L`).
             self.push_lit_verbatim(word);
         } else {
-            self.push_lit(word);
+            // Not braced, and every substitution marker was routed above: this
+            // word's text is already its value, so it goes out unsubstituted
+            // for the same reason the braced arm does — see `push_word_value`.
+            self.push_word_value(word);
         }
     }
 
@@ -673,7 +691,7 @@ impl CodegenCtx<'_> {
         // The `[list …]` / `[format …]` / `[dict create …]` folds and the two
         // `list` inlinings — shared with `emit_value_interpolated`, which
         // carried an identical copy of them (issues #1427 / #1585).
-        if self.try_emit_constant_fold(value, super::values::FoldedLiteral::NoDedup) {
+        if self.try_emit_constant_fold(value) {
             return;
         }
         // Whole-word variable-index array element `$arr($idx)`: route through
@@ -699,7 +717,9 @@ impl CodegenCtx<'_> {
         {
             for part in &parts {
                 match part {
-                    SubstPart::Lit(text) => self.push_lit(text),
+                    // A decoded fragment is finished text, never source — see
+                    // `push_word_value`, whose fragment rule this is.
+                    SubstPart::Lit(text) => self.push_lit_exact(text),
                     SubstPart::Cmd(cmd_text) => {
                         self.emit_inline_cmd_subst(cmd_text);
                     }

--- a/rust/tcl-compiler/src/codegen/expressions.rs
+++ b/rust/tcl-compiler/src/codegen/expressions.rs
@@ -195,9 +195,24 @@ impl CodegenCtx<'_> {
     /// `{...}` delimiters and processes backslash escapes.  Returns
     /// `false` (string isn't necessarily numeric).
     fn emit_expr_string(&mut self, text: &str) -> bool {
-        // A brace-delimited operand `{…}` is a literal — no substitution.
-        if text.len() >= 2 && text.starts_with('{') && text.ends_with('}') {
-            self.push_lit(&text[1..text.len() - 1]);
+        // A whole braced operand `{…}` is a literal — no substitution, which is
+        // both halves of this arm.
+        //
+        // *Whole*, through the shared owner, because `{` first and `}` last is
+        // only the necessary condition: `{}${z}` closes its leading brace at
+        // byte 1, and stripping it produced the unbalanced `}${z}`, on which the
+        // VM then raised `missing close-brace for variable name` — so
+        // `switch -- "{}$z" …` (whose subject reaches codegen as an
+        // `ExprNode::String` operand) refused a script both oracles run.
+        //
+        // *Verbatim*, because the content of a braced word is its finished
+        // value: pushed substituting, `expr {{a[nope]}}` ran `nope` where both
+        // oracles answer with the literal `a[nope]`. This is the brace-word
+        // entry point (`push_lit_verbatim`), not the plain-value one, because
+        // here the word really is braced and the `\<newline>` continuation
+        // collapse really is its rule.
+        if let Some(inner) = tcl_syntax::word_rules::whole_braced_word(text) {
+            self.push_lit_verbatim(inner);
             return false;
         }
         // A quote-delimited operand `"…"` is a double-quoted word: its `$var` /
@@ -244,7 +259,9 @@ impl CodegenCtx<'_> {
         }
         for part in parts {
             match part {
-                SubstPart::Lit(t) => self.push_lit(t),
+                // A decoded fragment is finished text, never source — see
+                // `push_word_value`, whose fragment rule this is.
+                SubstPart::Lit(t) => self.push_lit_exact(t),
                 SubstPart::Var(name) => self.load_var(name),
                 SubstPart::Cmd(cmd_text) => self.emit_inline_cmd_subst(cmd_text),
             }

--- a/rust/tcl-compiler/src/codegen/helpers.rs
+++ b/rust/tcl-compiler/src/codegen/helpers.rs
@@ -21,6 +21,8 @@
 //! These are standalone helpers with no emitter state — used by every
 //! other codegen submodule.
 
+use super::statements::has_unescaped_subst;
+
 /// Tcl 9.0 default trim characters — pushed when `string trim` is
 /// called without an explicit chars argument.  Includes ASCII
 /// whitespace, NUL, and all Unicode category Zs space separators.
@@ -699,15 +701,34 @@ fn parse_format_parts(inner: &str) -> Option<Vec<String>> {
             }
             _ => {
                 // Bare word — a `$`/`[` makes it a substitution, not a constant.
+                //
+                // A backslash escapes the byte after it, which is what ends the
+                // word *and* what the value is: `a\ b` is the one word `a b`, so
+                // the scan may not break on that space, and `\{\}` is the
+                // two-byte value `{}`, so the escapes are substituted here for
+                // the same reason the quoted arm above substitutes its own. The
+                // scan used to stop at any blank and the word went out as its
+                // *source spelling*, so `set v [format %s \{\}]` measured 4 where
+                // both oracles say 2, `[format %s a\ b]` folded to `a\`, and
+                // `[format %s a\tb]` froze the escape text instead of a tab.
                 let start = i;
                 while i < bytes.len() && !matches!(bytes[i], b' ' | b'\t' | b'\n' | b'\r') {
-                    i += 1;
+                    if bytes[i] == b'\\' {
+                        // Past the backslash — ASCII, so `i` is a char boundary
+                        // — then over the *whole* escaped character, which may
+                        // be multi-byte (`\é`). A flat `i += 2` would slice
+                        // through it.
+                        i += 1;
+                        i += inner[i..].chars().next().map_or(0, char::len_utf8);
+                    } else {
+                        i += 1;
+                    }
                 }
                 let word = &inner[start..i];
-                if word.contains('$') || word.contains('[') {
+                if has_unescaped_subst(word) {
                     return None;
                 }
-                parts.push(word.to_owned());
+                parts.push(tcl_lexer::backslash_subst(word).into_owned());
             }
         }
     }

--- a/rust/tcl-compiler/src/codegen/statements.rs
+++ b/rust/tcl-compiler/src/codegen/statements.rs
@@ -522,7 +522,7 @@ impl CodegenCtx<'_> {
         // The `[list …]` / `[format …]` / `[dict create …]` folds and the two
         // `list` inlinings — shared with `emit_value`, which carried an
         // identical copy of them (issues #1427 / #1585).
-        if self.try_emit_constant_fold(value, super::values::FoldedLiteral::Verbatim) {
+        if self.try_emit_constant_fold(value) {
             return;
         }
         // Whole-word variable-index array element `$arr($idx)`: route through
@@ -543,25 +543,41 @@ impl CodegenCtx<'_> {
         // normalised `${name}` but not an array element with a substituted
         // index, so decompose the word at compile time. Plain `$scalar`
         // interpolation keeps its existing (deferred-literal) lowering.
-        // Also decompose a `{…}`-wrapped value that contains a command
-        // substitution (e.g. `"{[list …]}"`): the braces are literal word
-        // content and the `[…]` must run, but pushing the value raw would let
-        // the runtime `subst_word` mistake it for a braced literal and strip the
-        // braces. A genuine braced argument never reaches here (it is emitted by
-        // the braced-word path), so decomposing is safe.
+        // Also decompose a `{…}`-wrapped value that still carries a live
+        // substitution (e.g. `"{[list …]}"`, `"{$z}"`): the braces are literal
+        // word content and the `[…]` / `${…}` must run, but pushing the value
+        // raw would let the runtime `subst_word` mistake it for a braced
+        // literal, strip the braces and hand back the *unsubstituted* inside —
+        // `puts "{$z}"` printed `${z}`, and `set q "{$z}"` stored four bytes
+        // where both oracles store three. This is the marker-carrying half of
+        // the value rule `push_word_value` states: a value the runtime still
+        // owns cannot simply be frozen, so it is resolved here instead. A
+        // genuine braced argument never reaches here (it is emitted by the
+        // braced-word path), so decomposing is safe.
+        //
+        // The brace test is the VM's own rule, through the same owner the VM
+        // asks (`whole_braced_word`) — this arm exists precisely because
+        // `subst_word` *will* strip, so anything looser decomposes words it
+        // would not have touched and anything two-byte repeats the bug this
+        // change is about. `{}${z}` is the discriminating case: it is not a
+        // braced word, the VM's general scan substitutes it correctly, and it
+        // stays on the literal path.
         if (value.contains('$') || value.contains('['))
             && let Some(parts) = parse_subst_template(value, self.escapes, self.braced_var)
             && parts.len() > 1
             && (parts
                 .iter()
                 .any(|p| matches!(p, SubstPart::Var(n) if split_array_ref(n).is_some()))
-                || (value.starts_with('{')
-                    && value.ends_with('}')
-                    && parts.iter().any(|p| matches!(p, SubstPart::Cmd(_)))))
+                || (tcl_syntax::word_rules::whole_braced_word(value).is_some()
+                    && parts
+                        .iter()
+                        .any(|p| matches!(p, SubstPart::Cmd(_) | SubstPart::Var(_)))))
         {
             for part in &parts {
                 match part {
-                    SubstPart::Lit(text) => self.push_lit(text),
+                    // A decoded fragment is finished text, never source — see
+                    // `push_word_value`, whose fragment rule this is.
+                    SubstPart::Lit(text) => self.push_lit_exact(text),
                     SubstPart::Cmd(cmd_text) => self.emit_inline_cmd_subst(cmd_text),
                     SubstPart::Var(name) => self.load_var(name),
                 }
@@ -597,8 +613,12 @@ impl CodegenCtx<'_> {
         if self.try_emit_whole_cmd_subst(value) {
             return;
         }
-        // Default: push as literal
-        self.push_lit(value);
+        // Default: the word's own text is its value — push it unsubstituted
+        // unless a `${…}` / `[…]` the runtime still owns survived the arms
+        // above (`push_word_value`). Substituting a finished value strips a
+        // brace layer that was never source: `set v "{}"` stored the empty
+        // string where both oracles store the two-byte `{}`.
+        self.push_word_value(value);
     }
 
     /// Whether a `set x VALUE` value should inline-compile its command
@@ -739,7 +759,7 @@ impl CodegenCtx<'_> {
             if a.contains('[') || a.contains("${") {
                 self.push_lit(a);
             } else {
-                self.push_lit(&tcl_lexer::backslash_subst_in(a, self.escapes));
+                self.push_word_value(&tcl_lexer::backslash_subst_in(a, self.escapes));
             }
         } else {
             self.emit_value_interpolated(a);

--- a/rust/tcl-compiler/src/codegen/values.rs
+++ b/rust/tcl-compiler/src/codegen/values.rs
@@ -45,28 +45,24 @@ pub(crate) fn is_bare_var_name(name: &str) -> bool {
             .all(|b| b.is_ascii_alphanumeric() || b == b'_' || b == b':')
 }
 
-/// Which literal-pool entry point a folded constant takes.
-///
-/// The only thing that ever distinguished the two value emitters' copies of
-/// the constant-fold block, and not interchangeable: the verbatim path also
-/// sets `push_verbatim`, which suppresses runtime word substitution on the
-/// pushed literal. That matters for a folded result that still contains a `$`
-/// — `[list {a$b}]` folds to `a$b`, since the braced word is literal — so each
-/// emitter keeps the entry point it had.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum FoldedLiteral {
-    /// [`CodegenCtx::push_lit_no_dedup_verbatim`] — `emit_value_interpolated`.
-    Verbatim,
-    /// [`CodegenCtx::push_lit_no_dedup`] — `emit_value`.
-    NoDedup,
-}
-
 // -- Literal emission --
 
 impl CodegenCtx<'_> {
     /// The `[list …]` / `[format …]` / `[dict create …]` constant folds and
     /// the two `list` inlinings that sit between them — one copy, shared by
-    /// both value emitters, which carried it identically apart from `kind`.
+    /// both value emitters.
+    ///
+    /// **A folded result is a value, so it is always pushed verbatim.** Folding
+    /// *is* running the command at compile time; its result has no word rule
+    /// left to apply, and handing it back to the VM's `subst_word` runs the
+    /// substitution a second time. The two emitters used to differ here — a
+    /// `kind` parameter picked the verbatim entry point for the assignment
+    /// emitter and the substituting one for `emit_value`, and the `dict create`
+    /// arm ignored `kind` and substituted in *both* — so a fold whose result
+    /// carried a marker or looked braced came back wrong: `set d [dict create k
+    /// {a${b}}]` read `b` and `set v [dict get [dict create k \{\}] k]` measured
+    /// 0 where both oracles say 5 characters and 2. That asymmetry was never a
+    /// decision, only two emitters keeping the entry point each already had.
     ///
     /// Every fold is gated on its own builtin still *being* the builtin
     /// anywhere in this unit (issue #1585): a fold **is** that command's
@@ -77,16 +73,12 @@ impl CodegenCtx<'_> {
     /// under `--tcl-version 8.4`.
     ///
     /// Returns `true` when it emitted the value and the caller must stop.
-    pub(crate) fn try_emit_constant_fold(&mut self, value: &str, kind: FoldedLiteral) -> bool {
-        let push = |ctx: &mut Self, folded: &str| match kind {
-            FoldedLiteral::Verbatim => ctx.push_lit_no_dedup_verbatim(folded),
-            FoldedLiteral::NoDedup => ctx.push_lit_no_dedup(folded),
-        };
+    pub(crate) fn try_emit_constant_fold(&mut self, value: &str) -> bool {
         // Constant-fold [list arg1 arg2 ...].
         if self.trusts_builtin("list")
             && let Some(folded) = super::helpers::fold_list_cmd(value, self.word_rules)
         {
-            push(self, &folded);
+            self.push_lit_no_dedup_verbatim(&folded);
             return true;
         }
         // Inline [list {*}$a {*}$b] → load a, load b, listConcat. tclsh 9.0
@@ -105,7 +97,7 @@ impl CodegenCtx<'_> {
         if self.trusts_builtin("format")
             && let Some(folded) = super::helpers::try_format_fold(value)
         {
-            push(self, &folded);
+            self.push_lit_no_dedup_verbatim(&folded);
             return true;
         }
         // Constant-fold [dict create k v ...].
@@ -113,7 +105,7 @@ impl CodegenCtx<'_> {
             && self.trusts_builtin("dict")
             && let Some(folded) = super::helpers::fold_dict_create_cmd(value, self.word_rules)
         {
-            self.push_lit(&folded);
+            self.push_lit_no_dedup_verbatim(&folded);
             self.emit(Op::DUP, vec![]);
             self.emit(Op::VERIFY_DICT, vec![]);
             return true;
@@ -182,6 +174,46 @@ impl CodegenCtx<'_> {
             &format!("\"{}\"", esc(value, 40)),
         );
         self.instructions[pos].push_verbatim = true;
+    }
+
+    /// Push a word's **finished value** — text every word-level rule has
+    /// already been applied to, so the VM must not run `subst_word` over it a
+    /// second time.
+    ///
+    /// A de-quoted or plain word is a value, not source: `"{}"` *is* the
+    /// two-byte string `{}`. Handed to the substituting [`push_lit`], the VM's
+    /// `subst_word` reads it back as a whole-word braced literal and strips the
+    /// braces a second time — `string index "{}" 0` answered empty where both
+    /// oracles say `{`, and `set v "{}"` stored the empty string (issue #1602
+    /// fixed the braced half of this; the quoted half is the same hole).
+    ///
+    /// The marker test is the VM's own, byte for byte: `subst_word` returns a
+    /// word carrying no `${` and no `[` unchanged *apart from* that brace
+    /// strip, so suppressing substitution on one is behaviour-preserving in
+    /// every other respect. A value that does still carry a marker is one the
+    /// codegen deliberately defers to the runtime scan, so it keeps
+    /// [`push_lit`].
+    ///
+    /// The same rule, unconditionally, covers a *fragment* — the `Lit` part a
+    /// composite word decomposes to. `parse_subst_template` has already carved
+    /// the real substitutions out of it and decoded its escapes, so a marker
+    /// left in one is data by construction and the three decomposition loops
+    /// push a `Lit` through [`push_lit_exact`](Self::push_lit_exact) directly.
+    /// A fragment that looked braced was being stripped too: `"{}$z"`
+    /// concatenated to `x` rather than `{}x`.
+    ///
+    /// This is [`push_lit_exact`](Self::push_lit_exact), not
+    /// [`push_lit_verbatim`](Self::push_lit_verbatim): the value is not a
+    /// braced word, so the brace-word `\<newline>` collapse is not its rule —
+    /// a quoted word's continuations were folded when its escapes were decoded.
+    /// The literal bytes are unchanged either way, so disassembly stays stable
+    /// and only the out-of-band `push_verbatim` flag differs.
+    pub fn push_word_value(&mut self, value: &str) {
+        if value.contains("${") || value.contains('[') {
+            self.push_lit(value);
+        } else {
+            self.push_lit_exact(value);
+        }
     }
 
     /// Push a literal using a fresh slot (no deduplication).

--- a/rust/tcl-syntax/src/word_rules.rs
+++ b/rust/tcl-syntax/src/word_rules.rs
@@ -64,6 +64,63 @@ impl Default for WordValueRules {
     }
 }
 
+/// If `word` is a single balanced brace group spanning the whole word
+/// (`{` … its matching `}` at the final byte), return the inner slice.
+///
+/// The one owner of "is this word a braced literal", asked by both sides of
+/// the compile: the VM's `subst_word` strips such a word's braces and returns
+/// the content with *all* substitution suppressed, and codegen must decide the
+/// same question the same way — for a braced `expr` operand, and before it
+/// pushes any word the VM will read back.
+///
+/// The balance walk is the whole point, and the reason this is a function
+/// rather than a two-byte test each caller writes for itself. `{` first and
+/// `}` last is only the *necessary* condition: in `{}${z}` the leading brace
+/// matches at byte 1, so the word is not a braced literal and stripping it
+/// yields the unbalanced `}${z}`. Codegen's braced-`expr`-operand arm did
+/// exactly that, and `switch -- "{}$z" …` raised `missing close-brace for
+/// variable name` on a script both oracles run (its `expr` sibling ran a
+/// `[cmd]` inside what it had already decided was a literal).
+///
+/// Dialect-blind by construction: a backslash escapes the next byte on every
+/// ladder, and brace *balance* is not one of the axes [`WordValueRules`]
+/// carries — the continuation collapse that is stays on
+/// [`WordValueRules::collapse_braced_word`].
+#[must_use]
+pub fn whole_braced_word(word: &str) -> Option<&str> {
+    let b = word.as_bytes();
+    let n = b.len();
+    if n < 2 || b[0] != b'{' || b[n - 1] != b'}' {
+        return None;
+    }
+    let mut depth = 0usize;
+    let mut i = 0usize;
+    while i < n {
+        match b[i] {
+            b'\\' => {
+                i += 2;
+                continue;
+            }
+            b'{' => depth += 1,
+            b'}' => {
+                depth -= 1;
+                // A premature return to depth 0 means the leading `{` does not
+                // match the trailing `}`, so this is not a whole-word literal.
+                if depth == 0 && i != n - 1 {
+                    return None;
+                }
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    if depth == 0 {
+        Some(&word[1..n - 1])
+    } else {
+        None
+    }
+}
+
 impl WordValueRules {
     /// Every build of the Tcl core, and the F5 fork.
     pub const TCL: Self = Self {
@@ -275,5 +332,35 @@ mod tests {
             WordValueRules::JIM.split_word_names("a {b").unwrap(),
             vec!["a", "b"]
         );
+    }
+
+    #[test]
+    fn whole_braced_word_strips_a_balanced_whole_word_group() {
+        assert_eq!(whole_braced_word("{abc}"), Some("abc"));
+        assert_eq!(whole_braced_word("{}"), Some("")); // empty group
+        assert_eq!(whole_braced_word("{a {b} c}"), Some("a {b} c"));
+        // A brace the escape neutralises is content, not structure.
+        assert_eq!(whole_braced_word(r"{a\}b}"), Some(r"a\}b"));
+    }
+
+    /// The condition the two-byte test cannot see, and the bug it caused: in
+    /// `{}${z}` the leading brace closes at byte 1, so the word is not a braced
+    /// literal — codegen stripped it anyway and produced the unbalanced
+    /// `}${z}`, which the VM then refused (`switch -- "{}$z" …`).
+    #[test]
+    fn whole_braced_word_rejects_a_word_that_only_looks_delimited() {
+        assert_eq!(whole_braced_word("{}${z}"), None);
+        assert_eq!(whole_braced_word("{a} {b}"), None);
+        assert_eq!(whole_braced_word("{}x{}"), None);
+    }
+
+    #[test]
+    fn whole_braced_word_rejects_undelimited_or_unbalanced_words() {
+        assert_eq!(whole_braced_word("abc"), None);
+        assert_eq!(whole_braced_word("{abc"), None);
+        assert_eq!(whole_braced_word("abc}"), None);
+        assert_eq!(whole_braced_word("{{a}"), None);
+        assert_eq!(whole_braced_word(""), None);
+        assert_eq!(whole_braced_word("{"), None);
     }
 }

--- a/rust/tcl-vm/src/subst.rs
+++ b/rust/tcl-vm/src/subst.rs
@@ -36,6 +36,14 @@
 //! owner's `SubstFlags::compiled_word()` rather than a private scanner.
 
 use tcl_runtime_api::Code;
+// A braced literal suppresses *all* substitution, so the codegen marks such
+// words by keeping their outer `{...}` braces (see `emit_one_proc_def` /
+// `emit_cmd_subst_arg`); `subst_word` strips them and returns the content
+// verbatim, mirroring the reference VM's `PUSH` handling. The balance walk is
+// shared with the codegen side, which has to answer the same question about
+// the same word — a second copy is how `{}${z}` came to be stripped to `}${z}`
+// there while the VM read it correctly.
+use tcl_syntax::word_rules::whole_braced_word as whole_braced;
 
 use crate::error::TclError;
 use crate::interp::Vm;
@@ -78,46 +86,6 @@ fn command_end(
         config,
     )
     .map(|end| end - 1)
-}
-
-/// If `word` is a single balanced brace group spanning the whole word
-/// (`{` … matching `}` at the final byte), return the inner slice. A braced
-/// literal suppresses *all* substitution, so the codegen marks such words by
-/// keeping their outer `{...}` braces (see `emit_one_proc_def` /
-/// `emit_cmd_subst_arg`); the runtime strips them here and returns the content
-/// verbatim, mirroring the reference VM's `PUSH` handling.
-fn whole_braced(word: &str) -> Option<&str> {
-    let b = word.as_bytes();
-    let n = b.len();
-    if n < 2 || b[0] != b'{' || b[n - 1] != b'}' {
-        return None;
-    }
-    let mut depth = 0usize;
-    let mut i = 0usize;
-    while i < n {
-        match b[i] {
-            b'\\' => {
-                i += 2;
-                continue;
-            }
-            b'{' => depth += 1,
-            b'}' => {
-                depth -= 1;
-                // A premature return to depth 0 means the leading `{` does not
-                // match the trailing `}`, so this is not a whole-word literal.
-                if depth == 0 && i != n - 1 {
-                    return None;
-                }
-            }
-            _ => {}
-        }
-        i += 1;
-    }
-    if depth == 0 {
-        Some(&word[1..n - 1])
-    } else {
-        None
-    }
 }
 
 fn read_var(vm: &mut Vm, name: &str) -> Result<Value, TclError> {

--- a/rust/tcl-vm/tests/word_value_resolution_e2e.rs
+++ b/rust/tcl-vm/tests/word_value_resolution_e2e.rs
@@ -1,0 +1,429 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Word-**value** resolution on the compiled path — the value half of the rule
+//! `variable_name_resolution_e2e` pins for names: *a word is resolved exactly
+//! once.*
+//!
+//! The compiled path resolved a word's value and then handed the result back to
+//! the VM's runtime word substitution, which read it as source a second time.
+//! For a value that happens to *look* like a braced word — `"{}"`, `"{x}"`,
+//! `"\{\}"` — `subst_word`'s whole-word-braced fast path then stripped a brace
+//! layer that was never in the source:
+//!
+//! ```text
+//! % puts [string index "{}" 0]           ;# 8.6.16 / 9.0.4: {    was: (empty)
+//! % set v "{}" ; puts [string length $v] ;# 8.6.16 / 9.0.4: 2    was: 0
+//! % set z x ; puts "{$z}"                ;# 8.6.16 / 9.0.4: {x}  was: ${z}
+//! ```
+//!
+//! The braced half of the same hole was closed twice before (issue #1602, then
+//! `emit_cmd_subst_arg`'s braced arm). A de-quoted word is finished for exactly
+//! the same reason a de-braced one is — the quotes are gone and the escapes are
+//! decoded — and so is each literal *fragment* a composite word decomposes to.
+//!
+//! Two shapes, two fixes, because a value that still carries a marker cannot
+//! simply be frozen:
+//!
+//! * **No marker left** (`"{}"`, a decoded `\{\}`, a `Lit` fragment): pushed
+//!   unsubstituted — `CodegenCtx::push_word_value` / `push_lit_exact`. The
+//!   marker test is the VM's own, so this can only remove the brace strip:
+//!   `subst_word` returns a word carrying no `${` and no `[` unchanged apart
+//!   from it.
+//! * **A live marker inside the braces** (`"{$z}"`, `"{[pz]}"`): decomposed at
+//!   compile time instead, because the `${…}` / `[…]` must still run and the
+//!   surrounding braces are word content. Pushed raw, the VM stripped the
+//!   braces and returned the inside *unsubstituted*.
+//!
+//! The same rule reaches two places that *produce* a value rather than write
+//! one, and both got it wrong in both halves. A **constant fold** runs its
+//! command at compile time, so its result is finished — yet the folds pushed it
+//! substituting, and `dict create` did so in both emitters. A **braced `expr`
+//! operand** is a literal — yet codegen decided "braced" on the necessary
+//! condition alone (`{` first, `}` last) and pushed the content substituting,
+//! so `{}${z}` was stripped to the unbalanced `}${z}` and `expr {{a[nope]}}`
+//! ran `nope`. That first one is why `switch -- "{}$z" …` raised on a script
+//! both oracles run: a switch subject reaches codegen as that operand. The
+//! balance walk now has one owner, `tcl_syntax::word_rules::whole_braced_word`,
+//! shared with the `subst_word` side that asks the same question.
+//!
+//! The negative vectors below pin both boundaries: live substitution still
+//! happens, and a genuinely braced word still loses exactly one layer.
+//!
+//! Every vector runs through the VM at all five releases and, when the matching
+//! real tclsh is installed, under it too, so the table cannot drift from C Tcl.
+//! A word's value is not a release axis — 8.6.16 and 9.0.4 agree on every
+//! vector here — so one expectation column is enough.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use tcl_compiler::cfg_builder::build_cfg_codegen;
+use tcl_compiler::codegen::codegen_module;
+use tcl_dialect::{DialectProfile, TclVersion};
+use tcl_vm::{CompileError, CompileService, Vm};
+
+/// The profile the vector selected, compiled exactly — never the ambient
+/// default, or every release column would be measured against one grammar.
+fn compile_exact_profile(
+    src: &str,
+    profile: &'static DialectProfile,
+) -> Result<tcl_bytecode::ModuleAsm, CompileError> {
+    let registry = tcl_registry::model::ingress::static_context_for_profile(profile).commands();
+    let config = tcl_lexer::LexerConfig::from_grammar(profile.grammar);
+    if let Some(message) = tcl_compiler::lowering::first_fatal_parse_error_with_config(src, config)
+    {
+        return Err(CompileError(message));
+    }
+    let ir = tcl_compiler::lowering::lower_to_ir_for_bytecode_with_dialect(
+        src,
+        registry,
+        config,
+        Some(profile),
+    );
+    let cfg = build_cfg_codegen(&ir, false);
+    Ok(codegen_module(&cfg, &ir, registry))
+}
+
+fn profile_of(version: TclVersion) -> &'static DialectProfile {
+    tcl_registry::model::ingress::resolve_environment(version.dialect_name()).analyser_profile()
+}
+
+/// Compiles at the release the VM is running, so a `[…]` the VM hands back for
+/// compilation is not silently lowered under a different grammar.
+struct CompilerSvc(TclVersion);
+
+impl CompileService for CompilerSvc {
+    type Module = tcl_bytecode::ModuleAsm;
+
+    fn compile(&self, src: &str) -> Result<tcl_bytecode::ModuleAsm, CompileError> {
+        compile_exact_profile(src, profile_of(self.0))
+    }
+
+    fn compile_for_profile(
+        &self,
+        src: &str,
+        profile: &'static DialectProfile,
+    ) -> Result<tcl_bytecode::ModuleAsm, CompileError> {
+        compile_exact_profile(src, profile)
+    }
+}
+
+#[derive(Clone, Default)]
+struct Capture(Rc<RefCell<Vec<u8>>>);
+
+impl std::io::Write for Capture {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.borrow_mut().extend_from_slice(buf);
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Run `src` in the VM at `version`, returning its trimmed `puts` output — the
+/// same shape the tclsh leg produces, so the two are directly comparable.
+fn vm_output(src: &str, version: TclVersion) -> String {
+    let asm = compile_exact_profile(src, profile_of(version))
+        .expect("test script compiles for its selected profile");
+    let capture = Capture::default();
+    let mut vm = Vm::with_output(Box::new(capture.clone()));
+    vm.set_compiler(Box::new(CompilerSvc(version)));
+    vm.set_runtime_version(version);
+    let _ = vm.run_module(&asm);
+    String::from_utf8_lossy(&capture.0.borrow())
+        .trim()
+        .to_string()
+}
+
+/// Run `src` under the real tclsh for `version`, or `None` when that binary
+/// isn't installed.
+fn tclsh_output(version: TclVersion, src: &str) -> Option<String> {
+    let tclsh = tcl_test_support::locate_tclsh(version).ok().flatten()?;
+    tcl_test_support::run_script(&tclsh.path, src.as_bytes())
+        .ok()?
+        .strict_text()
+        .ok()
+}
+
+/// One behaviour vector: the script prints its observations, `want` is the full
+/// expected stdout. Every `want` here was measured on tclsh 8.6.16 and 9.0.4,
+/// which agree, and `vectors_match_real_tclsh` keeps it that way.
+struct Vector {
+    name: &'static str,
+    script: &'static str,
+    want: &'static str,
+    /// Earliest release the vector runs at. Only the `dict` vectors need it:
+    /// `dict` arrived in 8.5, so at 8.4 the script is an `invalid command
+    /// name` on both sides and measures nothing about word values.
+    since: TclVersion,
+}
+
+const VECTORS: &[Vector] = &[
+    // -- No marker left: a finished value is pushed unsubstituted. --
+    Vector {
+        name: "a quoted value that looks braced keeps both braces in a command arg",
+        script: r#"puts [string index "{}" 0]:[string length "{}"]:[string length "{abc}"]
+"#,
+        want: "{:2:5",
+        since: TclVersion::V8_4,
+    },
+    Vector {
+        name: "a quoted value that looks braced keeps both braces through an assignment",
+        script: r#"set v "{}"
+set w "{abc}"
+puts [string length $v]:[string length $w]:$w
+"#,
+        want: "2:5:{abc}",
+        since: TclVersion::V8_4,
+    },
+    Vector {
+        // The proc body runs through the same word emitters as the top level
+        // but with the local-variable table in play, so it is pinned
+        // separately: #1602's braced half regressed in exactly that direction.
+        name: "the same value survives a proc-local round trip",
+        script: r#"proc pv {} { set v "{q}" ; return [string length $v]:[set v] }
+puts [pv]
+"#,
+        want: "3:{q}",
+        since: TclVersion::V8_4,
+    },
+    Vector {
+        name: "a quoted value that looks braced passes intact into a user proc",
+        script: r#"proc pl {s} { return [string length $s] }
+puts [pl "{}"]:[pl "{abc}"]
+"#,
+        want: "2:5",
+        since: TclVersion::V8_4,
+    },
+    Vector {
+        // Braces reached by *escape* rather than by quoting are the same case
+        // one step later: the word is finished once its escapes are decoded, so
+        // the decoded text must not be re-read as source either.
+        name: "escaped braces decode to a value that is not re-stripped",
+        script: r"set e \{\}
+puts [string length $e]:[string length \{\}]:$e
+",
+        want: "2:2:{}",
+        since: TclVersion::V8_4,
+    },
+    Vector {
+        // A nested substitution builds its arguments through the *inner* word
+        // emitter (`emit_cmd_subst_arg`), which had its own copy of the hole.
+        name: "the inner word emitter keeps the braces too",
+        script: r#"puts [string length [format %s%s "{}" "{}"]]:[format %s%s "{}" x]
+"#,
+        want: "4:{}x",
+        since: TclVersion::V8_4,
+    },
+    Vector {
+        // A composite word decomposes to literal *fragments*, which the
+        // template parser has already decoded — so they are finished for the
+        // same reason, and a fragment that looks braced was being stripped
+        // too. `[string length "{}$z"]` answered 1.
+        name: "a literal fragment of a composite word keeps its braces",
+        script: r#"set z x
+puts [string length "{}$z"]:[string length "$z{}"]
+puts "{}$z"
+"#,
+        want: "3:3\n{}x",
+        since: TclVersion::V8_4,
+    },
+    Vector {
+        // The same fragment rule inside an `expr` operand, which has its own
+        // copy of the decomposition loop.
+        name: "an expr operand's literal fragment keeps its braces",
+        script: r#"set z x
+puts [expr {"{}$z"}]:[string length [expr {"{}$z"}]]
+"#,
+        want: "{}x:3",
+        since: TclVersion::V8_4,
+    },
+    // -- A live marker: decomposed, not frozen. --
+    Vector {
+        // The marker test's whole purpose. Freezing every brace-shaped value
+        // would print the literal `{$z}` here; pushing it raw (what the VM did)
+        // stripped the braces and returned the *unsubstituted* `${z}`.
+        name: "a brace-shaped value with a live variable still substitutes",
+        script: r#"set z x
+puts [string length "{$z}"]
+puts "{$z}"
+set q "{$z}"
+puts $q:[string length $q]
+"#,
+        want: "3\n{x}\n{x}:3",
+        since: TclVersion::V8_4,
+    },
+    Vector {
+        name: "a brace-shaped value with a live command substitution still runs it",
+        script: r#"proc pz {} { return x }
+puts [string length "{[pz]}"]
+puts "{[pz]}"
+"#,
+        want: "3\n{x}",
+        since: TclVersion::V8_4,
+    },
+    // -- The negative boundary: the braced-word rule is untouched. --
+    Vector {
+        // The positive control for the arm this fix sits next to: a genuinely
+        // braced word still loses exactly one brace layer, and its `$` / `[`
+        // stay data. Freezing the quoted case must not disturb it.
+        name: "a genuinely braced word still loses exactly one layer",
+        script: r"puts [string length {{}}]:[string length {}]:[string length {$z[pz]}]
+puts {{a}}
+",
+        want: "2:0:6\n{a}",
+        since: TclVersion::V8_4,
+    },
+    // -- The same rule where the value is *produced*, not written. --
+    Vector {
+        // A constant fold runs the command at compile time, so its result is a
+        // value with no word rule left — but the folds pushed it substituting
+        // (`dict create` did so in both emitters, ignoring the `kind` its
+        // siblings took), and a result that looked braced lost its braces.
+        name: "a folded dict create result is a value, braces included",
+        script: r"set d [dict create k \{\}]
+set w [dict get [dict create k \{\}] k]
+puts [string length $d]:[string length $w]:$d
+",
+        want: "6:2:k {{}}",
+        since: TclVersion::V8_5,
+    },
+    Vector {
+        // The marker half of the same fold bug: pushed substituting, the folded
+        // result's `${b}` was read as a variable at run time.
+        name: "a folded dict create result keeps a marker as data",
+        script: r"set f [dict create k {a${b}}]
+puts $f:[string length $f]
+",
+        want: "k {a${b}}:9",
+        since: TclVersion::V8_5,
+    },
+    Vector {
+        // `format`'s fold read its *bare* arguments as source spelling: it
+        // stopped the word at any blank and never decoded the escapes, while
+        // the quoted arm beside it did both.
+        name: "a folded format result decodes its bare arguments",
+        script: r"set a [format %s \{\}]
+set b [format %s a\ b]
+set c [format %s a\tb]
+puts [string length $a]:$a:[string length $b]:$b:[string length $c]
+",
+        want: "2:{}:3:a b:3",
+        since: TclVersion::V8_4,
+    },
+    Vector {
+        name: "a folded list result keeps its braces",
+        script: r"set l [list \{\}]
+puts $l:[string length $l]
+",
+        want: "{{}}:4",
+        since: TclVersion::V8_4,
+    },
+    // -- The braced *operand* arm, which decided the same question twice. --
+    Vector {
+        // Codegen's braced-`expr`-operand arm stripped on "first `{`, last `}`"
+        // and pushed the content substituting. Both halves were wrong: the
+        // content is a braced word's finished value.
+        name: "a braced expr operand is a literal, and its markers are data",
+        script: r"puts [expr {{a[nope]}}]:[expr {{a$b}}]:[string length [expr {{}}]]
+",
+        want: "a[nope]:a$b:0",
+        since: TclVersion::V8_4,
+    },
+    Vector {
+        // A `switch` subject reaches codegen as that same operand. `{}${z}`
+        // closes its leading brace at byte 1, so stripping it left the
+        // unbalanced `}${z}` and the VM raised on a script both oracles run.
+        // The second arm proves the subject still substitutes to `{}x`.
+        name: "a brace-shaped switch subject is not a braced word",
+        script: r#"set z x
+switch -- "{}$z" "zz" { puts A:hit } default { puts A:def }
+switch -- "{}$z" "{}x" { puts B:hit } default { puts B:def }
+"#,
+        want: "A:def\nB:hit",
+        since: TclVersion::V8_4,
+    },
+    Vector {
+        // A brace-shaped value that is not a *whole* braced word never reached
+        // the VM's strip in the first place, so the fix is measured against a
+        // case it cannot have changed.
+        name: "a value that is not whole-word braced is unaffected",
+        script: r#"puts [string length "{} {}"]:[string length "a{}b"]
+"#,
+        want: "5:4",
+        since: TclVersion::V8_4,
+    },
+];
+
+#[test]
+fn vm_matches_the_pinned_word_value_vectors() {
+    for v in VECTORS {
+        assert_eq!(
+            vm_output(v.script, TclVersion::V8_6),
+            v.want,
+            "[8.6] {}",
+            v.name
+        );
+        assert_eq!(
+            vm_output(v.script, TclVersion::V9_0),
+            v.want,
+            "[9.0] {}",
+            v.name
+        );
+    }
+}
+
+/// A word's value is not a release axis: every vector holds unchanged at 8.4,
+/// 8.5 and 9.1 as well.
+#[test]
+fn the_vectors_hold_at_every_release() {
+    for v in VECTORS {
+        for version in [TclVersion::V8_4, TclVersion::V8_5, TclVersion::V9_1] {
+            if version < v.since {
+                continue;
+            }
+            assert_eq!(
+                vm_output(v.script, version),
+                v.want,
+                "[{version:?}] {}",
+                v.name
+            );
+        }
+    }
+}
+
+/// The table itself is pinned to C Tcl: every `want` must match what the
+/// matching real tclsh prints. Skips silently per-binary when not installed
+/// (CI / dev machines with `make ensure-test-deps` have both).
+#[test]
+fn vectors_match_real_tclsh() {
+    let mut ran = 0;
+    for v in VECTORS {
+        for version in [TclVersion::V8_6, TclVersion::V9_0] {
+            if let Some(got) = tclsh_output(version, v.script) {
+                assert_eq!(got, v.want, "[tclsh {:?}] {}", version, v.name);
+                ran += 1;
+            }
+        }
+    }
+    if ran == 0 {
+        eprintln!("skipping: neither tclsh8.6 nor tclsh9.0 found");
+    }
+}


### PR DESCRIPTION
`variable_name_resolution_e2e` pins that rule for a `set`'s *name* word
(#1602). Its *value* word had the same hole: codegen resolved a word and
then handed the result back to the VM's `subst_word`, which read it as
source a second time. For a value that happens to look like a braced word
the whole-word-braced fast path then stripped a brace layer that was never
in the source — `string index "{}" 0` answered empty and `set v "{}"`
stored the empty string, where 8.4/8.5/8.6/9.0 all answer `{` and 2.

`subst_word`'s brace strip is the *only* thing it does to a literal
carrying no `${` and no `[`, so `CodegenCtx::push_word_value` uses that
same marker test: on a marker-free value it can only remove the strip, and
the literal bytes are unchanged either way. It routes to `push_lit_exact`,
not `push_lit_verbatim` — a quoted word is not a braced word, so the
brace-word `\<newline>` collapse is not its rule. Five fall-throughs took
it: `emit_cmd_word` and `emit_cmd_subst_arg`, each in its plain arm and its
backslash-decoded arm, and `emit_value_interpolated`'s default. The two
backslash arms in `emit_cmd_subst_arg` were already written as if they made
this distinction — both branches pushed the same way, so it never was.

A value that *does* still carry a marker cannot be frozen, so the other
half is resolved at compile time instead. `emit_value_interpolated` already
decomposed a `{…}`-wrapped value holding a `[…]`; it now does so for a
`${…}` too, because pushing `{}${z}` raw let the VM strip the braces and
hand back the inside *unsubstituted* — `puts "{$z}"` printed `${z}`.

Doing that exposed the layer under it: the three decomposition loops (and
`expressions.rs`'s copy for `"…"` expr operands) pushed their `Lit`
fragments substituting. A fragment is already decoded by the template
parser, so `[string length "{}$z"]` answered 1 and `expr {"{}$z"}` answered
`x`.

The same rule reaches two places that *produce* a value rather than write
one, and both got it wrong in both halves:

- A constant fold runs its command at compile time, so its result is
  finished — but the folds pushed it substituting, and `dict create` did so
  in *both* emitters, ignoring the `kind` its siblings took. `set d [dict
  create k \{\}]` measured 0 and `[dict create k {a${b}}]` read `b`. A fold
  result is always a value, so `FoldedLiteral` is gone and both emitters
  take the verbatim entry point. `format`'s fold also read its *bare*
  arguments as source spelling — stopping the word at any blank and never
  decoding — so `[format %s \{\}]` froze 4 bytes, `[format %s a\ b]` folded
  to `a\`, and `[format %s a\tb]` kept the escape text. Its quoted arm had
  done both all along.

- A braced `expr` operand is a literal, but codegen decided "braced" on the
  necessary condition alone (`{` first, `}` last) and pushed the content
  substituting. `{}${z}` closes its leading brace at byte 1, so stripping
  gave the unbalanced `}${z}` and `switch -- "{}$z" …` — whose subject
  reaches codegen as that operand — raised `missing close-brace for
  variable name` on a script both oracles run; `expr {{a[nope]}}` ran
  `nope`. The balance walk now has one owner,
  `tcl_syntax::word_rules::whole_braced_word`, shared with the `subst_word`
  side that asks the same question about the same word, replacing the
  duplicate rather than adding a third copy.

`word_value_resolution_e2e` pins 18 vectors, every expectation measured
from a real tclsh rather than asserted, at all five releases plus the
real-tclsh leg. A 242-case corpus crossing brace-shaped values against word
contexts moves from 82 divergences to none; a 1500-script `tcl-fuzz`
campaign is unchanged at 0 findings both sides, which is a no-regression
signal only — its generator never emits these word shapes.

Not fixed here: #1646, the escaped-marker double decode (`"\$\{x}"` answers
1 where both oracles say 4). It is wrong on both sides of this change, and
the comment on the arm it passes through now says so.


## Verification

- `make prep-pr` and `make rust-check` green; `cargo test -p tcl-compiler -p tcl-vm -p tcl-syntax` 122 suites, 0 failed.
- A 242-case corpus crossing brace-shaped values (`"{}"`, `"{a b}"`, `"{$z}"`, `\{\}`, `"{"`, …) against 11 word contexts (assign, command arg, nested `[…]`, proc body, `list`, `switch`, `dict`, `append`, `expr`, interpolation, user proc) — measured against tclsh 8.6 and 9.0, and against a pre-change binary to separate *fixed* from *regressed*:

  | | pre-change | this branch |
  |---|---|---|
  | behavioural divergences | 82 | **0** |
  | regressions | — | **0** |

- `word_value_resolution_e2e` runs its 18 vectors at all five releases plus the real-tclsh leg; every `want` was measured from tclsh rather than asserted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
