### PR TITLE
fix(compiler): keep compiled word values opaque

### DIFF
--- a/rust/tcl-compiler/src/ir_helpers.rs
+++ b/rust/tcl-compiler/src/ir_helpers.rs
@@ -699,7 +699,10 @@ fn collect_expr_command_surface_refs<'a>(
                 collect_expr_command_surface_refs(arg, out, opaque, depth + 1);
             }
         }
-        ExprNode::Literal { .. } | ExprNode::String { .. } | ExprNode::Var { .. } => {}
+        ExprNode::Literal { .. }
+        | ExprNode::String { .. }
+        | ExprNode::CompiledWord { .. }
+        | ExprNode::Var { .. } => {}
     }
 }
 
@@ -1364,6 +1367,18 @@ mod tests {
         collect_expr_commands(&expr, &mut cmds);
         assert_eq!(cmds.len(), 1);
         assert_eq!(cmds[0], "[set x 1]");
+    }
+
+    #[test]
+    fn compiled_word_value_does_not_reparse_brackets_as_command_substitution() {
+        let registry = CommandRegistry::build_default();
+        let expr = ExprNode::CompiledWord {
+            text: "[set x 1]".into(),
+            braced: false,
+        };
+        let substitutions = expression_command_substitutions(&expr, &registry);
+        assert!(substitutions.commands.is_empty());
+        assert!(!substitutions.opaque);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- handle `ExprNode::CompiledWord` as a leaf when collecting command-surface references
- prevent already-reduced word values containing brackets from being reparsed as Tcl source
- add a focused regression for the bracket-shaped compiled value

This repairs the current `rust` compile regression introduced when `CompiledWord` was added in #1903.

## Proof

- focused regression: 1 passed
- `make rust-check`
- `make prep-pr` (30/30 smoke tests)