### PR TITLE
fix(tcl-vm): the vacating name reports the destination's namespace

### DIFF
--- a/docs/design/runtime/trace-implementation.md
+++ b/docs/design/runtime/trace-implementation.md
@@ -124,7 +124,7 @@ removal that fires no `delete` trace.
 | | publish | fire from | retire the source |
 |---|---|---|---|
 | `runtime/rust` | `Namespaces::publish_rename_destination` (writes the re-homed command into *both* slots) | `Interp::move_bound_command`, after moving the trace list, the import redirects, the TclOO registration and the coroutine | `Namespaces::retire_rename_source` |
-| `rust/tcl-vm` | `cmd_rename` registers the destination | `on_command_renamed_traces`, after moving the sidecars | `retire_renamed_command_source` |
+| `rust/tcl-vm` | `cmd_rename` registers the destination, and `install_renamed_command` re-points the standing source entry at the same re-homed command | `on_command_renamed_traces`, after moving the sidecars | `retire_renamed_command_source` |
 
 Neither has a shared command object to hang that equivalence on, so an open
 window is recorded as a source→destination pair — `TraceTable::rename_windows`

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -2839,10 +2839,20 @@ impl Vm {
         // fire destination delete traces and invalidate command/trace guard
         // state.
         self.register_command(new_key, command.clone());
+        // What that surviving entry points *at* does move, though: C re-homes
+        // the one `Command` (`cmdPtr->nsPtr = newNsPtr`) before it fires, and
+        // both hash entries reference it, so a proc invoked through the
+        // vacating name reports the *destination's* `namespace current` — and
+        // resolves `variable` there — for the callbacks' duration.
+        self.rebind_rename_source(&transaction.old_key.clone(), command);
         self.command_generations
             .insert(new_key.to_owned(), transaction.source_generation);
         if transaction.source_import_binding.is_none()
-            && let Command::Ensemble(token) = command
+            && let Command::Ensemble(token) = self
+                .commands
+                .get(new_key)
+                .cloned()
+                .expect("the renamed command was just registered")
         {
             token.rename(display_namespace(new_key));
         }
@@ -2864,6 +2874,20 @@ impl Vm {
             &CommandSidecarKey::visible(&transaction.old_key),
             &CommandSidecarKey::visible(new_key),
         );
+    }
+
+    /// Point the still-standing source entry of an open rename at the re-homed
+    /// command, without disturbing the entry itself.  Deliberately *not*
+    /// [`Self::register_command`]: this is not a replacement, so no `delete`
+    /// trace may fire, no generation may be minted and no sidecar may detach —
+    /// it is the one command under both of its names, which is what C gets for
+    /// free from the two hash entries sharing a `Command *`.  A callback that
+    /// deleted the source itself leaves nothing to rebind, and that is not an
+    /// error.
+    fn rebind_rename_source(&mut self, key: &str, cmd: Command) {
+        if self.commands.contains_key(key) {
+            self.commands.insert(key.to_owned(), cmd);
+        }
     }
 
     /// Drop the source half of a rename once its `rename` traces have run —

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -2844,15 +2844,11 @@ impl Vm {
         // both hash entries reference it, so a proc invoked through the
         // vacating name reports the *destination's* `namespace current` — and
         // resolves `variable` there — for the callbacks' duration.
-        self.rebind_rename_source(&transaction.old_key.clone(), command);
+        self.rebind_rename_source(&transaction.old_key.clone(), command.clone());
         self.command_generations
             .insert(new_key.to_owned(), transaction.source_generation);
         if transaction.source_import_binding.is_none()
-            && let Command::Ensemble(token) = self
-                .commands
-                .get(new_key)
-                .cloned()
-                .expect("the renamed command was just registered")
+            && let Command::Ensemble(token) = command
         {
             token.rename(display_namespace(new_key));
         }

--- a/rust/tcl-vm/tests/command_traces_e2e.rs
+++ b/rust/tcl-vm/tests/command_traces_e2e.rs
@@ -411,6 +411,23 @@ const VECTORS: &[Vector] = &[
                E:victim2|enter\nL:victim2\nnew:V\n\
                E:victim2|enter\nL:victim2\nout:V",
     },
+    // C re-homes the one `Command` (`cmdPtr->nsPtr = newNsPtr`) *before* it
+    // fires, and both hash entries reference it, so during the window a proc
+    // invoked through the vacating name reports the destination's `namespace
+    // current` and resolves `variable` there. The VM registered the re-homed
+    // command at the destination only, leaving the surviving source entry
+    // pointing at the un-re-homed one.
+    Vector {
+        name: "the vacating name reports the destination's namespace",
+        script: "namespace eval a { variable v A\n\
+                     proc p {} { variable v; return \"[namespace current] $v\" } }\n\
+                 namespace eval b { variable v B }\n\
+                 proc R {old new op} { puts \"old: [a::p]\"; puts \"new: [b::q]\" }\n\
+                 trace add command a::p rename R\n\
+                 rename a::p ::b::q\n\
+                 puts \"after: [b::q]\"\n",
+        want: "old: ::b B\nnew: ::b B\nafter: ::b B",
+    },
     Vector {
         name: "namespace-qualified names arrive fully qualified",
         script: "proc tracer args { puts \"T:[join $args |]\" }\n\

--- a/rust/tcl-vm/tests/namespace_surface_e2e.rs
+++ b/rust/tcl-vm/tests/namespace_surface_e2e.rs
@@ -398,6 +398,28 @@ fn namespace_import_rejects_self_and_unknown_sources() {
 
 // #1451 — namespace teardown (`TclTeardownNamespace`, tclNamesp.c:1084)
 
+/// A rename whose destination lands in the caller's *retained* namespace — one
+/// the running proc deleted out from under itself — leaves nothing publicly
+/// addressable at the new key: `register_command` ends in
+/// `absorb_retained_binding`, which moves the fresh binding into the retained
+/// namespace's own table. Anything on the rename path that expects to read the
+/// command back out of the live map afterwards is therefore wrong. tclsh
+/// 8.6.16 and 9.0.4 both complete the rename and invoke the ensemble.
+#[test]
+fn renaming_an_ensemble_into_a_retained_namespace_still_dispatches() {
+    assert_eq!(
+        run("namespace eval E { proc sub {} { return S }\n\
+             \x20   namespace export sub; namespace ensemble create }\n\
+             namespace eval N { proc p {} {\n\
+             \x20   namespace delete ::N\n\
+             \x20   rename ::E local\n\
+             \x20   return [local sub]\n\
+             } }\n\
+             N::p"),
+        "S"
+    );
+}
+
 #[test]
 fn deleting_a_namespace_clears_paths_in_both_directions() {
     // (a) another namespace's path loses the deleted entry, and a recreated


### PR DESCRIPTION
Found while verifying that everything from #1892 and #1885 actually landed: re-running the differential corpus against merged `rust` left one sheet failing, on the VM side.

## The gap

C's `TclRenameCommand` re-homes the one `Command` (`cmdPtr->nsPtr = newNsPtr`) *before* it fires the `rename` traces, and both hash entries reference it. So for the callbacks' duration a proc invoked through the **vacating** name reports the destination's `namespace current`, and resolves `variable` there.

```tcl
namespace eval a { variable v A; proc p {} { variable v; return "[namespace current] $v" } }
namespace eval b { variable v B }
proc R {old new op} { puts "old: [a::p]"; puts "new: [b::q]" }
trace add command a::p rename R
rename a::p ::b::q
```

tclsh 8.6.16 and 9.0.4 both print `old: ::b B`. The VM printed `old: ::a A`.

`cmd_rename` already builds the re-homed `Command::Proc`, but `install_renamed_command` registered it at the destination only. The source entry — which the window deliberately leaves standing — kept pointing at the un-re-homed command.

Only the window is affected: a plain cross-namespace rename was already correct.

## The fix

`rebind_rename_source` swaps what that standing entry points at. It is deliberately **not** `register_command`: this is not a replacement, so no `delete` trace may fire, no generation may be minted and no sidecar may detach — it is the one command under both of its names, which is what C gets for free from two hash entries sharing a `Command *`. A callback that deleted the source itself leaves nothing to rebind, and that is not an error.

`runtime/rust` has had this since `Namespaces::rehome_command`, which writes the re-homed command into both slots. With this, the "**both** runtimes reproduce that window" claim in `docs/design/runtime/trace-implementation.md` holds for the re-homing bullet too — until now the doc overstated the VM. The table row names the new step.

## Why #1885 missed it

`command_traces_e2e.rs` had no `namespace current` coverage of the window at all — `grep -c "namespace current"` was 0 — while `runtime/rust`'s `trace_semantics.rs` had one, which is why the two engines diverged on exactly this. The new vector closes that; `vectors_match_real_tclsh` checks it against both tclsh binaries.

## Testing

- New `Vector` in `command_traces_e2e.rs`, verified against tclsh 8.6.16 and 9.0.4 by the suite's own oracle test.
- 59 differential sheets (the whole rename-window / trace-gate / coroutine corpus from #1892) now match **both** tclsh releases with zero diffs — previously 58/59.
- Full `tcl-vm` suite green (48 sections, 0 failures); `make prep-pr` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
