### PR TITLE
ci: shard native LSP end-to-end tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -18,7 +18,7 @@
 
 # cargo-nextest configuration.
 #
-# CI archives the complete LSP e2e build once, then fans execution into two
+# CI archives the complete LSP e2e build once, then fans execution into three
 # deterministic hash partitions (see .github/workflows/ci.yml).
 # Two kinds of tests there are resource-hungry in a way that makes them starve
 # their neighbours:

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -18,7 +18,8 @@
 
 # cargo-nextest configuration.
 #
-# The LSP e2e suite runs in one parallel pool (see .github/workflows/rust-lsp-e2e.yml).
+# CI archives the complete LSP e2e build once, then fans execution into two
+# deterministic hash partitions (see .github/workflows/ci.yml).
 # Two kinds of tests there are resource-hungry in a way that makes them starve
 # their neighbours:
 #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1353,55 +1353,382 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  # Native-server lsp_e2e suite.  Its own job (hence its own status check)
-  # because it is a distinct, heavier surface: it builds the `tcl-lsp-server`
-  # binary and drives the end-to-end LSP suite against it over stdio JSON-RPC.
+  # Native-server lsp_e2e suite. The required lsp-e2e aggregate preserves its
+  # status context while one hosted producer builds and archives the suite and
+  # two execution-only hosted jobs consume it in parallel.
   # Fully native — the Rust port of the former Python `tests/lsp_e2e/` pytest
-  # suite, so no Python and no uv.  Also covers the crate's `*_smoke.rs` tests.
+  # suite, so no Python and no uv. Together they cover the crate's full test
+  # surface, including `*_smoke.rs` tests.
   lsp-e2e:
-    # Deliberately hosted -- see `rust-tests-heavy`.
+    # Preserve the required lsp-e2e status context while the matrix below
+    # provides two independently reported, deterministic partitions.
+    if: ${{ always() }}
+    needs: [channel, lsp-e2e-archive, lsp-e2e-partition]
+    runs-on: ubuntu-26.04
+    steps:
+      - name: Require both lsp-e2e partitions
+        env:
+          CHANNEL_RESULT: ${{ needs.channel.result }}
+          ARCHIVE_RESULT: ${{ needs.lsp-e2e-archive.result }}
+          PARTITIONS_RESULT: ${{ needs.lsp-e2e-partition.result }}
+        run: |
+          echo "channel=$CHANNEL_RESULT archive=$ARCHIVE_RESULT partitions=$PARTITIONS_RESULT"
+          if [ "$CHANNEL_RESULT" != "success" ] || [ "$ARCHIVE_RESULT" != "success" ] || [ "$PARTITIONS_RESULT" != "success" ]; then
+            echo "::error::lsp-e2e prerequisites did not pass"
+            exit 1
+          fi
+
+      - name: Check out verifier for transferred normal-path results
+        if: needs.channel.result == 'success' && needs.channel.outputs.docs_only != 'true' && needs.channel.outputs.already_green != 'true'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+
+      - name: Download producer proof metadata
+        if: needs.channel.result == 'success' && needs.channel.outputs.docs_only != 'true' && needs.channel.outputs.already_green != 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: lsp-e2e-proof
+          path: ${{ runner.temp }}/lsp-e2e-aggregate/producer
+
+      - name: Download partition 1 metadata
+        if: needs.channel.result == 'success' && needs.channel.outputs.docs_only != 'true' && needs.channel.outputs.already_green != 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: lsp-e2e-result-1-2
+          path: ${{ runner.temp }}/lsp-e2e-aggregate/first
+
+      - name: Download partition 2 metadata
+        if: needs.channel.result == 'success' && needs.channel.outputs.docs_only != 'true' && needs.channel.outputs.already_green != 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: lsp-e2e-result-2-2
+          path: ${{ runner.temp }}/lsp-e2e-aggregate/second
+
+      - name: Validate transferred lsp-e2e results
+        if: needs.channel.result == 'success' && needs.channel.outputs.docs_only != 'true' && needs.channel.outputs.already_green != 'true'
+        run: |
+          set -euo pipefail
+          python3 scripts/dev/verify-nextest-partitions.py --verify-results \
+            "$RUNNER_TEMP/lsp-e2e-aggregate/producer" \
+            "$RUNNER_TEMP/lsp-e2e-aggregate/first" \
+            "$RUNNER_TEMP/lsp-e2e-aggregate/second"
+
+  lsp-e2e-archive:
+    name: lsp-e2e archive
+    if: ${{ always() }}
     needs: [channel]
     runs-on: ubuntu-26.04
     env:
       RUSTC_WRAPPER: sccache
       SCCACHE_GHA_ENABLED: "true"
     steps:
+      - name: Skip lsp-e2e archive where no test is required
+        if: needs.channel.result != 'success' || needs.channel.outputs.docs_only == 'true' || (startsWith(github.ref, 'refs/tags/') && needs.channel.outputs.already_green == 'true')
+        run: echo "documentation-only, already-green tag, or unavailable channel — lsp-e2e archive is not required"
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        # Normal archive production and an already-green merge-push cache warm
+        # both need a checkout. Only an already-green tag skips all build work.
+        if: needs.channel.result == 'success' && needs.channel.outputs.docs_only != 'true' && !(startsWith(github.ref, 'refs/tags/') && needs.channel.outputs.already_green == 'true')
         with:
           fetch-depth: 1
 
       - name: Set up Rust
+        if: needs.channel.result == 'success' && needs.channel.outputs.docs_only != 'true' && !(startsWith(github.ref, 'refs/tags/') && needs.channel.outputs.already_green == 'true')
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           toolchain: stable
           cache-key: lsp-e2e
 
       - name: Set up sccache
+        if: needs.channel.result == 'success' && needs.channel.outputs.docs_only != 'true' && !(startsWith(github.ref, 'refs/tags/') && needs.channel.outputs.already_green == 'true')
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
         with:
           version: v0.17.0
 
       - name: Install cargo-nextest
+        if: needs.channel.result == 'success' && needs.channel.outputs.docs_only != 'true' && !(startsWith(github.ref, 'refs/tags/') && needs.channel.outputs.already_green == 'true')
         uses: taiki-e/install-action@e67fa11c4b9316fa714ddf0abed07a0c3143b95b # v2.87.4
         with:
           tool: nextest@0.9.143
 
-      # The integration tests spawn the real `tcl-lsp-server` binary via
-      # `CARGO_BIN_EXE_tcl-lsp-server` (cargo builds it as a test dependency)
-      # and talk LSP JSON-RPC to it over stdio.  nextest runs them in one
-      # parallel pool (no serial-per-binary penalty).
-      # Same skip/downgrade contract as rust-tests — see the channel job header.
-      - name: lsp_e2e against the native Rust server
-        if: needs.channel.outputs.docs_only != 'true' && !(startsWith(github.ref, 'refs/tags/') && needs.channel.outputs.already_green == 'true')
+      - name: Warm already-green merge push once
+        if: needs.channel.result == 'success' && needs.channel.outputs.docs_only != 'true' && needs.channel.outputs.already_green == 'true' && !startsWith(github.ref, 'refs/tags/')
+        run: cargo nextest run --no-run -p tcl-lsp-server
+
+      - name: Build and archive lsp_e2e once
+        if: needs.channel.result == 'success' && needs.channel.outputs.docs_only != 'true' && needs.channel.outputs.already_green != 'true'
         env:
-          ALREADY_GREEN: ${{ needs.channel.outputs.already_green }}
+          ARCHIVE: ${{ runner.temp }}/lsp-e2e.tar.zst
+          ARTIFACT_DIR: ${{ runner.temp }}/lsp-e2e-archive-artifact
+          PROOF_DIR: ${{ runner.temp }}/lsp-e2e-proof-artifact
         run: |
-          extra="--no-fail-fast"
-          if [ "$ALREADY_GREEN" = "true" ]; then
-            echo "tree already green on its PR run — building test binaries (cache warmth) without re-running them"
-            extra="--no-run"
-          fi
-          cargo nextest run $extra -p tcl-lsp-server
+          set -euo pipefail
+          start=$(date +%s)
+          cargo nextest archive -p tcl-lsp-server --all-features --archive-file "$ARCHIVE" 2>&1 | tee "$RUNNER_TEMP/lsp-e2e-archive.log"
+          test -s "$ARCHIVE" || { echo "::error::nextest archive was not created"; exit 1; }
+          mkdir -p "$ARTIFACT_DIR"
+          cp "$ARCHIVE" "$ARTIFACT_DIR/lsp-e2e.tar.zst"
+          mkdir -p "$PROOF_DIR"
+          (cd "$PROOF_DIR" && sha256sum "$ARCHIVE" | sed 's#  .*/#  #' > archive.sha256)
+          cargo nextest --version | tee "$PROOF_DIR/nextest-version.txt"
+          end=$(date +%s)
+          bytes=$(stat -c '%s' "$ARCHIVE")
+          seconds=$((end - start))
+          echo "lsp_e2e_archive_bytes=$bytes lsp_e2e_archive_seconds=$seconds"
+          {
+            echo "### lsp-e2e archive telemetry"
+            echo "- archive bytes: $bytes"
+            echo "- archive seconds: $seconds"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Verify hash-partition coverage
+        if: needs.channel.result == 'success' && needs.channel.outputs.docs_only != 'true' && needs.channel.outputs.already_green != 'true'
+        env:
+          ARCHIVE: ${{ runner.temp }}/lsp-e2e.tar.zst
+        run: |
+          set -euo pipefail
+          listing_dir="$RUNNER_TEMP/lsp-e2e-listings"
+          mkdir -p "$listing_dir"
+          cargo nextest list --archive-file "$ARCHIVE" --workspace-remap "$GITHUB_WORKSPACE" --message-format json > "$listing_dir/all.json"
+          cargo nextest list --archive-file "$ARCHIVE" --workspace-remap "$GITHUB_WORKSPACE" --partition hash:1/2 --message-format json > "$listing_dir/1-2.json"
+          cargo nextest list --archive-file "$ARCHIVE" --workspace-remap "$GITHUB_WORKSPACE" --partition hash:2/2 --message-format json > "$listing_dir/2-2.json"
+          scripts/dev/verify-nextest-partitions.py \
+            "$listing_dir/all.json" "$listing_dir/1-2.json" "$listing_dir/2-2.json"
+
+      - name: Record archive proof and listing metadata
+        if: needs.channel.result == 'success' && needs.channel.outputs.docs_only != 'true' && needs.channel.outputs.already_green != 'true'
+        env:
+          PROOF_DIR: ${{ runner.temp }}/lsp-e2e-proof-artifact
+          LISTING_DIR: ${{ runner.temp }}/lsp-e2e-listings
+        run: |
+          set -euo pipefail
+          workspace_sha=$(git rev-parse HEAD)
+          archive_sha=$(awk '{print $1}' "$PROOF_DIR/archive.sha256")
+          nextest_version=$(cat "$PROOF_DIR/nextest-version.txt")
+          all_sha=$(sha256sum "$LISTING_DIR/all.json" | awk '{print $1}')
+          first_sha=$(sha256sum "$LISTING_DIR/1-2.json" | awk '{print $1}')
+          second_sha=$(sha256sum "$LISTING_DIR/2-2.json" | awk '{print $1}')
+          cp "$LISTING_DIR/all.json" "$PROOF_DIR/all.json"
+          cp "$LISTING_DIR/1-2.json" "$PROOF_DIR/1-2.json"
+          cp "$LISTING_DIR/2-2.json" "$PROOF_DIR/2-2.json"
+          python3 - "$PROOF_DIR/producer-metadata.json" "$workspace_sha" "$nextest_version" "$archive_sha" "$all_sha" "$first_sha" "$second_sha" <<'PY'
+          import json
+          import sys
+
+          output, workspace_sha, nextest_version, archive_sha, all_sha, first_sha, second_sha = sys.argv[1:]
+          metadata = {
+              "schema": 1,
+              "kind": "producer",
+              "workspace_sha": workspace_sha,
+              "nextest_version": nextest_version,
+              "package": "tcl-lsp-server",
+              "filter": "default",
+              "partition": "all",
+              "result": "success",
+              "archive_sha256": archive_sha,
+              "listings": {"all.json": all_sha, "1-2.json": first_sha, "2-2.json": second_sha},
+          }
+          with open(output, "w", encoding="utf-8") as stream:
+              json.dump(metadata, stream, sort_keys=True)
+              stream.write("\n")
+          PY
+
+      - name: Upload lsp-e2e archive
+        if: needs.channel.result == 'success' && needs.channel.outputs.docs_only != 'true' && needs.channel.outputs.already_green != 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: lsp-e2e-archive
+          path: ${{ runner.temp }}/lsp-e2e-archive-artifact
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 1
+
+      - name: Upload lsp-e2e proof
+        if: needs.channel.result == 'success' && needs.channel.outputs.docs_only != 'true' && needs.channel.outputs.already_green != 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: lsp-e2e-proof
+          path: ${{ runner.temp }}/lsp-e2e-proof-artifact
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 1
+
+  lsp-e2e-partition:
+    name: lsp-e2e-partition (${{ matrix.partition }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - partition: "1/2"
+            artifact: 1-2
+          - partition: "2/2"
+            artifact: 2-2
+    # Deliberately hosted -- see `rust-tests-heavy`.
+    # Matrix contexts are not individually required; the aggregate above is.
+    needs: [channel, lsp-e2e-archive]
+    runs-on: ubuntu-26.04
+    steps:
+      - name: Prepare result metadata directory
+        if: needs.channel.result == 'success' && needs.channel.outputs.docs_only != 'true' && needs.channel.outputs.already_green != 'true'
+        env:
+          RESULT_DIR: ${{ runner.temp }}/lsp-e2e-result
+        run: |
+          set -euo pipefail
+          mkdir -p "$RESULT_DIR"
+          printf '%s\n' '{"rust-suites":{}}' > "$RESULT_DIR/selected.json"
+
+      - name: Skip lsp-e2e execution where no test is required
+        if: needs.channel.result != 'success' || needs.channel.outputs.docs_only == 'true' || needs.channel.outputs.already_green == 'true'
+        run: echo "lsp-e2e execution is not required for this channel result"
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: needs.channel.result == 'success' && needs.channel.outputs.docs_only != 'true' && needs.channel.outputs.already_green != 'true'
+        with:
+          fetch-depth: 1
+
+      - name: Set up Rust
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+        if: needs.channel.result == 'success' && needs.channel.outputs.docs_only != 'true' && needs.channel.outputs.already_green != 'true'
+        with:
+          toolchain: stable
+          cache-key: lsp-e2e
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@e67fa11c4b9316fa714ddf0abed07a0c3143b95b # v2.87.4
+        if: needs.channel.result == 'success' && needs.channel.outputs.docs_only != 'true' && needs.channel.outputs.already_green != 'true'
+        with:
+          # Keep the machine-readable partition proof and the runner on the
+          # same nextest format/version.
+          tool: nextest@0.9.143
+
+      # The integration tests spawn the real `tcl-lsp-server` binary via
+      # nextest's runtime `NEXTEST_BIN_EXE_tcl-lsp-server` path (the archive
+      # carries it as a non-test binary dependency; plain Cargo keeps the
+      # compile-time fallback) and talk LSP JSON-RPC to it over stdio. nextest runs
+      # one global parallel pool per partition; hash partitioning changes
+      # selection only, with no test mask or feature change.
+      # Same skip/downgrade contract as rust-tests — see the channel job header.
+      - name: Download lsp-e2e archive
+        if: needs.channel.result == 'success' && needs.channel.outputs.docs_only != 'true' && needs.channel.outputs.already_green != 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: lsp-e2e-archive
+          path: ${{ runner.temp }}/lsp-e2e-archive
+
+      - name: Download lsp-e2e proof
+        if: needs.channel.result == 'success' && needs.channel.outputs.docs_only != 'true' && needs.channel.outputs.already_green != 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: lsp-e2e-proof
+          path: ${{ runner.temp }}/lsp-e2e-proof
+
+      - name: Require lsp-e2e archive and report transfer size
+        if: needs.channel.result == 'success' && needs.channel.outputs.docs_only != 'true' && needs.channel.outputs.already_green != 'true'
+        env:
+          ARCHIVE: ${{ runner.temp }}/lsp-e2e-archive/lsp-e2e.tar.zst
+        run: |
+          set -euo pipefail
+          test -s "$ARCHIVE" || { echo "::error::lsp-e2e archive artifact is missing or empty: $ARCHIVE"; exit 1; }
+          bytes=$(stat -c '%s' "$ARCHIVE")
+          echo "lsp_e2e_archive_download_bytes=$bytes"
+
+      - name: Verify archive digest and nextest version
+        id: archive_verify
+        if: needs.channel.result == 'success' && needs.channel.outputs.docs_only != 'true' && needs.channel.outputs.already_green != 'true'
+        env:
+          ARCHIVE: ${{ runner.temp }}/lsp-e2e-archive/lsp-e2e.tar.zst
+          PROOF_DIR: ${{ runner.temp }}/lsp-e2e-proof
+        run: |
+          set -euo pipefail
+          expected_archive_sha=$(awk '{print $1}' "$PROOF_DIR/archive.sha256")
+          printf '%s  %s\n' "$expected_archive_sha" "$ARCHIVE" | sha256sum --status --check
+          expected=$(cat "$PROOF_DIR/nextest-version.txt")
+          actual=$(cargo nextest --version)
+          [ "$actual" = "$expected" ] || { echo "::error::nextest version mismatch: expected '$expected', got '$actual'"; exit 1; }
+
+      - name: Record selected partition listing
+        if: needs.channel.result == 'success' && needs.channel.outputs.docs_only != 'true' && needs.channel.outputs.already_green != 'true'
+        env:
+          ARCHIVE: ${{ runner.temp }}/lsp-e2e-archive/lsp-e2e.tar.zst
+          RESULT_DIR: ${{ runner.temp }}/lsp-e2e-result
+          PARTITION: ${{ matrix.partition }}
+        run: |
+          set -euo pipefail
+          cargo nextest list --archive-file "$ARCHIVE" --workspace-remap "$GITHUB_WORKSPACE" --partition "hash:$PARTITION" --message-format json > "$RESULT_DIR/selected.json"
+
+      - name: lsp_e2e partition ${{ matrix.partition }} against the native Rust server
+        id: tests
+        continue-on-error: true
+        if: needs.channel.result == 'success' && needs.channel.outputs.docs_only != 'true' && needs.channel.outputs.already_green != 'true'
+        env:
+          ARCHIVE: ${{ runner.temp }}/lsp-e2e-archive/lsp-e2e.tar.zst
+          PARTITION: ${{ matrix.partition }}
+        run: |
+          set -euo pipefail
+          start=$(date +%s)
+          cargo nextest run --archive-file "$ARCHIVE" --workspace-remap "$GITHUB_WORKSPACE" --no-fail-fast --partition "hash:$PARTITION"
+          end=$(date +%s)
+          seconds=$((end - start))
+          echo "lsp_e2e_partition=${PARTITION} lsp_e2e_partition_seconds=$seconds"
+          {
+            echo "### lsp-e2e partition telemetry ($PARTITION)"
+            echo "- execution seconds: $seconds"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Record partition result metadata
+        if: ${{ always() && needs.channel.result == 'success' && needs.channel.outputs.docs_only != 'true' && needs.channel.outputs.already_green != 'true' }}
+        env:
+          ARCHIVE: ${{ runner.temp }}/lsp-e2e-archive/lsp-e2e.tar.zst
+          RESULT_DIR: ${{ runner.temp }}/lsp-e2e-result
+          PARTITION: ${{ matrix.partition }}
+          TEST_OUTCOME: ${{ steps.tests.outcome }}
+          ARCHIVE_VERIFIED: ${{ steps.archive_verify.outcome }}
+        run: |
+          set -euo pipefail
+          archive_sha=""
+          listing_sha=""
+          test -f "$ARCHIVE" && archive_sha=$(sha256sum "$ARCHIVE" | awk '{print $1}') || true
+          test -f "$RESULT_DIR/selected.json" && listing_sha=$(sha256sum "$RESULT_DIR/selected.json" | awk '{print $1}') || true
+          nextest_version=$(cargo nextest --version 2>/dev/null || true)
+          workspace_sha=$(git rev-parse HEAD 2>/dev/null || printf '%s' "$GITHUB_SHA")
+          python3 - "$RESULT_DIR/result-metadata.json" "$workspace_sha" "$nextest_version" "$archive_sha" "$listing_sha" "$PARTITION" "$TEST_OUTCOME" "$ARCHIVE_VERIFIED" <<'PY'
+          import json
+          import sys
+
+          output, workspace_sha, nextest_version, archive_sha, listing_sha, partition, result, archive_verified = sys.argv[1:]
+          metadata = {
+              "schema": 1,
+              "kind": "consumer",
+              "workspace_sha": workspace_sha,
+              "nextest_version": nextest_version,
+              "package": "tcl-lsp-server",
+              "filter": "default",
+              "partition": f"hash:{partition}",
+              "result": result,
+              "archive_sha256": archive_sha,
+              "selected_listing_sha256": listing_sha,
+              "archive_verified": archive_verified == "success",
+          }
+          with open(output, "w", encoding="utf-8") as stream:
+              json.dump(metadata, stream, sort_keys=True)
+              stream.write("\n")
+          PY
+
+      - name: Upload partition listing and result metadata
+        if: ${{ always() && needs.channel.result == 'success' && needs.channel.outputs.docs_only != 'true' && needs.channel.outputs.already_green != 'true' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: lsp-e2e-result-${{ matrix.artifact }}
+          path: ${{ runner.temp }}/lsp-e2e-result
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 1
+
+      - name: Fail if lsp-e2e partition failed
+        if: ${{ always() && needs.channel.result == 'success' && needs.channel.outputs.docs_only != 'true' && needs.channel.outputs.already_green != 'true' && steps.tests.outcome != 'success' }}
+        run: exit 1
 
   # Supply-chain audit (advisories / licenses / bans / sources) via the
   # committed deny.toml.  Its own job so a denial is attributable independently

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1451,6 +1451,7 @@ jobs:
         if: needs.channel.result == 'success' && needs.channel.outputs.docs_only != 'true' && !(startsWith(github.ref, 'refs/tags/') && needs.channel.outputs.already_green == 'true')
         uses: taiki-e/install-action@e67fa11c4b9316fa714ddf0abed07a0c3143b95b # v2.87.4
         with:
+          # Archive/list/execute must use the exact same nextest format.
           tool: nextest@0.9.143
 
       - name: Warm already-green merge push once

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -797,7 +797,7 @@ jobs:
   #                     total.  Kept split for concurrency, not because it is
   #                     still the long pole.
   #   lsp-e2e           the native lsp_e2e suite: spawns the real tcl-lsp-server
-  #                     via CARGO_BIN_EXE_tcl-lsp-server and drives LSP JSON-RPC
+  #                     via nextest's archived runtime path and drives LSP JSON-RPC
   #                     over stdio (rust/tcl-lsp-server/tests/*_e2e.rs)
   #   cargo-deny        supply-chain audit, isolated so a denial is attributable
   #                     independently of the test surface
@@ -841,8 +841,10 @@ jobs:
     # healthy — a 2026-08 regression to 16 min turned out to be two oversized
     # `tcl-compiler` per_item tests, since fixed; if this job blows past ~5
     # min again, suspect a runaway test before suspecting the box or the
-    # cache).  No longer the longest pole: `lsp-e2e` now is (~390s vs ~150s
-    # here).  Note that neither is the workflow's critical path — the
+    # cache).  No longer the longest pole: the three archived `lsp-e2e`
+    # consumers now overlap their test pools instead of one unsharded run
+    # carrying the full suite.  Note that neither is the workflow's critical
+    # path — the
     # `build-tcl-lsp-server` -> `test-ext` chain is, finishing 40-80s after
     # `lsp-e2e` does, so shortening the test jobs cuts cost and the local
     # `make test-rust` loop rather than PR turnaround.
@@ -1355,18 +1357,18 @@ jobs:
 
   # Native-server lsp_e2e suite. The required lsp-e2e aggregate preserves its
   # status context while one hosted producer builds and archives the suite and
-  # two execution-only hosted jobs consume it in parallel.
+  # three execution-only hosted jobs consume it in parallel.
   # Fully native — the Rust port of the former Python `tests/lsp_e2e/` pytest
   # suite, so no Python and no uv. Together they cover the crate's full test
   # surface, including `*_smoke.rs` tests.
   lsp-e2e:
     # Preserve the required lsp-e2e status context while the matrix below
-    # provides two independently reported, deterministic partitions.
+    # provides three independently reported, deterministic partitions.
     if: ${{ always() }}
     needs: [channel, lsp-e2e-archive, lsp-e2e-partition]
     runs-on: ubuntu-26.04
     steps:
-      - name: Require both lsp-e2e partitions
+      - name: Require all lsp-e2e partitions
         env:
           CHANNEL_RESULT: ${{ needs.channel.result }}
           ARCHIVE_RESULT: ${{ needs.lsp-e2e-archive.result }}
@@ -1395,15 +1397,22 @@ jobs:
         if: needs.channel.result == 'success' && needs.channel.outputs.docs_only != 'true' && needs.channel.outputs.already_green != 'true'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: lsp-e2e-result-1-2
+          name: lsp-e2e-result-1-3
           path: ${{ runner.temp }}/lsp-e2e-aggregate/first
 
       - name: Download partition 2 metadata
         if: needs.channel.result == 'success' && needs.channel.outputs.docs_only != 'true' && needs.channel.outputs.already_green != 'true'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: lsp-e2e-result-2-2
+          name: lsp-e2e-result-2-3
           path: ${{ runner.temp }}/lsp-e2e-aggregate/second
+
+      - name: Download partition 3 metadata
+        if: needs.channel.result == 'success' && needs.channel.outputs.docs_only != 'true' && needs.channel.outputs.already_green != 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: lsp-e2e-result-3-3
+          path: ${{ runner.temp }}/lsp-e2e-aggregate/third
 
       - name: Validate transferred lsp-e2e results
         if: needs.channel.result == 'success' && needs.channel.outputs.docs_only != 'true' && needs.channel.outputs.already_green != 'true'
@@ -1412,7 +1421,8 @@ jobs:
           python3 scripts/dev/verify-nextest-partitions.py --verify-results \
             "$RUNNER_TEMP/lsp-e2e-aggregate/producer" \
             "$RUNNER_TEMP/lsp-e2e-aggregate/first" \
-            "$RUNNER_TEMP/lsp-e2e-aggregate/second"
+            "$RUNNER_TEMP/lsp-e2e-aggregate/second" \
+            "$RUNNER_TEMP/lsp-e2e-aggregate/third"
 
   lsp-e2e-archive:
     name: lsp-e2e archive
@@ -1493,10 +1503,11 @@ jobs:
           listing_dir="$RUNNER_TEMP/lsp-e2e-listings"
           mkdir -p "$listing_dir"
           cargo nextest list --archive-file "$ARCHIVE" --workspace-remap "$GITHUB_WORKSPACE" --message-format json > "$listing_dir/all.json"
-          cargo nextest list --archive-file "$ARCHIVE" --workspace-remap "$GITHUB_WORKSPACE" --partition hash:1/2 --message-format json > "$listing_dir/1-2.json"
-          cargo nextest list --archive-file "$ARCHIVE" --workspace-remap "$GITHUB_WORKSPACE" --partition hash:2/2 --message-format json > "$listing_dir/2-2.json"
+          cargo nextest list --archive-file "$ARCHIVE" --workspace-remap "$GITHUB_WORKSPACE" --partition hash:1/3 --message-format json > "$listing_dir/1-3.json"
+          cargo nextest list --archive-file "$ARCHIVE" --workspace-remap "$GITHUB_WORKSPACE" --partition hash:2/3 --message-format json > "$listing_dir/2-3.json"
+          cargo nextest list --archive-file "$ARCHIVE" --workspace-remap "$GITHUB_WORKSPACE" --partition hash:3/3 --message-format json > "$listing_dir/3-3.json"
           scripts/dev/verify-nextest-partitions.py \
-            "$listing_dir/all.json" "$listing_dir/1-2.json" "$listing_dir/2-2.json"
+            "$listing_dir/all.json" "$listing_dir/1-3.json" "$listing_dir/2-3.json" "$listing_dir/3-3.json"
 
       - name: Record archive proof and listing metadata
         if: needs.channel.result == 'success' && needs.channel.outputs.docs_only != 'true' && needs.channel.outputs.already_green != 'true'
@@ -1509,16 +1520,18 @@ jobs:
           archive_sha=$(awk '{print $1}' "$PROOF_DIR/archive.sha256")
           nextest_version=$(cat "$PROOF_DIR/nextest-version.txt")
           all_sha=$(sha256sum "$LISTING_DIR/all.json" | awk '{print $1}')
-          first_sha=$(sha256sum "$LISTING_DIR/1-2.json" | awk '{print $1}')
-          second_sha=$(sha256sum "$LISTING_DIR/2-2.json" | awk '{print $1}')
+          first_sha=$(sha256sum "$LISTING_DIR/1-3.json" | awk '{print $1}')
+          second_sha=$(sha256sum "$LISTING_DIR/2-3.json" | awk '{print $1}')
+          third_sha=$(sha256sum "$LISTING_DIR/3-3.json" | awk '{print $1}')
           cp "$LISTING_DIR/all.json" "$PROOF_DIR/all.json"
-          cp "$LISTING_DIR/1-2.json" "$PROOF_DIR/1-2.json"
-          cp "$LISTING_DIR/2-2.json" "$PROOF_DIR/2-2.json"
-          python3 - "$PROOF_DIR/producer-metadata.json" "$workspace_sha" "$nextest_version" "$archive_sha" "$all_sha" "$first_sha" "$second_sha" <<'PY'
+          cp "$LISTING_DIR/1-3.json" "$PROOF_DIR/1-3.json"
+          cp "$LISTING_DIR/2-3.json" "$PROOF_DIR/2-3.json"
+          cp "$LISTING_DIR/3-3.json" "$PROOF_DIR/3-3.json"
+          python3 - "$PROOF_DIR/producer-metadata.json" "$workspace_sha" "$nextest_version" "$archive_sha" "$all_sha" "$first_sha" "$second_sha" "$third_sha" <<'PY'
           import json
           import sys
 
-          output, workspace_sha, nextest_version, archive_sha, all_sha, first_sha, second_sha = sys.argv[1:]
+          output, workspace_sha, nextest_version, archive_sha, all_sha, first_sha, second_sha, third_sha = sys.argv[1:]
           metadata = {
               "schema": 1,
               "kind": "producer",
@@ -1529,7 +1542,7 @@ jobs:
               "partition": "all",
               "result": "success",
               "archive_sha256": archive_sha,
-              "listings": {"all.json": all_sha, "1-2.json": first_sha, "2-2.json": second_sha},
+              "listings": {"all.json": all_sha, "1-3.json": first_sha, "2-3.json": second_sha, "3-3.json": third_sha},
           }
           with open(output, "w", encoding="utf-8") as stream:
               json.dump(metadata, stream, sort_keys=True)
@@ -1562,10 +1575,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - partition: "1/2"
-            artifact: 1-2
-          - partition: "2/2"
-            artifact: 2-2
+          - partition: "1/3"
+            artifact: 1-3
+          - partition: "2/3"
+            artifact: 2-3
+          - partition: "3/3"
+            artifact: 3-3
     # Deliberately hosted -- see `rust-tests-heavy`.
     # Matrix contexts are not individually required; the aggregate above is.
     needs: [channel, lsp-e2e-archive]

--- a/Makefile
+++ b/Makefile
@@ -210,7 +210,7 @@ TS_SRCS  := $(shell find $(EXT_DIR)/src -name '*.ts' 2>/dev/null)
 # Tests
 .PHONY: test test-ext test-emacs test-rust rust-server rust-tcl rust-f5 rust-mcp rust-clis ensure-server-cross-deps server-cross-build server-cross-build-all mcp-cross-build-all cli-cross-build-all server-cross-test server-cross-test-build print-server-targets-all print-server-targets-jetbrains
 .PHONY: xtask-check xtask-editor-extensions xtask-kcs-index-links xtask-diag-tables xtask-diag-emission-check xtask-gen-editor-catalogs xtask-gen-bundled-environments xtask-gen-editor-dialects xtask-gen-irule-test-data xtask-gen-zed-queries xtask-gen-editor-settings xtask-gen-vscode-package xtask-gen-jetbrains-catalog xtask-gen-ai-diagnostics xtask-owner-resolution xtask-command-backing xtask-audit-option-dialects xtask-registry-oracle xtask-sslictcl-data xtask-runtime-stdlib tcltest-sweep tcltest-sweep-check xtask-f5query-builtins-doc xtask-bigip-data-schema xtask-c-api-ownership check-c-api-ownership
-.PHONY: xtask-workflow-sync xtask-resolution-drift xtask-retired-api-gate xtask-pack-goldens xtask-number-drift xtask-gen-tmlanguage-keywords xtask-option-registry-drift xtask-callback-inventory check-tcl-reference-toolchains check-spectcl-compat-paths check-runtime-rust-paths check-rust-tests-runner check-already-green check-monitoring-triggers check-smoke-targets check-wasm-cc-env check-homebrew-ci check-sign-and-upload xtask-dialect-drift xtask-segmentation-drift
+.PHONY: xtask-workflow-sync xtask-resolution-drift xtask-retired-api-gate xtask-pack-goldens xtask-number-drift xtask-gen-tmlanguage-keywords xtask-option-registry-drift xtask-callback-inventory check-tcl-reference-toolchains check-spectcl-compat-paths check-runtime-rust-paths check-rust-tests-runner check-lsp-e2e-partitions check-already-green check-monitoring-triggers check-smoke-targets check-wasm-cc-env check-homebrew-ci check-sign-and-upload xtask-dialect-drift xtask-segmentation-drift
 # Lint / format / typecheck
 .PHONY: lint format lint-ts format-ts typecheck-ts check-rust check-rust-pr _check-rust-pr rust-deny
 .PHONY: build-report-assets build-report-pyz lint-report-ts typecheck-report-ts check-report-assets lint-spec-studio-ts typecheck-spec-studio-ts
@@ -760,7 +760,7 @@ coverage-ext: compile $(NPM_STAMP) ensure-vscode-test-deps ## Run VS Code extens
 # --- Native (cargo xtask) check gates.  These need the Rust toolchain, so CI
 # runs them in the rust-tests job (rust-gate.yml / ci.yml).  `xtask-check` is
 # the CI aggregate.
-xtask-check: check-tcl-reference-toolchains check-spectcl-compat-paths check-runtime-rust-paths check-rust-tests-runner check-already-green check-monitoring-triggers check-smoke-targets check-wasm-cc-env check-homebrew-ci check-sign-and-upload xtask-workflow-sync xtask-kcs-index-links xtask-diag-tables xtask-diag-emission-check xtask-gen-editor-catalogs xtask-gen-bundled-environments xtask-gen-editor-dialects xtask-gen-irule-test-data xtask-gen-zed-queries xtask-gen-tmlanguage-keywords xtask-gen-editor-settings xtask-gen-vscode-package xtask-gen-jetbrains-catalog xtask-gen-ai-diagnostics xtask-owner-resolution xtask-resolution-drift xtask-retired-api-gate xtask-pack-goldens xtask-number-drift xtask-segmentation-drift xtask-command-backing xtask-callback-inventory xtask-option-registry-drift xtask-sslictcl-data xtask-runtime-stdlib xtask-editor-extensions xtask-f5query-builtins-doc xtask-bigip-data-schema xtask-c-api-ownership ## Rust-side check gates (docs index coverage + generated-table/catalog drift) xtask-dialect-drift
+xtask-check: check-tcl-reference-toolchains check-spectcl-compat-paths check-runtime-rust-paths check-rust-tests-runner check-lsp-e2e-partitions check-already-green check-monitoring-triggers check-smoke-targets check-wasm-cc-env check-homebrew-ci check-sign-and-upload xtask-workflow-sync xtask-kcs-index-links xtask-diag-tables xtask-diag-emission-check xtask-gen-editor-catalogs xtask-gen-bundled-environments xtask-gen-editor-dialects xtask-gen-irule-test-data xtask-gen-zed-queries xtask-gen-tmlanguage-keywords xtask-gen-editor-settings xtask-gen-vscode-package xtask-gen-jetbrains-catalog xtask-gen-ai-diagnostics xtask-owner-resolution xtask-resolution-drift xtask-retired-api-gate xtask-pack-goldens xtask-number-drift xtask-segmentation-drift xtask-command-backing xtask-callback-inventory xtask-option-registry-drift xtask-sslictcl-data xtask-runtime-stdlib xtask-editor-extensions xtask-f5query-builtins-doc xtask-bigip-data-schema xtask-c-api-ownership ## Rust-side check gates (docs index coverage + generated-table/catalog drift) xtask-dialect-drift
 
 check-tcl-reference-toolchains: ## Verify pinned C Tcl patchlevels across shell setup and Rust oracle discovery
 	@echo "==> Checking C Tcl reference toolchain ownership"
@@ -778,6 +778,10 @@ check-runtime-rust-paths: ## Verify CI's standalone-runtime dependency closure a
 check-rust-tests-runner: ## Verify trusted rust-tests jobs serialize on the shared tank host
 	@echo "==> Checking self-hosted Rust test scheduling"
 	@sh scripts/dev/test-rust-tests-runner.sh
+
+check-lsp-e2e-partitions: ## Verify archived native LSP e2e producer/consumer workflow wiring
+	@echo "==> Checking native lsp-e2e archive/partition scheduling"
+	@sh scripts/dev/test-lsp-e2e-partitions.sh
 
 check-already-green: ## Verify exact-tree green-result reuse stays fail-closed for merges and squashes
 	@echo "==> Checking exact-tree green-result reuse"

--- a/docs/design/contracts/test-tiers-and-ci-gates.md
+++ b/docs/design/contracts/test-tiers-and-ci-gates.md
@@ -13,14 +13,15 @@ behind it.
 | **exhaustive** — `make test-exhaustive`, `make fuzz`, `make tcltest-sweep[-check]` | only when a human invokes it by name | every `#[ignore]`d corpus sweep over `tmp/tcl*` and tcllib, differential-fuzz gates, privileged bpf/kernel tests, fuzz campaigns. **Never** wired into `prep-pr`, `test`, `check-all`, or CI. |
 
 The native `lsp-e2e` surface is produced once as a nextest 0.9.143 archive,
-then consumed by two hosted `hash:1/2` and `hash:2/2` jobs. Each consumer
-remaps the archive to its checkout and receives the relocated server through
+then consumed by three hosted `hash:1/3`, `hash:2/3`, and `hash:3/3` jobs.
+Each consumer remaps the archive to its checkout and receives the relocated server through
 `NEXTEST_BIN_EXE_tcl-lsp-server`; ordinary Cargo tests retain the compile-time
 `CARGO_BIN_EXE_tcl-lsp-server` fallback. The `lsp-e2e` aggregate is the
-required status and fails unless both consumers and the archive producer pass.
-The producer verifies that the two selected listings are a disjoint,
-complete union before uploading artifacts; `scripts/dev/verify-nextest-partitions.py`
-also validates transferred digests and metadata.
+required status and fails unless all three consumers and the archive producer
+pass. The producer verifies that the three selected listings are a disjoint,
+complete union before uploading artifacts;
+`scripts/dev/verify-nextest-partitions.py` also validates transferred digests
+and metadata.
 
 ## Decision rules / contracts
 

--- a/docs/design/contracts/test-tiers-and-ci-gates.md
+++ b/docs/design/contracts/test-tiers-and-ci-gates.md
@@ -12,6 +12,16 @@ behind it.
 | **deep** — CI jobs `rust-tests`, `rust-tests-heavy`, `runtime-rust-tests`, `lsp-e2e`, `test-ext`, `test-ext-web`, `cargo-deny`, `python`, `spectcl-compat` | every PR and every push to `rust` | the full workspace suite (native `lsp_e2e` included), the VM-sim heavies, the standalone `runtime/rust` unit suite, the VS Code extension on desktop and in a browser host, supply-chain audit, Python lint/typecheck. Skips only what demonstrably did not change (below). |
 | **exhaustive** — `make test-exhaustive`, `make fuzz`, `make tcltest-sweep[-check]` | only when a human invokes it by name | every `#[ignore]`d corpus sweep over `tmp/tcl*` and tcllib, differential-fuzz gates, privileged bpf/kernel tests, fuzz campaigns. **Never** wired into `prep-pr`, `test`, `check-all`, or CI. |
 
+The native `lsp-e2e` surface is produced once as a nextest 0.9.143 archive,
+then consumed by two hosted `hash:1/2` and `hash:2/2` jobs. Each consumer
+remaps the archive to its checkout and receives the relocated server through
+`NEXTEST_BIN_EXE_tcl-lsp-server`; ordinary Cargo tests retain the compile-time
+`CARGO_BIN_EXE_tcl-lsp-server` fallback. The `lsp-e2e` aggregate is the
+required status and fails unless both consumers and the archive producer pass.
+The producer verifies that the two selected listings are a disjoint,
+complete union before uploading artifacts; `scripts/dev/verify-nextest-partitions.py`
+also validates transferred digests and metadata.
+
 ## Decision rules / contracts
 
 1. **Fuzzing is always manual.** Campaigns (`make fuzz`, `tcl-fuzz`) and

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -41281,6 +41281,21 @@ proc p {} {
         // uniqueness is what makes it proof.
         let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
         let next_tag = Arc::new(std::sync::atomic::AtomicU64::new(0));
+        let snapshot_ready = Arc::new(tokio::sync::Notify::new());
+        let snapshot_release = Arc::new(tokio::sync::Notify::new());
+        let witness = {
+            let store = Arc::clone(&store);
+            let snapshot_ready = Arc::clone(&snapshot_ready);
+            let snapshot_release = Arc::clone(&snapshot_release);
+            tokio::spawn(async move {
+                let first = store.lock("hammer-witness-first").await;
+                drop(first);
+                let held = store.lock("hammer-witness-current").await;
+                snapshot_ready.notify_one();
+                snapshot_release.notified().await;
+                drop(held);
+            })
+        };
         let hammers: Vec<_> = (0..3)
             .map(|_| {
                 let store = Arc::clone(&store);
@@ -41303,6 +41318,11 @@ proc p {} {
             })
             .collect();
 
+        // Keep one unique-tagged hammer in the held state while the sampling
+        // loop starts. Without this hand-off, the synchronous loop can finish
+        // before any worker has released once and acquired again, making the
+        // proof depend on executor scheduling under a busy archive shard.
+        snapshot_ready.notified().await;
         let mut previous = store.contention().acquisitions;
         let mut seen_both = 0_u32;
         for _ in 0..100_000 {
@@ -41329,6 +41349,8 @@ proc p {} {
             }
         }
 
+        snapshot_release.notify_one();
+        witness.await.expect("the snapshot witness must finish");
         stop.store(true, std::sync::atomic::Ordering::Relaxed);
         for h in hammers {
             let _ = h.await;

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -41281,21 +41281,6 @@ proc p {} {
         // uniqueness is what makes it proof.
         let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
         let next_tag = Arc::new(std::sync::atomic::AtomicU64::new(0));
-        let snapshot_ready = Arc::new(tokio::sync::Notify::new());
-        let snapshot_release = Arc::new(tokio::sync::Notify::new());
-        let witness = {
-            let store = Arc::clone(&store);
-            let snapshot_ready = Arc::clone(&snapshot_ready);
-            let snapshot_release = Arc::clone(&snapshot_release);
-            tokio::spawn(async move {
-                let first = store.lock("hammer-witness-first").await;
-                drop(first);
-                let held = store.lock("hammer-witness-current").await;
-                snapshot_ready.notify_one();
-                snapshot_release.notified().await;
-                drop(held);
-            })
-        };
         let hammers: Vec<_> = (0..3)
             .map(|_| {
                 let store = Arc::clone(&store);
@@ -41318,11 +41303,13 @@ proc p {} {
             })
             .collect();
 
-        // Keep one unique-tagged hammer in the held state while the sampling
-        // loop starts. Without this hand-off, the synchronous loop can finish
-        // before any worker has released once and acquired again, making the
-        // proof depend on executor scheduling under a busy archive shard.
-        snapshot_ready.notified().await;
+        // Do not start the synchronous sampling loop until the real hammer
+        // workers are demonstrably running. They keep acquiring and releasing
+        // on the other runtime threads while sampling, preserving the
+        // concurrent-transition proof without depending on initial scheduling.
+        while store.contention().acquisitions < 100 {
+            crate::rt::yield_now().await;
+        }
         let mut previous = store.contention().acquisitions;
         let mut seen_both = 0_u32;
         for _ in 0..100_000 {
@@ -41349,8 +41336,6 @@ proc p {} {
             }
         }
 
-        snapshot_release.notify_one();
-        witness.await.expect("the snapshot witness must finish");
         stop.store(true, std::sync::atomic::Ordering::Relaxed);
         for h in hammers {
             let _ = h.await;

--- a/rust/tcl-lsp-server/tests/e2e/common/mod.rs
+++ b/rust/tcl-lsp-server/tests/e2e/common/mod.rs
@@ -591,7 +591,11 @@ impl Lsp {
     /// binary, and `std::env::set_var` here would leak into every other test
     /// sharing the runner process.
     pub fn spawn_with_env(config: Value, env: &[(&str, &str)]) -> Self {
-        let bin = env!("CARGO_BIN_EXE_tcl-lsp-server");
+        // Archived nextest runs relocate the executable beside the extracted
+        // test binaries. Prefer the runtime path there; ordinary Cargo test
+        // keeps using its compile-time path as the fallback.
+        let bin = std::env::var_os("NEXTEST_BIN_EXE_tcl-lsp-server")
+            .unwrap_or_else(|| env!("CARGO_BIN_EXE_tcl-lsp-server").into());
 
         // Isolate the server from the developer machine's config/cache so a
         // local `~/.../tcl-lsp/config.ini` can't poison the defaults. Fresh

--- a/rust/tcl-lsp-server/tests/e2e/common/mod.rs
+++ b/rust/tcl-lsp-server/tests/e2e/common/mod.rs
@@ -18,13 +18,13 @@
 
 //! Shared end-to-end harness for the native `tcl-lsp-server` binary.
 //!
-//! Each test spawns the real `tcl-lsp-server` binary (via
-//! `CARGO_BIN_EXE_tcl-lsp-server`), talks LSP JSON-RPC to it over stdio, and
-//! asserts on the responses — exactly what an editor does. A background reader
-//! thread parses framed messages,
-//! routing responses to blocked requests, buffering notifications (with a
-//! condvar so `await_*` can wait), and auto-answering server-initiated requests
-//! (`workspace/configuration`) so the server never blocks.
+//! Each test spawns the real `tcl-lsp-server` binary via nextest's archived
+//! runtime path, with `CARGO_BIN_EXE_tcl-lsp-server` as the ordinary Cargo
+//! fallback, talks LSP JSON-RPC to it over stdio, and asserts on the responses
+//! — exactly what an editor does. A background reader thread parses framed
+//! messages, routing responses to blocked requests, buffering notifications
+//! (with a condvar so `await_*` can wait), and auto-answering server-initiated
+//! requests (`workspace/configuration`) so the server never blocks.
 //!
 //! The client offers a request / notify / `open_ready` / `await_diagnostics` /
 //! `await_log` contract, XDG isolation per server, and a per-section reply to
@@ -88,11 +88,9 @@ const BARRIER_TIMEOUT_MARKER: &str = "LATENCY-BARRIER-TIMEOUT";
 /// latency failure, categorically distinct from an oracle/content divergence
 /// (those panic with "diverged" / "alignment broke" instead). On CI the
 /// dominant cause is the test process being denied CPU on an oversubscribed
-/// runner, not a server defect: the latency-sensitive e2e stress tests
-/// (`edit_tracking_stress::*` and the semantic-token latency benchmark) can
-/// starve each other, which is exactly why `.config/nextest.toml` isolates them
-/// into a single-slot `heavy-lsp-e2e` group and the dedicated `lsp-e2e` CI job
-/// runs them that way and stays green.
+/// runner, not a server defect. The latency-sensitive stress tests that once
+/// made this common are now contention-resistant or belong to the manual tier;
+/// CI runs the remaining native e2e surface in deterministic hash partitions.
 ///
 /// Rather than leave every investigator to re-derive that from a bare "timed
 /// out" message, we *probe scheduling health at the moment of giving up*: a

--- a/scripts/dev/test-lsp-e2e-partitions.sh
+++ b/scripts/dev/test-lsp-e2e-partitions.sh
@@ -49,10 +49,29 @@ case "$archive" in
     *) echo "archive job lost its no-op, pinned nextest, or archive command" >&2; exit 1 ;;
 esac
 
-for required in 'hash:1/2' 'hash:2/2' '--workspace-remap'     'cargo nextest list --archive-file' 'verify-nextest-partitions.py'
+for required in 'hash:1/3' 'hash:2/3' 'hash:3/3' '--workspace-remap' \
+    'cargo nextest list --archive-file' 'verify-nextest-partitions.py'
 do
     case "$archive" in *"$required"*) ;; *) echo "archive job is missing partition proof component $required" >&2; exit 1 ;; esac
 done
+
+for required in 'lsp-e2e-result-1-3' 'lsp-e2e-result-2-3' 'lsp-e2e-result-3-3' 'third'
+do
+    case "$aggregate" in *"$required"*) ;; *) echo "lsp-e2e aggregate is missing $required" >&2; exit 1 ;; esac
+done
+case "$aggregate" in
+    *'--verify-results'*'producer'*'first'*'second'*'third'*) ;;
+    *) echo "lsp-e2e aggregate must verify exactly three consumer results" >&2; exit 1 ;;
+esac
+
+matrix_partitions=$(printf '%s\n' "$partition" | grep -Ec 'partition: "[123]/3"')
+test "$matrix_partitions" -eq 3 || {
+    echo "lsp-e2e matrix must define exactly three hash partitions" >&2
+    exit 1
+}
+case "$partition$archive$aggregate" in
+    *'1/2'*|*'2/2'*) echo "lsp-e2e workflow retains obsolete two-way partitioning" >&2; exit 1 ;;
+esac
 
 case "$partition" in
     *'strategy:'*'fail-fast: false'*'needs: [channel, lsp-e2e-archive]'*'tool: nextest@0.9.143'*'--archive-file'*'--workspace-remap'*'--partition "hash:'*) ;;

--- a/scripts/dev/test-lsp-e2e-partitions.sh
+++ b/scripts/dev/test-lsp-e2e-partitions.sh
@@ -1,0 +1,73 @@
+#!/bin/sh
+# tcl-lsp — a language server and toolchain for Tcl
+# Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+# Contract test for the archived native lsp-e2e fan-out. Keep the required
+# aggregate, producer, and consumers wired together; a textual check catches
+# accidental job-level skips or a single unpartitioned fallback.
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+REPO_ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/../.." && pwd)
+WORKFLOW=$REPO_ROOT/.github/workflows/ci.yml
+
+workflow=$(cat "$WORKFLOW")
+job_block() {
+    awk -v wanted="$1" '
+        $0 == "  " wanted ":" { in_job = 1 }
+        in_job && $0 ~ /^  [A-Za-z0-9_-]+:/ && $0 != "  " wanted ":" { exit }
+        in_job { print }
+    ' "$WORKFLOW"
+}
+
+aggregate=$(job_block lsp-e2e)
+archive=$(job_block lsp-e2e-archive)
+partition=$(job_block lsp-e2e-partition)
+
+test -n "$aggregate" || { echo "ci.yml must define lsp-e2e aggregate" >&2; exit 1; }
+test -n "$archive" || { echo "ci.yml must define lsp-e2e-archive" >&2; exit 1; }
+test -n "$partition" || { echo "ci.yml must define lsp-e2e-partition" >&2; exit 1; }
+
+printf '%s\n' "$aggregate" | grep -Fq 'if: ${{ always() }}' || {
+    echo "lsp-e2e must be an always-running aggregate" >&2
+    exit 1
+}
+printf '%s\n' "$aggregate" | grep -Fq 'needs: [channel, lsp-e2e-archive, lsp-e2e-partition]' || {
+    echo "lsp-e2e must depend on both producer jobs" >&2
+    exit 1
+}
+for required in 'ARCHIVE_RESULT: $' 'PARTITIONS_RESULT: $' 'exit 1'
+do
+    case "$aggregate" in *"$required"*) ;; *) echo "lsp-e2e aggregate is missing $required" >&2; exit 1 ;; esac
+done
+
+case "$archive" in
+    *'if: $'*'needs: [channel]'*'tool: nextest@0.9.143'*'cargo nextest archive -p tcl-lsp-server --all-features'*) ;;
+    *) echo "archive job lost its no-op, pinned nextest, or archive command" >&2; exit 1 ;;
+esac
+
+for required in 'hash:1/2' 'hash:2/2' '--workspace-remap'     'cargo nextest list --archive-file' 'verify-nextest-partitions.py'
+do
+    case "$archive" in *"$required"*) ;; *) echo "archive job is missing partition proof component $required" >&2; exit 1 ;; esac
+done
+
+case "$partition" in
+    *'strategy:'*'fail-fast: false'*'needs: [channel, lsp-e2e-archive]'*'tool: nextest@0.9.143'*'--archive-file'*'--workspace-remap'*'--partition "hash:'*) ;;
+    *) echo "partition matrix lost fail-fast, archive remap, pinned nextest, or hash partitioning" >&2; exit 1 ;;
+esac
+
+for required in 'docs_only' 'already_green' 'Skip lsp-e2e' 'Warm already-green merge push once'
+do
+    case "$archive$partition" in *"$required"*) ;; *) echo "lsp-e2e no-op contract is missing $required" >&2; exit 1 ;; esac
+done
+
+case "$workflow" in *'NEXTEST_BIN_EXE_tcl-lsp-server'*) ;; *) echo "workflow/docs do not name the runtime server path" >&2; exit 1 ;; esac
+case "$(cat "$REPO_ROOT/rust/tcl-lsp-server/tests/e2e/common/mod.rs")" in
+    *'NEXTEST_BIN_EXE_tcl-lsp-server'*'CARGO_BIN_EXE_tcl-lsp-server'*) ;;
+    *) echo "e2e harness must retain Cargo fallback and use nextest runtime path" >&2; exit 1 ;;
+esac
+
+echo "lsp-e2e archive/partition workflow contract passed"

--- a/scripts/dev/verify-nextest-partitions.py
+++ b/scripts/dev/verify-nextest-partitions.py
@@ -17,7 +17,6 @@ import tempfile
 from pathlib import Path
 from typing import Any
 
-
 TestId = tuple[str, str]
 SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 
@@ -35,25 +34,25 @@ def _selected(path: Path) -> set[TestId]:
     document = _load(path)
     suites = document.get("rust-suites") if isinstance(document, dict) else None
     if not isinstance(suites, dict):
-        raise ValueError(f"{path}: missing rust-suites object")
+        raise TypeError(f"{path}: missing rust-suites object")
 
     selected: set[TestId] = set()
     seen: set[TestId] = set()
     testcase_count = 0
     for suite_name, suite in suites.items():
         if not isinstance(suite, dict):
-            raise ValueError(f"{path}: suite {suite_name!r} is not an object")
+            raise TypeError(f"{path}: suite {suite_name!r} is not an object")
         binary_id = suite.get("binary-id")
         testcases = suite.get("testcases")
         if not isinstance(binary_id, str) or not binary_id:
             raise ValueError(f"{path}: suite {suite_name!r} has no binary-id")
         if not isinstance(testcases, dict):
-            raise ValueError(f"{path}: suite {suite_name!r} has no testcases object")
+            raise TypeError(f"{path}: suite {suite_name!r} has no testcases object")
 
         for test_name, testcase in testcases.items():
             testcase_count += 1
             if not isinstance(test_name, str) or not isinstance(testcase, dict):
-                raise ValueError(f"{path}: malformed testcase in suite {suite_name!r}")
+                raise TypeError(f"{path}: malformed testcase in suite {suite_name!r}")
             match = testcase.get("filter-match")
             if not isinstance(match, dict) or "status" not in match:
                 raise ValueError(
@@ -118,7 +117,7 @@ def _sha256(path: Path) -> str:
 def _metadata(path: Path) -> dict[str, Any]:
     document = _load(path)
     if not isinstance(document, dict):
-        raise ValueError(f"{path}: metadata must be an object")
+        raise TypeError(f"{path}: metadata must be an object")
     return document
 
 
@@ -167,7 +166,7 @@ def _require_listing_digest(
 ) -> None:
     listings = metadata.get("listings")
     if not isinstance(listings, dict) or not isinstance(listings.get(key), str):
-        raise ValueError(f"{path}: metadata has no digest for {key}")
+        raise TypeError(f"{path}: metadata has no digest for {key}")
     digest = listings[key]
     if not SHA256_RE.fullmatch(digest):
         raise ValueError(f"{path}: listing digest for {key} is not SHA-256")
@@ -446,7 +445,7 @@ def main(argv: list[str]) -> int:
             return 2
         try:
             verify_results(*(Path(arg) for arg in argv[1:]))
-        except ValueError as exc:
+        except (TypeError, ValueError) as exc:
             print(exc, file=sys.stderr)
             return 1
         return 0
@@ -456,7 +455,7 @@ def main(argv: list[str]) -> int:
         return 2
     try:
         verify(*(Path(arg) for arg in argv))
-    except ValueError as exc:
+    except (TypeError, ValueError) as exc:
         print(exc, file=sys.stderr)
         return 1
     return 0

--- a/scripts/dev/verify-nextest-partitions.py
+++ b/scripts/dev/verify-nextest-partitions.py
@@ -1,4 +1,22 @@
 #!/usr/bin/env python3
+# tcl-lsp — a language server and toolchain for Tcl
+# Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 """Verify that three nextest listings are a disjoint, complete partition.
 
 The listing format deliberately contains tests which are present in the

--- a/scripts/dev/verify-nextest-partitions.py
+++ b/scripts/dev/verify-nextest-partitions.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Verify that two nextest listings are a disjoint, complete partition.
+"""Verify that three nextest listings are a disjoint, complete partition.
 
 The listing format deliberately contains tests which are present in the
 binary but excluded by the active profile, ignored-test mode, or a partition.
@@ -19,6 +19,14 @@ from typing import Any
 
 TestId = tuple[str, str]
 SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+PARTITION_COUNT = 3
+PARTITIONS = tuple(
+    f"hash:{index}/{PARTITION_COUNT}" for index in range(1, PARTITION_COUNT + 1)
+)
+LISTING_NAMES = {
+    "all.json",
+    *(f"{index}-{PARTITION_COUNT}.json" for index in range(1, PARTITION_COUNT + 1)),
+}
 
 
 def _load(path: Path) -> Any:
@@ -83,24 +91,53 @@ def _authoritative_selected(path: Path) -> set[TestId]:
     return selected
 
 
-def verify(all_path: Path, first_path: Path, second_path: Path) -> None:
-    all_tests = _authoritative_selected(all_path)
-    first = _selected(first_path)
-    second = _selected(second_path)
-    overlap = first & second
-    missing = all_tests - (first | second)
-    unexpected = (first | second) - all_tests
-    if overlap or missing or unexpected:
+def _verify_partition_sets(
+    all_tests: set[TestId], partitions: list[tuple[str, set[TestId]]]
+) -> None:
+    names = [name for name, _ in partitions]
+    if tuple(names) != PARTITIONS:
+        raise ValueError(
+            f"expected exactly the partitions {', '.join(PARTITIONS)}; got {', '.join(names)}"
+        )
+    union: set[TestId] = set()
+    for name, selected in partitions:
+        overlap = union & selected
+        if overlap:
+            raise ValueError(
+                f"nextest partition proof found duplicate tests in {name}: "
+                f"{sorted(overlap)[:5]}"
+            )
+        union.update(selected)
+    missing = all_tests - union
+    unexpected = union - all_tests
+    if missing or unexpected:
         details = [
             "nextest partition proof failed",
-            f"  overlap ({len(overlap)}): {sorted(overlap)[:5]}",
             f"  missing ({len(missing)}): {sorted(missing)[:5]}",
             f"  unexpected ({len(unexpected)}): {sorted(unexpected)[:5]}",
         ]
         raise ValueError("\n".join(details))
-    print(
-        f"nextest partition proof: all={len(all_tests)} 1/2={len(first)} 2/2={len(second)}"
+
+
+def verify(all_path: Path, *partition_paths: Path) -> None:
+    all_tests = _authoritative_selected(all_path)
+    if len(partition_paths) != PARTITION_COUNT:
+        raise ValueError(
+            f"expected exactly {PARTITION_COUNT} partition listings, got {len(partition_paths)}"
+        )
+    selected = [_selected(path) for path in partition_paths]
+    _verify_partition_sets(
+        all_tests,
+        [
+            (f"hash:{index}/{PARTITION_COUNT}", tests)
+            for index, tests in enumerate(selected, 1)
+        ],
     )
+    counts = " ".join(
+        f"{index}/{PARTITION_COUNT}={len(tests)}"
+        for index, tests in enumerate(selected, 1)
+    )
+    print(f"nextest partition proof: all={len(all_tests)} {counts}")
 
 
 def _sha256(path: Path) -> str:
@@ -173,6 +210,20 @@ def _require_listing_digest(
     _require_digest(listing, digest, f"listing {key}")
 
 
+def _require_exact_listing_keys(metadata: dict[str, Any], path: Path) -> None:
+    listings = metadata.get("listings")
+    if not isinstance(listings, dict):
+        raise TypeError(f"{path}: metadata has no listings object")
+    actual = set(listings)
+    if actual != LISTING_NAMES:
+        missing = sorted(LISTING_NAMES - actual)
+        extra = sorted(actual - LISTING_NAMES)
+        raise ValueError(
+            f"{path}: producer listings must be exactly {sorted(LISTING_NAMES)} "
+            f"(missing={missing}, extra={extra})"
+        )
+
+
 def _matching_metadata(
     producer: dict[str, Any], consumer: dict[str, Any], path: Path, partition: str
 ) -> None:
@@ -194,7 +245,7 @@ def _matching_metadata(
         raise ValueError(f"{path}: consumer did not verify the downloaded archive")
 
 
-def verify_results(proof_dir: Path, first_dir: Path, second_dir: Path) -> None:
+def verify_results(proof_dir: Path, *partition_dirs: Path) -> None:
     """Verify the transferred proof and consumer result artifacts."""
     producer_meta_path = proof_dir / "producer-metadata.json"
     producer = _metadata(producer_meta_path)
@@ -205,6 +256,12 @@ def verify_results(proof_dir: Path, first_dir: Path, second_dir: Path) -> None:
         or producer.get("result") != "success"
     ):
         raise ValueError(f"{producer_meta_path}: invalid producer metadata")
+    if len(partition_dirs) != PARTITION_COUNT:
+        raise ValueError(
+            f"expected exactly {PARTITION_COUNT} consumer result directories, "
+            f"got {len(partition_dirs)}"
+        )
+    _require_exact_listing_keys(producer, producer_meta_path)
 
     archive_digest = _read_archive_digest(proof_dir / "archive.sha256")
     if archive_digest != producer["archive_sha256"]:
@@ -225,55 +282,54 @@ def verify_results(proof_dir: Path, first_dir: Path, second_dir: Path) -> None:
         )
 
     all_path = proof_dir / "all.json"
-    producer_first_path = proof_dir / "1-2.json"
-    producer_second_path = proof_dir / "2-2.json"
-    for listing, key in (
+    producer_listing_paths = [
+        proof_dir / f"{index}-{PARTITION_COUNT}.json"
+        for index in range(1, PARTITION_COUNT + 1)
+    ]
+    listing_items = [
         (all_path, "all.json"),
-        (producer_first_path, "1-2.json"),
-        (producer_second_path, "2-2.json"),
-    ):
+        *[
+            (path, f"{index}-3.json")
+            for index, path in enumerate(producer_listing_paths, 1)
+        ],
+    ]
+    for listing, key in listing_items:
         _require_listing_digest(producer, producer_meta_path, listing, key)
 
-    first_meta_path = first_dir / "result-metadata.json"
-    second_meta_path = second_dir / "result-metadata.json"
-    first_meta = _metadata(first_meta_path)
-    second_meta = _metadata(second_meta_path)
-    _matching_metadata(producer, first_meta, first_meta_path, "hash:1/2")
-    _matching_metadata(producer, second_meta, second_meta_path, "hash:2/2")
-    first_listing = first_dir / "selected.json"
-    second_listing = second_dir / "selected.json"
-    for metadata, metadata_path, listing in (
-        (first_meta, first_meta_path, first_listing),
-        (second_meta, second_meta_path, second_listing),
-    ):
+    consumer_data: list[tuple[str, dict[str, Any], Path, Path]] = []
+    for index, directory in enumerate(partition_dirs, 1):
+        metadata_path = directory / "result-metadata.json"
+        metadata = _metadata(metadata_path)
+        partition = f"hash:{index}/{PARTITION_COUNT}"
+        _matching_metadata(producer, metadata, metadata_path, partition)
+        listing = directory / "selected.json"
+        consumer_data.append((partition, metadata, metadata_path, listing))
+    for _, metadata, metadata_path, listing in consumer_data:
         digest = metadata.get("selected_listing_sha256")
         if not isinstance(digest, str) or not SHA256_RE.fullmatch(digest):
             raise ValueError(f"{metadata_path}: selected listing digest is not SHA-256")
         _require_digest(listing, digest, "selected listing")
 
     all_tests = _authoritative_selected(all_path)
-    producer_first = _selected(producer_first_path)
-    producer_second = _selected(producer_second_path)
-    first = _selected(first_listing)
-    second = _selected(second_listing)
-    if (
-        producer_first & producer_second
-        or (producer_first | producer_second) != all_tests
-    ):
-        raise ValueError(
-            "producer hash-partition listings are not a disjoint complete union"
-        )
-    if first & second or (first | second) != all_tests:
-        raise ValueError(
-            "consumer hash-partition listings are not a disjoint complete union"
-        )
-    if first != producer_first or second != producer_second:
+    producer_selected = [_selected(path) for path in producer_listing_paths]
+    consumer_selected = [_selected(listing) for _, _, _, listing in consumer_data]
+    _verify_partition_sets(
+        all_tests,
+        [(partition, tests) for partition, tests in zip(PARTITIONS, producer_selected)],
+    )
+    _verify_partition_sets(
+        all_tests,
+        [(partition, tests) for partition, tests in zip(PARTITIONS, consumer_selected)],
+    )
+    if consumer_selected != producer_selected:
         raise ValueError(
             "consumer selected listings differ from producer partition listings"
         )
-    print(
-        f"transferred nextest proof: all={len(all_tests)} 1/2={len(first)} 2/2={len(second)}"
+    counts = " ".join(
+        f"{index}/{PARTITION_COUNT}={len(tests)}"
+        for index, tests in enumerate(consumer_selected, 1)
     )
+    print(f"transferred nextest proof: all={len(all_tests)} {counts}")
 
 
 def self_test() -> None:
@@ -327,7 +383,19 @@ def self_test() -> None:
         "status": "mismatch",
         "reason": "partition",
     }
-    fixtures = {"all": all_fixture, "first": first_fixture, "second": second_fixture}
+    third_fixture = json.loads(json.dumps(all_fixture))
+    for suite in third_fixture["rust-suites"].values():
+        for testcase in suite["testcases"].values():
+            testcase["filter-match"] = {
+                "status": "mismatch",
+                "reason": "partition",
+            }
+    fixtures = {
+        "all": all_fixture,
+        "first": first_fixture,
+        "second": second_fixture,
+        "third": third_fixture,
+    }
     expected = {("tcl-lsp-server", "ordinary"), ("other-server", "ordinary")}
     path = Path("<self-test>")
     # Exercise the same parser and set assertions without creating files.
@@ -337,7 +405,31 @@ def self_test() -> None:
     )
     try:
         assert _selected(path) == expected
-        verify(Path("all"), Path("first"), Path("second"))
+        verify(Path("all"), Path("first"), Path("second"), Path("third"))
+
+        for paths in (
+            (Path("first"), Path("second")),
+            (Path("first"), Path("second"), Path("third"), Path("third")),
+        ):
+            try:
+                verify(Path("all"), *paths)
+            except ValueError as exc:
+                assert "exactly 3 partition listings" in str(exc)
+            else:
+                raise AssertionError("wrong number of partition listings passed")
+        try:
+            _verify_partition_sets(
+                expected,
+                [
+                    ("hash:1/3", expected),
+                    ("hash:1/3", set()),
+                    ("hash:3/3", set()),
+                ],
+            )
+        except ValueError as exc:
+            assert "exactly the partitions" in str(exc)
+        else:
+            raise AssertionError("duplicate partition labels passed verification")
 
         empty_fixture = json.loads(json.dumps(all_fixture))
         for suite in empty_fixture["rust-suites"].values():
@@ -348,7 +440,7 @@ def self_test() -> None:
                 }
         fixtures["empty"] = empty_fixture
         try:
-            verify(Path("empty"), Path("empty"), Path("empty"))
+            verify(Path("empty"), Path("empty"), Path("empty"), Path("empty"))
         except ValueError as exc:
             assert "authoritative listing selects no tests" in str(exc)
         else:
@@ -362,11 +454,10 @@ def self_test() -> None:
     with tempfile.TemporaryDirectory() as temporary:
         root = Path(temporary)
         proof_dir = root / "proof"
-        first_dir = root / "first"
-        second_dir = root / "second"
+        partition_dirs = [root / name for name in ("first", "second", "third")]
         proof_dir.mkdir()
-        first_dir.mkdir()
-        second_dir.mkdir()
+        for directory in partition_dirs:
+            directory.mkdir()
         archive_sha = hashlib.sha256(b"archive").hexdigest()
         (proof_dir / "archive.sha256").write_text(
             f"{archive_sha}  lsp-e2e.tar.zst\n", encoding="utf-8"
@@ -376,15 +467,19 @@ def self_test() -> None:
         )
         listing_paths = {
             "all.json": proof_dir / "all.json",
-            "1-2.json": proof_dir / "1-2.json",
-            "2-2.json": proof_dir / "2-2.json",
+            "1-3.json": proof_dir / "1-3.json",
+            "2-3.json": proof_dir / "2-3.json",
+            "3-3.json": proof_dir / "3-3.json",
         }
         listing_paths["all.json"].write_text(json.dumps(all_fixture), encoding="utf-8")
-        listing_paths["1-2.json"].write_text(
+        listing_paths["1-3.json"].write_text(
             json.dumps(first_fixture), encoding="utf-8"
         )
-        listing_paths["2-2.json"].write_text(
+        listing_paths["2-3.json"].write_text(
             json.dumps(second_fixture), encoding="utf-8"
+        )
+        listing_paths["3-3.json"].write_text(
+            json.dumps(third_fixture), encoding="utf-8"
         )
         common: dict[str, Any] = {
             "schema": 1,
@@ -408,9 +503,8 @@ def self_test() -> None:
         (proof_dir / "producer-metadata.json").write_text(
             json.dumps(producer_metadata), encoding="utf-8"
         )
-        for directory, partition, fixture in (
-            (first_dir, "hash:1/2", first_fixture),
-            (second_dir, "hash:2/2", second_fixture),
+        for directory, partition, fixture in zip(
+            partition_dirs, PARTITIONS, (first_fixture, second_fixture, third_fixture)
         ):
             listing = directory / "selected.json"
             listing.write_text(json.dumps(fixture), encoding="utf-8")
@@ -428,7 +522,26 @@ def self_test() -> None:
                 json.dumps(metadata), encoding="utf-8"
             )
         assert not (proof_dir / "lsp-e2e.tar.zst").exists()
-        verify_results(proof_dir, first_dir, second_dir)
+        verify_results(proof_dir, *partition_dirs)
+        try:
+            verify_results(proof_dir, *partition_dirs[:2])
+        except ValueError as exc:
+            assert "exactly 3 consumer result directories" in str(exc)
+        else:
+            raise AssertionError("wrong number of consumer results passed verification")
+
+        extra_listing = proof_dir / "4-3.json"
+        extra_listing.write_text(json.dumps(third_fixture), encoding="utf-8")
+        producer_metadata["listings"]["4-3.json"] = _sha256(extra_listing)
+        (proof_dir / "producer-metadata.json").write_text(
+            json.dumps(producer_metadata), encoding="utf-8"
+        )
+        try:
+            verify_results(proof_dir, *partition_dirs)
+        except ValueError as exc:
+            assert "producer listings must be exactly" in str(exc)
+        else:
+            raise AssertionError("extra producer partition passed verification")
     print("nextest transferred-artifact self-test: ok (digest/metadata/result cases)")
 
 
@@ -437,9 +550,10 @@ def main(argv: list[str]) -> int:
         self_test()
         return 0
     if argv and argv[0] == "--verify-results":
-        if len(argv) != 4:
+        if len(argv) != PARTITION_COUNT + 2:
             print(
-                f"usage: {sys.argv[0]} --verify-results PROOF_DIR FIRST_DIR SECOND_DIR",
+                f"usage: {sys.argv[0]} --verify-results "
+                "PROOF_DIR FIRST_DIR SECOND_DIR THIRD_DIR",
                 file=sys.stderr,
             )
             return 2
@@ -449,8 +563,11 @@ def main(argv: list[str]) -> int:
             print(exc, file=sys.stderr)
             return 1
         return 0
-    if len(argv) != 3:
-        print(f"usage: {sys.argv[0]} ALL.json FIRST.json SECOND.json", file=sys.stderr)
+    if len(argv) != PARTITION_COUNT + 1:
+        print(
+            f"usage: {sys.argv[0]} ALL.json 1-3.json 2-3.json 3-3.json",
+            file=sys.stderr,
+        )
         print(f"       {sys.argv[0]} --self-test", file=sys.stderr)
         return 2
     try:

--- a/scripts/dev/verify-nextest-partitions.py
+++ b/scripts/dev/verify-nextest-partitions.py
@@ -386,7 +386,7 @@ def self_test() -> None:
         listing_paths["2-2.json"].write_text(
             json.dumps(second_fixture), encoding="utf-8"
         )
-        common = {
+        common: dict[str, Any] = {
             "schema": 1,
             "workspace_sha": "abc123",
             "nextest_version": "cargo-nextest 0.9.143",

--- a/scripts/dev/verify-nextest-partitions.py
+++ b/scripts/dev/verify-nextest-partitions.py
@@ -77,8 +77,15 @@ def _selected(path: Path) -> set[TestId]:
     return selected
 
 
+def _authoritative_selected(path: Path) -> set[TestId]:
+    selected = _selected(path)
+    if not selected:
+        raise ValueError(f"{path}: authoritative listing selects no tests")
+    return selected
+
+
 def verify(all_path: Path, first_path: Path, second_path: Path) -> None:
-    all_tests = _selected(all_path)
+    all_tests = _authoritative_selected(all_path)
     first = _selected(first_path)
     second = _selected(second_path)
     overlap = first & second
@@ -245,7 +252,7 @@ def verify_results(proof_dir: Path, first_dir: Path, second_dir: Path) -> None:
             raise ValueError(f"{metadata_path}: selected listing digest is not SHA-256")
         _require_digest(listing, digest, "selected listing")
 
-    all_tests = _selected(all_path)
+    all_tests = _authoritative_selected(all_path)
     producer_first = _selected(producer_first_path)
     producer_second = _selected(producer_second_path)
     first = _selected(first_listing)
@@ -332,6 +339,21 @@ def self_test() -> None:
     try:
         assert _selected(path) == expected
         verify(Path("all"), Path("first"), Path("second"))
+
+        empty_fixture = json.loads(json.dumps(all_fixture))
+        for suite in empty_fixture["rust-suites"].values():
+            for testcase in suite["testcases"].values():
+                testcase["filter-match"] = {
+                    "status": "mismatch",
+                    "reason": "default-filter",
+                }
+        fixtures["empty"] = empty_fixture
+        try:
+            verify(Path("empty"), Path("empty"), Path("empty"))
+        except ValueError as exc:
+            assert "authoritative listing selects no tests" in str(exc)
+        else:
+            raise AssertionError("empty authoritative selection passed verification")
     finally:
         globals()["_load"] = original_load
     print(

--- a/scripts/dev/verify-nextest-partitions.py
+++ b/scripts/dev/verify-nextest-partitions.py
@@ -1,0 +1,361 @@
+#!/usr/bin/env python3
+"""Verify that two nextest listings are a disjoint, complete partition.
+
+The listing format deliberately contains tests which are present in the
+binary but excluded by the active profile, ignored-test mode, or a partition.
+Only ``filter-match.status == matches`` is selected.  Test names are qualified
+by their nextest ``binary-id`` because names are not workspace-unique.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+TestId = tuple[str, str]
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+def _load(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{path}: expected one nextest JSON listing: {exc}") from exc
+    except OSError as exc:
+        raise ValueError(f"{path}: cannot read listing: {exc}") from exc
+
+
+def _selected(path: Path) -> set[TestId]:
+    document = _load(path)
+    suites = document.get("rust-suites") if isinstance(document, dict) else None
+    if not isinstance(suites, dict):
+        raise ValueError(f"{path}: missing rust-suites object")
+
+    selected: set[TestId] = set()
+    seen: set[TestId] = set()
+    testcase_count = 0
+    for suite_name, suite in suites.items():
+        if not isinstance(suite, dict):
+            raise ValueError(f"{path}: suite {suite_name!r} is not an object")
+        binary_id = suite.get("binary-id")
+        testcases = suite.get("testcases")
+        if not isinstance(binary_id, str) or not binary_id:
+            raise ValueError(f"{path}: suite {suite_name!r} has no binary-id")
+        if not isinstance(testcases, dict):
+            raise ValueError(f"{path}: suite {suite_name!r} has no testcases object")
+
+        for test_name, testcase in testcases.items():
+            testcase_count += 1
+            if not isinstance(test_name, str) or not isinstance(testcase, dict):
+                raise ValueError(f"{path}: malformed testcase in suite {suite_name!r}")
+            match = testcase.get("filter-match")
+            if not isinstance(match, dict) or "status" not in match:
+                raise ValueError(f"{path}: testcase {binary_id}:{test_name} has no filter-match.status")
+            # Do not infer selection from presence, ignored, or a testcase
+            # status: nextest's filter decision is authoritative.  This keeps
+            # repository/profile config and --run-ignored semantics intact.
+            if match["status"] != "matches":
+                continue
+            test_id = (binary_id, test_name)
+            if test_id in seen:
+                raise ValueError(f"{path}: duplicate selected testcase {binary_id}:{test_name}")
+            seen.add(test_id)
+            selected.add(test_id)
+
+    if testcase_count == 0:
+        raise ValueError(f"{path}: listing contains no testcases")
+    return selected
+
+
+def verify(all_path: Path, first_path: Path, second_path: Path) -> None:
+    all_tests = _selected(all_path)
+    first = _selected(first_path)
+    second = _selected(second_path)
+    overlap = first & second
+    missing = all_tests - (first | second)
+    unexpected = (first | second) - all_tests
+    if overlap or missing or unexpected:
+        details = [
+            "nextest partition proof failed",
+            f"  overlap ({len(overlap)}): {sorted(overlap)[:5]}",
+            f"  missing ({len(missing)}): {sorted(missing)[:5]}",
+            f"  unexpected ({len(unexpected)}): {sorted(unexpected)[:5]}",
+        ]
+        raise ValueError("\n".join(details))
+    print(f"nextest partition proof: all={len(all_tests)} 1/2={len(first)} 2/2={len(second)}")
+
+
+def _sha256(path: Path) -> str:
+    try:
+        digest = hashlib.sha256()
+        with path.open("rb") as stream:
+            for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+                digest.update(chunk)
+        return digest.hexdigest()
+    except OSError as exc:
+        raise ValueError(f"{path}: cannot hash file: {exc}") from exc
+
+
+def _metadata(path: Path) -> dict[str, Any]:
+    document = _load(path)
+    if not isinstance(document, dict):
+        raise ValueError(f"{path}: metadata must be an object")
+    return document
+
+
+def _require_common(metadata: dict[str, Any], path: Path) -> None:
+    required = ("schema", "workspace_sha", "nextest_version", "package", "filter", "archive_sha256")
+    missing = [key for key in required if key not in metadata]
+    if missing:
+        raise ValueError(f"{path}: metadata missing {', '.join(missing)}")
+    if metadata["schema"] != 1:
+        raise ValueError(f"{path}: unsupported metadata schema {metadata['schema']!r}")
+    for key in ("workspace_sha", "nextest_version", "package", "filter"):
+        if not isinstance(metadata[key], str) or not metadata[key]:
+            raise ValueError(f"{path}: metadata field {key} must be a non-empty string")
+    archive_sha = metadata["archive_sha256"]
+    if not isinstance(archive_sha, str) or not SHA256_RE.fullmatch(archive_sha):
+        raise ValueError(f"{path}: metadata archive_sha256 is not a SHA-256 digest")
+
+
+def _require_digest(path: Path, expected: str, label: str) -> None:
+    actual = _sha256(path)
+    if actual != expected:
+        raise ValueError(f"{path}: {label} digest mismatch (expected {expected}, got {actual})")
+
+
+def _read_archive_digest(path: Path) -> str:
+    try:
+        fields = path.read_text(encoding="utf-8").split()
+    except OSError as exc:
+        raise ValueError(f"{path}: cannot read archive digest: {exc}") from exc
+    if not fields or not SHA256_RE.fullmatch(fields[0]):
+        raise ValueError(f"{path}: expected a SHA-256 digest")
+    return fields[0]
+
+
+def _require_listing_digest(metadata: dict[str, Any], path: Path, listing: Path, key: str) -> None:
+    listings = metadata.get("listings")
+    if not isinstance(listings, dict) or not isinstance(listings.get(key), str):
+        raise ValueError(f"{path}: metadata has no digest for {key}")
+    digest = listings[key]
+    if not SHA256_RE.fullmatch(digest):
+        raise ValueError(f"{path}: listing digest for {key} is not SHA-256")
+    _require_digest(listing, digest, f"listing {key}")
+
+
+def _matching_metadata(
+    producer: dict[str, Any], consumer: dict[str, Any], path: Path, partition: str
+) -> None:
+    _require_common(consumer, path)
+    for key in ("workspace_sha", "nextest_version", "package", "filter", "archive_sha256"):
+        if consumer[key] != producer[key]:
+            raise ValueError(f"{path}: {key} does not match producer metadata")
+    if consumer.get("kind") != "consumer" or consumer.get("partition") != partition:
+        raise ValueError(f"{path}: expected consumer partition {partition}")
+    if consumer.get("result") != "success":
+        raise ValueError(f"{path}: consumer result is {consumer.get('result')!r}")
+    if consumer.get("archive_verified") is not True:
+        raise ValueError(f"{path}: consumer did not verify the downloaded archive")
+
+
+def verify_results(proof_dir: Path, first_dir: Path, second_dir: Path) -> None:
+    """Verify the transferred proof and consumer result artifacts."""
+    producer_meta_path = proof_dir / "producer-metadata.json"
+    producer = _metadata(producer_meta_path)
+    _require_common(producer, producer_meta_path)
+    if producer.get("kind") != "producer" or producer.get("partition") != "all" or producer.get("result") != "success":
+        raise ValueError(f"{producer_meta_path}: invalid producer metadata")
+
+    archive_digest = _read_archive_digest(proof_dir / "archive.sha256")
+    if archive_digest != producer["archive_sha256"]:
+        raise ValueError(f"{producer_meta_path}: archive.sha256 does not match producer metadata")
+    try:
+        version = (proof_dir / "nextest-version.txt").read_text(encoding="utf-8").strip()
+    except OSError as exc:
+        raise ValueError(f"{proof_dir}: cannot read nextest-version.txt: {exc}") from exc
+    if version != producer["nextest_version"]:
+        raise ValueError(f"{producer_meta_path}: nextest-version.txt does not match metadata")
+
+    all_path = proof_dir / "all.json"
+    producer_first_path = proof_dir / "1-2.json"
+    producer_second_path = proof_dir / "2-2.json"
+    for listing, key in (
+        (all_path, "all.json"),
+        (producer_first_path, "1-2.json"),
+        (producer_second_path, "2-2.json"),
+    ):
+        _require_listing_digest(producer, producer_meta_path, listing, key)
+
+    first_meta_path = first_dir / "result-metadata.json"
+    second_meta_path = second_dir / "result-metadata.json"
+    first_meta = _metadata(first_meta_path)
+    second_meta = _metadata(second_meta_path)
+    _matching_metadata(producer, first_meta, first_meta_path, "hash:1/2")
+    _matching_metadata(producer, second_meta, second_meta_path, "hash:2/2")
+    first_listing = first_dir / "selected.json"
+    second_listing = second_dir / "selected.json"
+    for metadata, metadata_path, listing in (
+        (first_meta, first_meta_path, first_listing),
+        (second_meta, second_meta_path, second_listing),
+    ):
+        digest = metadata.get("selected_listing_sha256")
+        if not isinstance(digest, str) or not SHA256_RE.fullmatch(digest):
+            raise ValueError(f"{metadata_path}: selected listing digest is not SHA-256")
+        _require_digest(listing, digest, "selected listing")
+
+    all_tests = _selected(all_path)
+    producer_first = _selected(producer_first_path)
+    producer_second = _selected(producer_second_path)
+    first = _selected(first_listing)
+    second = _selected(second_listing)
+    if producer_first & producer_second or (producer_first | producer_second) != all_tests:
+        raise ValueError("producer hash-partition listings are not a disjoint complete union")
+    if first & second or (first | second) != all_tests:
+        raise ValueError("consumer hash-partition listings are not a disjoint complete union")
+    if first != producer_first or second != producer_second:
+        raise ValueError("consumer selected listings differ from producer partition listings")
+    print(f"transferred nextest proof: all={len(all_tests)} 1/2={len(first)} 2/2={len(second)}")
+
+
+def self_test() -> None:
+    """Exercise selection against ignored and profile-filtered testcases."""
+    all_fixture = {
+        "rust-suites": {
+            "server": {
+                "binary-id": "tcl-lsp-server",
+                "testcases": {
+                    "ordinary": {"ignored": False, "filter-match": {"status": "matches"}},
+                    "ignored": {"ignored": True, "filter-match": {"status": "mismatch"}},
+                    "profile_filtered": {
+                        "ignored": False,
+                        "filter-match": {"status": "mismatch", "reason": "default-filter"},
+                    },
+                },
+            },
+            "other-server": {
+                "binary-id": "other-server",
+                "testcases": {
+                    "ordinary": {"ignored": False, "filter-match": {"status": "matches"}},
+                },
+            },
+        }
+    }
+    first_fixture = json.loads(json.dumps(all_fixture))
+    del first_fixture["rust-suites"]["other-server"]["testcases"]["ordinary"]["filter-match"]
+    first_fixture["rust-suites"]["other-server"]["testcases"]["ordinary"]["filter-match"] = {
+        "status": "mismatch",
+        "reason": "partition",
+    }
+    second_fixture = json.loads(json.dumps(all_fixture))
+    del second_fixture["rust-suites"]["server"]["testcases"]["ordinary"]["filter-match"]
+    second_fixture["rust-suites"]["server"]["testcases"]["ordinary"]["filter-match"] = {
+        "status": "mismatch",
+        "reason": "partition",
+    }
+    fixtures = {"all": all_fixture, "first": first_fixture, "second": second_fixture}
+    expected = {("tcl-lsp-server", "ordinary"), ("other-server", "ordinary")}
+    path = Path("<self-test>")
+    # Exercise the same parser and set assertions without creating files.
+    original_load = globals()["_load"]
+    globals()["_load"] = lambda current: fixtures["all"] if current == path else fixtures[current.name]
+    try:
+        assert _selected(path) == expected
+        verify(Path("all"), Path("first"), Path("second"))
+    finally:
+        globals()["_load"] = original_load
+    print("nextest partition verifier self-test: ok (ignored/config-filtered cases excluded)")
+
+    with tempfile.TemporaryDirectory() as temporary:
+        root = Path(temporary)
+        proof_dir = root / "proof"
+        first_dir = root / "first"
+        second_dir = root / "second"
+        proof_dir.mkdir()
+        first_dir.mkdir()
+        second_dir.mkdir()
+        archive_sha = hashlib.sha256(b"archive").hexdigest()
+        (proof_dir / "archive.sha256").write_text(f"{archive_sha}  lsp-e2e.tar.zst\n", encoding="utf-8")
+        (proof_dir / "nextest-version.txt").write_text("cargo-nextest 0.9.143\n", encoding="utf-8")
+        listing_paths = {
+            "all.json": proof_dir / "all.json",
+            "1-2.json": proof_dir / "1-2.json",
+            "2-2.json": proof_dir / "2-2.json",
+        }
+        listing_paths["all.json"].write_text(json.dumps(all_fixture), encoding="utf-8")
+        listing_paths["1-2.json"].write_text(json.dumps(first_fixture), encoding="utf-8")
+        listing_paths["2-2.json"].write_text(json.dumps(second_fixture), encoding="utf-8")
+        common = {
+            "schema": 1,
+            "workspace_sha": "abc123",
+            "nextest_version": "cargo-nextest 0.9.143",
+            "package": "tcl-lsp-server",
+            "filter": "default",
+            "archive_sha256": archive_sha,
+        }
+        producer_metadata = dict(common)
+        producer_metadata.update(
+            {
+                "kind": "producer",
+                "partition": "all",
+                "result": "success",
+                "listings": {name: _sha256(path) for name, path in listing_paths.items()},
+            }
+        )
+        (proof_dir / "producer-metadata.json").write_text(json.dumps(producer_metadata), encoding="utf-8")
+        for directory, partition, fixture in (
+            (first_dir, "hash:1/2", first_fixture),
+            (second_dir, "hash:2/2", second_fixture),
+        ):
+            listing = directory / "selected.json"
+            listing.write_text(json.dumps(fixture), encoding="utf-8")
+            metadata = dict(common)
+            metadata.update(
+                {
+                    "kind": "consumer",
+                    "partition": partition,
+                    "result": "success",
+                    "selected_listing_sha256": _sha256(listing),
+                    "archive_verified": True,
+                }
+            )
+            (directory / "result-metadata.json").write_text(json.dumps(metadata), encoding="utf-8")
+        assert not (proof_dir / "lsp-e2e.tar.zst").exists()
+        verify_results(proof_dir, first_dir, second_dir)
+    print("nextest transferred-artifact self-test: ok (digest/metadata/result cases)")
+
+
+def main(argv: list[str]) -> int:
+    if argv == ["--self-test"]:
+        self_test()
+        return 0
+    if argv and argv[0] == "--verify-results":
+        if len(argv) != 4:
+            print(f"usage: {sys.argv[0]} --verify-results PROOF_DIR FIRST_DIR SECOND_DIR", file=sys.stderr)
+            return 2
+        try:
+            verify_results(*(Path(arg) for arg in argv[1:]))
+        except ValueError as exc:
+            print(exc, file=sys.stderr)
+            return 1
+        return 0
+    if len(argv) != 3:
+        print(f"usage: {sys.argv[0]} ALL.json FIRST.json SECOND.json", file=sys.stderr)
+        print(f"       {sys.argv[0]} --self-test", file=sys.stderr)
+        return 2
+    try:
+        verify(*(Path(arg) for arg in argv))
+    except ValueError as exc:
+        print(exc, file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/dev/verify-nextest-partitions.py
+++ b/scripts/dev/verify-nextest-partitions.py
@@ -56,7 +56,9 @@ def _selected(path: Path) -> set[TestId]:
                 raise ValueError(f"{path}: malformed testcase in suite {suite_name!r}")
             match = testcase.get("filter-match")
             if not isinstance(match, dict) or "status" not in match:
-                raise ValueError(f"{path}: testcase {binary_id}:{test_name} has no filter-match.status")
+                raise ValueError(
+                    f"{path}: testcase {binary_id}:{test_name} has no filter-match.status"
+                )
             # Do not infer selection from presence, ignored, or a testcase
             # status: nextest's filter decision is authoritative.  This keeps
             # repository/profile config and --run-ignored semantics intact.
@@ -64,7 +66,9 @@ def _selected(path: Path) -> set[TestId]:
                 continue
             test_id = (binary_id, test_name)
             if test_id in seen:
-                raise ValueError(f"{path}: duplicate selected testcase {binary_id}:{test_name}")
+                raise ValueError(
+                    f"{path}: duplicate selected testcase {binary_id}:{test_name}"
+                )
             seen.add(test_id)
             selected.add(test_id)
 
@@ -88,7 +92,9 @@ def verify(all_path: Path, first_path: Path, second_path: Path) -> None:
             f"  unexpected ({len(unexpected)}): {sorted(unexpected)[:5]}",
         ]
         raise ValueError("\n".join(details))
-    print(f"nextest partition proof: all={len(all_tests)} 1/2={len(first)} 2/2={len(second)}")
+    print(
+        f"nextest partition proof: all={len(all_tests)} 1/2={len(first)} 2/2={len(second)}"
+    )
 
 
 def _sha256(path: Path) -> str:
@@ -110,7 +116,14 @@ def _metadata(path: Path) -> dict[str, Any]:
 
 
 def _require_common(metadata: dict[str, Any], path: Path) -> None:
-    required = ("schema", "workspace_sha", "nextest_version", "package", "filter", "archive_sha256")
+    required = (
+        "schema",
+        "workspace_sha",
+        "nextest_version",
+        "package",
+        "filter",
+        "archive_sha256",
+    )
     missing = [key for key in required if key not in metadata]
     if missing:
         raise ValueError(f"{path}: metadata missing {', '.join(missing)}")
@@ -127,7 +140,9 @@ def _require_common(metadata: dict[str, Any], path: Path) -> None:
 def _require_digest(path: Path, expected: str, label: str) -> None:
     actual = _sha256(path)
     if actual != expected:
-        raise ValueError(f"{path}: {label} digest mismatch (expected {expected}, got {actual})")
+        raise ValueError(
+            f"{path}: {label} digest mismatch (expected {expected}, got {actual})"
+        )
 
 
 def _read_archive_digest(path: Path) -> str:
@@ -140,7 +155,9 @@ def _read_archive_digest(path: Path) -> str:
     return fields[0]
 
 
-def _require_listing_digest(metadata: dict[str, Any], path: Path, listing: Path, key: str) -> None:
+def _require_listing_digest(
+    metadata: dict[str, Any], path: Path, listing: Path, key: str
+) -> None:
     listings = metadata.get("listings")
     if not isinstance(listings, dict) or not isinstance(listings.get(key), str):
         raise ValueError(f"{path}: metadata has no digest for {key}")
@@ -154,7 +171,13 @@ def _matching_metadata(
     producer: dict[str, Any], consumer: dict[str, Any], path: Path, partition: str
 ) -> None:
     _require_common(consumer, path)
-    for key in ("workspace_sha", "nextest_version", "package", "filter", "archive_sha256"):
+    for key in (
+        "workspace_sha",
+        "nextest_version",
+        "package",
+        "filter",
+        "archive_sha256",
+    ):
         if consumer[key] != producer[key]:
             raise ValueError(f"{path}: {key} does not match producer metadata")
     if consumer.get("kind") != "consumer" or consumer.get("partition") != partition:
@@ -170,18 +193,30 @@ def verify_results(proof_dir: Path, first_dir: Path, second_dir: Path) -> None:
     producer_meta_path = proof_dir / "producer-metadata.json"
     producer = _metadata(producer_meta_path)
     _require_common(producer, producer_meta_path)
-    if producer.get("kind") != "producer" or producer.get("partition") != "all" or producer.get("result") != "success":
+    if (
+        producer.get("kind") != "producer"
+        or producer.get("partition") != "all"
+        or producer.get("result") != "success"
+    ):
         raise ValueError(f"{producer_meta_path}: invalid producer metadata")
 
     archive_digest = _read_archive_digest(proof_dir / "archive.sha256")
     if archive_digest != producer["archive_sha256"]:
-        raise ValueError(f"{producer_meta_path}: archive.sha256 does not match producer metadata")
+        raise ValueError(
+            f"{producer_meta_path}: archive.sha256 does not match producer metadata"
+        )
     try:
-        version = (proof_dir / "nextest-version.txt").read_text(encoding="utf-8").strip()
+        version = (
+            (proof_dir / "nextest-version.txt").read_text(encoding="utf-8").strip()
+        )
     except OSError as exc:
-        raise ValueError(f"{proof_dir}: cannot read nextest-version.txt: {exc}") from exc
+        raise ValueError(
+            f"{proof_dir}: cannot read nextest-version.txt: {exc}"
+        ) from exc
     if version != producer["nextest_version"]:
-        raise ValueError(f"{producer_meta_path}: nextest-version.txt does not match metadata")
+        raise ValueError(
+            f"{producer_meta_path}: nextest-version.txt does not match metadata"
+        )
 
     all_path = proof_dir / "all.json"
     producer_first_path = proof_dir / "1-2.json"
@@ -215,13 +250,24 @@ def verify_results(proof_dir: Path, first_dir: Path, second_dir: Path) -> None:
     producer_second = _selected(producer_second_path)
     first = _selected(first_listing)
     second = _selected(second_listing)
-    if producer_first & producer_second or (producer_first | producer_second) != all_tests:
-        raise ValueError("producer hash-partition listings are not a disjoint complete union")
+    if (
+        producer_first & producer_second
+        or (producer_first | producer_second) != all_tests
+    ):
+        raise ValueError(
+            "producer hash-partition listings are not a disjoint complete union"
+        )
     if first & second or (first | second) != all_tests:
-        raise ValueError("consumer hash-partition listings are not a disjoint complete union")
+        raise ValueError(
+            "consumer hash-partition listings are not a disjoint complete union"
+        )
     if first != producer_first or second != producer_second:
-        raise ValueError("consumer selected listings differ from producer partition listings")
-    print(f"transferred nextest proof: all={len(all_tests)} 1/2={len(first)} 2/2={len(second)}")
+        raise ValueError(
+            "consumer selected listings differ from producer partition listings"
+        )
+    print(
+        f"transferred nextest proof: all={len(all_tests)} 1/2={len(first)} 2/2={len(second)}"
+    )
 
 
 def self_test() -> None:
@@ -231,25 +277,41 @@ def self_test() -> None:
             "server": {
                 "binary-id": "tcl-lsp-server",
                 "testcases": {
-                    "ordinary": {"ignored": False, "filter-match": {"status": "matches"}},
-                    "ignored": {"ignored": True, "filter-match": {"status": "mismatch"}},
+                    "ordinary": {
+                        "ignored": False,
+                        "filter-match": {"status": "matches"},
+                    },
+                    "ignored": {
+                        "ignored": True,
+                        "filter-match": {"status": "mismatch"},
+                    },
                     "profile_filtered": {
                         "ignored": False,
-                        "filter-match": {"status": "mismatch", "reason": "default-filter"},
+                        "filter-match": {
+                            "status": "mismatch",
+                            "reason": "default-filter",
+                        },
                     },
                 },
             },
             "other-server": {
                 "binary-id": "other-server",
                 "testcases": {
-                    "ordinary": {"ignored": False, "filter-match": {"status": "matches"}},
+                    "ordinary": {
+                        "ignored": False,
+                        "filter-match": {"status": "matches"},
+                    },
                 },
             },
         }
     }
     first_fixture = json.loads(json.dumps(all_fixture))
-    del first_fixture["rust-suites"]["other-server"]["testcases"]["ordinary"]["filter-match"]
-    first_fixture["rust-suites"]["other-server"]["testcases"]["ordinary"]["filter-match"] = {
+    del first_fixture["rust-suites"]["other-server"]["testcases"]["ordinary"][
+        "filter-match"
+    ]
+    first_fixture["rust-suites"]["other-server"]["testcases"]["ordinary"][
+        "filter-match"
+    ] = {
         "status": "mismatch",
         "reason": "partition",
     }
@@ -264,13 +326,17 @@ def self_test() -> None:
     path = Path("<self-test>")
     # Exercise the same parser and set assertions without creating files.
     original_load = globals()["_load"]
-    globals()["_load"] = lambda current: fixtures["all"] if current == path else fixtures[current.name]
+    globals()["_load"] = lambda current: (
+        fixtures["all"] if current == path else fixtures[current.name]
+    )
     try:
         assert _selected(path) == expected
         verify(Path("all"), Path("first"), Path("second"))
     finally:
         globals()["_load"] = original_load
-    print("nextest partition verifier self-test: ok (ignored/config-filtered cases excluded)")
+    print(
+        "nextest partition verifier self-test: ok (ignored/config-filtered cases excluded)"
+    )
 
     with tempfile.TemporaryDirectory() as temporary:
         root = Path(temporary)
@@ -281,16 +347,24 @@ def self_test() -> None:
         first_dir.mkdir()
         second_dir.mkdir()
         archive_sha = hashlib.sha256(b"archive").hexdigest()
-        (proof_dir / "archive.sha256").write_text(f"{archive_sha}  lsp-e2e.tar.zst\n", encoding="utf-8")
-        (proof_dir / "nextest-version.txt").write_text("cargo-nextest 0.9.143\n", encoding="utf-8")
+        (proof_dir / "archive.sha256").write_text(
+            f"{archive_sha}  lsp-e2e.tar.zst\n", encoding="utf-8"
+        )
+        (proof_dir / "nextest-version.txt").write_text(
+            "cargo-nextest 0.9.143\n", encoding="utf-8"
+        )
         listing_paths = {
             "all.json": proof_dir / "all.json",
             "1-2.json": proof_dir / "1-2.json",
             "2-2.json": proof_dir / "2-2.json",
         }
         listing_paths["all.json"].write_text(json.dumps(all_fixture), encoding="utf-8")
-        listing_paths["1-2.json"].write_text(json.dumps(first_fixture), encoding="utf-8")
-        listing_paths["2-2.json"].write_text(json.dumps(second_fixture), encoding="utf-8")
+        listing_paths["1-2.json"].write_text(
+            json.dumps(first_fixture), encoding="utf-8"
+        )
+        listing_paths["2-2.json"].write_text(
+            json.dumps(second_fixture), encoding="utf-8"
+        )
         common = {
             "schema": 1,
             "workspace_sha": "abc123",
@@ -305,10 +379,14 @@ def self_test() -> None:
                 "kind": "producer",
                 "partition": "all",
                 "result": "success",
-                "listings": {name: _sha256(path) for name, path in listing_paths.items()},
+                "listings": {
+                    name: _sha256(path) for name, path in listing_paths.items()
+                },
             }
         )
-        (proof_dir / "producer-metadata.json").write_text(json.dumps(producer_metadata), encoding="utf-8")
+        (proof_dir / "producer-metadata.json").write_text(
+            json.dumps(producer_metadata), encoding="utf-8"
+        )
         for directory, partition, fixture in (
             (first_dir, "hash:1/2", first_fixture),
             (second_dir, "hash:2/2", second_fixture),
@@ -325,7 +403,9 @@ def self_test() -> None:
                     "archive_verified": True,
                 }
             )
-            (directory / "result-metadata.json").write_text(json.dumps(metadata), encoding="utf-8")
+            (directory / "result-metadata.json").write_text(
+                json.dumps(metadata), encoding="utf-8"
+            )
         assert not (proof_dir / "lsp-e2e.tar.zst").exists()
         verify_results(proof_dir, first_dir, second_dir)
     print("nextest transferred-artifact self-test: ok (digest/metadata/result cases)")
@@ -337,7 +417,10 @@ def main(argv: list[str]) -> int:
         return 0
     if argv and argv[0] == "--verify-results":
         if len(argv) != 4:
-            print(f"usage: {sys.argv[0]} --verify-results PROOF_DIR FIRST_DIR SECOND_DIR", file=sys.stderr)
+            print(
+                f"usage: {sys.argv[0]} --verify-results PROOF_DIR FIRST_DIR SECOND_DIR",
+                file=sys.stderr,
+            )
             return 2
         try:
             verify_results(*(Path(arg) for arg in argv[1:]))


### PR DESCRIPTION
## Summary

- build the complete native `tcl-lsp-server --all-features` nextest archive once
- run three deterministic hash partitions from that exact archive on separate hosted runners
- fail closed unless the transferred archive digest, metadata, outcomes, disjointness, and complete union all verify
- preserve the concurrent contention hammer and keep one stable required `lsp-e2e` aggregate check

## Experimental proof

The exact 2,176-test archive on the final branch produces three disjoint,
complete partitions:

- partition 1/3: 762 tests
- partition 2/3: 709 tests
- partition 3/3: 705 tests
- union: all 2,176 selected tests exactly once, with no overlap
- a test executed successfully from the relocated archive using the runtime server path

The preceding two-way CI experiment reduced the warm archive-to-aggregate
critical path from the recent 11m02s unsplit run to 7m49s. The final three-way
run completed that path in 6m22s: 1m51s for the producer, 4m15s/3m44s/3m33s
for the consumers, and 10s for the transferred-proof aggregate. This is 42%
faster than the unsplit run and retains every test while checking the exact
union both before upload and after artifact transfer.

## Gates

- `make NPROC=1 rust-check` on Rust 1.98.1
- `CARGO_BUILD_JOBS=1 make NPROC=1 prep-pr` — 30/30 smoke tests passed
- `sh scripts/dev/test-lsp-e2e-partitions.sh`
- `python3 scripts/dev/verify-nextest-partitions.py --self-test`
- full Ruff, ty, and Pyright checks — clean
- independent final review — no functional or fail-open findings
- review feedback addressed: mandatory project copyright and AGPL/SPDX header added

Closes #1916
