### PR TITLE
fix(compiler): a word's value gets its own operand shape

### DIFF
--- a/rust/bpf-tcl-ir/src/lower.rs
+++ b/rust/bpf-tcl-ir/src/lower.rs
@@ -920,6 +920,9 @@ impl Lowerer<'_> {
                 Ok(dst)
             }
             ExprNode::String { .. }
+            // An IR-level word operand: outside this integer subset for the
+            // same reason a string is.
+            | ExprNode::CompiledWord { .. }
             | ExprNode::Command { .. }
             | ExprNode::Ternary { .. }
             | ExprNode::Call { .. }

--- a/rust/tcl-compiler/src/analyser/diagnostics/dataflow.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/dataflow.rs
@@ -2514,6 +2514,7 @@ fn collect_expr_command_texts_at(node: &ExprNode, out: &mut Vec<String>, depth: 
         }
         ExprNode::Literal { .. }
         | ExprNode::String { .. }
+        | ExprNode::CompiledWord { .. }
         | ExprNode::Var { .. }
         | ExprNode::Raw { .. } => {}
     }

--- a/rust/tcl-compiler/src/analyser/diagnostics/usage.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/usage.rs
@@ -1911,7 +1911,10 @@ fn node_extent_at(node: &ExprNode, depth: u32) -> Option<(u32, u32)> {
             let (_, fe) = node_extent_at(false_branch, depth + 1)?;
             Some((cs, fe))
         }
-        ExprNode::Raw { .. } => None,
+        // `CompiledWord` carries no source span either: it is a *word* the IR
+        // reduced to its value, not a slice of the expression text this
+        // extent indexes into.
+        ExprNode::Raw { .. } | ExprNode::CompiledWord { .. } => None,
     }
 }
 

--- a/rust/tcl-compiler/src/cfg_builder/cfg_lower.rs
+++ b/rust/tcl-compiler/src/cfg_builder/cfg_lower.rs
@@ -97,9 +97,17 @@ fn literal_true_expr() -> ExprNode {
 ///
 /// The subject is a *word*, never an expression: `TclCompileSwitchCmd`
 /// (`tclCompCmds.c`) pushes it through `TclCompileTokens` — ordinary word
-/// substitution — and compares the resulting string. `ExprNode::String` is the
-/// operand shape codegen emits as exactly that: a bare literal push, which the
-/// VM substitutes (so a `$v` / `[cmd]` inside the word still interpolates).
+/// substitution — and compares the resulting string. `ExprNode::CompiledWord`
+/// is the operand shape that says exactly that, carrying the word's value and
+/// whether it was braced.
+///
+/// It used to be `ExprNode::String`, whose text is *source including
+/// delimiters* — a contract a value cannot honour. A subject whose value
+/// merely looks like a braced word was read back as one and stripped, so
+/// `switch -- "{abc}"` matched the arm `abc` rather than `{abc}`, and
+/// re-bracketing a genuinely braced subject to escape that only made the two
+/// spellings collide on one text. Values and source need different shapes,
+/// which is what this variant is.
 ///
 /// The `ExprNode::Raw` shape this used to use lowered instead to `push` +
 /// `exprStk`, making the subject an expression — `switch -- abc …` evaluated
@@ -129,22 +137,18 @@ fn switch_subject_operand(subject: &str, braced: bool) -> ExprNode {
     // word the balance walk accepts. The same is not true of an arbitrary
     // value, which is why this is gated on the word really having been braced
     // rather than applied to anything that looks like it could be.
-    if braced {
-        return ExprNode::String {
-            text: format!("{{{subject}}}"),
-            start: 0,
-            end: 0,
-        };
-    }
-    if is_whole_var_ref(subject) {
+    // The whole-variable fast path is for a subject that *reads* a variable, so
+    // it must not fire on a braced word whose value merely spells one:
+    // `switch -- {${x}}` compares the literal text `${x}`, and taking `Raw`
+    // there loaded `x` instead (or errored when it was unset).
+    if !braced && is_whole_var_ref(subject) {
         return ExprNode::Raw {
             text: subject.to_owned(),
         };
     }
-    ExprNode::String {
+    ExprNode::CompiledWord {
         text: subject.to_owned(),
-        start: 0,
-        end: 0,
+        braced,
     }
 }
 
@@ -851,10 +855,18 @@ impl CfgBuilder {
                 ExprNode::Binary {
                     op: BinOp::StrEq,
                     left: Box::new(switch_subject_operand(subject, *subject_braced)),
-                    right: Box::new(ExprNode::Literal {
+                    // The pattern is a *word value* too — the arm list's
+                    // decoded element — so it takes the same operand shape as
+                    // the subject. In a `Literal` slot its text was read back
+                    // as expression source and a pattern that looks braced
+                    // lost a layer: `{7}` was compared as `7`.
+                    //
+                    // Per arm, not per switch: a single braced arm list holds
+                    // literal elements, but the multi-word form is a word each,
+                    // where `{${x}}` is literal and a bare `$pat` substitutes.
+                    right: Box::new(ExprNode::CompiledWord {
                         text: arm.pattern.clone(),
-                        start: 0,
-                        end: 0,
+                        braced: arm.pattern_braced,
                     }),
                 }
             } else {
@@ -1237,12 +1249,14 @@ mod tests {
     fn switch_exact_creates_branches() {
         let script = Script::from_statements(vec![Statement::Switch {
             subject_braced: false,
+            raw_arg_braced: Vec::new(),
             span: Span::new(0, 50),
             subject: "$x".into(),
             subject_span: Span::new(7, 9),
             arms: vec![
                 SwitchArm {
                     pattern: "a".into(),
+                    pattern_braced: true,
                     pattern_span: Span::new(11, 12),
                     body: Some(Script::new()),
                     body_span: Some(Span::new(13, 15)),
@@ -1250,6 +1264,7 @@ mod tests {
                 },
                 SwitchArm {
                     pattern: "b".into(),
+                    pattern_braced: true,
                     pattern_span: Span::new(16, 17),
                     body: Some(Script::new()),
                     body_span: Some(Span::new(18, 20)),
@@ -1274,11 +1289,13 @@ mod tests {
     fn glob_regexp_switch(mode: SwitchMode) -> Script {
         Script::from_statements(vec![Statement::Switch {
             subject_braced: false,
+            raw_arg_braced: Vec::new(),
             span: Span::new(0, 40),
             subject: "$x".into(),
             subject_span: Span::new(7, 9),
             arms: vec![SwitchArm {
                 pattern: "a*".into(),
+                pattern_braced: true,
                 pattern_span: Span::new(11, 13),
                 body: Some(Script::from_statements(vec![Statement::Call {
                     span: Span::new(15, 22),

--- a/rust/tcl-compiler/src/cfg_builder/mod.rs
+++ b/rust/tcl-compiler/src/cfg_builder/mod.rs
@@ -2627,6 +2627,7 @@ mod tests {
             .enumerate()
             .map(|(i, command)| SwitchArm {
                 pattern: i.to_string(),
+                pattern_braced: true,
                 pattern_span: Span::new(0, 1),
                 // Exercise absolute spellings inside both flattened and opaque
                 // switch paths; classification must normalise the `::` prefix.
@@ -2639,6 +2640,7 @@ mod tests {
             .collect();
         Script::from_statements(vec![Statement::Switch {
             subject_braced: false,
+            raw_arg_braced: Vec::new(),
             span: Span::new(0, 1),
             subject: "$which".into(),
             subject_span: Span::new(0, 1),

--- a/rust/tcl-compiler/src/codegen/emitter/terminator.rs
+++ b/rust/tcl-compiler/src/codegen/emitter/terminator.rs
@@ -312,7 +312,17 @@ impl CodegenCtx<'_> {
             if *op != BinOp::StrEq {
                 break;
             }
-            let ExprNode::Literal { text: pattern, .. } = right.as_ref() else {
+            // A jump table keys on *literal* strings, so only a pattern that
+            // is one qualifies: a braced arm list's decoded element, or the
+            // `Literal` shape this used to be handed. A substituting pattern
+            // (the multi-word `switch $s $pat …` form) has no key until run
+            // time and keeps the branch chain.
+            let (ExprNode::Literal { text: pattern, .. }
+            | ExprNode::CompiledWord {
+                text: pattern,
+                braced: true,
+            }) = right.as_ref()
+            else {
                 break;
             };
 

--- a/rust/tcl-compiler/src/codegen/expressions.rs
+++ b/rust/tcl-compiler/src/codegen/expressions.rs
@@ -227,7 +227,11 @@ impl CodegenCtx<'_> {
             // (`\xNN`, `\NNN`, `\uNNNN`, …), which the template parser's simplified
             // literal decoding does not cover (expr-8.13's `"\374"`).
             if !inner.contains('$') && !inner.contains('[') {
-                self.push_lit(&backslash_subst_in(inner, self.escapes));
+                // Decoded here, so this is the operand's finished value and
+                // must not be read back as source: `expr {"{abc}"}` answered
+                // `abc` because the value `{abc}` was pushed substituting and
+                // the VM took it for a braced literal.
+                self.push_word_value(&backslash_subst_in(inner, self.escapes));
                 return false;
             }
             match super::helpers::parse_subst_template(inner, self.escapes, self.braced_var) {
@@ -424,6 +428,29 @@ impl CodegenCtx<'_> {
             ExprNode::Literal { text, .. } => self.emit_expr_literal(text),
 
             ExprNode::String { text, .. } => self.emit_expr_string(text),
+            // A word already reduced to its value: pushed by the word-value
+            // rule, not re-read as expression source. A braced word's value is
+            // literal outright; anything else keeps whatever substitution the
+            // runtime still owns.
+            ExprNode::CompiledWord { text, braced } => {
+                if *braced {
+                    self.push_lit_verbatim(text);
+                } else if tcl_syntax::word_rules::whole_braced_word(text).is_some() {
+                    // The value looks like a braced word, so deferring it to
+                    // the runtime is not an option in either direction: the
+                    // VM's `subst_word` would strip a layer that was never
+                    // source *and* suppress the substitution the word still
+                    // owes. Resolve it here instead — `emit_value` decomposes
+                    // the word into its literal / `$var` / `[cmd]` parts and
+                    // concatenates, which is the only reading that gets both
+                    // halves right. `switch -- "{$x}"` is the case: value
+                    // `{${x}}`, which must compare as `{7}`.
+                    self.emit_value(text, true);
+                } else {
+                    self.push_word_value(text);
+                }
+                false
+            }
 
             ExprNode::Var { text, name, .. } => {
                 let var_ref = if text.contains('(') {

--- a/rust/tcl-compiler/src/codegen/statements.rs
+++ b/rust/tcl-compiler/src/codegen/statements.rs
@@ -417,20 +417,29 @@ impl CodegenCtx<'_> {
             // for these modes.
             Statement::Switch {
                 raw_args,
-                patterns_braced,
+                raw_arg_braced,
                 ..
             } => {
-                // The single-braced arm form `switch … { pat body … }` passes
-                // the whole arm block as one braced-literal word: its patterns
-                // and bodies are data, so a `[…]`/`$…` inside (e.g. a `-regexp`
-                // character class `{[0-9]+}`) must not be substituted. Mark that
-                // trailing word `Str` so it is pushed verbatim; the leading
-                // option/subject words still interpolate (the subject may be
-                // `$s`). The multi-word form keeps the all-interpolated path.
-                if *patterns_braced && !raw_args.is_empty() {
+                // Each word goes out the way it was written. A braced word is
+                // data — its `[…]` / `${…}` must not run — and that is true of
+                // every position, not just the trailing arm list this used to
+                // special-case: `switch -glob -- {a[bc]d} {a\[bc\]d} …` ran
+                // `bc` for the subject, and decoded the pattern to `a[bc]d`,
+                // which then matched as a character class rather than as the
+                // literal both oracles match.
+                //
+                // `raw_arg_braced` is the lexer's answer, carried through the
+                // IR because `raw_args` are values and a value cannot say how
+                // it was written. Empty means unknown (a hand-built
+                // statement), which keeps the old all-interpolated behaviour.
+                if raw_arg_braced.iter().any(|braced| *braced) {
                     let n = raw_args.len();
                     let mut kinds = vec![tcl_lexer::TokenType::Esc; n + 1];
-                    kinds[n] = tcl_lexer::TokenType::Str;
+                    for (i, braced) in raw_arg_braced.iter().enumerate() {
+                        if *braced && i + 1 < kinds.len() {
+                            kinds[i + 1] = tcl_lexer::TokenType::Str;
+                        }
+                    }
                     let toks = crate::ir::CommandTokens::from_lossy_parts(
                         Vec::new(),
                         Vec::new(),

--- a/rust/tcl-compiler/src/dispatch_proof.rs
+++ b/rust/tcl-compiler/src/dispatch_proof.rs
@@ -963,7 +963,7 @@ fn word_world_hazard(state: &WorldContents, word: &WordExpr) -> bool {
 fn expr_world_hazard(state: &WorldContents, expr: &tcl_syntax::expr::ExprNode) -> bool {
     use tcl_syntax::expr::ExprNode;
     match expr {
-        ExprNode::Literal { .. } | ExprNode::String { .. } => false,
+        ExprNode::Literal { .. } | ExprNode::String { .. } | ExprNode::CompiledWord { .. } => false,
         ExprNode::Var { name, .. } => state.variable_access_may_observe(name),
         ExprNode::Command { .. } | ExprNode::Call { .. } | ExprNode::Raw { .. } => true,
         ExprNode::Unary { operand, .. } => expr_world_hazard(state, operand),

--- a/rust/tcl-compiler/src/executable_ir.rs
+++ b/rust/tcl-compiler/src/executable_ir.rs
@@ -3649,6 +3649,7 @@ fn expr_has_raw(expr: &ExprNode) -> bool {
         ExprNode::Raw { .. } => true,
         ExprNode::Literal { .. }
         | ExprNode::String { .. }
+        | ExprNode::CompiledWord { .. }
         | ExprNode::Var { .. }
         | ExprNode::Command { .. } => false,
         ExprNode::Binary { left, right, .. } => expr_has_raw(left) || expr_has_raw(right),

--- a/rust/tcl-compiler/src/inlining/mod.rs
+++ b/rust/tcl-compiler/src/inlining/mod.rs
@@ -1170,6 +1170,7 @@ fn rewrite_switch_stmt(
         mode,
         nocase,
         raw_args,
+        raw_arg_braced,
         patterns_braced,
     } = stmt
     else {
@@ -1186,6 +1187,7 @@ fn rewrite_switch_stmt(
                     changed = true;
                     new_arms.push(SwitchArm {
                         pattern: a.pattern.clone(),
+                        pattern_braced: a.pattern_braced,
                         pattern_span: a.pattern_span,
                         body: Some(body),
                         body_span: a.body_span,
@@ -1212,6 +1214,7 @@ fn rewrite_switch_stmt(
     changed.then(|| {
         vec![Statement::Switch {
             subject_braced: *subject_braced,
+            raw_arg_braced: raw_arg_braced.clone(),
             span: *span,
             subject: subject.clone(),
             subject_span: *subject_span,
@@ -1579,6 +1582,7 @@ fn substitute_irreturn_stmt(stmt: &Statement, result_var: &str) -> Statement {
             mode,
             nocase,
             raw_args,
+            raw_arg_braced,
             patterns_braced,
         } => Statement::Switch {
             subject_braced: *subject_braced,
@@ -1589,6 +1593,7 @@ fn substitute_irreturn_stmt(stmt: &Statement, result_var: &str) -> Statement {
                 .iter()
                 .map(|a| SwitchArm {
                     pattern: a.pattern.clone(),
+                    pattern_braced: a.pattern_braced,
                     pattern_span: a.pattern_span,
                     body: a.body.as_ref().map(|b| substitute_irreturn(b, result_var)),
                     body_span: a.body_span,
@@ -1602,6 +1607,7 @@ fn substitute_irreturn_stmt(stmt: &Statement, result_var: &str) -> Statement {
             mode: *mode,
             nocase: *nocase,
             raw_args: raw_args.clone(),
+            raw_arg_braced: raw_arg_braced.clone(),
             patterns_braced: *patterns_braced,
         },
         other => other.clone(),

--- a/rust/tcl-compiler/src/inlining/rename.rs
+++ b/rust/tcl-compiler/src/inlining/rename.rs
@@ -448,6 +448,7 @@ fn rewrite_switch(stmt: &Statement, rename: &HashMap<String, String>) -> Stateme
         mode,
         nocase,
         raw_args,
+        raw_arg_braced,
         patterns_braced,
     } = stmt
     else {
@@ -474,6 +475,7 @@ fn rewrite_switch(stmt: &Statement, rename: &HashMap<String, String>) -> Stateme
             .iter()
             .map(|a| SwitchArm {
                 pattern: a.pattern.clone(),
+                pattern_braced: a.pattern_braced,
                 pattern_span: a.pattern_span,
                 body: a.body.as_ref().map(|b| rewrite_script(b, rename)),
                 body_span: a.body_span,
@@ -485,6 +487,7 @@ fn rewrite_switch(stmt: &Statement, rename: &HashMap<String, String>) -> Stateme
         mode: *mode,
         nocase: *nocase,
         raw_args: raw_args.clone(),
+        raw_arg_braced: raw_arg_braced.clone(),
         patterns_braced: *patterns_braced,
     }
 }
@@ -643,6 +646,13 @@ fn rewrite_expr_at(node: &ExprNode, rename: &HashMap<String, String>, depth: u32
             condition: Box::new(rewrite_expr_at(condition, rename, depth + 1)),
             true_branch: Box::new(rewrite_expr_at(true_branch, rename, depth + 1)),
             false_branch: Box::new(rewrite_expr_at(false_branch, rename, depth + 1)),
+        },
+        // A compiled word carries a *value*; a `$x` inside it is either data
+        // (braced) or resolved by word substitution, never an expression
+        // variable this rename owns.
+        ExprNode::CompiledWord { text, braced } => ExprNode::CompiledWord {
+            text: text.clone(),
+            braced: *braced,
         },
         ExprNode::Call {
             function,

--- a/rust/tcl-compiler/src/ir.rs
+++ b/rust/tcl-compiler/src/ir.rs
@@ -803,8 +803,17 @@ pub struct TryHandler {
 /// A `switch` arm: pattern + body.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct SwitchArm {
-    /// Pattern text.
+    /// Pattern text — the word's *value*.
     pub pattern: String,
+    /// Whether this arm's pattern word was braced, so its value is literal.
+    ///
+    /// Per-arm, because the two arm forms differ per *word*: a single braced
+    /// `{pat body …}` block holds literal list elements, while the multi-word
+    /// form (`switch $s $pat {body}`) is a word each, and `{${x}}` there is
+    /// literal while a bare `$pat` substitutes. The whole-switch
+    /// `Statement::Switch::patterns_braced` cannot say that, and using it
+    /// substituted a braced pattern.
+    pub pattern_braced: bool,
     /// Source span of the pattern.
     pub pattern_span: Span,
     /// Body script (`None` for fall-through arms).
@@ -1246,6 +1255,21 @@ pub enum Statement {
         nocase: bool,
         /// Raw argument texts for generic fallback.
         raw_args: Vec<String>,
+        /// Per-[`Self::Switch::raw_args`] "this word was braced" flags, for the
+        /// generic-invoke fallback the opaque modes take.
+        ///
+        /// `raw_args` are *values*, and a value cannot say how it was written,
+        /// so the emitter that pushes them has no way to tell a braced word's
+        /// literal content from a bare word that still substitutes. It used to
+        /// fabricate the flags — marking only a single braced arm list — and
+        /// everything else went out substituting: `switch -glob -- {a[bc]d}`
+        /// ran `bc`, and the pattern `{a\[bc\]d}` was decoded to `a[bc]d` and
+        /// matched as a character class, so it matched `abd` and not the
+        /// literal both oracles match.
+        ///
+        /// Empty when the flags are unknown (a hand-built statement), which the
+        /// emitter reads as "none braced" — the prior behaviour.
+        raw_arg_braced: Vec<bool>,
         /// `true` when the arms came from a single braced
         /// `{pat body …}` block — patterns are literal list elements
         /// with no substitution. `false` when supplied as separate
@@ -2084,12 +2108,14 @@ mod tests {
     fn switch_statement() {
         let stmt = Statement::Switch {
             subject_braced: false,
+            raw_arg_braced: Vec::new(),
             span: Span::new(0, 80),
             subject: "$cmd".into(),
             subject_span: Span::new(7, 11),
             arms: vec![
                 SwitchArm {
                     pattern: "start".into(),
+                    pattern_braced: true,
                     pattern_span: Span::new(13, 18),
                     body: Some(Script::new()),
                     body_span: Some(Span::new(19, 22)),
@@ -2097,6 +2123,7 @@ mod tests {
                 },
                 SwitchArm {
                     pattern: "stop".into(),
+                    pattern_braced: true,
                     pattern_span: Span::new(23, 27),
                     body: None,
                     body_span: None,

--- a/rust/tcl-compiler/src/ir_helpers.rs
+++ b/rust/tcl-compiler/src/ir_helpers.rs
@@ -504,6 +504,7 @@ fn expr_has_command_at(expr: &ExprNode, depth: u32) -> bool {
         ExprNode::Call { args, .. } => args.iter().any(|a| expr_has_command_at(a, depth + 1)),
         ExprNode::Literal { .. }
         | ExprNode::String { .. }
+        | ExprNode::CompiledWord { .. }
         | ExprNode::Var { .. }
         | ExprNode::Raw { .. } => false,
     }

--- a/rust/tcl-compiler/src/lowering/mod.rs
+++ b/rust/tcl-compiler/src/lowering/mod.rs
@@ -42,7 +42,10 @@ use tcl_dialect::model::surface_admits;
 use tcl_syntax::word_rules::WordValueRules;
 
 pub(crate) mod hooks;
-mod structured;
+// `pub(crate)` for one item: `structured::parse_switch_options`, which the
+// opaque-switch emitter asks where a `switch`'s options end rather than
+// carrying a second copy of that rule.
+pub(crate) mod structured;
 
 /// Stand-in `Script` for a body past [`MAX_LOWER_NEST_DEPTH`]: a single
 /// [`Statement::Barrier`] spanning `[base_offset, base_offset + len)`, so

--- a/rust/tcl-compiler/src/lowering/structured.rs
+++ b/rust/tcl-compiler/src/lowering/structured.rs
@@ -41,6 +41,9 @@ use tcl_syntax::word_rules::WordValueRules;
 /// pair vector's type signature readable.
 struct SwitchPair {
     pattern: String,
+    /// Whether the pattern word was braced — literal for every element of a
+    /// single braced arm list, and per-word in the multi-word form.
+    pattern_braced: bool,
     pattern_span: Span,
     body_text: String,
     body_span: Option<Span>,
@@ -120,13 +123,43 @@ fn switch_body_elements(body_text: &str) -> Option<Vec<SwitchElement>> {
     Some(elements)
 }
 
+/// Whether the `index`-th argument was written as a braced word.
+///
+/// One predicate, because two callers ask it: the `switch` subject's own flag
+/// and the per-argument flags the generic fallback pushes by. `TokenType::Str`
+/// is the braced word, and the single-token check excludes a composite word
+/// that merely starts with a brace — `arg_single` alone is *not* the question,
+/// since `$x` and a bare word satisfy it too.
+fn word_is_braced(arg_tokens: &[tcl_lexer::Token], arg_single: &[bool], index: usize) -> bool {
+    matches!(
+        arg_tokens.get(index).map(|t| t.kind),
+        Some(tcl_lexer::TokenType::Str)
+    ) && arg_single.get(index).copied().unwrap_or(false)
+}
+
+/// [`word_is_braced`] for every argument, for the generic-invoke fallback.
+fn braced_word_flags(
+    arg_tokens: &[tcl_lexer::Token],
+    arg_single: &[bool],
+    len: usize,
+) -> Vec<bool> {
+    (0..len)
+        .map(|i| word_is_braced(arg_tokens, arg_single, i))
+        .collect()
+}
+
 /// Parse switch options, returning `(first_non_option_index, mode, nocase,
 /// unknown)`. `unknown` is set when a leading `-word` is not one of the options
 /// the compiler inlines (`-exact`/`-glob`/`-regexp`/`-nocase`/`--`) — an
 /// arg-taking `-indexvar`/`-matchvar`, or an invalid option such as `-foo`. The
 /// caller bails the whole switch to the runtime command, which validates the
 /// option set (tclsh rejects `-foo`) and handles the side-channel writes.
-fn parse_switch_options(args: &[String]) -> (usize, SwitchMode, bool, bool) {
+///
+/// `pub(crate)` so the opaque-switch emitter can ask the same question this
+/// answers for lowering — which argument the subject is — rather than keeping
+/// a second copy of the option rule. There is one owner of "where do the
+/// options end", and this is it.
+pub(crate) fn parse_switch_options(args: &[String]) -> (usize, SwitchMode, bool, bool) {
     let mut i = 0;
     let mut mode = SwitchMode::Exact;
     let mut nocase = false;
@@ -854,6 +887,7 @@ impl Lowerer<'_> {
             if pair.body_text == "-" {
                 arms.push(SwitchArm {
                     pattern,
+                    pattern_braced: pair.pattern_braced,
                     pattern_span: pair.pattern_span,
                     body: None,
                     body_span: None,
@@ -892,6 +926,7 @@ impl Lowerer<'_> {
             } else {
                 arms.push(SwitchArm {
                     pattern,
+                    pattern_braced: pair.pattern_braced,
                     pattern_span: pair.pattern_span,
                     body: Some(body),
                     body_span: pair.body_span,
@@ -930,10 +965,7 @@ impl Lowerer<'_> {
         // alone is not it — it means "one token", which `$x` and a bare word
         // also satisfy, and bracing those would freeze a subject that must
         // substitute.
-        let subject_braced = matches!(
-            arg_tokens.get(i).map(|t| t.kind),
-            Some(tcl_lexer::TokenType::Str)
-        ) && arg_single.get(i).copied().unwrap_or(false);
+        let subject_braced = word_is_braced(arg_tokens, arg_single, i);
         i += 1;
         if i >= args.len() {
             return self.barrier(seg, "switch missing arms");
@@ -989,6 +1021,8 @@ impl Lowerer<'_> {
                     // (`a\ b` matches the subject `a b`); the body keeps
                     // its raw spelling for script lowering.
                     pattern: pat.value.clone(),
+                    // Every element of a single braced arm list is literal.
+                    pattern_braced: true,
                     pattern_span: relocate(pat.span),
                     body_text: body.raw.clone(),
                     body_span: Some(relocate(body.span)),
@@ -1026,6 +1060,9 @@ impl Lowerer<'_> {
                 let body_span_val = arg_tokens.get(body_tok_idx).map(|t| t.span);
                 pairs.push(SwitchPair {
                     pattern,
+                    // Per word here: `{${x}}` is literal, a bare `$pat`
+                    // substitutes.
+                    pattern_braced: word_is_braced(arg_tokens, arg_single, i),
                     pattern_span,
                     body_text: body_text_inner,
                     body_span: body_span_val,
@@ -1049,6 +1086,7 @@ impl Lowerer<'_> {
             mode,
             nocase,
             raw_args: args.to_vec(),
+            raw_arg_braced: braced_word_flags(arg_tokens, arg_single, args.len()),
             patterns_braced,
         }
     }

--- a/rust/tcl-compiler/src/native_lowering/lower.rs
+++ b/rust/tcl-compiler/src/native_lowering/lower.rs
@@ -1401,6 +1401,16 @@ impl<'a> Lowerer<'a> {
     fn lower_expr(&mut self, node: &ExprNode) -> Result<NativeValueId, ExprDecline> {
         match node {
             ExprNode::Literal { text, .. } => Ok(self.lower_literal(text)),
+            // A word already reduced to its value: no delimiters to strip, and
+            // a live substitution means the value is not known here.
+            ExprNode::CompiledWord { text, braced } => {
+                if *braced || !(text.contains("${") || text.contains('[')) {
+                    Ok(self.lower_literal(text))
+                } else {
+                    // The same decline a substituted string operand takes.
+                    Err(ExprDecline::SubstitutedString)
+                }
+            }
             ExprNode::String { text, .. } => {
                 let inner = text
                     .strip_prefix('{')

--- a/rust/tcl-compiler/src/optimiser/helpers/expr_simplify.rs
+++ b/rust/tcl-compiler/src/optimiser/helpers/expr_simplify.rs
@@ -1596,7 +1596,9 @@ fn expr_has_command_subst_at(node: &ExprNode, depth: u32) -> bool {
         ExprNode::Literal { .. }
         | ExprNode::Var { .. }
         | ExprNode::Raw { .. }
-        | ExprNode::String { .. } => false,
+        | ExprNode::String { .. }
+        // A word, not an expression: it holds no command substitution.
+        | ExprNode::CompiledWord { .. } => false,
     }
 }
 
@@ -1663,6 +1665,8 @@ fn expr_uses_shadowed_mathfunc_at<S: std::hash::BuildHasher>(
         | ExprNode::Var { .. }
         | ExprNode::Raw { .. }
         | ExprNode::String { .. }
+        // A word, not an expression: it can hold no math-function call.
+        | ExprNode::CompiledWord { .. }
         | ExprNode::Command { .. } => false,
     }
 }

--- a/rust/tcl-compiler/src/ssa.rs
+++ b/rust/tcl-compiler/src/ssa.rs
@@ -4170,11 +4170,13 @@ mod tests {
     fn opaque_switch(subject: &str, pattern: &str, body: crate::ir::Script) -> Statement {
         Statement::Switch {
             subject_braced: false,
+            raw_arg_braced: Vec::new(),
             span: Span::new(0, 40),
             subject: subject.into(),
             subject_span: Span::new(0, 1),
             arms: vec![crate::ir::SwitchArm {
                 pattern: pattern.into(),
+                pattern_braced: true,
                 pattern_span: Span::new(0, 1),
                 body: Some(body),
                 body_span: Some(Span::new(0, 1)),

--- a/rust/tcl-compiler/src/static_loops.rs
+++ b/rust/tcl-compiler/src/static_loops.rs
@@ -593,11 +593,13 @@ mod tests {
     fn mode_switch() -> Statement {
         Statement::Switch {
             subject_braced: false,
+            raw_arg_braced: Vec::new(),
             span: sp(),
             subject: "$mode".into(),
             subject_span: sp(),
             arms: vec![SwitchArm {
                 pattern: "a".into(),
+                pattern_braced: true,
                 pattern_span: sp(),
                 body: Some(script_of(vec![assign_const("v", "1")])),
                 body_span: Some(sp()),

--- a/rust/tcl-compiler/src/taint.rs
+++ b/rust/tcl-compiler/src/taint.rs
@@ -1369,6 +1369,17 @@ fn expr_command_taint<S: std::hash::BuildHasher>(
                 TaintLattice::clean()
             }
         }
+        // A word already reduced to its value. A braced one is literal, so
+        // nothing can flow into it; otherwise whatever substitution is still
+        // live is what a taint can arrive through, which is the same question
+        // `word_taint` answers for a quoted operand.
+        ExprNode::CompiledWord { text, braced } => {
+            if *braced {
+                TaintLattice::clean()
+            } else {
+                word_taint(text, uses, taints, ctx)
+            }
+        }
         ExprNode::Binary { left, right, .. } => expr_command_taint(
             left,
             uses,
@@ -4959,7 +4970,10 @@ fn collect_coercion_operands(
                 });
             }
         }
-        ExprNode::Literal { .. } | ExprNode::String { .. } | ExprNode::Command { .. } => {}
+        ExprNode::Literal { .. }
+        | ExprNode::String { .. }
+        | ExprNode::CompiledWord { .. }
+        | ExprNode::Command { .. } => {}
         ExprNode::Binary { op, left, right } => {
             let child_ctx = binop_coerces(*op);
             collect_coercion_operands(left, child_ctx, out, depth + 1, grammar);

--- a/rust/tcl-compiler/src/type_infer.rs
+++ b/rust/tcl-compiler/src/type_infer.rs
@@ -310,7 +310,7 @@ fn infer_expr_type(
     match node {
         ExprNode::Literal { text, .. } => expr_literal_type(text, numbers),
 
-        ExprNode::String { .. } => TypeLattice::of(TclType::String),
+        ExprNode::String { .. } | ExprNode::CompiledWord { .. } => TypeLattice::of(TclType::String),
 
         ExprNode::Var { name, .. } => {
             let base = normalise_var_name(name);

--- a/rust/tcl-compiler/src/uri_split.rs
+++ b/rust/tcl-compiler/src/uri_split.rs
@@ -786,7 +786,11 @@ fn walk_expr(
                 walk_expr(&reparsed, ssa_versions, ctx, out, depth + 1);
             }
         }
-        ExprNode::Literal { .. } | ExprNode::String { .. } | ExprNode::Var { .. } => {}
+        // `CompiledWord` is a word, not an expression: nothing here to inspect.
+        ExprNode::Literal { .. }
+        | ExprNode::String { .. }
+        | ExprNode::CompiledWord { .. }
+        | ExprNode::Var { .. } => {}
     }
 }
 

--- a/rust/tcl-compiler/tests/codegen_integration.rs
+++ b/rust/tcl-compiler/tests/codegen_integration.rs
@@ -507,6 +507,7 @@ fn switch_glob_emits_generic_invoke_not_jump_table() {
 
     let arm = |pat: &str| SwitchArm {
         pattern: pat.into(),
+        pattern_braced: true,
         pattern_span: sp(),
         body: Some(Script::from_statements(vec![Statement::AssignConst {
             span: sp(),
@@ -521,6 +522,7 @@ fn switch_glob_emits_generic_invoke_not_jump_table() {
     let make = |mode: SwitchMode| {
         Script::from_statements(vec![Statement::Switch {
             subject_braced: false,
+            raw_arg_braced: Vec::new(),
             span: sp(),
             subject: "$x".into(),
             subject_span: sp(),

--- a/rust/tcl-compiler/tests/pipeline_coverage.rs
+++ b/rust/tcl-compiler/tests/pipeline_coverage.rs
@@ -549,11 +549,13 @@ mod defs_from_ir_script_arms {
     fn switch_arm_and_default_defs_collected() {
         let s = Script::from_statements(vec![Statement::Switch {
             subject_braced: false,
+            raw_arg_braced: Vec::new(),
             span: Span::new(0, 40),
             subject: "$x".into(),
             subject_span: Span::new(7, 9),
             arms: vec![SwitchArm {
                 pattern: "a".into(),
+                pattern_braced: true,
                 pattern_span: Span::new(10, 11),
                 body: Some(Script::from_statements(vec![assign("arm")])),
                 body_span: Some(Span::new(12, 20)),

--- a/rust/tcl-registry/src/expr_surface.rs
+++ b/rust/tcl-registry/src/expr_surface.rs
@@ -209,6 +209,10 @@ impl RuntimeExprSurface {
             | ExprNode::String { .. }
             | ExprNode::Var { .. }
             | ExprNode::Command { .. }
+            // An operand shape the expression *parser* never produces, so this
+            // surface check — which asks whether a release's `expr` grammar
+            // admits the construct — has nothing to reject in one.
+            | ExprNode::CompiledWord { .. }
             | ExprNode::Raw { .. } => Ok(()),
         }
     }

--- a/rust/tcl-syntax/src/expr/ast.rs
+++ b/rust/tcl-syntax/src/expr/ast.rs
@@ -302,6 +302,30 @@ pub enum ExprNode {
         end: ExprOffset,
     },
 
+    /// A word already reduced to its **value**, carrying the compiled-word
+    /// substitution convention rather than expression-source semantics.
+    ///
+    /// The expression parser never produces this: it is an IR-level operand for
+    /// a construct whose operand is a *word*, not an expression — today only a
+    /// `switch` subject, which `TclCompileSwitchCmd` pushes through
+    /// `TclCompileTokens`. [`Self::String`] cannot carry it, because that
+    /// variant's text is *source including delimiters* and a value that merely
+    /// looks like a braced word (`switch -- "{abc}"`, whose value is the
+    /// five-character `{abc}`) is then read back as one and stripped.
+    ///
+    /// The two conventions really do differ, which is why re-encoding the
+    /// value as a `String` operand is not an option either: under the
+    /// compiled-word rule a surviving bare `$` is data and only `${…}`
+    /// substitutes, while an expression's quoted operand substitutes `$var`
+    /// too.
+    CompiledWord {
+        /// The word's value.
+        text: String,
+        /// Whether the word was braced, so its value suppresses substitution
+        /// outright.
+        braced: bool,
+    },
+
     /// Variable reference (`$var`, `${var}`, `$arr(idx)`).
     Var {
         /// Full text including `$`.
@@ -489,6 +513,7 @@ impl ExprNode {
             Self::Command { .. }
             | Self::Literal { .. }
             | Self::String { .. }
+            | Self::CompiledWord { .. }
             | Self::Var { .. }
             | Self::Raw { .. } => {}
         }
@@ -520,7 +545,11 @@ impl ExprNode {
                     arg.collect_command_texts(out);
                 }
             }
-            Self::Var { .. } | Self::Literal { .. } | Self::String { .. } | Self::Raw { .. } => {}
+            Self::Var { .. }
+            | Self::Literal { .. }
+            | Self::String { .. }
+            | Self::CompiledWord { .. }
+            | Self::Raw { .. } => {}
         }
     }
 
@@ -549,6 +578,7 @@ impl ExprNode {
             Self::Command { .. }
             | Self::Literal { .. }
             | Self::String { .. }
+            | Self::CompiledWord { .. }
             | Self::Raw { .. } => {}
         }
     }
@@ -580,6 +610,7 @@ impl ExprNode {
             Self::Command { .. }
             | Self::Literal { .. }
             | Self::String { .. }
+            | Self::CompiledWord { .. }
             | Self::Var { .. }
             | Self::Raw { .. } => {}
         }
@@ -685,7 +716,14 @@ impl ExprNode {
             // but extracting them requires script-level analysis that
             // lives in the SSA module. At the pure-AST level we stop
             // at the command boundary.
-            Self::Command { .. } | Self::Literal { .. } | Self::String { .. } => {}
+            // `CompiledWord` is a leaf here for the same reason `String` is:
+            // the walk reads *expression* variable operands, and a compiled
+            // word's `${…}` is resolved by the word substitution rule rather
+            // than by this grammar.
+            Self::Command { .. }
+            | Self::Literal { .. }
+            | Self::String { .. }
+            | Self::CompiledWord { .. } => {}
             // Raw fallback text is unparsed Tcl (e.g. a `switch -- $col`
             // subject preserved verbatim). Re-lex it and collect
             // top-level `$var` references so liveness / unused-parameter
@@ -776,6 +814,18 @@ pub fn render_expr(node: &ExprNode) -> String {
         | ExprNode::Var { text, .. }
         | ExprNode::Command { text, .. }
         | ExprNode::Raw { text } => text.clone(),
+
+        // Rendered back as the *word*, so a diagnostic quoting the condition
+        // reads as what was written: a braced word gets its braces, which is
+        // also what stops `{a[nosuchcmd]} eq zz` reading as though the bracket
+        // would run.
+        ExprNode::CompiledWord { text, braced } => {
+            if *braced {
+                format!("{{{text}}}")
+            } else {
+                text.clone()
+            }
+        }
 
         ExprNode::Binary {
             op, left, right, ..

--- a/rust/tcl-syntax/src/expr/eval.rs
+++ b/rust/tcl-syntax/src/expr/eval.rs
@@ -135,6 +135,24 @@ pub fn eval<O: ExprOps>(node: &ExprNode, ops: &mut O) -> Result<O::Value, O::Err
     match node {
         ExprNode::Literal { text, .. } => ops.literal(text),
         ExprNode::String { text, .. } => ops.string(strip_delims(text)),
+        // The value as-is — there are no delimiters to strip, which is the
+        // whole reason this operand exists: `strip_delims` on a value that
+        // merely looks braced (`switch -- "{abc}"`) takes a layer that was
+        // never source.
+        //
+        // A braced word's value is literal, so it always evaluates. An
+        // unbraced one is a constant only while nothing is left for the word
+        // substitution to do; with a `${…}` or `[…]` still live the value is
+        // not known here and the evaluator must decline rather than fold the
+        // unsubstituted text. That is the same marker test the codegen side
+        // applies (`push_word_value`).
+        ExprNode::CompiledWord { text, braced } => {
+            if *braced || !(text.contains("${") || text.contains('[')) {
+                ops.string(text)
+            } else {
+                Err(ops.unsupported("compiled word with a live substitution"))
+            }
+        }
         // Pass the index-preserving reference (`arr(idx)`), not the base name,
         // so an evaluator can read array elements; the base `name` field stays
         // for analysis (`.vars_with_grammar(...)`).

--- a/rust/tcl-vm/tests/word_value_resolution_e2e.rs
+++ b/rust/tcl-vm/tests/word_value_resolution_e2e.rs
@@ -458,6 +458,68 @@ puts [string length $f]:$f
         want: "4:café",
         since: TclVersion::V8_4,
     },
+    // -- The operand contract: a word's value is not expression source. --
+    Vector {
+        // A `switch` subject is a *word*, and its value was handed to an
+        // operand shape whose text is source-including-delimiters. A value
+        // that merely looks braced was read back as one and stripped, so the
+        // five-character `{abc}` matched the arm `abc`. The second line is the
+        // case that cannot be rescued by re-bracketing: the value both looks
+        // braced *and* still owes a substitution, so it is resolved at compile
+        // time instead.
+        name: "a switch subject is a value, not expression source",
+        script: r#"switch -- "{abc}" abc {puts A:abc} {{abc}} {puts A:braced} default {puts A:def}
+set x 7
+switch -- "{$x}" {{7}} {puts B:match} default {puts B:def}
+"#,
+        want: "A:braced\nB:match",
+        since: TclVersion::V8_4,
+    },
+    Vector {
+        // The same rule for the *pattern*, and through the opaque modes, whose
+        // emitter fabricated its word kinds: it marked only a single braced arm
+        // list, so a braced subject ran its `[…]` and a braced pattern was
+        // decoded and then matched as a glob character class — `a\[bc\]d`
+        // matched `abd` and not the literal `a[bc]d`.
+        name: "an opaque switch pushes each word the way it was written",
+        script: r"switch -glob -- {a[bc]d} {a\[bc\]d} {puts C:match} default {puts C:def}
+switch -glob -- abd {a\[bc\]d} {puts D:class} default {puts D:def}
+switch -glob -- {a[nosuchcmd]} zz {puts E:hit} default {puts E:def}
+",
+        want: "C:match\nD:def\nE:def",
+        since: TclVersion::V8_4,
+    },
+    Vector {
+        // A quoted `expr` operand's decoded inner is finished text too, and was
+        // pushed substituting: `expr {"{abc}"}` answered `abc`.
+        name: "a quoted expr operand keeps a brace-shaped value",
+        script: r#"puts [expr {"{abc}"}]:[string length [expr {"{abc}"}]]:[string length [expr {"{}"}]]
+"#,
+        want: "{abc}:5:2",
+        since: TclVersion::V8_4,
+    },
+    Vector {
+        // A braced subject whose value *spells* a variable reference is still
+        // literal, and the whole-variable fast path must not claim it: it read
+        // `x` instead, which also errors when the name is unset. The pattern
+        // side is per *arm*, not per switch — the multi-word form is a word
+        // each, so a braced `{${…}}` pattern is literal while `$p`
+        // substitutes.
+        //
+        // The first two lines used to pass by accident: the subject wrongly
+        // loaded the variable *and* the pattern wrongly substituted, so the two
+        // wrongs compared equal. The third line separates them — a literal
+        // subject cannot match the variable's value.
+        name: "a braced subject that spells a variable is still literal",
+        script: r"switch -- {${undefinedvar}} {${undefinedvar}} {puts A:literal} default {puts A:def}
+set p {${undefinedvar}}
+switch -- {${undefinedvar}} $p {puts B:match} default {puts B:def}
+set x foo
+switch -- {${x}} foo {puts C:value} default {puts C:literal}
+",
+        want: "A:literal\nB:match\nC:literal",
+        since: TclVersion::V8_4,
+    },
 ];
 
 #[test]


### PR DESCRIPTION
The two `switch`-subject holes left open by #1900 were one bug: an operand
shape asked to carry two incompatible contracts. `ExprNode::String`'s text
is *source including delimiters* — that is its documented meaning — and
`switch_subject_operand` was handing it a **value**. Everything else
followed. A subject whose value merely looks braced was read back as one
and stripped, so `switch -- "{abc}"` matched the arm `abc` rather than the
five-character `{abc}`; and re-bracketing a genuinely braced subject to
escape that only made the two spellings collide on one text.

Re-encoding the value as source is not an alternative: under the
compiled-word rule a surviving bare `$` is data and only `${…}`
substitutes, while an expression's quoted operand substitutes `$var` too.
Nor is `ExprNode::Raw`, which lowers to `push` + `exprStk` — the bug that
operand choice already escaped once, recorded in its own doc.

So values get their own shape. `ExprNode::CompiledWord { text, braced }`
carries a word already reduced to its value and whether it was braced; the
expression parser never produces one. Codegen pushes it by the word-value
rule — verbatim when braced, and decomposed at compile time when the value
both looks braced *and* still owes a substitution (`switch -- "{$x}"`,
whose value `{${x}}` must compare as `{7}`), because deferring that to the
runtime gets it wrong in both directions at once.

The variant is the point rather than a detail: every consumer's exhaustive
match had to decide what a word value means to it. That surfaced three
further instances of the same confusion, none of which were in the
reported gaps:

* The switch **pattern** had it too — a decoded arm-list element sitting in
  a `Literal` slot, so `{7}` was compared as `7`. `patterns_braced` was
  already the right question. The jump-table detector accepts the new shape
  only when `braced`, since a substituting pattern has no key until run
  time.
* `expr {"{abc}"}` answered `abc`: the quoted operand's decoded inner is
  finished text and was pushed substituting.
* The **opaque** modes' emitter fabricated its word kinds, marking only a
  single braced arm list. Fixing the subject alone still left
  `switch -glob -- {a[bc]d} {a\[bc\]d} …` wrong, because the pattern was
  decoded to `a[bc]d` and then matched as a glob character class — it
  matched `abd` and not the literal both oracles match. It now uses the
  lexer's real kinds, carried as `Statement::Switch::raw_arg_braced`,
  because `raw_args` are values and a value cannot say how it was written.

`parse_switch_options` becomes `pub(crate)` so that emitter asks the owner
where a switch's options end instead of keeping a second copy of the rule.

Three vectors join `word_value_resolution_e2e`, every expectation measured
from a real tclsh, at all five releases plus the real-tclsh leg.


## Verification

Both reported gaps, plus the three instances found closing them:

| | oracles | before | now |
| --- | --- | --- | --- |
| `switch -- "{abc}"` | arm `{abc}` | arm `abc` | arm `{abc}` |
| `switch -- "{$x}"` (x=7) | arm `{7}` | default | arm `{7}` |
| `switch -glob -- {a[bc]d} {a\[bc\]d}` | match | ran `bc`, then matched as a class | match |
| `switch -glob -- abd {a\[bc\]d}` | default | matched as a class | default |
| `expr {"{abc}"}` | `{abc}` | `abc` | `{abc}` |

- `make prep-pr` green; `cargo test -p tcl-compiler -p tcl-vm -p tcl-syntax` — 138 suites, 0 failed.
- 14 regression scripts from the earlier passes all still match `tclsh8.6`.
- Three vectors added to `word_value_resolution_e2e`, measured from a real tclsh, run at all five releases plus the real-tclsh leg.

The new variant reached three crates beyond the compiler — `tcl-syntax`'s walkers, `tcl-registry`'s expr-surface check, and `bpf-tcl-ir`'s integer-subset lowering. Every one was a compiler error rather than a silent inheritance of source semantics, which is the argument for the variant over smuggling values through `String`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
