### PR TITLE
fix(compiler): handle the word-value operand in the effect-surface walk

### DIFF
--- a/rust/tcl-compiler/src/ir_helpers.rs
+++ b/rust/tcl-compiler/src/ir_helpers.rs
@@ -699,6 +699,17 @@ fn collect_expr_command_surface_refs<'a>(
                 collect_expr_command_surface_refs(arg, out, opaque, depth + 1);
             }
         }
+        // A word already reduced to its value. Braced, its brackets are data
+        // and provably never run, so it is inert — the one case this may skip
+        // without guessing. Unbraced, whatever substitution the word still owes
+        // *is* executed at run time, and omitting an executed substitution is
+        // the failure this inventory exists to avoid, so its text is collected
+        // like any other surface.
+        ExprNode::CompiledWord { text, braced } => {
+            if !*braced {
+                push_text(text, out);
+            }
+        }
         ExprNode::Literal { .. } | ExprNode::String { .. } | ExprNode::Var { .. } => {}
     }
 }


### PR DESCRIPTION
`rust` does not compile at a522cb01. #1903 added
`ExprNode::CompiledWord` and #1754 added an exhaustive match over
`ExprNode` in `collect_expr_command_surface_refs`; each passed CI against
a base without the other, and git merged them cleanly. A semantic
conflict, so no gate on either PR could have caught it — only the merged
tree fails.

The arm follows the inventory's stated rule. A braced word's brackets are
data and provably never run, so it is inert and skipped — the one case
this may skip without guessing. An unbraced word still owes whatever
substitution the runtime performs, and omitting an executed substitution
is precisely the failure this inventory exists to prevent, so its text is
collected like any other surface.

## Urgency

`rust` does not compile at `a522cb01`. `cargo build --workspace` fails with a non-exhaustive match in `ir_helpers.rs`; `make prep-pr` is green with this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)