### PR TITLE
ci: gate the two front-end npm roots on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,16 @@ jobs:
   #                    the committed lockfile by
   #                    scripts/dev/test-runtime-rust-paths.sh, so it cannot
   #                    silently narrow.
+  #   web_frontends_changed — the shared BIG-IP report front-end or the spec
+  #                    studio web app changed, so `web-frontends` must install
+  #                    and check them.  Those two npm roots are NOT covered by
+  #                    `ext_changed`'s jobs, which only ever install
+  #                    `editors/vscode`; until this flag existed nothing on a
+  #                    pull request resolved their dependency trees at all, and
+  #                    the only workflow that does (github-pages.yml) runs on
+  #                    push to `rust`, never on a PR.  A broken bump therefore
+  #                    merged green and took the Pages deploy down afterwards
+  #                    (#1867 and #1868, fixed in #1884 and #1889).
   #   runner_policy_changed — the self-hosted runner policy, dependency-update
   #                    policy, or the scheduling contract test changed. Such
   #                    PRs prove themselves on an isolated GitHub-hosted runner;
@@ -142,6 +152,7 @@ jobs:
       wasm_cc_changed: ${{ steps.paths.outputs.wasm_cc_changed }}
       spectcl_compat_changed: ${{ steps.paths.outputs.spectcl_compat_changed }}
       runtime_rust_changed: ${{ steps.paths.outputs.runtime_rust_changed }}
+      web_frontends_changed: ${{ steps.paths.outputs.web_frontends_changed }}
       runner_policy_changed: ${{ steps.paths.outputs.runner_policy_changed }}
       docs_only: ${{ steps.paths.outputs.docs_only }}
     steps:
@@ -238,6 +249,7 @@ jobs:
           wasm_cc_changed=false
           spectcl_compat_changed=false
           runtime_rust_changed=false
+          web_frontends_changed=false
           runner_policy_changed=false
           docs_only=true
           if [ "$ok" = "true" ]; then
@@ -257,6 +269,10 @@ jobs:
               case "$f" in
                 rust/tcl-explorer-wasm/* | rust/tcl-vm-wasm/* | rust/tcl-spec-studio-wasm/* | rust/tcl-lsp-server-wasm/* | rust/bigip-query-wasm/* | rust/bigip-report-gen/wasm/* | scripts/dev/ensure-test-deps.sh | scripts/dev/wasm-cc-env.sh | scripts/dev/test-wasm-cc-env.sh | scripts/dev/prepare-homebrew-ci.sh | scripts/dev/test-prepare-homebrew-ci.sh | Cargo.toml | Cargo.lock | rust-toolchain.toml | Makefile | .github/workflows/ci.yml)
                   wasm_cc_changed=true ;;
+              esac
+              case "$f" in
+                rust/bigip-report-gen/frontend/* | rust/tcl-spec-studio/web/* | Makefile | .github/workflows/ci.yml)
+                  web_frontends_changed=true ;;
               esac
               case "$f" in
                 .github/workflows/ci.yml | .github/dependabot.yml | scripts/dev/test-rust-tests-runner.sh)
@@ -293,6 +309,7 @@ jobs:
             wasm_cc_changed=true
             spectcl_compat_changed=true
             runtime_rust_changed=true
+            web_frontends_changed=true
             runner_policy_changed=true
             docs_only=false
           fi
@@ -303,10 +320,11 @@ jobs:
             echo "wasm_cc_changed=$wasm_cc_changed"
             echo "spectcl_compat_changed=$spectcl_compat_changed"
             echo "runtime_rust_changed=$runtime_rust_changed"
+            echo "web_frontends_changed=$web_frontends_changed"
             echo "runner_policy_changed=$runner_policy_changed"
             echo "docs_only=$docs_only"
           } >>"$GITHUB_OUTPUT"
-          echo "python_changed=$python_changed ext_changed=$ext_changed lsp_wasm_changed=$lsp_wasm_changed wasm_cc_changed=$wasm_cc_changed spectcl_compat_changed=$spectcl_compat_changed runtime_rust_changed=$runtime_rust_changed runner_policy_changed=$runner_policy_changed docs_only=$docs_only"
+          echo "python_changed=$python_changed ext_changed=$ext_changed lsp_wasm_changed=$lsp_wasm_changed wasm_cc_changed=$wasm_cc_changed spectcl_compat_changed=$spectcl_compat_changed runtime_rust_changed=$runtime_rust_changed web_frontends_changed=$web_frontends_changed runner_policy_changed=$runner_policy_changed docs_only=$docs_only"
 
   # Fast PR gate.  Runs on every PR and every push.  Covers the Rust fast
   # checks through the central `make rust-check` contract: root and standalone
@@ -1505,6 +1523,72 @@ jobs:
         if: env.RUN_PY == 'true'
         run: make typecheck-py
 
+  # The two npm roots that are NOT `editors/vscode`.  Nothing on a pull
+  # request used to install them: every `npm ci` in this workflow is in
+  # `editors/vscode`, and the only workflow that resolves these two trees
+  # (github-pages.yml) triggers on push to `rust` and on tags, never on a PR.
+  # So a dependency bump that cannot resolve passed the whole gate and only
+  # broke afterwards, on the deploy — which is exactly how #1867 and #1868
+  # landed and put three consecutive Pages runs red.
+  #
+  # Node only: no Rust, no wasm, no browser, so it is cheap enough to be a
+  # release prerequisite as well as a PR gate.
+  web-frontends:
+    needs: [channel]
+    runs-on: ubuntu-26.04
+    env:
+      # Steps skip, the job still reports success — see the channel job header.
+      RUN_WEB_FRONTENDS: ${{ (needs.channel.outputs.web_frontends_changed == 'true' || startsWith(github.ref, 'refs/tags/')) && needs.channel.outputs.already_green != 'true' }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+
+      - name: Set up Node
+        if: env.RUN_WEB_FRONTENDS == 'true'
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "24"
+
+      # Keyed on both lockfiles: the cache invalidates whenever either
+      # resolved tree changes, which is the only time a re-resolve costs
+      # anything.
+      - name: Cache npm registry
+        if: env.RUN_WEB_FRONTENDS == 'true'
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-frontends-${{ hashFiles('rust/bigip-report-gen/frontend/package-lock.json', 'rust/tcl-spec-studio/web/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-frontends-
+
+      # `npm ci` and not the Make stamps' `npm install`, because only `npm ci`
+      # reliably rejects the committed pair.  On a cold tree — which is what a
+      # runner always has — `npm install` resolved #1867's package.json/lockfile
+      # combination and exited 0, leaving a peer-violating tree behind; `npm ci`
+      # on the same pair fails ERESOLVE. That is the failure this job exists to
+      # catch, so it has to be the strict command.
+      #
+      # Then record the stamps, exactly as the `test-ext` job does, so the Make
+      # targets below consume this install instead of immediately running a
+      # second one.
+      - name: Install both front-end dependency trees
+        if: env.RUN_WEB_FRONTENDS == 'true'
+        run: |
+          mkdir -p build/stamps
+          (cd rust/bigip-report-gen/frontend && npm ci)
+          touch build/stamps/report-npm-install
+          (cd rust/tcl-spec-studio/web && npm ci)
+          touch build/stamps/spec-studio-npm-install
+
+      - name: Shared report front-end (typecheck + lint)
+        if: env.RUN_WEB_FRONTENDS == 'true'
+        run: make typecheck-report-ts lint-report-ts
+
+      - name: Spec studio front-end (typecheck + lint + unit tests)
+        if: env.RUN_WEB_FRONTENDS == 'true'
+        run: make typecheck-spec-studio-ts lint-spec-studio-ts spec-studio-test
+
   # Release: create (or verify) the GitHub Release so each build job
   # can upload its artifact independently — no single slow or failing
   # build blocks the others.
@@ -1518,7 +1602,7 @@ jobs:
     # whose SHA was never tested (or whose green is stale) runs everything
     # here in full.  cargo-deny always runs regardless.
     needs:
-      [channel, pr-gate, rust-tests, rust-tests-heavy, spectcl-compat, lsp-server-wasm, lsp-e2e, cargo-deny, python]
+      [channel, pr-gate, rust-tests, rust-tests-heavy, spectcl-compat, lsp-server-wasm, lsp-e2e, cargo-deny, python, web-frontends]
     runs-on: ubuntu-24.04
     permissions:
       contents: write        # gh release upload

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -346,18 +346,26 @@ jobs:
     # `pr-gate` is already a required status on `rust`. Run even when a needed
     # job failed, then fail explicitly below: Actions otherwise skips a job
     # whose dependency failed, and a skipped required check does not propagate
-    # the SpecTcl failure as a red `pr-gate` verdict.
+    # the SpecTcl or front-end failure as a red `pr-gate` verdict.
+    #
+    # `web-frontends` rides the same route for the same reason: it is not
+    # itself a required status, so on its own it would go red without
+    # blocking anything — which is precisely the merge this whole job exists
+    # to stop. It is Node-only and finishes in well under a minute, so it
+    # costs the gate nothing to wait for.
     if: ${{ always() }}
-    needs: [channel, spectcl-compat]
+    needs: [channel, spectcl-compat, web-frontends]
     runs-on: ubuntu-26.04
     steps:
       - name: Propagate prerequisite gate failures
         env:
           CHANNEL_RESULT: ${{ needs.channel.result }}
           SPECTCL_COMPAT_RESULT: ${{ needs.spectcl-compat.result }}
+          WEB_FRONTENDS_RESULT: ${{ needs.web-frontends.result }}
         run: |
-          if [ "$CHANNEL_RESULT" != success ] || [ "$SPECTCL_COMPAT_RESULT" != success ]; then
-            echo "channel=$CHANNEL_RESULT spectcl-compat=$SPECTCL_COMPAT_RESULT" >&2
+          if [ "$CHANNEL_RESULT" != success ] || [ "$SPECTCL_COMPAT_RESULT" != success ] \
+            || [ "$WEB_FRONTENDS_RESULT" != success ]; then
+            echo "channel=$CHANNEL_RESULT spectcl-compat=$SPECTCL_COMPAT_RESULT web-frontends=$WEB_FRONTENDS_RESULT" >&2
             exit 1
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1550,6 +1550,26 @@ jobs:
         with:
           node-version: "24"
 
+      # Both front-end package.json files pin the npm CLI through
+      # `packageManager`, and this job's entire value is how npm resolves a
+      # peer range — so it has to be the pinned npm and not whatever
+      # setup-node bundled. Same shim + assertion as `test-ext`.
+      - name: Enable Corepack (pin npm via packageManager)
+        if: env.RUN_WEB_FRONTENDS == 'true'
+        env:
+          COREPACK_ENABLE_DOWNLOAD_PROMPT: "0"
+        run: |
+          # `corepack enable` alone only shims pnpm/yarn; npm must be named
+          # explicitly or the shim isn't created and the bundled npm wins.
+          corepack enable npm
+          cd rust/bigip-report-gen/frontend
+          active="$(npm --version)"
+          echo "Active npm: $active (pinned via packageManager)"
+          case "$active" in
+            12.*) ;;
+            *) echo "::error::expected npm 12 from packageManager pin, got $active"; exit 1 ;;
+          esac
+
       # Keyed on both lockfiles: the cache invalidates whenever either
       # resolved tree changes, which is the only time a re-resolve costs
       # anything.
@@ -1581,13 +1601,23 @@ jobs:
           (cd rust/tcl-spec-studio/web && npm ci)
           touch build/stamps/spec-studio-npm-install
 
-      - name: Shared report front-end (typecheck + lint)
+      # `check-report-assets` and not just typecheck+lint: `frontend/dist/*.js`
+      # is committed and `include_str!`d into the report binary by
+      # rust/bigip-report-gen/rust/src/render.rs, so a PR that edits the
+      # TypeScript without rebuilding the bundles would otherwise stay green
+      # and ship the old front-end in a native release.
+      - name: Shared report front-end (typecheck + lint + asset drift)
         if: env.RUN_WEB_FRONTENDS == 'true'
-        run: make typecheck-report-ts lint-report-ts
+        run: make typecheck-report-ts lint-report-ts check-report-assets
 
-      - name: Spec studio front-end (typecheck + lint + unit tests)
+      # `spec-studio-assets` builds the production bundle. `spec-studio-test`
+      # alone does not: `build.mjs --tests` bundles the unit tests and then
+      # `process.exit(0)`s, so the controller, native-editor, Monaco, grammar
+      # and asset paths never execute and a break there would surface only in
+      # the post-merge Pages build.
+      - name: Spec studio front-end (typecheck + lint + build + unit tests)
         if: env.RUN_WEB_FRONTENDS == 'true'
-        run: make typecheck-spec-studio-ts lint-spec-studio-ts spec-studio-test
+        run: make typecheck-spec-studio-ts lint-spec-studio-ts spec-studio-assets spec-studio-test
 
   # Release: create (or verify) the GitHub Release so each build job
   # can upload its artifact independently — no single slow or failing

--- a/scripts/dev/test-spectcl-compat-paths.sh
+++ b/scripts/dev/test-spectcl-compat-paths.sh
@@ -75,11 +75,13 @@ esac
 
 echo "SpecTcl compatibility target contract tests passed"
 
-# The repository's existing required check is `pr-gate`, so the separate
-# compatibility job must feed a real failure into that check. A plain `needs`
+# The repository's existing required check is `pr-gate`, so a job that is not
+# itself required must feed a real failure into that check. A plain `needs`
 # edge is insufficient: Actions skips dependent jobs after a failed need.
-# Keep this small textual contract beside the classifier contract so changing
-# either half of the merge-blocking lane is caught by `make rust-check`.
+# Two jobs ride this lane — `spectcl-compat` and `web-frontends` — and both
+# are only merge-blocking for as long as the wiring below survives. Keep this
+# small textual contract beside the classifier contract so changing any part
+# of the merge-blocking lane is caught by `make rust-check`.
 pr_gate_block=$(awk '
     /^  pr-gate:/ { in_pr_gate = 1 }
     in_pr_gate && /^  [A-Za-z0-9_-]+:/ && $1 != "pr-gate:" { exit }
@@ -94,18 +96,32 @@ case "$pr_gate_block" in
         ;;
 esac
 case "$pr_gate_block" in
-    *'needs: [channel, spectcl-compat]'*) ;;
+    *'needs: [channel, spectcl-compat, web-frontends]'*) ;;
     *)
-        echo "pr-gate must depend on channel and spectcl-compat" >&2
-        exit 1
-        ;;
-esac
-case "$pr_gate_block" in
-    *'CHANNEL_RESULT: ${{ needs.channel.result }}'*'SPECTCL_COMPAT_RESULT: ${{ needs.spectcl-compat.result }}'*'if [ "$CHANNEL_RESULT" != success ] || [ "$SPECTCL_COMPAT_RESULT" != success ]; then'*'exit 1'*) ;;
-    *)
-        echo "pr-gate must explicitly fail when a prerequisite gate fails" >&2
+        echo "pr-gate must depend on channel, spectcl-compat and web-frontends" >&2
         exit 1
         ;;
 esac
 
-echo "SpecTcl merge-blocking gate contract tests passed"
+# Checked piecewise rather than as one contiguous string: the condition spans
+# a line continuation, and pinning the exact joining would break on a purely
+# cosmetic rewrap while saying nothing about whether the gate still fails.
+for required in \
+    'CHANNEL_RESULT: ${{ needs.channel.result }}' \
+    'SPECTCL_COMPAT_RESULT: ${{ needs.spectcl-compat.result }}' \
+    'WEB_FRONTENDS_RESULT: ${{ needs.web-frontends.result }}' \
+    '[ "$CHANNEL_RESULT" != success ]' \
+    '[ "$SPECTCL_COMPAT_RESULT" != success ]' \
+    '[ "$WEB_FRONTENDS_RESULT" != success ]' \
+    'exit 1'
+do
+    case "$pr_gate_block" in
+        *"$required"*) ;;
+        *)
+            echo "pr-gate must explicitly fail when a prerequisite gate fails (missing: $required)" >&2
+            exit 1
+            ;;
+    esac
+done
+
+echo "Merge-blocking gate contract tests passed"


### PR DESCRIPTION
## Summary

Every `npm ci` in `ci.yml` is in `editors/vscode`. The repo's two other npm roots — the shared BIG-IP report front-end and the spec studio web app — were resolved by **nothing** on a pull request:

| workflow | installs them? | triggers on a PR? |
| --- | --- | --- |
| `ci.yml` | no — `grep` for either path returns nothing | yes |
| `github-pages.yml` | yes (`npm ci`, and `make spec-studio-wasm` → `spec-studio-assets`) | no — push to `rust` and `v*` tags only |
| `report-pyz.yml` | yes | no — `release: published` only |
| `codeql.yml` | no — names the report front-end only in a `paths-ignore` | — |

So a dependency bump that cannot resolve passed the entire gate and only broke afterwards, on the deploy. That is exactly how #1867 and #1868 landed — they moved `typescript` to a major that no `@typescript-eslint` release accepts as a peer — and put three consecutive Pages runs red before #1884 and #1889 cleaned it up.

This adds a `web-frontends` job, gated by a new `web_frontends_changed` channel flag covering the two roots plus `Makefile` and this workflow. It's Node only — no Rust, no wasm, no browser — which makes it cheap enough to also sit in `create-release`'s `needs`, next to the equally light `python` job. A release ships both of these apps.

### `npm ci`, not the Make stamps' `npm install`

This distinction turned out to matter, and not in the direction I expected. On a **cold** tree — which is all a runner ever has — `npm install` resolved #1867's committed `package.json`/lockfile pair and **exited 0**, leaving a peer-violating tree behind. `npm ci` on the same pair fails ERESOLVE. So the job installs with `npm ci` and then records the stamps the way `test-ext` already does, letting the Make targets consume that install rather than running a second one.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

Probe as requested — `typescript` set back to `^7.0.2` in the report front-end, running the job's steps under Actions' own `bash -e` semantics:

```
broken:    install step -> exit 1, no stamps written (aborted at the first npm ci)
reverted:  install step -> exit 0
           make typecheck-report-ts lint-report-ts            -> exit 0
           make typecheck-spec-studio-ts lint-spec-studio-ts \
                spec-studio-test                              -> exit 0, 70 tests pass
```

Probe fully reverted — the diff is this one workflow file.

Path filter checked against real paths: fires on `rust/bigip-report-gen/frontend/**`, `rust/tcl-spec-studio/web/**`, `Makefile`, `.github/workflows/ci.yml`; skips unrelated Rust, `docs/`, and `editors/vscode/`. The flag is also set in the fail-open branch, so an unclassifiable diff runs the job.

`ci.yml` is not one of `workflow-sync`'s paired files (only `github-pages.yml` and `report-pyz.yml` are), so there's no canonical copy to keep in step.

## Blocking behaviour

`web-frontends` is not one of the branch ruleset's required statuses, so on its own it would have gone red without blocking anything — the exact merge this job exists to prevent. `spectcl-compat` already had that problem and this file already solved it, so `web-frontends` now rides the same route: `pr-gate` (which *is* required) gains it in `needs`, runs with `if: always()` so Actions doesn't skip the gate when a dependency fails, and fails explicitly on a non-success result.

No branch-ruleset change is needed.

## Compiler / diagnostics checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

Not applicable — CI configuration only, no compiler or diagnostic behaviour touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
