### PR TITLE
ci: spill rust-tests from a busy Tank lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,7 @@ jobs:
       runtime_rust_changed: ${{ steps.paths.outputs.runtime_rust_changed }}
       web_frontends_changed: ${{ steps.paths.outputs.web_frontends_changed }}
       runner_policy_changed: ${{ steps.paths.outputs.runner_policy_changed }}
+      rust_tests_runner: ${{ steps.rust-runner.outputs.runner }}
       docs_only: ${{ steps.paths.outputs.docs_only }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -275,7 +276,7 @@ jobs:
                   web_frontends_changed=true ;;
               esac
               case "$f" in
-                .github/workflows/ci.yml | .github/dependabot.yml | scripts/dev/test-rust-tests-runner.sh)
+                .github/workflows/ci.yml | .github/dependabot.yml | scripts/dev/select-rust-tests-runner.sh | scripts/dev/test-rust-tests-runner.sh)
                   runner_policy_changed=true ;;
               esac
               if scripts/dev/spectcl-compat-path.sh "$f"; then
@@ -325,6 +326,30 @@ jobs:
             echo "docs_only=$docs_only"
           } >>"$GITHUB_OUTPUT"
           echo "python_changed=$python_changed ext_changed=$ext_changed lsp_wasm_changed=$lsp_wasm_changed wasm_cc_changed=$wasm_cc_changed spectcl_compat_changed=$spectcl_compat_changed runtime_rust_changed=$runtime_rust_changed web_frontends_changed=$web_frontends_changed runner_policy_changed=$runner_policy_changed docs_only=$docs_only"
+
+      - name: Select the broad Rust test runner
+        id: rust-runner
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          RUNNER_POLICY_CHANGED: ${{ steps.paths.outputs.runner_policy_changed }}
+          DISPATCH_RUNNER: ${{ inputs.rust_tests_runner }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [[ "$EVENT_NAME" == pull_request && ("$PR_HEAD_REPOSITORY" != "$GITHUB_REPOSITORY" || "$PR_AUTHOR" == 'dependabot[bot]' || "$RUNNER_POLICY_CHANGED" == true) ]]; then
+            runner=hosted
+          elif [[ "$EVENT_NAME" == workflow_dispatch ]]; then
+            runner="$DISPATCH_RUNNER"
+          else
+            runner="$(scripts/dev/select-rust-tests-runner.sh "$GITHUB_REPOSITORY" "$GITHUB_RUN_ID")"
+          fi
+          case "$runner" in
+            tank | hosted) ;;
+            *) echo "::error::invalid broad Rust runner: $runner"; exit 1 ;;
+          esac
+          echo "runner=$runner" >> "$GITHUB_OUTPUT"
+          echo "broad Rust runner: $runner"
 
   # Fast PR gate.  Runs on every PR and every push.  Covers the Rust fast
   # checks through the central `make rust-check` contract: root and standalone
@@ -876,19 +901,20 @@ jobs:
     # or execute newly selected dependency code there.
     #
     # Untrusted code must never reach the self-hosted runner, so PRs from forks
-    # stay on GitHub-hosted. Trusted PRs prefer `tank`; a maintainer can dispatch
-    # the workflow against the same head with `rust_tests_runner=hosted` when
-    # the tank queue is overloaded. Pushes stay on `tank`, and runner-policy
-    # changes prove themselves on hosted capacity.
+    # and Dependabot stay on GitHub-hosted. Trusted PRs and pushes prefer `tank`
+    # while its logical lane is idle, then spill onto hosted capacity when
+    # another run is already occupying that lane. A manual dispatch remains an
+    # explicit override, and runner-policy changes prove themselves on hosted
+    # capacity.
     needs: [channel]
-    runs-on: ${{ ((github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || needs.channel.outputs.runner_policy_changed == 'true')) || (github.event_name == 'workflow_dispatch' && inputs.rust_tests_runner == 'hosted')) && 'ubuntu-26.04' || 'tank' }}
+    runs-on: ${{ ((github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]' || needs.channel.outputs.runner_policy_changed == 'true')) || needs.channel.outputs.rust_tests_runner == 'hosted') && 'ubuntu-26.04' || 'tank' }}
     # The action starts the sccache server during setup, so the backend must be
     # configured at job scope rather than only on the later Cargo steps.
     env:
       RUSTC_WRAPPER: sccache
       SCCACHE_GHA_ENABLED: "true"
     concurrency:
-      group: rust-tests-${{ ((github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || needs.channel.outputs.runner_policy_changed == 'true')) || (github.event_name == 'workflow_dispatch' && inputs.rust_tests_runner == 'hosted')) && format('hosted-{0}', github.run_id) || 'tank' }}
+      group: rust-tests-${{ ((github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]' || needs.channel.outputs.runner_policy_changed == 'true')) || needs.channel.outputs.rust_tests_runner == 'hosted') && format('hosted-{0}', github.run_id) || 'tank' }}
       queue: max
       cancel-in-progress: false
     steps:

--- a/docs/design/contracts/test-tiers-and-ci-gates.md
+++ b/docs/design/contracts/test-tiers-and-ci-gates.md
@@ -155,13 +155,15 @@ CI skips only what demonstrably did not change. The rules live in
 - Every skip fails safe: API error or ambiguity → run everything.
 
 Trusted pull requests prefer the self-hosted `tank` runner for `rust-tests`.
-When that serial queue is overloaded, a maintainer may cancel the queued run
-and manually dispatch CI against the same pull-request head branch with
-`rust_tests_runner` set to `hosted`. This changes runner placement only: it does
-not skip a test, alter the nextest filter, or carry forward a result. Fork pull
-requests and runner-policy changes always use hosted capacity. Tank jobs retain
-every pending request and remain serial because its runner registrations share
-one physical host.
+The `channel` job queries every nonterminal workflow state and routes to hosted
+capacity when another active `rust-tests` job already targets `tank`. The API
+snapshot is advisory: simultaneous channel jobs can both observe an idle lane,
+so the non-cancelling `rust-tests-tank` concurrency group remains the final
+one-physical-host safety guard. API errors, malformed data, and incomplete
+pagination fail safely to hosted capacity. Fork, Dependabot, and runner-policy
+pull requests independently force hosted placement. A manual dispatch remains
+an explicit `tank` or `hosted` override. Placement never changes the test
+filter, skips coverage, or carries forward a result.
 
 Keep these properties: skips are **step-level** (jobs still report success so
 required checks and the release `needs:` graph hold), keyed on **content

--- a/scripts/dev/select-rust-tests-runner.sh
+++ b/scripts/dev/select-rust-tests-runner.sh
@@ -1,0 +1,101 @@
+#!/bin/sh
+# tcl-lsp — a language server and toolchain for Tcl
+# Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+# Print the preferred runner for a trusted broad Rust suite. Tank remains the
+# default while its logical lane is idle; ambiguous API state fails over to a
+# fresh hosted runner instead of risking an unbounded self-hosted queue. This
+# is deliberately best-effort: the job-level concurrency group remains the
+# final guard if two channel jobs observe the lane as idle simultaneously.
+
+set -eu
+
+repository=${1:-}
+current_run_id=${2:-}
+gh_bin=${GH_BIN:-gh}
+
+case "$repository" in
+    */*) ;;
+    *)
+        echo hosted
+        exit 0
+        ;;
+esac
+
+case "$current_run_id" in
+    '' | *[!0-9]*)
+        echo hosted
+        exit 0
+        ;;
+esac
+
+active_runs=
+for status in in_progress queued requested waiting pending; do
+    if ! response=$(
+        "$gh_bin" api \
+            "repos/$repository/actions/workflows/ci.yml/runs?status=$status&per_page=100" \
+            --paginate --slurp \
+            2>/dev/null
+    ); then
+        echo hosted
+        exit 0
+    fi
+    if ! run_ids=$(printf '%s\n' "$response" | jq -er \
+        --argjson current "$current_run_id" '
+        if type != "array"
+            or any(.[]; type != "object" or (.workflow_runs | type) != "array")
+            or any(.[].workflow_runs[];
+                type != "object" or (.id | type) != "number"
+                or (.status != "in_progress" and .status != "queued"
+                    and .status != "requested" and .status != "waiting"
+                    and .status != "pending"))
+        then error("malformed workflow-run response")
+        else [.[].workflow_runs[] | select(.id != $current) | .id] | @tsv
+        end
+        ' 2>/dev/null); then
+        echo hosted
+        exit 0
+    fi
+    active_runs="$active_runs $run_ids"
+done
+
+for run_id in $active_runs; do
+    if ! response=$(
+        "$gh_bin" api \
+            "repos/$repository/actions/runs/$run_id/jobs?filter=latest&per_page=100" \
+            --paginate --slurp \
+            2>/dev/null
+    ); then
+        echo hosted
+        exit 0
+    fi
+    if ! occupied=$(printf '%s\n' "$response" | jq -er '
+        if type != "array"
+            or any(.[]; type != "object" or (.jobs | type) != "array")
+            or any(.[].jobs[];
+                type != "object" or (.name | type) != "string"
+                or (.labels | type) != "array"
+                or any(.labels[]; type != "string")
+                or (.status != "in_progress" and .status != "queued"
+                    and .status != "requested" and .status != "waiting"
+                    and .status != "pending" and .status != "completed"))
+        then error("malformed workflow-job response")
+        else [.[].jobs[] | select(
+                .name == "rust-tests"
+                and (.labels | index("tank"))
+                and .status != "completed"
+            )] | length
+        end
+        ' 2>/dev/null); then
+        echo hosted
+        exit 0
+    fi
+    if [ "$occupied" -gt 0 ]; then
+        echo hosted
+        exit 0
+    fi
+done
+
+echo tank

--- a/scripts/dev/test-rust-tests-runner.sh
+++ b/scripts/dev/test-rust-tests-runner.sh
@@ -33,15 +33,15 @@ case "$(cat "$WORKFLOW")" in
         ;;
 esac
 
+hosted_condition="(github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]' || needs.channel.outputs.runner_policy_changed == 'true')) || needs.channel.outputs.rust_tests_runner == 'hosted'"
+
 case "$(cat "$WORKFLOW")" in
-    *'.github/workflows/ci.yml | .github/dependabot.yml | scripts/dev/test-rust-tests-runner.sh)'*) ;;
+    *'.github/workflows/ci.yml | .github/dependabot.yml | scripts/dev/select-rust-tests-runner.sh | scripts/dev/test-rust-tests-runner.sh)'*) ;;
     *)
         echo "runner and dependency-policy changes must classify themselves for hosted proof" >&2
         exit 1
         ;;
 esac
-
-hosted_condition="(github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || needs.channel.outputs.runner_policy_changed == 'true')) || (github.event_name == 'workflow_dispatch' && inputs.rust_tests_runner == 'hosted')"
 
 case "$(cat "$WORKFLOW")" in
     *'rust_tests_runner:'*'type: choice'*'- tank'*'- hosted'*) ;;
@@ -51,10 +51,18 @@ case "$(cat "$WORKFLOW")" in
         ;;
 esac
 
+case "$(cat "$WORKFLOW")" in
+    *'rust_tests_runner: ${{ steps.rust-runner.outputs.runner }}'*) ;;
+    *)
+        echo "the channel job must publish its broad Rust runner decision" >&2
+        exit 1
+        ;;
+esac
+
 case "$rust_tests_job" in
     *"runs-on:"*"($hosted_condition)"*"&& 'ubuntu-26.04' || 'tank'"*) ;;
     *)
-        echo "rust-tests must keep fork, hosted dispatch, and runner-policy PRs off tank" >&2
+        echo "rust-tests must use the channel job's runner decision" >&2
         exit 1
         ;;
 esac
@@ -62,7 +70,7 @@ esac
 case "$rust_tests_job" in
     *"group: rust-tests-"*"($hosted_condition)"*"format('hosted-{0}', github.run_id)"*"|| 'tank'"*) ;;
     *)
-        echo "rust-tests must serialize tank jobs and keep hosted jobs unique" >&2
+        echo "rust-tests must serialize tank jobs and keep load-spilled hosted jobs unique" >&2
         exit 1
         ;;
 esac
@@ -76,5 +84,65 @@ if ! printf '%s\n' "$rust_tests_job" | grep -Fqx '      queue: max'; then
     echo "the tank concurrency group must retain every pending workspace suite" >&2
     exit 1
 fi
+
+selector=$REPO_ROOT/scripts/dev/select-rust-tests-runner.sh
+tmp=${TMPDIR:-/tmp}/tcl-lsp-runner-policy.$$
+trap 'rm -rf "$tmp"' EXIT HUP INT TERM
+mkdir -p "$tmp"
+
+cat >"$tmp/gh" <<'EOF'
+#!/bin/sh
+set -eu
+endpoint=${2:-}
+case "${SCENARIO:-idle}:$endpoint" in
+    fail:*) exit 1 ;;
+    occupied:*'status=in_progress'*) printf '%s\n' '[{"workflow_runs":[{"id":41,"status":"in_progress"}]}]' ;;
+    hosted:*'status=in_progress'*) printf '%s\n' '[{"workflow_runs":[{"id":42,"status":"in_progress"}]}]' ;;
+    current:*'status=in_progress'*) printf '%s\n' '[{"workflow_runs":[{"id":99,"status":"in_progress"}]}]' ;;
+    waiting:*'status=waiting'*) printf '%s\n' '[{"workflow_runs":[{"id":43,"status":"waiting"}]}]' ;;
+    page2:*'status=pending'*) printf '%s\n' '[{"workflow_runs":[]},{"workflow_runs":[{"id":44,"status":"pending"}]}]' ;;
+    *:*'status='*) printf '%s\n' '[{"workflow_runs":[]}]' ;;
+    occupied:*'/runs/41/jobs'*) printf '%s\n' '[{"jobs":[{"name":"rust-tests","status":"in_progress","labels":["tank"]}]}]' ;;
+    hosted:*'/runs/42/jobs'*) printf '%s\n' '[{"jobs":[{"name":"rust-tests","status":"in_progress","labels":["ubuntu-26.04"]}]}]' ;;
+    waiting:*'/runs/43/jobs'*) printf '%s\n' '[{"jobs":[{"name":"rust-tests","status":"waiting","labels":["tank"]}]}]' ;;
+    page2:*'/runs/44/jobs'*) printf '%s\n' '[{"jobs":[]},{"jobs":[{"name":"rust-tests","status":"pending","labels":["tank"]}]}]' ;;
+    *) printf '%s\n' '[{"jobs":[]}]' ;;
+esac
+EOF
+chmod +x "$tmp/gh"
+
+expect_selection() {
+    scenario=$1
+    expected=$2
+    actual=$(SCENARIO=$scenario GH_BIN="$tmp/gh" "$selector" owner/repo 99)
+    if [ "$actual" != "$expected" ]; then
+        echo "$scenario: expected $expected, got $actual" >&2
+        exit 1
+    fi
+}
+
+expect_selection idle tank
+expect_selection occupied hosted
+expect_selection hosted tank
+expect_selection current tank
+expect_selection waiting hosted
+expect_selection page2 hosted
+expect_selection fail hosted
+
+case "$(cat "$selector")" in
+    *'for status in in_progress queued requested waiting pending; do'*'--paginate --slurp'*) ;;
+    *)
+        echo "the load detector must cover and paginate every active workflow state" >&2
+        exit 1
+        ;;
+esac
+
+case "$(cat "$WORKFLOW")" in
+    *'if [[ "$EVENT_NAME" == pull_request && ("$PR_HEAD_REPOSITORY" != "$GITHUB_REPOSITORY" || "$PR_AUTHOR" == '\''dependabot[bot]'\'' || "$RUNNER_POLICY_CHANGED" == true) ]]'*'runner=hosted'*'elif [[ "$EVENT_NAME" == workflow_dispatch ]]'*'runner="$DISPATCH_RUNNER"'*) ;;
+    *)
+        echo "fork, Dependabot, policy-change, and manual-dispatch routing must stay outside the mutable selector" >&2
+        exit 1
+        ;;
+esac
 
 echo "self-hosted Rust test scheduling contract passed"


### PR DESCRIPTION
Closes #1911

## Root cause

The repository has several Tank runner registrations but one physical Rust-test capacity lane. The global `rust-tests-tank` mutex protects the host, yet every trusted PR was still assigned to Tank before the mutex was evaluated, so later Rust suites could remain queued for tens of minutes even while GitHub-hosted capacity was available.

## Fix

- Publish a `rust_tests_runner` channel decision before the broad Rust job is scheduled.
- Prefer Tank when its lane is idle, and spill to `ubuntu-24.04` when an active Tank `rust-tests` job is visible.
- Keep fork, Dependabot, and runner-policy changes independently forced to hosted capacity.
- Fail safely to hosted capacity on malformed, paginated, or unavailable Actions API data.
- Retain the Tank concurrency mutex as the final race guard.
- Add deterministic scheduling-contract coverage and document the best-effort snapshot boundary.

## Experimental proof

The motivating live queue reproduced on run 34119901440: its Rust lane remained pending behind the already-active Tank workload while the other PR jobs completed. Against that occupied repository state, the final selector returned `hosted`. The fixture suite covers idle and occupied Tank lanes, hosted-only activity, current-run exclusion, second-page activity, `waiting`/`pending` states, malformed responses, and API failure.

## Validation

- `make NPROC=1 rust-check`
- `make NPROC=1 prep-pr` (30/30 smoke tests)
- `sh scripts/dev/test-rust-tests-runner.sh`
- live occupied-lane selection: `hosted`
- `git diff --check`