### PR TITLE
ci: reuse green PR proof for release tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,22 +66,19 @@ jobs:
   #   already_green  — this exact code already passed this workflow, verified
   #                    against the Actions API.  Fail-safe: any API error, no
   #                    match, or a match older than 24 h → false → full run.
-  #                    True in exactly two shapes:
+  #                    True in exactly these shapes:
   #                      * a v* tag whose commit has a green push run on
   #                        rust — the release flow (make release-tag) tags
   #                        an already-green tip, so the tag-time re-test was
   #                        pure repetition (measured: v2.1.18 re-ran the
   #                        identical 20-job surface on the same SHA 74 minutes
   #                        after it went green);
-  #                      * a push to rust of a merge or squash commit whose
-  #                        tree is byte-identical to the associated PR head
-  #                        with a green PR run — what the merge button produces
-  #                        when the PR was up to date with the base.  Tree
-  #                        equality is the guarantee that matters: identical
-  #                        tree ⇒ identical inputs ⇒ identical verdict, and a
-  #                        merge that DID pick up new base-branch commits gets
-  #                        a different tree and a full re-test — exactly the
-  #                        case where re-testing has value.
+  #                      * a v* tag or push to rust whose commit has exactly
+  #                        one merged PR association onto rust, whose PR head
+  #                        has the identical Git tree, and whose PR run is
+  #                        green within 24 h. The release-tag fallback covers
+  #                        the race where the rust push run has not completed
+  #                        yet (issue #1913).
   #                    The 24 h bound stops the skip compounding into stale
   #                    territory: the floating `stable` toolchain and the
   #                    advisory database both move under an unchanged tree, so
@@ -179,46 +176,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          already=false
-          cutoff="$(date -u -d '24 hours ago' '+%Y-%m-%dT%H:%M:%SZ')"
-          api="repos/$GITHUB_REPOSITORY/actions/workflows/ci.yml/runs"
-          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
-            # Tag: does this exact SHA have a green push run on rust?
-            n="$(gh api "$api?head_sha=$GITHUB_SHA&event=push&status=success&per_page=20" \
-                  --jq "[.workflow_runs[] | select(.head_branch==\"rust\" and .updated_at > \"$cutoff\")] | length" \
-                  2>/dev/null || echo 0)"
-            [ "${n:-0}" -gt 0 ] && already=true
-          elif [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
-            # Merge push: find the PR head, then require exact tree equality
-            # before carrying its green result forward. A two-parent merge has
-            # the head locally as HEAD^2. For a squash merge, GitHub records
-            # the association even though the PR head is not an ancestor.
-            pr_heads="$(git rev-parse -q --verify HEAD^2 || true)"
-            if [ -z "$pr_heads" ]; then
-              pr_heads="$(gh api "repos/$GITHUB_REPOSITORY/commits/$GITHUB_SHA/pulls" \
-                --jq ".[] | select(.merged_at != null and .merge_commit_sha == \"$GITHUB_SHA\" and .base.ref == \"rust\") | .head.sha" \
-                2>/dev/null)" || pr_heads=""
-            fi
-            # More than one association is ambiguous even if one candidate
-            # happens to share the tree. Ambiguity must run the complete suite.
-            if [ "$(printf '%s\n' "$pr_heads" | awk 'NF { n += NF } END { print n + 0 }')" -eq 1 ]; then
-              pr_head="$pr_heads"
-              current_tree="$(git rev-parse 'HEAD^{tree}')"
-              pr_tree="$(git rev-parse "$pr_head^{tree}" 2>/dev/null || true)"
-              if [ -z "$pr_tree" ]; then
-                pr_tree="$(gh api "repos/$GITHUB_REPOSITORY/git/commits/$pr_head" \
-                  --jq '.tree.sha' 2>/dev/null)" || pr_tree=""
-              fi
-              if [ -n "$pr_tree" ] && [ "$current_tree" = "$pr_tree" ]; then
-                n="$(gh api "$api?head_sha=$pr_head&event=pull_request&status=success&per_page=20" \
-                      --jq "[.workflow_runs[] | select(.updated_at > \"$cutoff\")] | length" \
-                      2>/dev/null || echo 0)"
-                [ "${n:-0}" -gt 0 ] && already=true
-              fi
-            fi
-          fi
-          echo "already_green=$already" >> "$GITHUB_OUTPUT"
-          echo "already_green=$already (ref=$GITHUB_REF sha=$GITHUB_SHA)"
+          # The helper is covered by scripts/dev/test-already-green.sh and
+          # fails closed on every local Git, API, and schema error.
+          bash scripts/dev/already-green.sh
 
       - name: Classify changed paths
         id: paths

--- a/docs/design/contracts/release-and-publish.md
+++ b/docs/design/contracts/release-and-publish.md
@@ -41,6 +41,15 @@ generates SBOMs, and attaches everything to a GitHub Release.  The
 publish jobs then push those same signed artefacts to the marketplaces
 behind the approval gate.
 
+The tag-triggered test surface may carry forward a recent proof from the
+release PR when the exact-SHA push proof is not yet available. This is a
+fail-closed content-identity check: GitHub must report exactly one merged PR
+onto `rust` for the tag commit, the PR head and tag commit must have identical
+Git trees, and that PR's successful CI run must be newer than 24 hours. Any
+ambiguous association, changed tree, stale result, or local/API/schema/network
+failure runs the complete test surface. `cargo-deny` remains unconditional so
+new advisories are audited at every release point.
+
 ## The four layers
 
 ```

--- a/docs/design/contracts/test-tiers-and-ci-gates.md
+++ b/docs/design/contracts/test-tiers-and-ci-gates.md
@@ -133,7 +133,13 @@ CI skips only what demonstrably did not change. The rules live in
 `ci.yml`'s `channel` job; read its header before editing them.
 
 - A **tag** whose SHA went green on a `rust` push within 24 h step-skips the
-  test surface (the release graph still runs).
+  test surface (the release graph still runs). If that exact-SHA push proof is
+  not available, a tag may carry forward a PR proof only when GitHub reports
+  exactly one merged PR for the tag commit on `rust`, its head commit's tree
+  exactly equals the tag tree, and the PR's CI run is successful and newer
+  than 24 h. The association API is authoritative even for two-parent merge
+  commits; the fetched second parent is only a consistency check. A missing,
+  ambiguous, stale, malformed, or failed lookup runs the full surface.
 - A **merge push** byte-identical to its already-green PR head downgrades
   tests to a cache-warming build (`--no-run`).
 - **Docs-only** changes skip the cargo test steps; `python`, `test-ext`, and
@@ -152,7 +158,9 @@ CI skips only what demonstrably did not change. The rules live in
   silently narrow. It is an additional semantic gate, not a replacement for
   the real link.
 - `cargo-deny` never skips: new advisories arrive against unchanged trees.
-- Every skip fails safe: API error or ambiguity → run everything.
+- Every skip fails safe: API/schema/network error, changed tree, stale result,
+  or ambiguous PR association → run everything. `cargo-deny` is unconditional
+  because its advisory database can change without a source-tree change.
 
 Trusted pull requests prefer the self-hosted `tank` runner for `rust-tests`.
 The `channel` job queries every nonterminal workflow state and routes to hosted

--- a/scripts/dev/already-green.sh
+++ b/scripts/dev/already-green.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# tcl-lsp — a language server and toolchain for Tcl
+# Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+# Decide whether this ref may carry forward a recent green CI result. Every
+# lookup is advisory: an API, schema, or local Git failure leaves the answer
+# false so the caller runs the complete test surface.
+
+set -euo pipefail
+
+already=false
+cutoff="$(date -u -d '24 hours ago' '+%Y-%m-%dT%H:%M:%SZ')" || cutoff=''
+cutoff_epoch="$(date -u -d '24 hours ago' '+%s')" || cutoff_epoch=''
+api="repos/$GITHUB_REPOSITORY/actions/workflows/ci.yml/runs"
+
+recent_success() {
+    local path=$1
+    local expected_sha=$2
+    local expected_event=$3
+    local expected_branch=$4
+    local branch_filter='true'
+    local jq_filter
+    local count
+
+    [ -n "$cutoff" ] || return 2
+    case "$cutoff_epoch" in
+        '' | *[!0-9]*) return 2 ;;
+    esac
+    if [ -n "$expected_branch" ]; then
+        branch_filter=".head_branch == \"$expected_branch\""
+    fi
+    # Validate the complete response before counting. In particular, jq's
+    # normal cross-type comparison rules must not let a malformed timestamp
+    # pass a freshness check. fromdateiso8601 also validates the calendar.
+    jq_filter="
+        def canonical_utc:
+            (type == \"string\")
+            and (test(\"^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$\"))
+            and ((try fromdateiso8601 catch null) | type == \"number\");
+        if (type != \"object\" or (.workflow_runs | type) != \"array\") then
+            error(\"invalid workflow-runs response\")
+        else
+            [.workflow_runs[] |
+                if (type != \"object\"
+                    or (.head_sha | type) != \"string\"
+                    or (.event | type) != \"string\"
+                    or (.status | type) != \"string\"
+                    or (.conclusion | type) != \"string\"
+                    or (.head_branch | type) != \"string\"
+                    or ((.updated_at | canonical_utc) | not)) then
+                    error(\"invalid workflow-run record\")
+                else
+                    select(.head_sha == \"$expected_sha\"
+                        and .event == \"$expected_event\"
+                        and .status == \"completed\"
+                        and .conclusion == \"success\"
+                        and $branch_filter
+                        and (.updated_at | fromdateiso8601) > $cutoff_epoch)
+                    | 1
+                end
+            ] | add // 0
+        end"
+    count="$(gh api "$path" --jq "$jq_filter" 2>/dev/null)" || return 2
+    case "$count" in
+        '' | *[!0-9]*) return 2 ;;
+    esac
+    [ "$count" -gt 0 ]
+}
+
+valid_sha() {
+    [[ "$1" =~ ^[0-9a-f]{40}$ ]]
+}
+
+if ! valid_sha "${GITHUB_SHA:-}"; then
+    printf 'already_green=false\n' >> "${GITHUB_OUTPUT:-/dev/null}"
+    printf 'already_green=false (invalid GITHUB_SHA)\n'
+    exit 0
+fi
+
+resolve_pr_heads() {
+    local heads
+
+    # The API association is authoritative even for a two-parent merge. The
+    # local second parent is checked below, but is not itself proof that a
+    # merged PR exists (an unrelated merge must not inherit a green result).
+    heads="$(gh api "repos/$GITHUB_REPOSITORY/commits/$GITHUB_SHA/pulls" \
+        --jq "
+            def canonical_utc:
+                (type == \"string\")
+                and (test(\"^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$\"))
+                and ((try fromdateiso8601 catch null) | type == \"number\");
+            if type != \"array\" then
+                error(\"invalid pull-request association response\")
+            else
+                [.[] |
+                    if (type != \"object\"
+                        or (has(\"merged_at\") | not)
+                        or (has(\"merge_commit_sha\") | not)
+                        or (has(\"base\") | not)
+                        or (has(\"head\") | not)
+                        or (.merge_commit_sha | type) != \"string\"
+                        or (.merge_commit_sha | test(\"^[0-9a-f]{40}$\") | not)
+                        or ((.merged_at != null) and ((.merged_at | canonical_utc) | not))
+                        or (.base | type) != \"object\"
+                        or (.base.ref | type) != \"string\"
+                        or (.head | type) != \"object\"
+                        or (.head.sha | type) != \"string\"
+                        or (.head.sha | test(\"^[0-9a-f]{40}$\") | not)) then
+                        error(\"invalid pull-request association record\")
+                    else
+                        select(.merged_at != null
+                            and .merge_commit_sha == \"$GITHUB_SHA\"
+                            and .base.ref == \"rust\")
+                        | .head.sha
+                    end
+                ] | .[]
+            end" \
+        2>/dev/null)" || return 1
+    printf '%s\n' "$heads"
+}
+
+green_pr_for_current_tree() {
+    local pr_heads pr_count pr_head merge_head current_tree pr_tree
+
+    pr_heads="$(resolve_pr_heads)" || return 1
+    pr_count="$(printf '%s\n' "$pr_heads" | awk 'NF { n += 1 } END { print n + 0 }')"
+    [ "$pr_count" -eq 1 ] || return 1
+    pr_head=$pr_heads
+    valid_sha "$pr_head" || return 1
+
+    # fetch-depth: 2 makes the PR head available for a normal merge commit.
+    # It is only a consistency check; the API above remains the association
+    # proof and is required for squash merges and for all tag refs.
+    merge_head="$(git rev-parse -q --verify HEAD^2 2>/dev/null || true)"
+    [ -z "$merge_head" ] || valid_sha "$merge_head" || return 1
+    [ -z "$merge_head" ] || [ "$merge_head" = "$pr_head" ] || return 1
+
+    current_tree="$(git rev-parse 'HEAD^{tree}' 2>/dev/null || true)"
+    valid_sha "$current_tree" || return 1
+    pr_tree="$(git rev-parse "$pr_head^{tree}" 2>/dev/null || true)"
+    if [ -z "$pr_tree" ]; then
+        pr_tree="$(gh api "repos/$GITHUB_REPOSITORY/git/commits/$pr_head" \
+            --jq '.tree.sha' 2>/dev/null || true)"
+    fi
+    valid_sha "$pr_tree" && [ "$current_tree" = "$pr_tree" ] || return 1
+    recent_success \
+        "$api?head_sha=$pr_head&event=pull_request&status=success&per_page=20" \
+        "$pr_head" pull_request ''
+}
+
+if [ -n "$cutoff" ] && [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+    # Preserve the cheap exact-SHA push proof for tags cut from an already
+    # green rust tip. If that result is absent, use the merged-PR proof below.
+    if recent_success \
+        "$api?head_sha=$GITHUB_SHA&event=push&status=success&per_page=20" \
+        "$GITHUB_SHA" push rust; then
+        already=true
+    else
+        push_status=$?
+        # An API/schema failure is not the same as a successful query with no
+        # matching run: only the latter may fall through to the PR proof.
+        if [ "$push_status" -eq 1 ] && green_pr_for_current_tree; then
+            already=true
+        fi
+    fi
+elif [ "$GITHUB_EVENT_NAME" = push ] && [ "$GITHUB_REF" = refs/heads/rust ]; then
+    if green_pr_for_current_tree; then
+        already=true
+    fi
+fi
+
+printf 'already_green=%s\n' "$already" >> "${GITHUB_OUTPUT:-/dev/null}"
+printf 'already_green=%s (ref=%s sha=%s)\n' "$already" "$GITHUB_REF" "$GITHUB_SHA"

--- a/scripts/dev/test-already-green.sh
+++ b/scripts/dev/test-already-green.sh
@@ -4,15 +4,17 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-# Contract for carrying a green pull-request result onto its merge push. The
-# optimization is safe only while it resolves the real PR head, compares exact
-# Git tree identities, is bounded in time, and fails closed on every API error.
+# Contract for carrying a green pull-request result onto its merge push or
+# release tag. The optimization is safe only while it resolves one merged PR,
+# compares exact Git tree identities, is bounded in time, and fails closed on
+# every API or local-Git error.
 
 set -eu
 
 SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 REPO_ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/../.." && pwd)
 WORKFLOW=$REPO_ROOT/.github/workflows/ci.yml
+HELPER=$REPO_ROOT/scripts/dev/already-green.sh
 
 green_step=$(awk '
     /      - name: Check whether this exact code is already green/ { in_step = 1 }
@@ -37,6 +39,18 @@ require_text() {
     esac
 }
 
+require_helper_text() {
+    description=$1
+    wanted=$2
+    case "$(cat "$HELPER")" in
+        *"$wanted"*) ;;
+        *)
+            echo "already-green helper lost $description" >&2
+            exit 1
+            ;;
+    esac
+}
+
 case "$(cat "$WORKFLOW")" in
     *'pull-requests: read # resolve a squash commit back to its PR head'*) ;;
     *)
@@ -45,17 +59,155 @@ case "$(cat "$WORKFLOW")" in
         ;;
 esac
 
-require_text "the 24-hour freshness bound" "date -u -d '24 hours ago'"
-require_text "two-parent merge-head resolution" 'git rev-parse -q --verify HEAD^2'
-require_text "squash-to-PR resolution" 'commits/$GITHUB_SHA/pulls'
-require_text "the exact merged-commit association" '.merge_commit_sha == \"$GITHUB_SHA\"'
-require_text "the protected base-branch restriction" '.base.ref == \"rust\"'
-require_text "fail-closed ambiguous association handling" "awk 'NF { n += NF } END { print n + 0 }')\" -eq 1"
-require_text "the PR-head tree lookup" 'git/commits/$pr_head'
-require_text "local current-tree identity" "git rev-parse 'HEAD^{tree}'"
-require_text "exact tree equality" '[ "$current_tree" = "$pr_tree" ]'
-require_text "successful PR workflow lookup" 'head_sha=$pr_head&event=pull_request&status=success'
-require_text "fail-closed PR resolution" '|| pr_heads=""'
-require_text "fail-closed tree resolution" '|| pr_tree=""'
+require_text "the helper invocation" 'bash scripts/dev/already-green.sh'
+require_helper_text "the 24-hour freshness bound" "date -u -d '24 hours ago'"
+require_helper_text "two-parent merge-head consistency" 'git rev-parse -q --verify HEAD^2'
+require_helper_text "squash-to-PR resolution" 'commits/$GITHUB_SHA/pulls'
+require_helper_text "the exact merged-commit association" '.merge_commit_sha == \"$GITHUB_SHA\"'
+require_helper_text "the protected base-branch restriction" '.base.ref == \"rust\"'
+require_helper_text "fail-closed ambiguous association handling" 'pr_count" -eq 1'
+require_helper_text "the PR-head tree lookup" 'git/commits/$pr_head'
+require_helper_text "local current-tree identity" "git rev-parse 'HEAD^{tree}'"
+require_helper_text "exact tree equality" '[ "$current_tree" = "$pr_tree" ]'
+require_helper_text "successful PR workflow lookup" 'head_sha=$pr_head&event=pull_request&status=success'
+require_helper_text "workflow response shape validation" '.workflow_runs | type'
+require_helper_text "workflow timestamp type validation" 'def canonical_utc'
+require_helper_text "workflow timestamp epoch validation" 'fromdateiso8601'
+require_helper_text "workflow head SHA validation" '.head_sha == \"$expected_sha\"'
+require_helper_text "workflow conclusion validation" '.conclusion == \"success\"'
+require_helper_text "protected merge-push ref" 'refs/heads/rust'
+require_helper_text "association response shape validation" 'invalid pull-request association response'
+require_helper_text "association merged timestamp validation" '.merged_at | canonical_utc'
+require_helper_text "association head SHA validation" '.head.sha | test'
+require_helper_text "fail-closed PR resolution" '|| return 1'
+require_helper_text "fail-closed tree resolution" '|| true)'
+
+# Deterministic fixtures for the decision itself. These fake only the small
+# Git/GitHub surface used by the helper; no network, repository state, or
+# Cargo build is involved.
+fixture=$(mktemp -d)
+trap 'rm -rf "$fixture"' EXIT
+fake_bin=$fixture/bin
+mkdir -p "$fake_bin"
+
+{
+    printf '%s\n' '#!/bin/sh'
+    printf '%s\n' 'case "$*" in *"%s"*) printf "%s\\n" "1788782400" ;; *) printf "%s\\n" "2026-09-07T12:00:00Z" ;; esac'
+} > "$fake_bin/date"
+{
+    printf '%s\n' '#!/bin/sh'
+    printf '%s\n' 'set -eu'
+    printf '%s\n' 'case "$*" in'
+    printf '%s\n' '    *"HEAD^2"*) [ -n "${ALREADY_GREEN_MERGE_HEAD:-}" ] && printf "%s\\n" "$ALREADY_GREEN_MERGE_HEAD" || exit 1 ;;'
+    printf '%s\n' '    *"HEAD^{tree}"*) printf "%s\\n" "$ALREADY_GREEN_CURRENT_TREE" ;;'
+    printf '%s\n' '    *"^{tree}"*) [ "${ALREADY_GREEN_LOCAL_PR_TREE:-}" != missing ] && printf "%s\\n" "$ALREADY_GREEN_PR_TREE" || exit 1 ;;'
+    printf '%s\n' '    *) exit 1 ;;'
+    printf '%s\n' 'esac'
+} > "$fake_bin/git"
+{
+    printf '%s\n' '#!/bin/sh'
+    printf '%s\n' 'set -eu'
+    printf '%s\n' 'url=${2:-}'
+    printf '%s\n' 'jq_filter=${4:-}'
+    printf '%s\n' 'case "${ALREADY_GREEN_GH_MODE:-}" in api-failure) exit 1 ;; esac'
+    printf '%s\n' 'case "$url" in'
+    printf '%s\n' '    */commits/*/pulls) case "${ALREADY_GREEN_GH_MODE:-}" in malformed-association) printf "%s\\n" "{\"bad\":true}" | jq -r "$jq_filter" ;; *) if [ "${ALREADY_GREEN_GH_MODE:-}" = ambiguous ]; then json="[{\"merged_at\":\"2026-09-07T10:00:00Z\",\"merge_commit_sha\":\"$GITHUB_SHA\",\"base\":{\"ref\":\"rust\"},\"head\":{\"sha\":\"$ALREADY_GREEN_PR_SHA\"}},{\"merged_at\":\"2026-09-07T10:00:00Z\",\"merge_commit_sha\":\"$GITHUB_SHA\",\"base\":{\"ref\":\"rust\"},\"head\":{\"sha\":\"cccccccccccccccccccccccccccccccccccccccc\"}}]"; else json="[{\"merged_at\":\"2026-09-07T10:00:00Z\",\"merge_commit_sha\":\"$GITHUB_SHA\",\"base\":{\"ref\":\"rust\"},\"head\":{\"sha\":\"$ALREADY_GREEN_PR_SHA\"}}]"; fi; printf "%s\\n" "$json" | jq -r "$jq_filter" ;; esac ;;'
+    printf '%s\n' '    */git/commits/*) printf "%s\\n" "$ALREADY_GREEN_PR_TREE" ;;'
+    printf '%s\n' '    */actions/workflows/ci.yml/runs?*) case "${ALREADY_GREEN_GH_MODE:-}:$url" in push-failure:*"event=push"*) exit 1 ;; esac; case "$url" in *"event=push"*) count=${ALREADY_GREEN_PUSH_COUNT:-0}; head_sha=$GITHUB_SHA; event=push; branch=rust ;; *) count=${ALREADY_GREEN_PR_COUNT:-0}; head_sha=$ALREADY_GREEN_PR_SHA; event=pull_request; branch=release/v2.2.3 ;; esac; if [ "${ALREADY_GREEN_GH_MODE:-}" = malformed-schema ]; then printf "%s\\n" "{\"workflow_runs\":\"not-an-array\"}" | jq -r "$jq_filter"; elif [ "${ALREADY_GREEN_GH_MODE:-}" = malformed-timestamp ]; then printf "%s\\n" "{\"workflow_runs\":[{\"head_sha\":\"$head_sha\",\"event\":\"$event\",\"status\":\"completed\",\"conclusion\":\"success\",\"head_branch\":\"$branch\",\"updated_at\":\"9999-99-99T99:99:99Z\"}]}" | jq -r "$jq_filter"; elif [ "$count" -gt 0 ]; then printf "%s\\n" "{\"workflow_runs\":[{\"head_sha\":\"$head_sha\",\"event\":\"$event\",\"status\":\"completed\",\"conclusion\":\"success\",\"head_branch\":\"$branch\",\"updated_at\":\"2026-09-07T13:00:00Z\"}]}" | jq -r "$jq_filter"; else printf "%s\\n" "{\"workflow_runs\":[]}" | jq -r "$jq_filter"; fi ;;'
+    printf '%s\n' '    *) exit 1 ;;'
+    printf '%s\n' 'esac'
+} > "$fake_bin/gh"
+chmod 0755 "$fake_bin/date" "$fake_bin/git" "$fake_bin/gh"
+
+tag_sha=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+pr_sha=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+run_fixture() {
+    name=$1
+    expected=$2
+    shift 2
+    output=$fixture/$name.out
+    : > "$output"
+    if ! env PATH="$fake_bin:$PATH" \
+        GITHUB_REPOSITORY=bitwisecook/tcl-lsp \
+        GITHUB_REF=refs/tags/v2.2.3 GITHUB_EVENT_NAME=push GITHUB_SHA="$tag_sha" \
+        GITHUB_OUTPUT="$output" ALREADY_GREEN_PR_TREE=cccccccccccccccccccccccccccccccccccccccc \
+        ALREADY_GREEN_CURRENT_TREE=cccccccccccccccccccccccccccccccccccccccc \
+        ALREADY_GREEN_MERGE_HEAD="$pr_sha" ALREADY_GREEN_LOCAL_PR_TREE=present ALREADY_GREEN_PR_SHA="$pr_sha" \
+        "$@" "$HELPER" >/dev/null; then
+        echo "$name: helper failed instead of failing closed" >&2
+        exit 1
+    fi
+    if ! grep -Fxq "already_green=$expected" "$output"; then
+        echo "$name: expected already_green=$expected" >&2
+        cat "$output" >&2
+        exit 1
+    fi
+}
+
+run_fixture tag-after-green-pr true \
+    env ALREADY_GREEN_PUSH_COUNT=0 ALREADY_GREEN_PR_COUNT=1 \
+        ALREADY_GREEN_ASSOCIATIONS="$pr_sha"
+run_fixture exact-sha-push true \
+    env ALREADY_GREEN_PUSH_COUNT=1 ALREADY_GREEN_PR_COUNT=0
+run_fixture changed-tree false \
+    env ALREADY_GREEN_PUSH_COUNT=0 ALREADY_GREEN_PR_COUNT=1 \
+        ALREADY_GREEN_ASSOCIATIONS="$pr_sha" ALREADY_GREEN_CURRENT_TREE=dddddddddddddddddddddddddddddddddddddddd
+run_fixture ambiguous-association false \
+    env ALREADY_GREEN_PUSH_COUNT=0 ALREADY_GREEN_PR_COUNT=1 \
+        ALREADY_GREEN_GH_MODE=ambiguous
+run_fixture stale false \
+    env ALREADY_GREEN_PUSH_COUNT=0 ALREADY_GREEN_PR_COUNT=0 \
+        ALREADY_GREEN_ASSOCIATIONS="$pr_sha"
+run_fixture push-api-failure false \
+    env ALREADY_GREEN_GH_MODE=push-failure ALREADY_GREEN_PR_COUNT=1 \
+        ALREADY_GREEN_ASSOCIATIONS="$pr_sha"
+run_fixture api-failure false env ALREADY_GREEN_GH_MODE=api-failure
+run_fixture malformed-schema false \
+    env ALREADY_GREEN_PUSH_COUNT=0 ALREADY_GREEN_PR_COUNT=1 \
+        ALREADY_GREEN_ASSOCIATIONS="$pr_sha" ALREADY_GREEN_GH_MODE=malformed-schema
+run_fixture malformed-timestamp false \
+    env ALREADY_GREEN_PUSH_COUNT=0 ALREADY_GREEN_PR_COUNT=1 \
+        ALREADY_GREEN_ASSOCIATIONS="$pr_sha" ALREADY_GREEN_GH_MODE=malformed-timestamp
+run_fixture malformed-association false \
+    env ALREADY_GREEN_PUSH_COUNT=0 ALREADY_GREEN_PR_COUNT=1 \
+        ALREADY_GREEN_GH_MODE=malformed-association
+run_fixture invalid-sha false \
+    env GITHUB_SHA=not-a-commit ALREADY_GREEN_PUSH_COUNT=1
+
+# The same PR proof must work for a merge push and remain fail-closed on each
+# proof failure in the non-tag branch.
+run_fixture merge-push-success true \
+    env GITHUB_REF=refs/heads/rust ALREADY_GREEN_PUSH_COUNT=0 ALREADY_GREEN_PR_COUNT=1 \
+        ALREADY_GREEN_ASSOCIATIONS="$pr_sha"
+run_fixture merge-push-changed-tree false \
+    env GITHUB_REF=refs/heads/rust ALREADY_GREEN_PUSH_COUNT=0 ALREADY_GREEN_PR_COUNT=1 \
+        ALREADY_GREEN_ASSOCIATIONS="$pr_sha" ALREADY_GREEN_CURRENT_TREE=dddddddddddddddddddddddddddddddddddddddd
+run_fixture merge-push-ambiguous false \
+    env GITHUB_REF=refs/heads/rust ALREADY_GREEN_PUSH_COUNT=0 ALREADY_GREEN_PR_COUNT=1 \
+        ALREADY_GREEN_GH_MODE=ambiguous
+run_fixture merge-push-stale false \
+    env GITHUB_REF=refs/heads/rust ALREADY_GREEN_PUSH_COUNT=0 ALREADY_GREEN_PR_COUNT=0 \
+        ALREADY_GREEN_ASSOCIATIONS="$pr_sha"
+run_fixture merge-push-api-failure false \
+    env GITHUB_REF=refs/heads/rust ALREADY_GREEN_GH_MODE=api-failure
+run_fixture merge-push-parent-mismatch false \
+    env GITHUB_REF=refs/heads/rust ALREADY_GREEN_MERGE_HEAD=cccccccccccccccccccccccccccccccccccccccc \
+        ALREADY_GREEN_PR_COUNT=1 ALREADY_GREEN_ASSOCIATIONS="$pr_sha"
+run_fixture wrong-merge-push-ref false \
+    env GITHUB_REF=refs/heads/other ALREADY_GREEN_PR_COUNT=1 \
+        ALREADY_GREEN_ASSOCIATIONS="$pr_sha"
+
+# The supply-chain audit is intentionally outside every already-green gate.
+cargo_deny_job=$(awk '
+    /^  cargo-deny:/ { in_job = 1 }
+    in_job && /^  [A-Za-z0-9_-]+:/ && $1 != "cargo-deny:" { exit }
+    in_job { print }
+' "$WORKFLOW")
+case "$cargo_deny_job" in
+    *already_green*)
+        echo "cargo-deny must remain unconditional" >&2
+        exit 1
+        ;;
+esac
 
 echo "exact-tree green-result reuse contract passed"


### PR DESCRIPTION
Closes #1913

## Root cause

The tag-time `already_green` check accepted only a recent successful push run for the exact tag SHA. A release tag created immediately from a green release PR therefore repeated the complete test surface whenever the post-merge `rust` run had not finished, even if the tag commit and PR head had byte-identical Git trees.

## Fix

- Preserve the exact-SHA successful-`rust`-push proof as the first path.
- For a `v*` tag with a genuine no-match, allow one fallback: exactly one merged PR association onto `rust`, a canonical valid head SHA, exact tag/PR tree equality, merge-parent consistency, and a completed successful PR CI run newer than 24 hours.
- Apply the same hardened helper to tree-equivalent merge pushes.
- Fail closed on API/network/schema/Git errors, ambiguous associations, invalid timestamps or SHAs, changed trees, wrong refs, stale results, or parent mismatches.
- Keep `cargo-deny` unconditional because advisories move independently of the source tree.

## Experimental proof

For v2.2.3, tag commit `ee405faf2` and release PR #1909 head `c13ea1dff` both resolve to tree `bd6f09d34f463d33969db221b28a6a765b4fa932`, and PR CI run 34111884226 was green before tag run 34114032622 repeated the test surface. The deterministic helper suite covers that positive case plus exact-SHA push, non-tag merge push, changed trees, ambiguity, staleness, API failure, malformed schema/timestamps/associations, invalid SHA, wrong ref, and merge-parent mismatch.

## Validation

- `make NPROC=1 rust-check`
- `make NPROC=1 prep-pr` (30/30 smoke tests)
- `bash scripts/dev/test-already-green.sh`
- `sh scripts/dev/test-rust-tests-runner.sh`
- YAML parse and `git diff --check`