### PR TITLE
fix(compiler): word-value reads the first pass did not reach, under the document's grammar

### DIFF
--- a/rust/tcl-compiler/src/cfg_builder/cfg_lower.rs
+++ b/rust/tcl-compiler/src/cfg_builder/cfg_lower.rs
@@ -115,7 +115,27 @@ fn literal_true_expr() -> ExprNode {
 /// `fold_const_branch` only folds a whole-condition literal, never a `Binary`.
 /// So the arm-pruning behaviour is unchanged, and an unsubstituted subject word
 /// can never be compared as if it were its own literal text.
-fn switch_subject_operand(subject: &str) -> ExprNode {
+fn switch_subject_operand(subject: &str, braced: bool) -> ExprNode {
+    // A braced subject is a literal: its `$` and `[` are data. `ExprNode::String`
+    // carries *source text including delimiters* — that is its documented
+    // contract — so the braces go back on and `emit_expr_string` recognises the
+    // word through the shared `whole_braced_word` owner and pushes its content
+    // verbatim. Handing over the bare value instead made it indistinguishable
+    // from an unbraced word, and `switch -- {a[nosuchcmd]}` ran the command
+    // where both oracles match the literal and take the default arm.
+    //
+    // Re-bracing is lossless here, and only here: a braced word's content is
+    // brace-balanced or escaped by construction, so wrapping it always yields a
+    // word the balance walk accepts. The same is not true of an arbitrary
+    // value, which is why this is gated on the word really having been braced
+    // rather than applied to anything that looks like it could be.
+    if braced {
+        return ExprNode::String {
+            text: format!("{{{subject}}}"),
+            start: 0,
+            end: 0,
+        };
+    }
     if is_whole_var_ref(subject) {
         return ExprNode::Raw {
             text: subject.to_owned(),
@@ -763,6 +783,7 @@ impl CfgBuilder {
         let Statement::Switch {
             span,
             subject,
+            subject_braced,
             arms,
             default_body,
             default_span,
@@ -829,7 +850,7 @@ impl CfgBuilder {
             let cond = if *mode == SwitchMode::Exact {
                 ExprNode::Binary {
                     op: BinOp::StrEq,
-                    left: Box::new(switch_subject_operand(subject)),
+                    left: Box::new(switch_subject_operand(subject, *subject_braced)),
                     right: Box::new(ExprNode::Literal {
                         text: arm.pattern.clone(),
                         start: 0,
@@ -1215,6 +1236,7 @@ mod tests {
     #[test]
     fn switch_exact_creates_branches() {
         let script = Script::from_statements(vec![Statement::Switch {
+            subject_braced: false,
             span: Span::new(0, 50),
             subject: "$x".into(),
             subject_span: Span::new(7, 9),
@@ -1251,6 +1273,7 @@ mod tests {
     /// Build a one-arm switch (body reads `$y`) in the given mode.
     fn glob_regexp_switch(mode: SwitchMode) -> Script {
         Script::from_statements(vec![Statement::Switch {
+            subject_braced: false,
             span: Span::new(0, 40),
             subject: "$x".into(),
             subject_span: Span::new(7, 9),

--- a/rust/tcl-compiler/src/cfg_builder/mod.rs
+++ b/rust/tcl-compiler/src/cfg_builder/mod.rs
@@ -2638,6 +2638,7 @@ mod tests {
             })
             .collect();
         Script::from_statements(vec![Statement::Switch {
+            subject_braced: false,
             span: Span::new(0, 1),
             subject: "$which".into(),
             subject_span: Span::new(0, 1),

--- a/rust/tcl-compiler/src/codegen/cmd_subst.rs
+++ b/rust/tcl-compiler/src/codegen/cmd_subst.rs
@@ -147,6 +147,24 @@ pub fn has_command_separator(text: &str) -> bool {
 /// in `{…}` (braces are stripped from the returned text). This
 /// lets the caller decide whether to re-wrap the value in braces.
 // Sequential character-walk parser; the brace / quote / bracket / escape
+/// Whether `byte` separates two words inside a `[…]` substitution body.
+///
+/// The one place this private splitter states the rule, delegating to the
+/// dialect owner rather than spelling out a byte set. It is pinned to
+/// [`WordSeparators::Tcl`] because that is what every caller is: each one is a
+/// [`CodegenCtx`] method compiling a document whose grammar the context
+/// already carries, and no dialect on the Tcl ladder moves this axis — only
+/// `JimTcl` does, by making `\v` a word character.
+///
+/// That is what makes this *ready* rather than *aware*: threading the
+/// document's axis is changing this constant to a parameter and passing
+/// `self`'s, not rewriting the scan. Kept a constant until a Jim-dialect
+/// caller exists, so the change lands with a test that can tell the
+/// difference.
+const fn is_word_sep(byte: u8) -> bool {
+    tcl_dialect::WordSeparators::Tcl.is_separator(byte)
+}
+
 /// Skip past a balanced `[...]` substitution starting at *i*.
 /// Returns the new cursor position past the matching `]`.
 fn skip_cmd_subst(bytes: &[u8], n: usize, mut i: usize) -> usize {
@@ -215,7 +233,7 @@ fn parse_braced_part(text: &str, bytes: &[u8], n: usize, mut i: usize) -> (Strin
 /// `[cmd]` mid-word is consumed as an opaque substitution.
 fn parse_bareword_part(text: &str, bytes: &[u8], n: usize, mut i: usize) -> (String, usize) {
     let start = i;
-    while i < n && bytes[i] != b' ' && bytes[i] != b'\t' {
+    while i < n && !is_word_sep(bytes[i]) {
         if bytes[i] == b'[' {
             i = skip_cmd_subst(bytes, n, i);
         } else if bytes[i] == b'\\' {
@@ -251,7 +269,7 @@ fn parse_bareword_part(text: &str, bytes: &[u8], n: usize, mut i: usize) -> (Str
 /// every test file using the `{-body … -result …}` dict form).
 fn skip_word_seps(bytes: &[u8], n: usize, mut i: usize) -> usize {
     loop {
-        if i < n && (bytes[i] == b' ' || bytes[i] == b'\t') {
+        if i < n && is_word_sep(bytes[i]) {
             i += 1;
         } else if i + 1 < n && bytes[i] == b'\\' && (bytes[i + 1] == b'\n' || bytes[i + 1] == b'\r')
         {
@@ -346,7 +364,7 @@ pub fn parse_cmd_parts(text: &str) -> Vec<(String, bool)> {
                 let start = i;
                 i = skip_cmd_subst(bytes, n, i);
                 // Continue past trailing non-ws (e.g. ``[ns current]::foo``).
-                while i < n && bytes[i] != b' ' && bytes[i] != b'\t' {
+                while i < n && !is_word_sep(bytes[i]) {
                     if bytes[i] == b'[' {
                         i = skip_cmd_subst(bytes, n, i);
                     } else {
@@ -390,8 +408,7 @@ pub fn parse_cmd_parts_expand(text: &str) -> Vec<(String, bool, bool)> {
         }
         // `{*}` immediately followed by non-whitespace word content → expansion.
         let mut expand = false;
-        if i + 3 < n && &bytes[i..i + 3] == b"{*}" && bytes[i + 3] != b' ' && bytes[i + 3] != b'\t'
-        {
+        if i + 3 < n && &bytes[i..i + 3] == b"{*}" && !is_word_sep(bytes[i + 3]) {
             expand = true;
             i += 3;
         }
@@ -407,7 +424,7 @@ pub fn parse_cmd_parts_expand(text: &str) -> Vec<(String, bool, bool)> {
             b'[' => {
                 let start = i;
                 let mut j = skip_cmd_subst(bytes, n, i);
-                while j < n && bytes[j] != b' ' && bytes[j] != b'\t' {
+                while j < n && !is_word_sep(bytes[j]) {
                     if bytes[j] == b'[' {
                         j = skip_cmd_subst(bytes, n, j);
                     } else {

--- a/rust/tcl-compiler/src/codegen/cmd_subst.rs
+++ b/rust/tcl-compiler/src/codegen/cmd_subst.rs
@@ -218,6 +218,22 @@ fn parse_bareword_part(text: &str, bytes: &[u8], n: usize, mut i: usize) -> (Str
     while i < n && bytes[i] != b' ' && bytes[i] != b'\t' {
         if bytes[i] == b'[' {
             i = skip_cmd_subst(bytes, n, i);
+        } else if bytes[i] == b'\\' {
+            // A backslash escapes the next character, and an escaped blank is
+            // *word content*, not a separator: `a\ b` is one word whose value
+            // is `a b`. Splitting on it handed `string length` two arguments,
+            // so `[string length a\ b]` raised `wrong # args` where both
+            // oracles answer 3.
+            //
+            // `\<newline>` is the one exception — that really is a word
+            // separator ([`skip_word_seps`] owns it) — so the word ends before
+            // it and the caller consumes it.
+            if matches!(bytes.get(i + 1), Some(b'\n' | b'\r')) {
+                break;
+            }
+            i += 1;
+            // Over the whole escaped character, which may be multi-byte.
+            i += text[i..].chars().next().map_or(0, char::len_utf8);
         } else {
             i += 1;
         }
@@ -784,8 +800,12 @@ impl CodegenCtx<'_> {
         if interpolate && self.try_emit_whole_cmd_subst(value) {
             return;
         }
-        // Default: push as literal
-        self.push_lit(value);
+        // Default: the word's own text is its value — unsubstituted unless a
+        // `${…}` / `[…]` the runtime still owns survived the arms above. The
+        // twin of `emit_value_interpolated`'s default, and missed when that one
+        // was fixed: this is the emitter a proc's `return` value goes through,
+        // so `proc p {} { return "{abc}" }` answered `abc`.
+        self.push_word_value(value);
     }
 
     /// Resolve the registry-stamped [`InlineCodegenHookId`] for a

--- a/rust/tcl-compiler/src/codegen/helpers.rs
+++ b/rust/tcl-compiler/src/codegen/helpers.rs
@@ -469,11 +469,25 @@ fn fold_cmd_arg_values(
     }
 
     // Cannot fold if UNBRACED arguments contain substitutions.
+    //
+    // "Braced" means *the word is a braced word*, which is why the quote state
+    // has to be tracked alongside the depth: inside a `"…"` word a brace is
+    // ordinary content, not a group, and it suppresses nothing. Counting it as
+    // a group made `"{$x}"` look protected, so `[list "{$x}"]` folded and froze
+    // the source spelling — `{{$x}}` where both oracles say `{{7}}` — and
+    // `[dict create k "{[…]}"]` froze an unrun command substitution.
+    //
+    // Deliberately still blind to backslashes: an escaped `\$` in a bare word
+    // is a constant this declines to fold, which costs a fold and answers
+    // correctly. Teaching it to escape-skip would *enable* new folds, which is
+    // a different change with a different risk.
     let mut depth: i32 = 0;
+    let mut in_quotes = false;
     for ch in inner.bytes() {
         match ch {
-            b'{' => depth += 1,
-            b'}' => depth -= 1,
+            b'"' => in_quotes = !in_quotes,
+            b'{' if !in_quotes => depth += 1,
+            b'}' if !in_quotes => depth -= 1,
             b'$' | b'[' if depth == 0 => return None,
             _ => {}
         }
@@ -618,8 +632,14 @@ pub fn try_format_fold(value: &str) -> Option<String> {
                 _ => return None,
             }
         } else {
-            result.push(char::from(fmt_bytes[fi]));
-            fi += 1;
+            // The *character*, not the byte. Every `%`-arm above advances by
+            // two ASCII bytes, so `fi` is always a char boundary here.
+            let ch = fmt[fi..]
+                .chars()
+                .next()
+                .expect("fi is a char boundary inside fmt");
+            result.push(ch);
+            fi += ch.len_utf8();
         }
     }
 
@@ -641,27 +661,32 @@ fn parse_format_parts(inner: &str) -> Option<Vec<String>> {
             b'"' => {
                 // Quoted string — subject to substitution, so a `$`/`[` makes it
                 // non-constant (an escaped `\$`/`\[` stays literal).
+                //
+                // Scanned by *slice*, not by pushing one byte at a time
+                // through `char::from`: that maps a byte to the Latin-1 code
+                // point of its value, so every byte of a multi-byte character
+                // became its own mojibake char and `[format %s "café"]` folded
+                // to five characters of `cafÃ©`. The same mistake was fixed in
+                // `parse_subst_template` for issue #1441
+                // (`subst_template_multibyte_literal_text_with_var`) and
+                // survived here, in its neighbour.
                 i += 1;
-                let mut buf = String::new();
+                let start = i;
                 let mut subst = false;
                 while i < bytes.len() && bytes[i] != b'"' {
                     if bytes[i] == b'\\' {
-                        if i + 1 < bytes.len() {
-                            buf.push(char::from(bytes[i]));
-                            buf.push(char::from(bytes[i + 1]));
-                            i += 2;
-                        } else {
-                            buf.push(char::from(bytes[i]));
-                            i += 1;
-                        }
-                    } else {
-                        if matches!(bytes[i], b'$' | b'[') {
-                            subst = true;
-                        }
-                        buf.push(char::from(bytes[i]));
+                        // Past the backslash — ASCII, so `i` stays a char
+                        // boundary — then over the whole escaped character.
                         i += 1;
+                        i += inner[i..].chars().next().map_or(0, char::len_utf8);
+                        continue;
                     }
+                    if matches!(bytes[i], b'$' | b'[') {
+                        subst = true;
+                    }
+                    i += inner[i..].chars().next().map_or(1, char::len_utf8);
                 }
+                let buf = &inner[start..i];
                 if i < bytes.len() {
                     i += 1; // skip closing "
                 }
@@ -679,7 +704,7 @@ fn parse_format_parts(inner: &str) -> Option<Vec<String>> {
                 // release-variant forms (`\x` with three or more hex digits,
                 // `\U`, three-digit octal at or above `\40`) are the ones it
                 // therefore folds under 9.0 for every dialect (issue #1479).
-                parts.push(tcl_lexer::backslash_subst(&buf).into_owned());
+                parts.push(tcl_lexer::backslash_subst(buf).into_owned());
             }
             b'{' => {
                 // Braced string — always literal.

--- a/rust/tcl-compiler/src/codegen/helpers.rs
+++ b/rust/tcl-compiler/src/codegen/helpers.rs
@@ -485,7 +485,15 @@ fn fold_cmd_arg_values(
     let mut in_quotes = false;
     for ch in inner.bytes() {
         match ch {
-            b'"' => in_quotes = !in_quotes,
+            // The two states gate each other, and both directions matter. A
+            // brace inside a *quoted* word is content, so it opens no group —
+            // miss that and `"{$x}"` looks protected. A quote inside a *braced*
+            // word is equally content, so it opens no quoted region — miss that
+            // and the `}` that closes the brace is skipped as "inside a quote",
+            // depth never returns to 0, and everything after `[list {"} $x]`
+            // looks protected: it folded to `{"} {$x}` where both oracles say
+            // `{"} 7`.
+            b'"' if depth == 0 => in_quotes = !in_quotes,
             b'{' if !in_quotes => depth += 1,
             b'}' if !in_quotes => depth -= 1,
             b'$' | b'[' if depth == 0 => return None,
@@ -589,15 +597,28 @@ pub fn fold_dict_create_cmd(
 ///
 /// Only handles simple `%s` and `%d` conversions with literal args.
 /// Returns `None` if the format cannot be folded.
+///
+/// `escapes` is the *document's* escape grammar, threaded because the fold
+/// decodes its arguments and that decode is a release axis (#1479): `\x`
+/// runs unbounded before 8.6, so `[format %s "\x4142"]` is the one byte `B`
+/// on 8.4 and `A42` from 8.6 on. Folding under one grammar for every document
+/// answered `A42` at `--dialect tcl8.4`, where the real 8.4 says `B`.
+///
+/// This is reached from the optimiser as well as codegen
+/// (`sccp::fold_builtin_call`), so the wrong answer is one the LSP shows.
+/// Both callers have the axis in hand — codegen from its own `CodegenCtx`,
+/// SCCP from `FoldPolicy::dialect` — which is what makes threading it
+/// possible now; the note this replaces said the SCCP caller had no release
+/// to give, and that stopped being true when the policy gained a profile.
 #[must_use]
-pub fn try_format_fold(value: &str) -> Option<String> {
+pub fn try_format_fold(value: &str, escapes: EscapeSyntax) -> Option<String> {
     let inner = value.strip_prefix("[format ")?.strip_suffix(']')?;
 
     // Parse the command parts (format string + arguments). Bails (`None`) when
     // any word is a runtime substitution (`$var` / `[cmd]`) rather than a
     // compile-time constant — folding those would freeze the literal source
     // text (`$cmd`) into the result instead of its value.
-    let parts = parse_format_parts(inner)?;
+    let parts = parse_format_parts(inner, escapes)?;
     if parts.is_empty() {
         return None;
     }
@@ -650,7 +671,7 @@ pub fn try_format_fold(value: &str) -> Option<String> {
 /// is a runtime substitution (a quoted or bare word containing an unescaped `$`
 /// or `[`) — such a word is not a compile-time constant and must not be folded.
 /// Braced words are always literal (Tcl braces suppress substitution).
-fn parse_format_parts(inner: &str) -> Option<Vec<String>> {
+fn parse_format_parts(inner: &str, escapes: EscapeSyntax) -> Option<Vec<String>> {
     let bytes = inner.as_bytes();
     let mut parts = Vec::new();
     let mut i = 0;
@@ -698,13 +719,12 @@ fn parse_format_parts(inner: &str) -> Option<Vec<String>> {
                 // `\$`/`\[`, …) must be substituted to get the folded value —
                 // otherwise `[format "x\"y"]` would freeze the literal `x\"y`.
                 //
-                // Release-blind by necessity: `try_format_fold` is also an SCCP
-                // const-folder, which has no target release in hand, so this
-                // reads under Tcl 9.0 — the documented `Unknown` posture. The
-                // release-variant forms (`\x` with three or more hex digits,
-                // `\U`, three-digit octal at or above `\40`) are the ones it
-                // therefore folds under 9.0 for every dialect (issue #1479).
-                parts.push(tcl_lexer::backslash_subst(buf).into_owned());
+                // Decoded under the *document's* escape grammar, which the
+                // caller threads: the release-variant forms (`\x` with three or
+                // more hex digits, `\U`, three-digit octal at or above `\40`)
+                // fold to different values per release (#1479), and this fold
+                // is one the optimiser shows in the editor.
+                parts.push(tcl_lexer::backslash_subst_in(buf, escapes).into_owned());
             }
             b'{' => {
                 // Braced string — always literal.
@@ -753,7 +773,7 @@ fn parse_format_parts(inner: &str) -> Option<Vec<String>> {
                 if has_unescaped_subst(word) {
                     return None;
                 }
-                parts.push(tcl_lexer::backslash_subst(word).into_owned());
+                parts.push(tcl_lexer::backslash_subst_in(word, escapes).into_owned());
             }
         }
     }
@@ -1089,6 +1109,28 @@ mod tests {
         );
     }
 
+    /// The fold decodes under the *document's* escape grammar, and that
+    /// grammar changes the answer. `\x` runs unbounded before 8.6
+    /// (`TclParseHex` gets the whole remaining input as its digit budget), so
+    /// `\x4142` is the single byte `B` there and `A` + a literal `42` from 8.6
+    /// on — measured on `tclsh8.4`/`tclsh8.5` (`1:B`) and
+    /// `tclsh8.6`/`tclsh9.0` (`3:A42`).
+    ///
+    /// Worth a test of its own because this fold is reached from the optimiser
+    /// (`sccp::fold_builtin_call`) as well as codegen, so folding under one
+    /// grammar for every document put the wrong constant in front of an editor
+    /// — `A42` at `--dialect tcl8.4`.
+    #[test]
+    fn format_fold_decodes_under_the_documents_escape_grammar() {
+        let fold = |escapes| try_format_fold(r#"[format %s "\x4142"]"#, escapes);
+        assert_eq!(fold(EscapeSyntax::Tcl84), Some("B".into()));
+        assert_eq!(fold(EscapeSyntax::default()), Some("A42".into()));
+        // The bare-word arm decodes through the same axis as the quoted one.
+        let bare = |escapes| try_format_fold(r"[format %s \x4142]", escapes);
+        assert_eq!(bare(EscapeSyntax::Tcl84), Some("B".into()));
+        assert_eq!(bare(EscapeSyntax::default()), Some("A42".into()));
+    }
+
     #[test]
     fn subst_template_octal_escape() {
         // Regression for issue #1441: `\101` was emitted as the literal text
@@ -1184,6 +1226,30 @@ mod tests {
 
     // -- fold_cmd_args / fold_list_cmd / fold_dict_create_cmd --
 
+    /// The two delimiter states gate each other. A brace inside a quoted word
+    /// opens no group, and a quote inside a braced word opens no quoted
+    /// region — get the second wrong and the `}` that closes the brace is
+    /// skipped, `depth` never returns to 0, and every later `$` looks
+    /// protected. Both directions are asserted because fixing only the first
+    /// is what introduced the second.
+    #[test]
+    fn fold_declines_when_a_marker_is_live_under_either_delimiter() {
+        let tcl = tcl_syntax::word_rules::WordValueRules::TCL;
+        // Quoted word, live marker inside braces that are only content.
+        assert_eq!(fold_list_cmd(r#"[list "{$x}"]"#, tcl), None);
+        assert_eq!(fold_list_cmd(r#"[list "{[cmd]}"]"#, tcl), None);
+        // Braced word containing a quote: the brace still closes, so the `$x`
+        // after it is unprotected and the fold declines. Folding it froze the
+        // literal `{$x}` where both oracles substitute.
+        assert_eq!(fold_list_cmd(r#"[list {"} $x]"#, tcl), None);
+        // A braced word really does protect its own markers.
+        assert_eq!(
+            fold_list_cmd("[list {a$b}]", tcl),
+            Some("{a$b}".into()),
+            "a braced word's markers are data and still fold"
+        );
+    }
+
     #[test]
     fn fold_list_cmd_basic() {
         assert_eq!(
@@ -1236,47 +1302,68 @@ mod tests {
     #[test]
     fn format_fold_simple_s() {
         assert_eq!(
-            try_format_fold("[format \"%s world\" hello]"),
+            try_format_fold("[format \"%s world\" hello]", EscapeSyntax::default()),
             Some("hello world".into())
         );
     }
 
     #[test]
     fn format_fold_simple_d() {
-        assert_eq!(try_format_fold("[format \"%d\" 42]"), Some("42".into()));
+        assert_eq!(
+            try_format_fold("[format \"%d\" 42]", EscapeSyntax::default()),
+            Some("42".into())
+        );
     }
 
     #[test]
     fn format_fold_percent_escape() {
-        assert_eq!(try_format_fold("[format \"100%%\"]"), Some("100%".into()));
+        assert_eq!(
+            try_format_fold("[format \"100%%\"]", EscapeSyntax::default()),
+            Some("100%".into())
+        );
     }
 
     #[test]
     fn format_fold_no_match() {
-        assert_eq!(try_format_fold("not format"), None);
+        assert_eq!(try_format_fold("not format", EscapeSyntax::default()), None);
     }
 
     #[test]
     fn format_fold_bails_on_variable_arg() {
         // A `$var` argument is a runtime substitution, not a constant — folding
         // it would freeze the literal text `$cmd` into the result.
-        assert_eq!(try_format_fold("[format {x %s} $cmd]"), None);
-        assert_eq!(try_format_fold("[format {%s} $cmd]"), None);
+        assert_eq!(
+            try_format_fold("[format {x %s} $cmd]", EscapeSyntax::default()),
+            None
+        );
+        assert_eq!(
+            try_format_fold("[format {%s} $cmd]", EscapeSyntax::default()),
+            None
+        );
     }
 
     #[test]
     fn format_fold_bails_on_command_sub_arg() {
-        assert_eq!(try_format_fold("[format {%s} [id]]"), None);
+        assert_eq!(
+            try_format_fold("[format {%s} [id]]", EscapeSyntax::default()),
+            None
+        );
     }
 
     #[test]
     fn format_fold_bails_on_quoted_subst() {
-        assert_eq!(try_format_fold("[format {%s} \"$x\"]"), None);
+        assert_eq!(
+            try_format_fold("[format {%s} \"$x\"]", EscapeSyntax::default()),
+            None
+        );
     }
 
     #[test]
     fn format_fold_multiline_template_constant_args() {
         // A multi-line braced template with constant args still folds.
-        assert_eq!(try_format_fold("[format {a\n%s} hi]"), Some("a\nhi".into()));
+        assert_eq!(
+            try_format_fold("[format {a\n%s} hi]", EscapeSyntax::default()),
+            Some("a\nhi".into())
+        );
     }
 }

--- a/rust/tcl-compiler/src/codegen/values.rs
+++ b/rust/tcl-compiler/src/codegen/values.rs
@@ -95,7 +95,7 @@ impl CodegenCtx<'_> {
         }
         // Constant-fold [format "..." arg ...] with literal args (%s/%d/%%).
         if self.trusts_builtin("format")
-            && let Some(folded) = super::helpers::try_format_fold(value)
+            && let Some(folded) = super::helpers::try_format_fold(value, self.escapes)
         {
             self.push_lit_no_dedup_verbatim(&folded);
             return true;

--- a/rust/tcl-compiler/src/inlining/mod.rs
+++ b/rust/tcl-compiler/src/inlining/mod.rs
@@ -1162,6 +1162,7 @@ fn rewrite_switch_stmt(
     let Statement::Switch {
         span,
         subject,
+        subject_braced,
         subject_span,
         arms,
         default_body,
@@ -1210,6 +1211,7 @@ fn rewrite_switch_stmt(
     };
     changed.then(|| {
         vec![Statement::Switch {
+            subject_braced: *subject_braced,
             span: *span,
             subject: subject.clone(),
             subject_span: *subject_span,
@@ -1569,6 +1571,7 @@ fn substitute_irreturn_stmt(stmt: &Statement, result_var: &str) -> Statement {
         Statement::Switch {
             span,
             subject,
+            subject_braced,
             subject_span,
             arms,
             default_body,
@@ -1578,6 +1581,7 @@ fn substitute_irreturn_stmt(stmt: &Statement, result_var: &str) -> Statement {
             raw_args,
             patterns_braced,
         } => Statement::Switch {
+            subject_braced: *subject_braced,
             span: *span,
             subject: subject.clone(),
             subject_span: *subject_span,

--- a/rust/tcl-compiler/src/inlining/rename.rs
+++ b/rust/tcl-compiler/src/inlining/rename.rs
@@ -456,7 +456,19 @@ fn rewrite_switch(stmt: &Statement, rename: &HashMap<String, String>) -> Stateme
     Statement::Switch {
         subject_braced: *subject_braced,
         span: *span,
-        subject: rewrite_value_string(subject, rename),
+        // A braced subject's value is literal — a `$x` inside it is data, not
+        // a read — so alpha-renaming must leave it alone, exactly as the arm
+        // patterns below are cloned rather than rewritten. The rewrite was
+        // harmless while the subject was substituted at run time regardless of
+        // its braces: renaming it and then reading the renamed variable
+        // happened to give an answer. Now that a braced subject is the literal
+        // it always was, rewriting it compares `$__inline_…__x` against the
+        // pattern `$x` and takes the wrong arm.
+        subject: if *subject_braced {
+            subject.clone()
+        } else {
+            rewrite_value_string(subject, rename)
+        },
         subject_span: *subject_span,
         arms: arms
             .iter()

--- a/rust/tcl-compiler/src/inlining/rename.rs
+++ b/rust/tcl-compiler/src/inlining/rename.rs
@@ -440,6 +440,7 @@ fn rewrite_switch(stmt: &Statement, rename: &HashMap<String, String>) -> Stateme
     let Statement::Switch {
         span,
         subject,
+        subject_braced,
         subject_span,
         arms,
         default_body,
@@ -453,6 +454,7 @@ fn rewrite_switch(stmt: &Statement, rename: &HashMap<String, String>) -> Stateme
         unreachable!("rewrite_switch dispatched a non-switch statement");
     };
     Statement::Switch {
+        subject_braced: *subject_braced,
         span: *span,
         subject: rewrite_value_string(subject, rename),
         subject_span: *subject_span,

--- a/rust/tcl-compiler/src/inlining/tests.rs
+++ b/rust/tcl-compiler/src/inlining/tests.rs
@@ -104,6 +104,44 @@ fn deeply_nested_if_survives_inlining_walks() {
 
 // v0 / verbatim tests
 
+/// A braced `switch` subject is literal: alpha-renaming must not rewrite a
+/// `$x` inside it, exactly as it already leaves the arm patterns alone.
+///
+/// Latent until the subject's braced-ness was recorded — while the subject was
+/// substituted at run time regardless of its braces, renaming it and then
+/// reading the renamed variable happened to produce an answer. Once a braced
+/// subject is the literal it always was, a rewritten subject compares
+/// `$__inline_…__x` against the pattern `$x` and takes the wrong arm.
+#[test]
+fn a_braced_switch_subject_survives_alpha_renaming() {
+    let stmts = inlined_top(
+        "proc ::f {x} { switch -- {$x} {$x} { puts hit } default { puts miss } }
+f {$x}",
+    );
+    let subjects: Vec<(&str, bool)> = stmts
+        .iter()
+        .filter_map(|s| match s {
+            Statement::Switch {
+                subject,
+                subject_braced,
+                ..
+            } => Some((subject.as_str(), *subject_braced)),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        !subjects.is_empty(),
+        "the switch did not survive inlining, so this proves nothing: {stmts:#?}"
+    );
+    for (subject, braced) in subjects {
+        assert!(braced, "the subject should still be marked braced");
+        assert_eq!(
+            subject, "$x",
+            "a braced subject is literal and must not be alpha-renamed"
+        );
+    }
+}
+
 #[test]
 fn empty_body_call_vanishes() {
     let module = module_for("proc ::noop {} {}\nnoop\nputs done");

--- a/rust/tcl-compiler/src/ir.rs
+++ b/rust/tcl-compiler/src/ir.rs
@@ -1218,8 +1218,20 @@ pub enum Statement {
     Switch {
         /// Source span.
         span: Span,
-        /// Subject text being matched.
+        /// Subject text being matched — the word's *value*, with any
+        /// delimiters already removed.
         subject: String,
+        /// `true` when the subject came from a braced word, so its value is
+        /// literal and suppresses substitution.
+        ///
+        /// The sibling of [`Self::Switch::patterns_braced`], and asked for the
+        /// same reason: codegen hands the subject to the expression emitter as
+        /// a word, and a word that lost its braces on the way in is
+        /// indistinguishable from a bare one. Without this,
+        /// `switch -- {a[nosuchcmd]}` *ran* `nosuchcmd` where both oracles
+        /// match the literal and take the default arm. Defaults to `false` —
+        /// an unbraced subject substitutes, which is the common form.
+        subject_braced: bool,
         /// Source span of the subject.
         subject_span: Span,
         /// Pattern/body arms.
@@ -2071,6 +2083,7 @@ mod tests {
     #[test]
     fn switch_statement() {
         let stmt = Statement::Switch {
+            subject_braced: false,
             span: Span::new(0, 80),
             subject: "$cmd".into(),
             subject_span: Span::new(7, 11),

--- a/rust/tcl-compiler/src/lowering/structured.rs
+++ b/rust/tcl-compiler/src/lowering/structured.rs
@@ -923,6 +923,17 @@ impl Lowerer<'_> {
         }
 
         let subject = args[i].clone();
+        // Whether the subject word was *braced*, which decides whether its
+        // value is literal. `TokenType::Str` is the braced word plus a
+        // single-token check, which is the predicate the rest of lowering uses
+        // for this question (`braced_at` in `lowering::mod`). `arg_single`
+        // alone is not it — it means "one token", which `$x` and a bare word
+        // also satisfy, and bracing those would freeze a subject that must
+        // substitute.
+        let subject_braced = matches!(
+            arg_tokens.get(i).map(|t| t.kind),
+            Some(tcl_lexer::TokenType::Str)
+        ) && arg_single.get(i).copied().unwrap_or(false);
         i += 1;
         if i >= args.len() {
             return self.barrier(seg, "switch missing arms");
@@ -1030,6 +1041,7 @@ impl Lowerer<'_> {
         Statement::Switch {
             span: seg.span,
             subject,
+            subject_braced,
             subject_span: arg_tokens.first().map_or(seg.span, |t| t.span),
             arms,
             default_body,

--- a/rust/tcl-compiler/src/sccp.rs
+++ b/rust/tcl-compiler/src/sccp.rs
@@ -1914,8 +1914,18 @@ fn try_fold_cmd_subst<S1: std::hash::BuildHasher, S2: std::hash::BuildHasher>(
         return Some(LatticeValue::Const(ConstValue::String(folded)));
     }
     // `[format "..." args…]` with literal args.
+    // The document's escape grammar, from the same resolved profile the rest
+    // of the policy's axes come from. A caller with no dialect keeps the 9.0
+    // default, which is what `FoldPolicy::numbers` documents for its own axis
+    // — the fold stays available, it just stops guessing once a dialect is
+    // known.
+    let escapes = policy
+        .dialect
+        .map_or_else(tcl_dialect::EscapeSyntax::default, |profile| {
+            profile.grammar.escapes
+        });
     if trusted("format")
-        && let Some(folded) = crate::codegen::helpers::try_format_fold(value)
+        && let Some(folded) = crate::codegen::helpers::try_format_fold(value, escapes)
     {
         return Some(LatticeValue::Const(ConstValue::String(folded)));
     }

--- a/rust/tcl-compiler/src/ssa.rs
+++ b/rust/tcl-compiler/src/ssa.rs
@@ -4169,6 +4169,7 @@ mod tests {
     /// arm's pattern and the canonical braced arm block.
     fn opaque_switch(subject: &str, pattern: &str, body: crate::ir::Script) -> Statement {
         Statement::Switch {
+            subject_braced: false,
             span: Span::new(0, 40),
             subject: subject.into(),
             subject_span: Span::new(0, 1),

--- a/rust/tcl-compiler/src/static_loops.rs
+++ b/rust/tcl-compiler/src/static_loops.rs
@@ -592,6 +592,7 @@ mod tests {
     /// switch-dispatch case and its unresolvable-subject counterpart.
     fn mode_switch() -> Statement {
         Statement::Switch {
+            subject_braced: false,
             span: sp(),
             subject: "$mode".into(),
             subject_span: sp(),

--- a/rust/tcl-compiler/tests/codegen_integration.rs
+++ b/rust/tcl-compiler/tests/codegen_integration.rs
@@ -520,6 +520,7 @@ fn switch_glob_emits_generic_invoke_not_jump_table() {
     };
     let make = |mode: SwitchMode| {
         Script::from_statements(vec![Statement::Switch {
+            subject_braced: false,
             span: sp(),
             subject: "$x".into(),
             subject_span: sp(),

--- a/rust/tcl-compiler/tests/pipeline_coverage.rs
+++ b/rust/tcl-compiler/tests/pipeline_coverage.rs
@@ -548,6 +548,7 @@ mod defs_from_ir_script_arms {
     #[test]
     fn switch_arm_and_default_defs_collected() {
         let s = Script::from_statements(vec![Statement::Switch {
+            subject_braced: false,
             span: Span::new(0, 40),
             subject: "$x".into(),
             subject_span: Span::new(7, 9),

--- a/rust/tcl-vm/tests/word_value_resolution_e2e.rs
+++ b/rust/tcl-vm/tests/word_value_resolution_e2e.rs
@@ -65,6 +65,20 @@
 //! The negative vectors below pin both boundaries: live substitution still
 //! happens, and a genuinely braced word still loses exactly one layer.
 //!
+//! The last group is the paths the first pass at this rule did not reach, all
+//! found by the fuzzer once it could generate a word whose value is not its
+//! spelling (#1897). Two are the same rule in an emitter that was missed —
+//! `emit_value`'s default push, the twin of the one that was fixed, which is
+//! the path a proc's `return` value takes; and a braced `switch` subject,
+//! whose braced-ness the IR recorded for the *patterns* but never for the
+//! subject. Three are neighbouring reads of a word that were wrong in their own
+//! way: a fold's brace-depth scan that counted braces inside a quoted word as a
+//! group, a word splitter that ended a word at an escaped blank, and a fold
+//! that walked a quoted argument one byte at a time. The last is the mistake
+//! `parse_subst_template` had fixed for #1441, surviving in its neighbour —
+//! which is the argument for pinning all of them here rather than beside each
+//! emitter.
+//!
 //! Every vector runs through the VM at all five releases and, when the matching
 //! real tclsh is installed, under it too, so the table cannot drift from C Tcl.
 //! A word's value is not a release axis — 8.6.16 and 9.0.4 agree on every
@@ -368,6 +382,80 @@ switch -- "{}$z" "{}x" { puts B:hit } default { puts B:def }
         script: r#"puts [string length "{} {}"]:[string length "a{}b"]
 "#,
         want: "5:4",
+        since: TclVersion::V8_4,
+    },
+    // -- The paths the first pass at this rule did not reach. --
+    Vector {
+        // `emit_value`'s default push — the twin of `emit_value_interpolated`'s,
+        // fixed at the same time as its sibling was not. It is the emitter a
+        // proc's `return` value goes through, so the value came back de-braced.
+        name: "a proc's return value is a value, braces included",
+        script: r#"proc pr {} { return "{abc}" }
+proc pe {} { return "{}" }
+puts [pr]:[string length [pr]]:[string length [pe]]
+"#,
+        want: "{abc}:5:2",
+        since: TclVersion::V8_4,
+    },
+    Vector {
+        // A braced `switch` subject is a literal: its `[…]` and `${…}` are
+        // data. The IR recorded whether the *patterns* were braced but never
+        // the subject, so codegen could not tell it from a bare word and ran
+        // the command. The third arm is the boundary — an unbraced subject
+        // still substitutes, which is the common form and what broke first
+        // when the braced flag was read off the wrong predicate.
+        name: "a braced switch subject is a literal, and an unbraced one is not",
+        script: r"switch -- {a[nosuchcmd]} zz {puts A:hit} default {puts A:def}
+switch -- {a${nosuchvar}} zz {puts B:hit} default {puts B:def}
+set z hit
+switch -- $z hit {puts C:match} default {puts C:def}
+",
+        want: "A:def\nB:def\nC:match",
+        since: TclVersion::V8_4,
+    },
+    Vector {
+        // The `list` fold's brace-depth scan counted a brace inside a *quoted*
+        // word as a group, so a live `$x` / `[…]` looked protected and the fold
+        // froze the source spelling instead of declining.
+        name: "a fold declines on a quoted word that still substitutes",
+        script: r#"set x 7
+set l [list "{$x}"]
+set m [list "{[string length ab]}"]
+puts [string length $l]:$l:$m
+"#,
+        want: "5:{{7}}:{{2}}",
+        since: TclVersion::V8_4,
+    },
+    Vector {
+        name: "the same fold rule reaches dict create",
+        script: r#"set d [dict create k "{[string length ab]}"]
+puts [string length [dict get $d k]]
+"#,
+        want: "3",
+        since: TclVersion::V8_5,
+    },
+    Vector {
+        // An escaped blank is word *content*: `a\ b` is one word. The bracket
+        // word splitter ended the word there anyway, so `string length` was
+        // handed two arguments. The `\t` case is the same escape one step on —
+        // the value carries a character no spelling of it contains.
+        name: "an escaped blank does not end a word",
+        script: r"puts [string length a\ b]:[llength [list a\ b c]]:[string length a\tb]
+",
+        want: "3:2:3",
+        since: TclVersion::V8_4,
+    },
+    Vector {
+        // `format`'s fold walked its quoted argument one *byte* at a time
+        // through `char::from`, which maps a byte to that value's Latin-1 code
+        // point — so every byte of a multi-byte character became its own
+        // mojibake char. The same mistake was fixed in `parse_subst_template`
+        // for #1441 and survived in its neighbour.
+        name: "a folded format result counts characters, not bytes",
+        script: r#"set f [format %s "café"]
+puts [string length $f]:$f
+"#,
+        want: "4:café",
         since: TclVersion::V8_4,
     },
 ];


### PR DESCRIPTION
#1893 established that a word is resolved exactly once and #1897 gave the
fuzzer words whose value is not their spelling. Its first campaigns found
five live divergences, all pre-existing, all confirmed against tclsh
8.6.16 and 9.0.4. Two are that same rule in a place the first pass missed;
three are neighbouring reads of a word that were each wrong in their own
way.

**The rule, missed twice.**

`emit_value`'s default push is the twin of `emit_value_interpolated`'s,
and only the latter was fixed. It is the emitter a proc's `return` value
goes through, so `proc p {} { return "{abc}" }` answered `abc`.

A braced `switch` subject is a literal — its `[…]` and `${…}` are data —
but the IR recorded whether the *patterns* were braced and never the
subject, so codegen could not tell one from a bare word and
`switch -- {a[nosuchcmd]} …` ran `nosuchcmd` where both oracles match the
literal. `Statement::Switch` gains `subject_braced` beside the
`patterns_braced` that answers the identical question about the other half
of the same command, and the subject goes to the expression emitter with
its delimiters on — `ExprNode::String`'s documented contract — so the
shared `whole_braced_word` owner recognises it. Re-bracing is lossless
because a braced word's content is balanced or escaped by construction,
which is why it is gated on the word really having been braced.

Deriving that flag in codegen instead would have meant a second copy of
the switch option parser, pointing codegen back at lowering; the cost of
the field is eight construction sites, most of them fixtures.

**Three neighbouring reads.**

`fold_cmd_arg_values` counted a brace inside a *quoted* word as a group,
so a live `$x` looked protected and `[list "{$x}"]` folded and froze its
source spelling — `{{$x}}` where both oracles say `{{7}}`. It now tracks
quote state. Still deliberately blind to backslashes: declining to fold an
escaped `\$` costs a fold and answers correctly, while escape-skipping
would *enable* new folds, which is a different change.

`parse_bareword_part` ended a word at any blank, but an escaped blank is
word content: `[string length a\ b]` raised `wrong # args` where both
oracles answer 3. `\<newline>` stays a separator, which `skip_word_seps`
owns.

`try_format_fold` and `parse_format_parts` walked their input one byte at
a time through `char::from`, which maps a byte to that value's Latin-1
code point, so every byte of a multi-byte character became its own
mojibake char: `[format %s "café"]` folded to five characters of `cafÃ©`.
This is the mistake `parse_subst_template` had fixed for #1441
(`subst_template_multibyte_literal_text_with_var`), surviving in its
neighbours.

Six vectors join `word_value_resolution_e2e`, every expectation measured
from a real tclsh, at all five releases plus the real-tclsh leg. The
`switch` vector carries its own negative boundary: an unbraced subject
must still substitute, which is what broke first when the braced flag was
read off `arg_single_token` — that means "one token", which `$x` satisfies
too.

Not fixed here: `switch -glob -- {a[bc]d}` substitutes its braced subject.
Glob mode lowers to the *opaque* switch, which never reaches any code this
touches, and closing it needs the subject's index in `raw_args` and a
rework of how that emitter builds its word kinds.


## Verification

- `make prep-pr` green; `cargo test -p tcl-compiler -p tcl-vm -p tcl-syntax` — 122 suites, 0 failed.
- Six vectors added to `word_value_resolution_e2e` (24 total), every expectation measured from a real tclsh, run at all five releases plus the real-tclsh leg.
- The `tcl-fuzz` campaign that found all five (seed 21, 600 scripts vs `tclsh9.0`) goes from 2 findings to **0**, 600/600 matched. Seeds 7, 99, 4242 and 31337 are clean at 400 iterations each.

## Known, not fixed here

A shape-heavy campaign (`--word-shape-permille 400`) surfaced a second `switch`-subject hole, pre-existing and byte-identical before and after this change:

```tcl
switch -- "{abc}" abc {puts hit} default {puts def}   ;# oracles: def, we say hit
```

It shares a root cause with the `-glob` case noted above: `switch_subject_operand` hands the subject's **value** to `ExprNode::String`, whose documented contract is *source text including delimiters*. A braced word can be re-bracketed back into that contract (what this change does); a quoted word whose value merely looks braced cannot, and `ExprNode::Raw` is not an alternative — it lowers to `push` + `exprStk`, which is the bug that operand choice already escaped once. Closing both needs an operand shape that means "this is a value", which is a design step rather than a patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Second commit: the document's grammar, and both review findings

`try_format_fold` is reached from `sccp::fold_builtin_call`, not just codegen, so its constants reach the editor. It decoded under one grammar for every document, and that decode is a release axis (#1479) — `\x` runs unbounded before 8.6:

| | `[format %s "\x4142"]` |
| --- | --- |
| tclsh8.4 / tclsh8.5 | `B` |
| tclsh8.6 / tclsh9.0 | `A42` |
| us, at any `--dialect` | `A42` |

Now threaded from both call sites, which had the axis all along — codegen from `CodegenCtx`, SCCP from `FoldPolicy::dialect`, whose call site passes `policy.word_rules` to the sibling `list` fold on the next line. A dialect-less caller keeps the 9.0 default, the posture `FoldPolicy::numbers` documents for its own axis.

Codegen-side readiness: the escaped-blank fix landed in `parse_cmd_parts`, a private splitter with no dialect that spelled ` `/`\t` out in five places. That is one `is_word_sep` delegating to `WordSeparators::Tcl`, so threading is a constant becoming a parameter. Its neighbouring escape rule needs no threading — a backslash escapes the next character on every ladder, so the *boundary* is release-invariant while the *value* decodes downstream through the dialect-carrying `self.escapes`.

The front end needed nothing: lowering always segments with the document's `LexerConfig`, so the `TokenType::Str` behind `subject_braced` is already the dialect's answer (checked at tcl8.4, tcl8.6, tcl9.0, f5-irules).

Both Codex findings were correct and are fixed:

- **The quote/brace states gate each other** and I had only one direction, so `[list {"} $x]` folded to `{"} {$x}` — a bug this PR introduced. Both directions now asserted.
- **A braced `switch` subject must not be alpha-renamed.** Latent before the braced-ness was recorded; the test was validated against a reverted fix rather than trusted.

`make prep-pr` and `cargo test -p tcl-compiler -p tcl-vm -p tcl-syntax` green — 464 suites, 0 failed.
