### PR TITLE
perf(ci): avoid recursive xtask fixture build

### DIFF
--- a/rust/xtask/src/smoke_targets.rs
+++ b/rust/xtask/src/smoke_targets.rs
@@ -3796,11 +3796,8 @@ fn literal_include_scanner_self_test() -> Result<()> {
     Ok(())
 }
 
-fn cargo_fixture_self_test_subprocess() -> Result<()> {
-    let cargo_home = Fixture::new()?;
-    let mut command = Command::new(env::current_exe().context("locating xtask executable")?);
+fn configure_cargo_fixture_subprocess(command: &mut Command, cargo_home: &Fixture) {
     command
-        .args(["smoke-targets", "fixture-self-test"])
         .env("CARGO_HOME", cargo_home.root.join("cargo-home"))
         .env("CARGO_MANIFEST_LINKS", "inherited")
         .env("CARGO_BIN_EXE_unrelated", "inherited")
@@ -3821,6 +3818,13 @@ fn cargo_fixture_self_test_subprocess() -> Result<()> {
             command.env_remove(name);
         }
     }
+}
+
+fn cargo_fixture_self_test_subprocess() -> Result<()> {
+    let cargo_home = Fixture::new()?;
+    let mut command = Command::new(env::current_exe().context("locating xtask executable")?);
+    command.args(["smoke-targets", "fixture-self-test"]);
+    configure_cargo_fixture_subprocess(&mut command, &cargo_home);
     command_output(&mut command)?;
     Ok(())
 }
@@ -3832,22 +3836,16 @@ fn cargo_fixture_self_test() -> Result<()> {
 
 #[cfg(test)]
 fn cargo_fixture_self_test() -> Result<()> {
-    // A binary unit test's current executable is libtest, not the xtask CLI.
-    // Ask Cargo to launch the CLI, whose isolated bridge then starts the
-    // fixture under exactly the same scrubbed environment as production.
-    let mut command = Command::new(env::var_os("CARGO").unwrap_or_else(|| "cargo".into()));
+    let cargo_home = Fixture::new()?;
+    let mut command = Command::new(env::current_exe().context("locating xtask test executable")?);
     command
         .args([
-            "run",
-            "--quiet",
-            "--locked",
-            "-p",
-            "xtask",
-            "--",
-            "smoke-targets",
-            "fixture-self-test-isolated",
+            "--exact",
+            "cargo_smoke::tests::cargo_fixture_environment_bridge",
+            "--nocapture",
         ])
-        .current_dir(repo_root());
+        .env("TCL_LSP_CARGO_FIXTURE_TEST_BRIDGE", "1");
+    configure_cargo_fixture_subprocess(&mut command, &cargo_home);
     command_output(&mut command)?;
     Ok(())
 }
@@ -4295,6 +4293,13 @@ pub fn run(operation: &str, package: Option<&str>) -> Result<ExitCode> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn cargo_fixture_environment_bridge() {
+        if env::var_os("TCL_LSP_CARGO_FIXTURE_TEST_BRIDGE").is_some() {
+            cargo_fixture_self_test_inner().expect("isolated Cargo fixture self-test");
+        }
+    }
 
     #[test]
     fn target_helpers_cover_static_edge_cases() {


### PR DESCRIPTION
Closes #1908.

## Root cause

The `target_helpers_cover_static_edge_cases` unit test launched `cargo run -p xtask` to reach the isolated Cargo fixture. On a cold target, Cargo had already built the xtask libtest executable, so that nested invocation compiled the xtask binary and its dependency graph a second time.

## Fix

Re-execute the already-built libtest binary through a marker-gated bridge test, while applying the same Cargo/Rust environment scrub used by the production xtask subprocess. The production `smoke-targets check` path remains unchanged.

## Experimental proof

- Baseline cold focused test: 190.31s inside the test (394.78s including its initial xtask test build).
- Patched cold focused test: 3.99s inside the test (92.51s including its initial xtask test build).
- Patched warm focused test: 1.89s.
- Cold focused test time reduced by 97.9%.
- Full xtask suite: 209/209 passed in 2.20s.
- Production `cargo xtask smoke-targets check`: passed.
- Production smoke-target fixture run: passed all selected workspace fixtures.
- `make rust-check`: passed.
- `make prep-pr`: passed serially with an isolated target.

No checks or fixture assertions are removed.
