### PR TITLE
fix(compiler): an escaped marker is data, before and after decoding

### DIFF
--- a/rust/tcl-compiler/src/codegen/cmd_subst.rs
+++ b/rust/tcl-compiler/src/codegen/cmd_subst.rs
@@ -952,6 +952,33 @@ impl CodegenCtx<'_> {
         if interpolate && self.try_emit_whole_cmd_subst(value) {
             return;
         }
+        // A word whose markers are *escaped* is still source, not a value: the
+        // escapes have to be decoded before anything is pushed, and deferring
+        // it to the VM hands over backslashes that its compiled-word
+        // convention reads as ordinary characters. The template parser decodes
+        // each literal run, so `"\$\{x}"` becomes the four-character value
+        // `${x}` rather than its six-character spelling. The twin of the same
+        // arm in `emit_value_interpolated`.
+        if crate::codegen::statements::has_escaped_subst_marker(value)
+            && let Some(parts) = parse_subst_template(value, self.escapes, self.braced_var)
+        {
+            for part in &parts {
+                match part {
+                    SubstPart::Lit(text) => self.push_lit_exact(text),
+                    SubstPart::Cmd(cmd_text) => self.emit_inline_cmd_subst(cmd_text),
+                    SubstPart::Var(name) => self.load_var(name),
+                }
+            }
+            if parts.len() > 1 {
+                self.emit(
+                    Op::STR_CONCAT1,
+                    vec![Operand::Imm(bytecode_imm(parts.len()))],
+                );
+            } else if parts.is_empty() {
+                self.push_lit_exact("");
+            }
+            return;
+        }
         // Default: the word's own text is its value — unsubstituted unless a
         // `${…}` / `[…]` the runtime still owns survived the arms above. The
         // twin of `emit_value_interpolated`'s default, and missed when that one

--- a/rust/tcl-compiler/src/codegen/statements.rs
+++ b/rust/tcl-compiler/src/codegen/statements.rs
@@ -55,6 +55,33 @@ pub(crate) fn has_unescaped_subst(s: &str) -> bool {
     false
 }
 
+/// Whether `s` contains a **backslash-escaped** substitution marker (`\$` or
+/// `\[`).
+///
+/// The sibling of [`has_unescaped_subst`], and the question that decides
+/// whether a word may be deferred to the VM's `subst_word`. It may not: the
+/// VM reads a compiled literal under the convention that codegen already
+/// decoded the word's escapes, so a surviving backslash is an ordinary
+/// character and the `$` after it starts a live `${…}`. Handing over an
+/// *undecoded* word therefore breaks that contract — `puts A:[string length
+/// "\$\{x}"]` read the variable `x`, and with no closing brace it raised
+/// `missing close-brace for variable name`, on scripts both oracles run.
+pub(crate) fn has_escaped_subst_marker(s: &str) -> bool {
+    let b = s.as_bytes();
+    let mut i = 0;
+    while i + 1 < b.len() {
+        if b[i] == b'\\' {
+            if matches!(b[i + 1], b'$' | b'[') {
+                return true;
+            }
+            i += 2;
+        } else {
+            i += 1;
+        }
+    }
+    false
+}
+
 /// Tag appended to no-dedup literal comments.
 pub(crate) const NO_DEDUP_TAG: &str = " #nodedup";
 
@@ -355,7 +382,14 @@ impl CodegenCtx<'_> {
         value: &str,
         value_needs_backsubst: bool,
     ) {
-        let value = if value_needs_backsubst && !value.contains('[') && !value.contains("${") {
+        // Whether this word's escapes were decoded *here*. A decoded value is
+        // finished: every marker left in it came from an escape and is data, so
+        // it must not be read as source again. `set v "\$\{x}"` decodes to the
+        // four characters `${x}`, and re-reading that as a variable reference —
+        // which is what the value emitter's `${…}` fast path does — loaded `x`
+        // and stored one character instead.
+        let decoded_here = value_needs_backsubst && !value.contains('[') && !value.contains("${");
+        let value = if decoded_here {
             tcl_lexer::backslash_subst_in(value, self.escapes).into_owned()
         } else {
             // A value carrying a `[` or `${` (an escaped `\[` / `\${` or
@@ -380,7 +414,10 @@ impl CodegenCtx<'_> {
         // command surface declines the fold, dispatch the same whole-word
         // substitution through that surface's inline hook rather than a
         // command-name allow/deny list in this consumer.
-        if self.try_emit_constant_fold(&value) {
+        if decoded_here {
+            // Finished above: byte-exact, with no further reading of the text.
+            self.push_lit_exact(&value);
+        } else if self.try_emit_constant_fold(&value) {
             // The shared fold emitted the value.
         } else if inline {
             self.emit_inline_cmd_subst(&value);
@@ -676,6 +713,35 @@ impl CodegenCtx<'_> {
         // stack) rather than via the runtime `subst_word` fallback, so a
         // `[yield]`/`[cmd]` inside it stays yieldable in a coroutine.
         if self.try_emit_whole_cmd_subst(value) {
+            return;
+        }
+        // A word carrying an *escaped* marker cannot be deferred at all, even
+        // when it also carries a live one. The VM reads a compiled literal's
+        // backslashes as ordinary characters, so an undecoded `\$\{x}` handed
+        // over raw is read back as a live `${x}`. Resolve the word here
+        // instead: the template parser decodes each literal run and separates
+        // the substitutions that really are live, so the escaped marker ends up
+        // as data and the `[…]` beside it still runs.
+        if has_escaped_subst_marker(value)
+            && let Some(parts) = parse_subst_template(value, self.escapes, self.braced_var)
+        {
+            for part in &parts {
+                match part {
+                    SubstPart::Lit(text) => self.push_lit_exact(text),
+                    SubstPart::Cmd(cmd_text) => self.emit_inline_cmd_subst(cmd_text),
+                    SubstPart::Var(name) => self.load_var(name),
+                }
+            }
+            if parts.len() > 1 {
+                self.emit(
+                    Op::STR_CONCAT1,
+                    vec![Operand::Imm(
+                        i32::try_from(parts.len()).expect("part count fits in i32"),
+                    )],
+                );
+            } else if parts.is_empty() {
+                self.push_lit_exact("");
+            }
             return;
         }
         // Default: the word's own text is its value — push it unsubstituted

--- a/rust/tcl-vm/tests/word_value_resolution_e2e.rs
+++ b/rust/tcl-vm/tests/word_value_resolution_e2e.rs
@@ -488,6 +488,31 @@ switch -- {${x}} foo {puts C:value} default {puts C:literal}
         want: "A:literal\nB:match\nC:literal",
         since: TclVersion::V8_4,
     },
+    Vector {
+        // The escaped-marker family #1646 named. Its own repro (the last line)
+        // was fixed by #1754; these are the rest of it.
+        //
+        // An escaped marker is *data*, and stays data after the escape is
+        // decoded — so a decoded word is finished and must not be read as
+        // source again. The assignment path decoded `"\$\{x}"` to the four
+        // characters `${x}` and then took them for a variable reference,
+        // storing one. A composite word went the other way: deferred to the VM
+        // with its escapes *undecoded*, which breaks the compiled-word
+        // convention the VM documents — a surviving backslash is an ordinary
+        // character there, so `\$\{x}` read back as a live `${x}`, and without
+        // a closing brace it raised `missing close-brace for variable name` on
+        // a script both oracles run.
+        name: "an escaped marker is data, before and after decoding",
+        script: r#"set x V
+set v "\$\{x}"
+puts [string length $v]:$v
+puts A:[string length "\$\{x}"]
+puts B:[string length "\$\{x"]
+puts C:[string length "x\$y"]
+"#,
+        want: "4:${x}\nA:4\nB:3\nC:3",
+        since: TclVersion::V8_4,
+    },
 ];
 
 #[test]


### PR DESCRIPTION
#1646's own repro was fixed by #1754 and the issue closed; this is the
rest of that family. The escaped-marker case was wrong in *both*
directions at once, which is why it survived:

    set v "\$\{x}"                   ;# oracles 4:${x}, we stored 1:V
    puts A:[string length "\$\{x}"]  ;# oracles A:4, we read `x`
    puts B:[string length "\$\{x"]   ;# oracles B:3, we raised
                                     ;# "missing close-brace for variable name"

The assignment path decoded the word and then read the *result* as
source: `"\$\{x}"` decodes to the four characters `${x}`, and the value
emitter's `${…}` fast path took that for a variable reference. A decoded
word is finished, so it is now pushed byte-exact with no further reading.

The composite-word path went the other way, deferring the word to the VM
with its escapes still **undecoded**. That breaks a convention the VM
states in `subst_word`'s own comment — "the codegen has already decoded
this word's source escapes once" — so a surviving backslash is an ordinary
character there and `\$\{x}` reads back as a live `${x}`. Deferral is only
sound for a word whose remaining markers really are the runtime's;
`has_escaped_subst_marker` is the test, and a word that fails it is
decomposed here instead, where the template parser decodes each literal
run and separates the substitutions that genuinely are live. Both value
emitters carried the same gap, so both take the same arm.

The bare bracket word was always correct — only the composite form
deferred — which is the shape of evidence that located it: the same word
compiles right at the top level and wrong one nesting in.

Vectors added to `word_value_resolution_e2e`, measured from a real tclsh
and holding at all five releases. 41 regression scripts from this
work stream still match `tclsh8.6`, with one expected divergence:
`[format %s "🙂x"]` is 3 on 8.6 and 2 on 9.0 — the astral-plane rule —
and the VM tracks its own release.


## Verification

| | oracles | before | now |
| --- | --- | --- | --- |
| `set v "\$\{x}"` | `4:${x}` | `1:V` | ✓ |
| `puts A:[string length "\$\{x}"]` | `A:4` | `can't read "x"` | ✓ |
| `puts B:[string length "\$\{x"]` | `B:3` | `missing close-brace for variable name` | ✓ |
| `set n [string length "x\$y"]` (#1646's repro) | 3 | 3 (fixed by #1754) | ✓ |

- `make prep-pr` green; `cargo test -p tcl-compiler -p tcl-vm -p tcl-syntax` — 139 suites, 0 failed.
- 41 regression scripts accumulated across this work stream still match `tclsh8.6`; the single difference is `[format %s "🙂x"]`, which is 3 on 8.6 and 2 on 9.0 (the astral-plane rule) and where the VM correctly tracks its own release.
- The new vectors hold at 8.4, 8.5, 8.6, 9.0 and 9.1, and against the real `tclsh8.4`/`8.5`/`8.6`/`9.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
