### PR TITLE
fix(spec-studio): drive the Export pane the boot check still calls a tab

### DIFF
--- a/rust/tcl-spec-studio-wasm/test/boot.mjs
+++ b/rust/tcl-spec-studio-wasm/test/boot.mjs
@@ -496,7 +496,28 @@ async function main() {
     });
     await page.waitForSelector("#importOut .found", { timeout: 30_000 });
     await page.click("#importAll");
-    await page.click("#tab-rs");
+    // The per-command Rendered .rs and Tcl stub panes are now one Export pane
+    // listing everything the pack produces, so the generated Rust is reached
+    // by opening a file rather than by its own tab. The list opens on the
+    // .tclspec, which draws on the Tcl surface — the Rust surface is only on
+    // screen once a Rust file is chosen, and the one that carries the
+    // imported command is its own .rs, not the pack's mod.rs.
+    await page.click("#tab-export");
+    await page.waitForSelector('#exportList [role="option"]', {
+      timeout: 30_000,
+    });
+    const rsAt = await page.$$eval('#exportList [role="option"]', (rows) =>
+      rows.findIndex((row) => {
+        const name = row.querySelector(".nm")?.textContent ?? "";
+        return name.endsWith(".rs") && name !== "mod.rs";
+      }),
+    );
+    if (rsAt < 0) {
+      throw new Error(
+        "the export list offered no per-command .rs for the imported command",
+      );
+    }
+    await page.click(`#exportList [role="option"] >> nth=${rsAt}`);
     await page.waitForFunction(
       () => {
         const text =


### PR DESCRIPTION
## Summary

Pages has been red on `rust` since #1883 ([failing run](https://github.com/bitwisecook/tcl-lsp/actions/runs/34032928939)). That change replaced the per-command **Rendered .rs** and **Tcl stub** tabs with a single **Export** pane, but the boot smoke check still clicked `#tab-rs`, which no longer exists — so Playwright waited the full 30 s on a locator that would never appear:

```
Monaco mounted on the Test tab
FAIL: page.click: Timeout 30000ms exceeded.
Call log:
  - waiting for locator('#tab-rs')
```

`#tab-rs` was the only stale selector — I checked every id the check drives against `studio.html`, and `reference`, `editor`, `dsl`, `test` and `import` all still exist.

Step 6 asserts that an imported Tcl file activates the generated Rust rather than leaving the `mycommand` placeholder, so this keeps that assertion and only changes how the pane is reached.

**Opening `#tab-export` alone isn't enough.** The list opens on the `.tclspec`, and `surfaceOf` puts that on the Tcl surface — `#exportRust`, which holds `#rsEditor`, stays hidden until a Rust file is selected. So the check now picks the row for the command's own `.rs`, matched by name rather than index: `mod.rs` is the pack's collector, and `mod.rs.additions` isn't a `.rs` at all, so excluding the first by name and the second by suffix leaves exactly the per-command file. If no such row is offered it throws with that reason, instead of timing out on an assertion about an editor that was never brought forward.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

Against a real bundle (`make spec-studio-wasm`) and the CI-pinned browser (`playwright@1.63.0` chromium), run exactly as the Pages workflow does — `NODE_PATH="$PWD/node_modules" node ../../tcl-spec-studio-wasm/test/boot.mjs` — in both directions:

```
with the fix     imported Tcl activates generated Rust for the imported command
                 ==> boot check passed                                  exit 0

test reverted    FAIL: page.click: Timeout 30000ms exceeded.
                 Call log:
                   - waiting for locator('#tab-rs')                     exit 1
```

The reverted run reproduces the CI failure exactly, which is what makes this the cause rather than a plausible-looking nearby edit.

Note: this file isn't prettier-governed (the web package's lint globs are `src/**/*.ts` and `test/**/*.ts`, and the file was already non-conforming before this change), so I've matched the surrounding style rather than reformatting it.

## Follow-up worth considering

The boot check runs **only** in `github-pages.yml`, which triggers on push to `rust` — never on a PR. That's why #1883 merged green and broke the deploy afterwards, the same shape as the dependency gap #1898 just closed. Gating it on PRs would need the full wasm build plus chromium, so it's a real cost trade rather than an obvious yes — happy to do it if you want it.

## Compiler / diagnostics checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

Not applicable — a smoke-test selector fix; no compiler, diagnostic or analysis contract touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)