### PR TITLE
fix(compiler): account for switch word substitution effects

### DIFF
--- a/rust/tcl-compiler/src/cfg_builder/cfg_lower.rs
+++ b/rust/tcl-compiler/src/cfg_builder/cfg_lower.rs
@@ -807,6 +807,15 @@ impl CfgBuilder<'_> {
             unreachable!("lower_switch called with non-Switch");
         };
 
+        // All unbraced subject and pattern words substitute before `switch`
+        // dispatches. Preserve those writes and opaque effects even when the
+        // switch itself is flattened into branch terminators.
+        self.push_embedded_control_effects(
+            stmt,
+            block_name,
+            "switch word invokes an opaque embedded command",
+        );
+
         // Glob/regexp switches, and exact switches with any fall-through arm,
         // are kept *opaque* — a single `Statement::Switch` in the current block,
         // no expanded arm blocks. Their shared-body / OR-matching topology can't

--- a/rust/tcl-compiler/src/cfg_builder/mod.rs
+++ b/rust/tcl-compiler/src/cfg_builder/mod.rs
@@ -1353,22 +1353,42 @@ impl<'a> CfgBuilder<'a> {
         };
 
         // Every substitution in the returned value runs before the frame
-        // unwinds. Feed the same shared effect inventory used by ordinary
-        // statements through caller-frame, alias-observation, global-write,
-        // and builtin-write handling before installing the terminator.
-        self.record_caller_frame_barrier(stmt);
-        self.record_alias_observed(stmt);
+        // unwinds. Materialise its analysis effects before installing the
+        // terminator.
+        self.push_embedded_control_effects(
+            stmt,
+            current,
+            "return value invokes an opaque embedded command",
+        );
         if let Some(binding) = command_binding {
             self.command_binding_sites.push(CommandBindingSite {
                 span: *span,
                 binding: binding.clone(),
             });
         }
+        self.block_mut(current).terminator = Some(Terminator::Return {
+            value: value.clone(),
+            span: Some(*span),
+            expr: expr.clone(),
+            braced: *braced,
+        });
+    }
+
+    /// Materialise the variable effects of substitutions executed by a
+    /// control statement before its terminator or dispatch is installed.
+    fn push_embedded_control_effects(
+        &mut self,
+        stmt: &Statement,
+        current: &str,
+        opaque_reason: &str,
+    ) {
+        self.record_caller_frame_barrier(stmt);
+        self.record_alias_observed(stmt);
         let (extras, opaque) = self.embedded_subst_extras(stmt);
         if opaque {
             self.block_mut(current).statements.push(Statement::Barrier {
-                span: *span,
-                reason: "return value invokes an opaque embedded command".to_owned(),
+                span: stmt.span(),
+                reason: opaque_reason.to_owned(),
                 command: "<global-frame-script>".to_owned(),
                 canonical_command: None,
                 args: Vec::new(),
@@ -1379,7 +1399,7 @@ impl<'a> CfgBuilder<'a> {
         }
         if !extras.is_empty() {
             self.block_mut(current).statements.push(Statement::Call {
-                span: *span,
+                span: stmt.span(),
                 command: "<upvar-invalidate>".to_string(),
                 canonical_command: None,
                 args: Vec::new(),
@@ -1393,12 +1413,6 @@ impl<'a> CfgBuilder<'a> {
                 foreach_groups: None,
             });
         }
-        self.block_mut(current).terminator = Some(Terminator::Return {
-            value: value.clone(),
-            span: Some(*span),
-            expr: expr.clone(),
-            braced: *braced,
-        });
     }
 
     fn lower_script_statement(&mut self, stmt: &Statement, current: &str) -> Option<String> {
@@ -4306,6 +4320,52 @@ mod tests {
                 .values()
                 .any(|block| { matches!(block.terminator, Some(Terminator::Return { .. })) })
         );
+    }
+
+    #[test]
+    fn switch_word_substitutions_invalidate_before_dispatch() {
+        let module = lower_module(
+            "proc setter {name} { upvar 1 $name value; set value 1; return 0 }\n\
+             proc outer {} {\n\
+                 set subject 1\n\
+                 set pattern 1\n\
+                 switch [setter subject] [setter pattern] { return ok } default { return no }\n\
+             }",
+        );
+        let cfg = build_cfg(&module, false);
+        let outer = cfg.procedures.get("::outer").expect("::outer CFG");
+        for name in ["subject", "pattern"] {
+            assert_eq!(
+                find_call_with_def(outer, name),
+                Some("<upvar-invalidate>"),
+                "the unbraced switch {name} substitution must invalidate before dispatch"
+            );
+        }
+        assert!(outer.blocks.values().any(|block| {
+            block.statements.iter().any(|stmt| {
+                matches!(
+                    stmt,
+                    Statement::Call { command, defs, .. }
+                        if command == "<upvar-invalidate>"
+                            && defs.iter().any(|name| name == "subject")
+                            && defs.iter().any(|name| name == "pattern")
+                )
+            }) && matches!(block.terminator, Some(Terminator::Branch { .. }))
+        }));
+    }
+
+    #[test]
+    fn braced_switch_words_do_not_invalidate_before_dispatch() {
+        let module = lower_module(
+            "proc setter {name} { upvar 1 $name value; set value 1; return 0 }\n\
+             proc outer {} {\n\
+                 switch {[setter subject]} {[setter pattern]} { return ok }\n\
+             }",
+        );
+        let cfg = build_cfg(&module, false);
+        let outer = cfg.procedures.get("::outer").expect("::outer CFG");
+        assert_eq!(find_call_with_def(outer, "subject"), None);
+        assert_eq!(find_call_with_def(outer, "pattern"), None);
     }
 
     #[test]

--- a/rust/tcl-compiler/src/ir_helpers.rs
+++ b/rust/tcl-compiler/src/ir_helpers.rs
@@ -795,15 +795,15 @@ pub(crate) fn evaluated_command_substitution_surfaces(
         }
         Statement::Switch {
             subject,
+            subject_braced,
             arms,
-            patterns_braced,
             ..
         } => {
-            push_text(subject, &mut texts);
-            if !patterns_braced {
-                for arm in arms {
-                    push_text(&arm.pattern, &mut texts);
-                }
+            if !subject_braced {
+                push_text(subject, &mut texts);
+            }
+            for arm in arms.iter().filter(|arm| !arm.pattern_braced) {
+                push_text(&arm.pattern, &mut texts);
             }
         }
         Statement::AssignConst { .. } | Statement::Block { .. } | Statement::UpFrame { .. } => {}
@@ -1375,6 +1375,24 @@ mod tests {
         collect_expr_commands(&expr, &mut cmds);
         assert_eq!(cmds.len(), 1);
         assert_eq!(cmds[0], "[set x 1]");
+    }
+
+    #[test]
+    fn compiled_word_surfaces_only_execute_when_unbraced() {
+        let registry = CommandRegistry::build_default();
+        let commands = |braced| {
+            expression_command_substitutions(
+                &ExprNode::CompiledWord {
+                    text: "prefix[set x 1]".into(),
+                    braced,
+                },
+                &registry,
+            )
+            .commands
+        };
+
+        assert_eq!(commands(false)[0][0].text, "set");
+        assert!(commands(true).is_empty());
     }
 
     #[test]

--- a/rust/tcl-lsp-core/src/workspace_index.rs
+++ b/rust/tcl-lsp-core/src/workspace_index.rs
@@ -2772,6 +2772,15 @@ impl WorkspaceIndex {
     /// latter creates a transient missing-definition state and loses the fact
     /// that a body-only edit left command-resolution inputs untouched.
     pub fn replace_document(&mut self, uri: &str, analysis: &AnalysisResult) {
+        self.replace_document_with_revision(uri, analysis);
+    }
+
+    /// Replace one document and return the revision assigned to its records.
+    ///
+    /// A publisher that releases the index before its final source-currency
+    /// check can use this token to roll back only its own obsolete replacement,
+    /// without deleting a newer writer's records for the same URI.
+    pub fn replace_document_with_revision(&mut self, uri: &str, analysis: &AnalysisResult) -> u64 {
         let revision = self.allocate_document_revision();
         let slot = self.slot_for(uri);
         let old = self.docs[slot].settlement_dependencies();
@@ -2780,6 +2789,7 @@ impl WorkspaceIndex {
         self.docs[slot].revision = revision;
         let changed = old != self.docs[slot].settlement_dependencies();
         self.invalidate(changed, slot);
+        revision
     }
 
     /// `uri`'s slot, allocating one — the most recently freed, else a fresh
@@ -2845,6 +2855,18 @@ impl WorkspaceIndex {
             self.free_slots.push(slot);
             self.invalidate(true, slot);
         }
+    }
+
+    /// Remove `uri` only when its records still have `revision`.
+    ///
+    /// This is the compare-and-remove counterpart to
+    /// [`Self::replace_document_with_revision`].
+    pub fn remove_document_if_revision(&mut self, uri: &str, revision: u64) -> bool {
+        if self.document_revision(uri) != Some(revision) {
+            return false;
+        }
+        self.remove_document(uri);
+        true
     }
 
     /// Every indexed `source FILE` reference.
@@ -10163,6 +10185,25 @@ mod tests {
         );
         index.remove_document("file:///a.tcl");
         assert_eq!(index.document_revision("file:///a.tcl"), None);
+    }
+
+    #[test]
+    fn conditional_revision_removal_preserves_a_newer_replacement() {
+        let old = analyse("proc old {} {}\n");
+        let new = analyse("proc new {} {}\n");
+        let mut index = WorkspaceIndex::new();
+        let old_revision = index.replace_document_with_revision("file:///a.tcl", &old);
+        let new_revision = index.replace_document_with_revision("file:///a.tcl", &new);
+
+        assert!(
+            !index.remove_document_if_revision("file:///a.tcl", old_revision),
+            "an obsolete publisher must not remove a newer replacement",
+        );
+        assert_eq!(index.document_revision("file:///a.tcl"), Some(new_revision));
+        assert!(index.workspace_command_exists("::new"));
+        assert!(!index.workspace_command_exists("::old"));
+        assert!(index.remove_document_if_revision("file:///a.tcl", new_revision));
+        assert!(!index.contains_document("file:///a.tcl"));
     }
 
     #[test]

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -9077,7 +9077,7 @@ impl Backend {
             if self.live_publication_uri_generation(uri) != uri_generation {
                 return false;
             }
-            index.replace_document(uri.as_str(), &seed.analysis);
+            let index_revision = index.replace_document_with_revision(uri.as_str(), &seed.analysis);
             drop(index);
             // This is a standalone replacement. Invalidate any source-site
             // view marker in the same rehoming transaction so the next
@@ -9089,6 +9089,11 @@ impl Backend {
                 .is_some_and(|doc| doc.matches_open_publication(text, dialect, version))
                 || self.live_publication_uri_generation(uri) != uri_generation
             {
+                drop(documents);
+                self.workspace_index
+                    .write()
+                    .await
+                    .remove_document_if_revision(uri.as_str(), index_revision);
                 return false;
             }
             documents.retag("did_open_publish_complete: commit");
@@ -9142,7 +9147,7 @@ impl Backend {
             if self.live_publication_uri_generation(uri) != uri_generation {
                 return false;
             }
-            index.replace_document(uri.as_str(), &seed.analysis);
+            let index_revision = index.replace_document_with_revision(uri.as_str(), &seed.analysis);
             drop(index);
             self.rehomed_source_seeds.lock().await.remove(uri.as_str());
             let mut documents = self.documents.lock("did_change_publish_complete").await;
@@ -9151,6 +9156,11 @@ impl Backend {
                 .is_some_and(|doc| doc.matches_live_publication(text, dialect, revision))
                 || self.live_publication_uri_generation(uri) != uri_generation
             {
+                drop(documents);
+                self.workspace_index
+                    .write()
+                    .await
+                    .remove_document_if_revision(uri.as_str(), index_revision);
                 return false;
             }
             documents.retag("did_change_publish_complete: commit");
@@ -44050,6 +44060,87 @@ proc p {} {
                 .expect("the publisher task must not panic"),
             "the still-current open seed must publish",
         );
+    }
+
+    /// #1907 automated review: if a newer document revision lands after an
+    /// index replacement but before the final currency check, the obsolete
+    /// publisher must remove its own records instead of leaving stale spans
+    /// visible under the newer buffer.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn superseded_open_index_replacement_is_rolled_back_1907() {
+        let backend = Arc::new(test_backend());
+        let uri = Uri::from_str("file:///superseded-open-index-1907.tcl").unwrap();
+        let text = "proc obsolete {} {}\n";
+        backend.documents.lock("test").await.insert(
+            uri.clone(),
+            DocumentState::with_version(text.to_owned(), "tcl8.6".to_owned(), 1),
+        );
+        backend
+            .documents
+            .lock("test")
+            .await
+            .get_mut(&uri)
+            .expect("the open document exists")
+            .publication = DocumentPublication::Salsa;
+        let seed = FreshAnalysisSeed {
+            analysis: Arc::new(Analyser::new().analyse(text, "tcl8.6").clone()),
+            analyser_inputs_epoch: backend.diag_inputs_epoch(),
+            class_factory_generation: 0,
+        };
+
+        let index_reader = backend.workspace_index.read().await;
+        let publishing = crate::rt::spawn({
+            let backend = Arc::clone(&backend);
+            let uri = uri.clone();
+            async move {
+                backend
+                    .publish_open_index_if_current(&uri, text, "tcl8.6", 1, seed)
+                    .await
+            }
+        });
+        crate::rt::timeout(std::time::Duration::from_secs(5), async {
+            while backend.workspace_index.try_read().is_ok() {
+                crate::rt::yield_now().await;
+            }
+        })
+        .await
+        .expect("the old publisher must queue behind the index reader");
+
+        let mut documents = backend.documents.lock("test_newer_revision").await;
+        let mut newer =
+            DocumentState::with_version("proc current {} {}\n".to_owned(), "tcl8.6".to_owned(), 2);
+        newer.publication = DocumentPublication::Salsa;
+        documents.insert(uri.clone(), newer);
+        drop(index_reader);
+        crate::rt::timeout(std::time::Duration::from_secs(5), async {
+            loop {
+                if backend
+                    .workspace_index
+                    .try_read()
+                    .is_ok_and(|index| index.workspace_command_exists("::obsolete"))
+                {
+                    break;
+                }
+                crate::rt::yield_now().await;
+            }
+        })
+        .await
+        .expect("the obsolete replacement must reach the index before its final check");
+        drop(documents);
+
+        assert!(
+            !crate::rt::timeout(std::time::Duration::from_secs(5), publishing)
+                .await
+                .expect("the obsolete publisher must finish")
+                .expect("the obsolete publisher must not panic"),
+            "the newer document revision must supersede the old publisher",
+        );
+        let index = backend.workspace_index.read().await;
+        assert!(
+            !index.contains_document(uri.as_str()),
+            "the obsolete publisher must roll back its own index revision",
+        );
+        assert!(!index.workspace_command_exists("::obsolete"));
     }
 
     async fn mark_open_buffer_deleted_while_publication_waits_1854(

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -448,24 +448,6 @@ struct FreshAnalysisSeed {
     class_factory_generation: u64,
 }
 
-/// The no-await write set that publishes one live document's index seed.
-struct LiveIndexCommitLocks<'a> {
-    documents: DocumentsGuard<'a>,
-    index: tokio::sync::RwLockWriteGuard<'a, core_workspace_index::WorkspaceIndex>,
-    seeds: tokio::sync::MutexGuard<'a, HashMap<String, Vec<String>>>,
-}
-
-/// A fair dependency turn retained into the next live-index bundle attempt.
-///
-/// Tokio hands a released writer to the readers queued behind it before a
-/// later `try_write` can barge in. Keeping the acquired turn here is what
-/// turns fair admission into an actual atomic commit opportunity.
-enum LiveIndexFairTurn<'a> {
-    Documents(DocumentsGuard<'a>),
-    WorkspaceIndex(tokio::sync::RwLockWriteGuard<'a, core_workspace_index::WorkspaceIndex>),
-    RehomedSourceSeeds(tokio::sync::MutexGuard<'a, HashMap<String, Vec<String>>>),
-}
-
 /// A snapshot of what the editor holds for every open document, by path.
 ///
 /// Built by [`Backend::open_document_texts`] and handed to the iRulesLX
@@ -971,12 +953,6 @@ impl<T> TrackedMutex<T> {
 /// on guard drop.
 struct DocumentStore {
     docs: Mutex<HashMap<Uri, DocumentState>>,
-    /// Ordinary acquisitions take a shared admission only until they own
-    /// `docs`. A live-index commit takes the exclusive admission after two
-    /// different dependencies defeat its fair turns, giving that rare slow
-    /// path one quiet document-map hand-off. The ordinary optimistic path
-    /// holds only a shared admission until it acquires the map.
-    admission: tokio::sync::RwLock<()>,
     /// Who holds the map, who held it last, and how many times it has been
     /// taken — under **one** lock, deliberately.
     ///
@@ -1147,7 +1123,6 @@ impl Default for DocumentStore {
     fn default() -> Self {
         Self {
             docs: Mutex::new(HashMap::new()),
-            admission: tokio::sync::RwLock::new(()),
             tracking: std::sync::Mutex::new(DocumentsTracking::default()),
         }
     }
@@ -1160,14 +1135,6 @@ impl DocumentStore {
     /// `site` is a `&'static str` naming the caller — it ends up in a stall
     /// line a human reads, so name the function, not the file and line.
     async fn lock(&self, site: &'static str) -> DocumentsGuard<'_> {
-        let admission = self.admission.read().await;
-        let docs = self.lock_without_admission(site).await;
-        drop(admission);
-        docs
-    }
-
-    /// Take the map while the caller owns the exclusive admission.
-    async fn lock_without_admission(&self, site: &'static str) -> DocumentsGuard<'_> {
         // Uncontended fast path: no waiter, so nothing to instrument, and the
         // poll/wake shim's per-poll waker allocation is never paid. tokio's
         // mutex is fair, so `try_lock` cannot barge past a queued waiter — a
@@ -1186,14 +1153,10 @@ impl DocumentStore {
     /// what prevents that low-priority work from inverting the foreground
     /// `documents -> db -> workspace_index` order used by document sync.
     fn try_lock(&self, site: &'static str) -> Option<DocumentsGuard<'_>> {
-        let admission = self.admission.try_read().ok()?;
-        let documents = self
-            .docs
+        self.docs
             .try_lock()
             .ok()
-            .map(|docs| self.record_acquisition(docs, site));
-        drop(admission);
-        documents
+            .map(|docs| self.record_acquisition(docs, site))
     }
 
     /// Attach holder telemetry to an already-acquired map guard.
@@ -9053,165 +9016,6 @@ impl Backend {
         );
     }
 
-    fn try_live_index_commit_locks<'a>(
-        &'a self,
-        site: &'static str,
-        fair_turn: Option<LiveIndexFairTurn<'a>>,
-    ) -> Result<LiveIndexCommitLocks<'a>, LivePublicationWait> {
-        match fair_turn {
-            None => {
-                let documents = self
-                    .documents
-                    .try_lock(site)
-                    .ok_or(LivePublicationWait::Documents)?;
-                let index = self
-                    .workspace_index
-                    .try_write()
-                    .map_err(|_| LivePublicationWait::WorkspaceIndex)?;
-                let seeds = self
-                    .rehomed_source_seeds
-                    .try_lock()
-                    .map_err(|_| LivePublicationWait::RehomedSourceSeeds)?;
-                Ok(LiveIndexCommitLocks {
-                    documents,
-                    index,
-                    seeds,
-                })
-            }
-            Some(LiveIndexFairTurn::Documents(documents)) => {
-                let index = self
-                    .workspace_index
-                    .try_write()
-                    .map_err(|_| LivePublicationWait::WorkspaceIndex)?;
-                let seeds = self
-                    .rehomed_source_seeds
-                    .try_lock()
-                    .map_err(|_| LivePublicationWait::RehomedSourceSeeds)?;
-                Ok(LiveIndexCommitLocks {
-                    documents,
-                    index,
-                    seeds,
-                })
-            }
-            Some(LiveIndexFairTurn::WorkspaceIndex(index)) => {
-                let documents = self
-                    .documents
-                    .try_lock(site)
-                    .ok_or(LivePublicationWait::Documents)?;
-                let seeds = self
-                    .rehomed_source_seeds
-                    .try_lock()
-                    .map_err(|_| LivePublicationWait::RehomedSourceSeeds)?;
-                Ok(LiveIndexCommitLocks {
-                    documents,
-                    index,
-                    seeds,
-                })
-            }
-            Some(LiveIndexFairTurn::RehomedSourceSeeds(seeds)) => {
-                let documents = self
-                    .documents
-                    .try_lock(site)
-                    .ok_or(LivePublicationWait::Documents)?;
-                let index = self
-                    .workspace_index
-                    .try_write()
-                    .map_err(|_| LivePublicationWait::WorkspaceIndex)?;
-                Ok(LiveIndexCommitLocks {
-                    documents,
-                    index,
-                    seeds,
-                })
-            }
-        }
-    }
-
-    /// Acquire the live-index commit bundle without ever awaiting while a
-    /// partial bundle is held. The dependency awaited fairly is retained into
-    /// the next optimistic attempt, so sustained readers cannot take its turn
-    /// back before the no-await commit begins.
-    async fn live_index_commit_locks(&self, site: &'static str) -> LiveIndexCommitLocks<'_> {
-        let mut fair_turn = None;
-        loop {
-            let retained_turn = fair_turn.take();
-            let had_retained_turn = retained_turn.is_some();
-            match self.try_live_index_commit_locks(site, retained_turn) {
-                Ok(locks) => return locks,
-                Err(LivePublicationWait::Documents) => {
-                    if had_retained_turn {
-                        break;
-                    }
-                    fair_turn = Some(LiveIndexFairTurn::Documents(
-                        self.documents.lock(site).await,
-                    ));
-                }
-                Err(LivePublicationWait::WorkspaceIndex) => {
-                    if had_retained_turn {
-                        break;
-                    }
-                    fair_turn = Some(LiveIndexFairTurn::WorkspaceIndex(
-                        self.workspace_index.write().await,
-                    ));
-                }
-                Err(LivePublicationWait::RehomedSourceSeeds) => {
-                    if had_retained_turn {
-                        break;
-                    }
-                    fair_turn = Some(LiveIndexFairTurn::RehomedSourceSeeds(
-                        self.rehomed_source_seeds.lock().await,
-                    ));
-                }
-                Err(wait) => unreachable!(
-                    "live index publication cannot wait for {}",
-                    wait.dependency()
-                ),
-            }
-        }
-
-        self.live_index_commit_locks_after_alternating_contention(site)
-            .await
-    }
-
-    /// Close an alternating-contention cycle without holding `documents`
-    /// while an index reader drains.
-    ///
-    /// The exclusive admission starts only after two different fair turns
-    /// failed to form the bundle. It lets every already-admitted document-map
-    /// user finish, then stops a fresh one from taking the map between our
-    /// queued index writer and the final no-await commit. The index writer is
-    /// polled while the map is held, as in `did_open`, so a document holder
-    /// that follows the canonical `documents -> workspace_index` order is
-    /// already ahead of us rather than deadlocking behind us.
-    async fn live_index_commit_locks_after_alternating_contention(
-        &self,
-        site: &'static str,
-    ) -> LiveIndexCommitLocks<'_> {
-        let admission = self.documents.admission.write().await;
-        let documents = self.documents.lock_without_admission(site).await;
-        let mut index_write = std::pin::pin!(self.workspace_index.write());
-        let mut index = None;
-        std::future::poll_fn(|cx| {
-            if let Poll::Ready(guard) = index_write.as_mut().poll(cx) {
-                index = Some(guard);
-            }
-            Poll::Ready(())
-        })
-        .await;
-        drop(documents);
-        let index = match index {
-            Some(index) => index,
-            None => index_write.await,
-        };
-        let documents = self.documents.lock_without_admission(site).await;
-        let seeds = self.rehomed_source_seeds.lock().await;
-        drop(admission);
-        LiveIndexCommitLocks {
-            documents,
-            index,
-            seeds,
-        }
-    }
-
     /// Mark the matching `didOpen` revision safe for Salsa-backed providers.
     async fn mark_open_salsa_published_if_current(
         &self,
@@ -9243,6 +9047,7 @@ impl Backend {
         version: i32,
         mut seed: FreshAnalysisSeed,
     ) -> bool {
+        let uri_generation = self.live_publication_uri_generation(uri);
         loop {
             let analyser_inputs_guard = self.analyser_inputs_gate.read().await;
             let rehoming_guard = self.rehoming_gate.lock().await;
@@ -9258,31 +9063,39 @@ impl Backend {
                     .await;
                 continue;
             }
-            let LiveIndexCommitLocks {
-                mut documents,
-                mut index,
-                mut seeds,
-            } = self
-                .live_index_commit_locks("did_open_publish_complete")
-                .await;
-            let current = documents
-                .get(uri)
-                .is_some_and(|doc| doc.matches_open_publication(text, dialect, version));
-            if !current {
+            {
+                let documents = self.documents.lock("did_open_index_currency").await;
+                if !documents
+                    .get(uri)
+                    .is_some_and(|doc| doc.matches_open_publication(text, dialect, version))
+                    || self.live_publication_uri_generation(uri) != uri_generation
+                {
+                    return false;
+                }
+            }
+            let mut index = self.workspace_index.write().await;
+            if self.live_publication_uri_generation(uri) != uri_generation {
                 return false;
             }
-            documents.retag("did_open_publish_complete: commit");
             index.replace_document(uri.as_str(), &seed.analysis);
+            drop(index);
             // This is a standalone replacement. Invalidate any source-site
             // view marker in the same rehoming transaction so the next
             // workspace query reapplies its qualified views.
-            seeds.remove(uri.as_str());
+            self.rehomed_source_seeds.lock().await.remove(uri.as_str());
+            let mut documents = self.documents.lock("did_open_publish_complete").await;
+            if !documents
+                .get(uri)
+                .is_some_and(|doc| doc.matches_open_publication(text, dialect, version))
+                || self.live_publication_uri_generation(uri) != uri_generation
+            {
+                return false;
+            }
+            documents.retag("did_open_publish_complete: commit");
             documents
                 .get_mut(uri)
                 .expect("the document cannot disappear while its map is locked")
                 .publication = DocumentPublication::Indexed;
-            drop(seeds);
-            drop(index);
             drop(documents);
             self.live_publication_advanced.notify_waiters();
             return true;
@@ -9299,6 +9112,7 @@ impl Backend {
         revision: u64,
         mut seed: FreshAnalysisSeed,
     ) -> bool {
+        let uri_generation = self.live_publication_uri_generation(uri);
         loop {
             let analyser_inputs_guard = self.analyser_inputs_gate.read().await;
             let rehoming_guard = self.rehoming_gate.lock().await;
@@ -9314,28 +9128,36 @@ impl Backend {
                     .await;
                 continue;
             }
-            let LiveIndexCommitLocks {
-                mut documents,
-                mut index,
-                mut seeds,
-            } = self
-                .live_index_commit_locks("did_change_publish_complete")
-                .await;
-            let current = documents
+            {
+                let documents = self.documents.lock("did_change_index_currency").await;
+                if !documents
+                    .get(uri)
+                    .is_some_and(|doc| doc.matches_live_publication(text, dialect, revision))
+                    || self.live_publication_uri_generation(uri) != uri_generation
+                {
+                    return false;
+                }
+            }
+            let mut index = self.workspace_index.write().await;
+            if self.live_publication_uri_generation(uri) != uri_generation {
+                return false;
+            }
+            index.replace_document(uri.as_str(), &seed.analysis);
+            drop(index);
+            self.rehomed_source_seeds.lock().await.remove(uri.as_str());
+            let mut documents = self.documents.lock("did_change_publish_complete").await;
+            if !documents
                 .get(uri)
-                .is_some_and(|doc| doc.matches_live_publication(text, dialect, revision));
-            if !current {
+                .is_some_and(|doc| doc.matches_live_publication(text, dialect, revision))
+                || self.live_publication_uri_generation(uri) != uri_generation
+            {
                 return false;
             }
             documents.retag("did_change_publish_complete: commit");
-            index.replace_document(uri.as_str(), &seed.analysis);
-            seeds.remove(uri.as_str());
             documents
                 .get_mut(uri)
                 .expect("the document cannot disappear while its map is locked")
                 .publication = DocumentPublication::Indexed;
-            drop(seeds);
-            drop(index);
             drop(documents);
             self.live_publication_advanced.notify_waiters();
             return true;
@@ -44148,22 +43970,44 @@ proc p {} {
             .expect("the later reader must not panic");
     }
 
-    /// Fresh automated review of #1854: a publisher that fairly drains the
-    /// document map and then the index must not surrender each turn to traffic
-    /// queued on the other dependency forever.
+    /// #1849: a live index publisher waiting for an existing index reader must
+    /// leave the document map available to that reader. The former
+    /// alternating-contention fallback retained exclusive document admission
+    /// while awaiting the index writer; an earlier reader that next needed the
+    /// document map then formed a permanent cycle and left `didOpen` at Salsa
+    /// readiness forever.
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-    async fn live_index_commit_closes_alternating_dependency_contention_1854() {
+    async fn open_index_publish_does_not_wedge_an_index_reader_needing_documents_1849() {
         let backend = Arc::new(test_backend());
+        let uri = Uri::from_str("file:///open-index-reader-documents-1849.tcl").unwrap();
+        let text = "proc current {} {}\n";
+        let documents = backend.documents.lock("test_alternating_initial").await;
+        drop(documents);
+        backend.documents.lock("test").await.insert(
+            uri.clone(),
+            DocumentState::with_version(text.to_owned(), "tcl8.6".to_owned(), 1),
+        );
+        backend
+            .documents
+            .lock("test")
+            .await
+            .get_mut(&uri)
+            .expect("the open document exists")
+            .publication = DocumentPublication::Salsa;
+        let seed = FreshAnalysisSeed {
+            analysis: Arc::new(Analyser::new().analyse(text, "tcl8.6").clone()),
+            analyser_inputs_epoch: backend.diag_inputs_epoch(),
+            class_factory_generation: 0,
+        };
         let documents = backend.documents.lock("test_alternating_initial").await;
         let index = backend.workspace_index.read().await;
         let publishing = crate::rt::spawn({
             let backend = Arc::clone(&backend);
+            let uri = uri.clone();
             async move {
-                drop(
-                    backend
-                        .live_index_commit_locks("test_alternating_publisher")
-                        .await,
-                );
+                backend
+                    .publish_open_index_if_current(&uri, text, "tcl8.6", 1, seed)
+                    .await
             }
         });
         crate::rt::timeout(std::time::Duration::from_secs(5), async {
@@ -44171,7 +44015,7 @@ proc p {} {
                 .documents
                 .waiters()
                 .iter()
-                .any(|waiter| waiter.site == "test_alternating_publisher")
+                .any(|waiter| waiter.site == "did_open_index_currency")
             {
                 crate::rt::yield_now().await;
             }
@@ -44185,75 +44029,27 @@ proc p {} {
             }
         })
         .await
-        .expect("the publisher must retain admission while queueing for the index");
+        .expect("the publisher must queue for the index writer");
 
-        let (documents_polled, documents_were_polled) = tokio::sync::oneshot::channel();
-        let (release_documents, documents_release) = tokio::sync::oneshot::channel();
-        let late_documents = crate::rt::spawn({
-            let backend = Arc::clone(&backend);
-            async move {
-                let mut acquisition =
-                    std::pin::pin!(backend.documents.lock("test_alternating_late"));
-                let mut guard = None;
-                std::future::poll_fn(|cx| {
-                    if let Poll::Ready(acquired) = acquisition.as_mut().poll(cx) {
-                        guard = Some(acquired);
-                    }
-                    Poll::Ready(())
-                })
-                .await;
-                let _ = documents_polled.send(());
-                let _guard = match guard {
-                    Some(guard) => guard,
-                    None => acquisition.await,
-                };
-                let _ = documents_release.await;
-            }
-        });
-        documents_were_polled
-            .await
-            .expect("the later document acquisition must be polled");
-        let (index_polled, index_was_polled) = tokio::sync::oneshot::channel();
-        let (release_index, index_release) = tokio::sync::oneshot::channel();
-        let late_index = crate::rt::spawn({
-            let workspace_index = Arc::clone(&backend.workspace_index);
-            async move {
-                let mut acquisition = std::pin::pin!(workspace_index.read());
-                let mut guard = None;
-                std::future::poll_fn(|cx| {
-                    if let Poll::Ready(acquired) = acquisition.as_mut().poll(cx) {
-                        guard = Some(acquired);
-                    }
-                    Poll::Ready(())
-                })
-                .await;
-                let _ = index_polled.send(());
-                let _guard = match guard {
-                    Some(guard) => guard,
-                    None => acquisition.await,
-                };
-                let _ = index_release.await;
-            }
-        });
-        index_was_polled
-            .await
-            .expect("the later index acquisition must be polled");
+        let reader_documents = crate::rt::timeout(
+            std::time::Duration::from_millis(500),
+            backend.documents.lock("index_reader_followup_1849"),
+        )
+        .await
+        .expect(
+            "an index reader must be able to finish document work while live publication waits \
+             for its index guard (#1849)",
+        );
+        drop(reader_documents);
 
         drop(index);
-        crate::rt::timeout(std::time::Duration::from_secs(2), publishing)
-            .await
-            .expect("the publisher must commit ahead of both later contenders")
-            .expect("the publisher task must not panic");
-        let _ = release_documents.send(());
-        let _ = release_index.send(());
-        crate::rt::timeout(std::time::Duration::from_secs(5), late_documents)
-            .await
-            .expect("the later document holder must finish after release")
-            .expect("the later document task must not panic");
-        crate::rt::timeout(std::time::Duration::from_secs(5), late_index)
-            .await
-            .expect("the later index reader must finish after release")
-            .expect("the later index task must not panic");
+        assert!(
+            crate::rt::timeout(std::time::Duration::from_secs(5), publishing)
+                .await
+                .expect("the publisher must finish once the index reader drains")
+                .expect("the publisher task must not panic"),
+            "the still-current open seed must publish",
+        );
     }
 
     async fn mark_open_buffer_deleted_while_publication_waits_1854(


### PR DESCRIPTION
## Summary

- retain live unbraced CompiledWord command substitutions in the shared evaluated-surface inventory while excluding braced literals
- materialise upvar/global/builtin-write invalidations and opaque barriers before both flattened and opaque switch dispatch
- respect subject_braced and each arm pattern_braced flag instead of treating every switch word alike
- share the existing return/control effect materialisation path without changing return diagnostics

## Context

The 2.2.3 preflight exposed a semantic merge conflict between #1903 and #1754. #1904 restored exhaustiveness, then automated review correctly identified that switch operands still bypassed the sole CFG effect consumer. Without this follow-up, a setter substitution in the subject or pattern could mutate caller/global state while CFG optimisation retained stale facts. Command-binding transitions already consume the same shared statement inventory before CFG construction; this change completes the corresponding CFG variable-effect path.

## Regression coverage

- an unbraced switch subject and multi-word pattern both emit one synthetic upvar invalidation before the dispatch branch
- braced subject/pattern bracket text remains inert
- direct CompiledWord inventory coverage retains the unbraced/braced distinction

## Validation

- focused regressions: pass
- make rust-check: pass
- make prep-pr NPROC=1: pass (30/30 smoke tests)
- git diff --check: pass
