### PR TITLE
fix(tclvm): preserve stable variable identity and constant introspection

### DIFF
--- a/docs/design/contracts/variable-trace-dispatch-and-introspection.md
+++ b/docs/design/contracts/variable-trace-dispatch-and-introspection.md
@@ -1,8 +1,8 @@
 # Contract: variable-trace dispatch & introspection coherence
 
-> The firing, ordering, error, and re-entrancy contract both runtimes
-> implement for variable traces, and the rule that introspection (`info`,
-> `trace info`) reads live state. Builds on
+> The Tcl firing, ordering, error, and re-entrancy contract variable-trace
+> implementations target, and the rule that introspection (`info`, `trace
+> info`) reads live state. Runtime-specific gaps are called out below. Builds on
 > [runtime-variable-frame-model.md](runtime-variable-frame-model.md); the
 > as-built dispatch is
 > [runtime/trace-implementation.md](../runtime/trace-implementation.md). The
@@ -32,8 +32,9 @@ array}`, `name1`/`name2` are the array-and-element (scalar ⇒ `name2` empty):
 1. **Order.** Whole-array (`name1`) traces fire **before** element
    (`name1(name2)`) traces — as *groups*, so registration order never puts an
    element trace ahead of an array one. Within a group, **newest-first
-   (LIFO)**, for every op. A re-entrancy guard (`active` flag per record)
-   skips a record already on the stack.
+   (LIFO)**, for every op. A re-entrancy guard belongs to the resolved `Var`
+   cell: recursive access to that exact scalar/array/element is suppressed,
+   while a callback may enter a different element of the same array.
 2. **Callback shape.** Each callback is evaluated as a *script*: the verbatim
    command prefix with `name1`, `name2`, and the **full op word**
    (`read`/`write`/`unset`/`array`) appended as list elements. (This is what
@@ -78,9 +79,11 @@ Where C commits the operation around the trace, the runtime must too:
   `lappend` — on scalars and array elements alike, **including a variable or
   element the failing write itself created**: it stays in existence, holding
   the new value.
-* **Unset:** the cell is torn down as part of the unset; unset traces fire
-  *during* teardown and their errors are ignored (#4). The variable is gone
-  regardless — a subsequent read must error `no such variable`.
+* **Ordinary unset:** the old cell is detached as part of the unset; unset
+  traces fire *during* teardown and their errors are ignored (#4). A value
+  recreated by a callback survives as a replacement binding, without the
+  taken trace list. Owner teardown is intentionally stronger: frame/namespace
+  destruction purges callback recreation because the owner itself is dying.
 
 * **The result is the value read back *after* the write traces**, not the
   value the store was handed: C's `TclPtrSetVarIdx` returns
@@ -116,6 +119,33 @@ Where C commits the operation around the trace, the runtime must too:
   carries no traces (not even a write trace that would otherwise have fired on
   that store). A whole-array trace is not the element's, so an element unset
   leaves it in place.
+* Moving an unset list to C's dummy cell clears the old cell's active bit. An
+  unset initiated by that same cell's write callback therefore still runs the
+  taken unset callbacks; the ordinary exact-cell guard continues to suppress
+  other recursive operations.
+* Destroying a whole array detaches its old element table and tears down those
+  element cells one at a time. Each element's unset callbacks run, later old
+  elements remain observable until their own turn, and an alias to an old
+  element becomes dangling rather than retargeting a same-name element in a
+  newly created array.
+* In `rust/tcl-vm`, every array subcommand implemented and advertised by the VM
+  adapter runs the array-operation trace through one LocateArray-equivalent
+  owner after dialect-aware subcommand and arity resolution. The target comes
+  from registry argument roles, so direct, lowered and dedicated-opcode
+  consumers agree. An operation reference retains the reached `VarId` and its
+  direct binding shell, so unset-and-recreate refills the same cell. That target
+  is passed to the shared `array` core: `exists`/`size`/`names`, `get` key
+  enumeration, and patterned `unset` retain it when a callback retargets an alias. Tcl
+  deliberately re-resolves `get` values, `array set`, and whole-array `unset`;
+  `array for` rejects a changed identity or active-search revision as `array
+  changed during iteration` even when key deletion/recreation leaves the same
+  final set. Its search snapshots physical element-table keys, including
+  undefined trace/link shells, then skips or reads each candidate live; defining
+  an existing shell does not invalidate the search and can make a later row
+  visible.
+  `array for` validates its two-variable list before firing, as Tcl does. Tcl
+  9's `array default` is not yet in the adapter surface. This describes the VM
+  change only; tree-walker parity remains tracked separately.
 * **A trace a callback removes does not fire in the same pass**, whether it is
   older and not yet reached or newer and already run; one a callback adds does
   not fire until the next access. `trace info` reflects both at once. This
@@ -145,8 +175,13 @@ compile-time-foldable:
   have their own fixed orders (`rename delete`; `enter leave enterstep
   leavestep`). 8.x's `trace vinfo` reports the same live list with each op set
   collapsed to its `rwua` letters.
-* `info vars` / `info locals` / `info level` read the current cell table and
-  call stack.
+* `info vars` / `info locals` / `info consts` / `info level` read the current
+  cell table and call stack. `info consts` enumerates direct constant bindings
+  plus typed TclOO instance projections, but not ordinary link targets, and
+  namespace-scope scans include unshadowed global constants. Tcl's observable
+  direct-lookup fast path is retained too: a metacharacter-free exact pattern
+  falls through to a global constant even past a same-named non-constant local
+  binding. Both runtimes use the same byte-preserving Family-B core.
 
 **Rule:** any compile-time const/liveness map MUST be invalidated by `unset`,
 `upvar`, `global`, `variable`, `trace add variable`, and every
@@ -164,7 +199,7 @@ interpreter can't see by name can't be traced.
 | Full `arr(key)` name reported even for a whole-array trace | **Contract** | The accessed element's name, not the matched key. |
 | Unset-trace error ignored; unset succeeds; later unset traces still fire | **Contract** | C disposes the result, leaves code OK, continues. |
 | Read/write error stops further trace firing; whole-array before element; LIFO | **Contract** | Ordering is observable. |
-| Value stored before write trace; cell gone after unset regardless of trace | **Contract** | Mutation not gated on trace outcome — a failed write keeps the new value and any cell it created. |
+| Value stored before write trace; ordinary unset detaches the old cell before tracing | **Contract** | Mutation is not gated on trace outcome. A failed write keeps the new value; an unset callback may create a distinct replacement cell that survives ordinary unset. Owner teardown forcibly purges such recreation. |
 | `trace info` op order is C's fixed per-kind order, not the spelled order | **Contract** | `array read write unset` / `rename delete` / `enter leave enterstep leavestep`. |
 | 8.x `trace variable`/`vdelete`/`vinfo` exist ≤8.6 and are `bad option` at 9.0+ | **Contract** | The registry's `DialectSet::TCL8X` gate states the boundary; the option enumeration follows it. |
 | An old-style-installed callback gets the `rwua` letter, not the op word | **Contract** | `TCL_TRACE_OLD_STYLE`; matching still ignores the flag. |

--- a/docs/design/family-b-routing.md
+++ b/docs/design/family-b-routing.md
@@ -16,10 +16,10 @@ them, so a consumer generic over the traits drives either runtime:
 
 | Trait | Surface |
 |-------|---------|
-| `VarStore` | `get`/`set`/`unset`/`exists` + the explicit array-element pairs `get_elem`/`set_elem`/`unset_elem`/`exists_elem`, addressed by `FrameId` |
-| `Frames` | `push(NsId)`/`pop`/`current`/`link` (the `upvar` install), plus active-frame variable enumeration `in_proc()`/`var_names(include_links)` |
+| `VarStore` | `get`/`set`/`unset`/`exists` + explicit array-element access, addressed by `FrameId`; `unset_command` preserves immutable-cell refusals for command consumers; `ArrayTarget` and the `*_at` rungs preserve a located array cell across callbacks when the runtime has stable `VarId`s |
+| `Frames` | `push(NsId)`/`pop`/`current`/`link` (the `upvar` install), plus active-frame variable enumeration `in_proc()`/`var_names(include_links)`/`const_names()` |
 | `Commands` | `dispatch(name, argv)` and `dispatch_id(CommandId, argv)` — the resolve-then-invoke pair with `find_command` |
-| `Namespaces` | `find_command(cxt, name) -> CommandId`, `current() -> NsId`, `name(NsId) -> String`, `command_name(CommandId) -> Option<String>`, tree nav `find_namespace`/`parent`/`children`, and member enumeration `commands_in(NsId)`/`procs_in(NsId)`/`vars_in(NsId)` |
+| `Namespaces` | `find_command(cxt, name) -> CommandId`, `current() -> NsId`, `name(NsId) -> String`, `command_name(CommandId) -> Option<String>`, tree nav `find_namespace`/`parent`/`children`, and member enumeration `commands_in(NsId)`/`procs_in(NsId)`/`vars_in(NsId)`/`consts_in(NsId)` |
 | `Traces` | `fire(var, op)` (read/write/unset; read/write errors abort) |
 | `Introspect` | `level()`, `level_argv(n)` |
 | `Procs` | `proc_info(name) -> Option<ProcInfo>` (a proc's body + formals, for `info body`/`args`/`default`) |
@@ -98,17 +98,34 @@ Shared in `tcl-cmd-core`:
   `commands_in`, and the frame rungs read the active frame's table. Routing split
   `info vars` from `info locals` on the VM (it had aliased them, so `info vars` in
   a proc dropped its links) and gave `info globals` the global-only filter.
-  `info consts` (TIP 677) stays per-adapter — the VM has no `const`.
-- `array::dispatch` — the `array` **read-side** (`exists`/`size`/`names`/`get`)
+  `info::consts` adds the binding-specific constant rungs
+  (`Frames::const_names`/`Namespaces::consts_in`). They inspect the direct
+  binding rather than following an ordinary link: `info constant alias` follows
+  an alias, but `info consts` enumerates only direct constants and typed TclOO
+  instance projections. At namespace scope the core merges unshadowed global
+  constants for scans and preserves Tcl's direct-lookup fallback for a
+  metacharacter-free exact pattern. Its byte entry points keep runtime names
+  lossless through glob matching and result construction.
+- `array::{dispatch, dispatch_at}` — the `array` **read-side** (`exists`/`size`/`names`/`get`)
   + `unset`, over `VarStore` + `Frames` + `ValueOps`. This is the first stateful
   *command* family shared over the interp-state seam (the `info`/`namespace`
   entries above are individual subcommands). It needed one new contract rung,
   `VarStore::array_keys` — the **enumeration** surface the otherwise-listing-free
   state traits expose, returning an array's element keys (or `None` for a
-  scalar/unset, the existence signal). `array set`'s per-element write-trace store
+  scalar/unset, the existence signal). `ArrayTarget` is the operation-scoped
+  LocateArray result. A stable-cell runtime retains the cell and its direct
+  binding shell across the command, and routes `exists`/`size`/`names`, the
+  key half of `get`, and patterned `unset` through its `VarId`; the shared core
+  deliberately re-resolves the spelling for `get` values and whole-array
+  `unset`, matching Tcl's post-operation-trace target policy. Whole-array
+  mutation uses the fallible `VarStore::unset_command` rung, so a trace that
+  retargets the live spelling to a Tcl 9 constant keeps its structured
+  `TCL UNSET CONST` refusal in either adapter. The trace-aware
+  value read required by `array get` remains tracked in #1932. `array set`'s per-element write-trace store
   stays per-adapter (`VarStore::set_elem` is storage-only, like `incr`/`append`);
   `array default`/`array for` stay per-adapter (TIP 508 state / Family-B
-  iteration). Routing fixed a VM bug: `array unset a` with no pattern now removes
+  iteration), with shared storage rungs for physical search keys, live candidate
+  existence, and active-search revision. Routing fixed a VM bug: `array unset a` with no pattern now removes
   the **whole array** (was: iterate-and-unset elements, leaving an empty array).
 - `namespace::{tail, qualifiers}` — pure byte ops.
 - `namespace::{current, which_command}` — over `Namespaces` (`current`/`name`/
@@ -321,12 +338,12 @@ manipulates list *element values*, never their string rep. This is the
   consumer needs cross-frame element access.
 - The enumeration surface is complete for the shared listing subcommands:
   `VarStore::array_keys` (array elements), `Namespaces::commands_in`/`procs_in`/
-  `vars_in` (a namespace's commands/procs/variables), and the active-frame
-  `Frames::var_names`/`in_proc` (frame locals + links). These back `info
-  commands`/`procs`/`vars`/`locals`/`globals` and `array names`. The one
-  listing left per-adapter is `info consts` (TIP 677, runtime-only — the VM
-  has no `const`). The VM stores namespace variables flat, in the global
-  frame keyed by qualified name, so the rungs read them directly.
+  `vars_in`/`consts_in` (a namespace's commands/procs/variables/constants), and
+  the active-frame `Frames::var_names`/`const_names`/`in_proc` (frame locals,
+  links, and constant-visible bindings). These back `info commands`/`procs`/
+  `vars`/`locals`/`globals`/`consts` and `array names`. Constant enumeration is
+  binding-specific: automatic TclOO instance projections are visible, while
+  ordinary links are not; the singular `info constant` query follows both.
 - `append`/`lappend` fire the write trace **once** over the whole operation, not
   per value (C's `append` fires per value). The user-visible common case — a
   write trace that runs on a mutating append — is covered; the exact count is

--- a/docs/design/runtime/command-introspection.md
+++ b/docs/design/runtime/command-introspection.md
@@ -11,6 +11,8 @@ rename/alias layer ([`rename-alias.md`](rename-alias.md)):
   probes, plus ``namespace current``.
 - ``info commands ?pattern?`` / ``info procs ?pattern?`` listings that
   consume the same command tables dispatch resolves against.
+- ``info consts ?pattern?`` over constant-visible bindings in frames and
+  direct constant bindings in namespaces.
 - ``info body`` / ``info args`` / ``info default proc arg var``
   for interpreted procs.
 - ``info level`` / ``info script``.
@@ -21,7 +23,8 @@ live here, not in ``tclInterp.c``, which holds only the ``ChildHide`` /
 ``ChildExpose`` / ``ChildInvokeHidden`` argument wrappers),
 ``tmp/tcl9.0.4/generic/tclNamesp.c`` (``Tcl_NamespaceWhichObjCmd``,
 ``Tcl_GetCommandFullName``), and ``tmp/tcl9.0.4/generic/tclCmdIL.c``
-(``InfoCommandsCmd``, ``InfoProcsCmd``, ``InfoDefaultCmd``).
+(``InfoCommandsCmd``, ``InfoProcsCmd``, ``InfoDefaultCmd``), and
+``tmp/tcl9.0.4/generic/tclVar.c`` (``InfoConstsCmd``).
 
 ## 1. Scope
 
@@ -31,6 +34,7 @@ In:
   addressing the interpreter named by a (possibly nested) path.
 - ``namespace which`` (find-only) + ``namespace current``.
 - ``info commands`` / ``info procs`` listings over the ns tree.
+- ``info consts`` listings over procedure and namespace bindings.
 - ``info body`` / ``info args`` / ``info default`` for
   interpreted procs, following ``namespace import`` redirects to the
   underlying proc.
@@ -237,6 +241,21 @@ Hidden-table entries never appear in ``info commands`` — tclsh
 treats hidden commands as invisible to the resolver.  The
 listing consults only the namespace command tables and never probes
 the hidden side-table.
+
+### 3.4 Constant bindings
+
+``info consts`` is the shared `tcl_cmd_core::info::consts` core over the
+Family-B `Frames` and `Namespaces` roles. Its enumeration is deliberately
+binding-specific: automatic TclOO instance-variable projections are included
+when their target is constant, while a local `upvar`/`global` alias may make
+``info constant alias`` true but remains absent from ``info consts``. The link
+origin is typed in the shared runtime contract rather than inferred from a
+command name. At namespace scope, unqualified scans include global constants
+not shadowed by any current-namespace variable; a metacharacter-free exact
+pattern preserves Tcl's direct-lookup fallback to a global constant even past a
+same-named non-constant local binding. Qualified patterns select one namespace
+and return qualified names. Enumeration, glob matching, and value construction
+remain byte-preserving for the standalone runtime.
 
 ## 4. Compiled procs and rename
 

--- a/docs/design/runtime/trace-implementation.md
+++ b/docs/design/runtime/trace-implementation.md
@@ -64,21 +64,42 @@ one firing site. Both runtimes funnel accordingly.
 
 | Trace kind | Storage | Fired from |
 |---|---|---|
-| variable | keyed by resolved variable identity — home namespace *or* local call-frame level, plus the simple name | `Interp::fire_var_trace` / `fire_var_trace_resolved`, called from the scalar and array-element read/write/unset paths |
+| variable | keyed by resolved variable location — home namespace *or* local call-frame level, plus the simple name and optional element | `Interp::fire_var_trace` / `fire_var_trace_resolved`, called from the scalar and array-element read/write/unset paths |
 | command | keyed by resolved FQN (`Interp::resolve_cmd_fqn`) | `Interp::fire_cmd_trace`, from the `rename` and command-delete paths |
 | execution | keyed by resolved FQN | `Interp::dispatch` — `enter`/`leave` around the traced command's own invocation, `enterstep`/`leavestep` around every command executed while a step-traced command is on the stack |
 
-Because the key is the *resolved* identity rather than the written name, a
+Because the key is the resolved location rather than the written name, a
 trace follows the variable or command through `upvar`/`global` links and
 through a `rename` (`move_cmd_traces`), and is dropped when the command is
 deleted (`remove_cmd_traces`) or its frame is popped
-(`clear_frame_var_traces`).
+(`clear_frame_var_traces`). The variable location does not yet carry a stable
+cell generation: an unset callback that recreates the same spelling can still
+collide with the old active scope. That remaining #1574 work is why this
+section does not describe the key as a variable identity.
 
 ### `rust/tcl-vm` (bytecode VM)
 
-The VM keeps the same three tables (`cmd_traces` / `exec_traces` on the
-interpreter) keyed by resolved FQN, plus one extra piece of state that the
-tree-walker does not need: because the VM executes compiled proc bodies,
+The VM stores frame and namespace bindings as simple-name → monotonic `VarId`
+tables. Namespace tables belong to `NsId`, while an interpreter-global sparse
+arena owns scalar, array, link and undefined cells; array element tables point
+to their own `VarId`s. Variable traces and their active stack use the resolved
+`VarId`, so parked coroutine frames and retained/recreated same-name namespace
+tokens cannot collide. Link cells retain a target ID rather than a
+frame/name pair, and unbound/unlinked/unpinned cells are collected without ID
+reuse.
+
+The representation owner is `rust/tcl-vm/src/vars.rs`; the single
+name→owner→cell resolver and lifecycle transitions live in `interp.rs`.
+`cmd_array.rs` derives array-operation targets from the active profile's
+registry argument roles, and `exec.rs` routes dedicated array opcodes through
+the same owner. The Tcl 9.0.4 transcripts and direct consumer checks are in
+`variable_trace_semantics_e2e.rs`, `variable_name_resolution_e2e.rs`,
+`namespace_surface_e2e.rs`, and `opcode_c_parity.rs`; arena/storage retirement
+invariants are unit-tested beside the owners.
+
+Command/execution traces remain the command-side tables described below. The
+VM also needs one extra piece of state that the tree-walker does not: because
+it executes compiled proc bodies,
 installing a new `enterstep`/`leavestep`-capable trace has to invalidate the
 compiled bodies that would otherwise skip the per-command step hook. An
 epoch counter, bumped on every `trace add|remove execution … enterstep`,
@@ -187,7 +208,16 @@ goes. Every removal site therefore searches from the newest end (`rposition`
 over our oldest-first Vecs), as does the teardown path that collects a
 namespace's unset traces before firing them.
 
-Namespace teardown fires **command**-delete traces one command at a time, in
+In `rust/tcl-vm`, namespace teardown removes and fires **variable** unset traces
+before command retirement, one variable cell at a time. The callback sees its
+own cell absent but later cells still present; an exact-name recreation/new
+trace is forcibly purged without a second callback. Trace-only undefined cells
+participate too. The callback name is the variable's fully-qualified namespace
+spelling, and a retained token is addressed by `NsId`, never by resolving a
+possibly recreated public name. This paragraph does not claim the same stable
+cell-generation implementation for `runtime/rust`.
+
+Namespace teardown then fires **command**-delete traces one command at a time, in
 the order `TclTeardownNamespace` snapshots `nsPtr->cmdTable` — the retained
 `TCL_STRING_KEYS` bucket order, not registration or lexical order (issue
 #1752). Each token's traces fire while its entry is still in the table, then

--- a/runtime/rust/src/cmd_array.rs
+++ b/runtime/rust/src/cmd_array.rs
@@ -122,7 +122,13 @@ fn array_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
                 interp.set_result(v);
                 Code::Ok
             }
-            Err(e) => interp.set_error(e.message().as_bytes()),
+            Err(e) => {
+                let (message, error_code) = e.into_parts();
+                match error_code {
+                    Some(code) => interp.error_with_code(message.as_bytes(), code.as_bytes()),
+                    None => interp.set_error(message.as_bytes()),
+                }
+            }
         };
     }
     // Per-runtime: `set` (per-element write traces), `default` (TIP 508), `for`
@@ -484,6 +490,22 @@ mod tests {
             assert_eq!(run(i, b"array names a"), b"x z");
             run(i, b"array unset a"); // whole array
             assert_eq!(run(i, b"array exists a"), b"0");
+        });
+    }
+
+    #[test]
+    fn whole_array_unset_preserves_constant_error_identity() {
+        leak_free(|i| {
+            run(i, b"array set a {x 1}");
+            i.mark_constant(b"a");
+
+            assert_eq!(i.eval_str(b"array unset a"), Code::Error);
+            let message = i.result_bytes();
+            assert_eq!(message, br#"can't unset "a": variable is a constant"#);
+            // An outermost `eval_str` publishes the live exception state to
+            // Tcl's compatibility globals before it returns.
+            assert_eq!(run(i, b"set ::errorCode"), b"TCL UNSET CONST");
+            assert!(i.array_names(b"a").is_some());
         });
     }
 }

--- a/runtime/rust/src/cmd_info.rs
+++ b/runtime/rust/src/cmd_info.rs
@@ -240,13 +240,7 @@ fn info_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             interp.set_result_bytes(if is_const { b"1" } else { b"0" });
             Code::Ok
         }
-        b"consts" => set_list_qualified(
-            interp,
-            argv,
-            b"info consts ?pattern?",
-            Interp::consts_in_namespace,
-            Interp::visible_const_names,
-        ),
+        b"consts" => info_consts(interp, argv),
         other => interp.set_error(&tcl_cmd_core::ensemble::unknown_subcommand_message(
             SUBS,
             other,
@@ -302,57 +296,11 @@ fn set_filtered(interp: &mut Interp, names: Vec<Vec<u8>>, pattern: Option<&[u8]>
     Code::Ok
 }
 
-/// `info commands|procs|vars ?pattern?` — a namespace-qualified pattern
-/// (`::ns::glob`) lists the matching names *in that namespace* (re-qualified);
-/// an unqualified pattern filters the names visible from the current scope.
-fn set_list_qualified(
-    interp: &mut Interp,
-    argv: &[*mut TclObj],
-    usage: &[u8],
-    in_namespace: fn(&Interp, &[u8]) -> Vec<Vec<u8>>,
-    visible: fn(&Interp) -> Vec<Vec<u8>>,
-) -> Code {
-    if argv.len() > 3 {
-        return interp.wrong_args(usage);
-    }
-    let pattern = argv.get(2).map(|&a| obj_bytes(a));
-    // Find the last `::` so a qualified pattern splits into (prefix, tail glob).
-    let split = pattern.as_deref().and_then(|p| {
-        p.windows(2)
-            .rposition(|w| w == b"::")
-            .map(|i| (&p[..i], &p[i + 2..]))
-    });
-    if let Some((prefix, tail)) = split {
-        // Re-qualify through the namespace's canonical full name so results are
-        // absolute even for a *relative* qualifier (`info commands ns::pat`).
-        let Some(canon) = interp.canonical_ns_prefix(prefix) else {
-            interp.set_result(list::new_list_obj(&[]));
-            return Code::Ok;
-        };
-        let names = in_namespace(interp, prefix);
-        let objs: Vec<*mut TclObj> = names
-            .iter()
-            .filter(|n| glob_match(tail, n))
-            .map(|n| {
-                let mut full = canon.clone();
-                full.extend_from_slice(n);
-                new_string(&full)
-            })
-            .collect();
-        let l = list::new_list_obj(&objs);
-        interp.set_result(l);
-        return Code::Ok;
-    }
-    let list = visible(interp);
-    set_filtered(interp, list, pattern.as_deref())
-}
-
 /// `info commands ?pattern?` / `info procs ?pattern?` — the shared
 /// namespace-aware command/proc listing core (over the `Namespaces` enumeration
 /// rungs); `procs_only` selects `procs`. The qualified-pattern split,
 /// re-qualification, glob filter, and the global-merge asymmetry all live in the
-/// core. (Variable listing — `vars`/`locals`/`globals`/`consts` — stays on
-/// [`set_list_qualified`]: the VM has no namespace variables to share against.)
+/// core.
 fn info_command_list(
     interp: &mut Interp,
     argv: &[*mut TclObj],
@@ -380,8 +328,7 @@ enum VarList {
 /// `info vars`/`locals`/`globals` — the shared variable-listing cores (over
 /// `Namespaces::vars_in` + the active-frame `Frames` rungs). The whole
 /// context/namespace/link logic lives in the core; this adapter only checks
-/// arity and maps the result. (`consts` stays on [`set_list_qualified`] — TIP 677
-/// is runtime-only.)
+/// arity and maps the result.
 fn info_var_list(interp: &mut Interp, argv: &[*mut TclObj], usage: &[u8], which: VarList) -> Code {
     if argv.len() > 3 {
         return interp.wrong_args(usage);
@@ -392,6 +339,15 @@ fn info_var_list(interp: &mut Interp, argv: &[*mut TclObj], usage: &[u8], which:
         VarList::Locals => tcl_cmd_core::info::locals(interp, pattern),
         VarList::Globals => tcl_cmd_core::info::globals(interp, pattern),
     };
+    interp.set_result(result);
+    Code::Ok
+}
+
+fn info_consts(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
+    if argv.len() > 3 {
+        return interp.wrong_args(b"info consts ?pattern?");
+    }
+    let result = tcl_cmd_core::info::consts(interp, argv.get(2));
     interp.set_result(result);
     Code::Ok
 }
@@ -802,6 +758,112 @@ mod tests {
             assert_eq!(run(i, b"info exists a(nope)"), b"0");
             assert_eq!(run(i, b"info exists a"), b"1"); // the array exists
             i.eval_str(b"unset x a");
+        });
+    }
+
+    #[test]
+    fn info_consts_enumerates_bindings_and_namespace_global_fallback() {
+        leak_free(|i| {
+            assert_eq!(
+                run(
+                    i,
+                    concat!(
+                        "const G 1; namespace eval N {const C 2; set ordinary 0}; ",
+                        "list [lsort [info consts]] [info consts G] ",
+                        "[info consts N::*] [info consts ::N::*]"
+                    )
+                    .as_bytes(),
+                ),
+                b"G G ::N::C ::N::C"
+            );
+            assert_eq!(
+                run(
+                    i,
+                    concat!(
+                        "namespace eval N {list [lsort [info consts]] ",
+                        "[lsort [info consts *]] [info consts G] [info consts C] ",
+                        "[info consts ::*]}"
+                    )
+                    .as_bytes(),
+                ),
+                b"{C G} {C G} G C ::G"
+            );
+            assert_eq!(
+                run(
+                    i,
+                    concat!(
+                        "proc p {} {const L 3; set ordinary 0; global G; ",
+                        "upvar #0 ::N::C U; list [lsort [info vars]] ",
+                        "[lsort [info consts]] [info constant L] [info constant G] ",
+                        "[info constant U] [info consts ::*] [info consts N::*]}; p"
+                    )
+                    .as_bytes(),
+                ),
+                b"{G L U ordinary} L 1 1 1 ::G ::N::C"
+            );
+            assert_eq!(
+                run(
+                    i,
+                    concat!(
+                        "namespace eval M {const C 4; namespace upvar :: G A; ",
+                        "list [lsort [info vars]] [lsort [info consts]] ",
+                        "[info constant A] [info consts A] [info consts G]}"
+                    )
+                    .as_bytes(),
+                ),
+                b"{A C} {C G} 1 {} G"
+            );
+            assert_eq!(
+                run(
+                    i,
+                    concat!(
+                        "namespace eval S {const C 5; set G shadow; ",
+                        "list [lsort [info consts]] [info consts G] ",
+                        "[info consts G*] [info constant G] [info constant ::G]}"
+                    )
+                    .as_bytes(),
+                ),
+                b"C G {} 0 1"
+            );
+            assert_eq!(
+                run(
+                    i,
+                    b"const ::x 1; list [info consts :::x] [info consts ::::x] [info consts ::::::*]",
+                ),
+                b"::x ::x {::G ::x}"
+            );
+        });
+    }
+
+    #[test]
+    fn info_consts_includes_only_tcloo_instance_links() {
+        leak_free(|i| {
+            assert_eq!(
+                run(
+                    i,
+                    concat!(
+                        "const G 9; oo::class create C {variable X; ",
+                        "constructor {} {const X 1}; method inspect {} {global G; ",
+                        "upvar #0 ::G U; list [info consts] [info constant G] ",
+                        "[info constant U]}; method retarget {} {upvar #0 ::G X; ",
+                        "list [info consts] [info constant X]}; method shadow {X} ",
+                        "{list $X [info consts]}}; set o [C new]; ",
+                        "oo::object create O; oo::objdefine O {variable P; ",
+                        "method init {} {const P 2}; method inspect {} {info consts}}; ",
+                        "O init; oo::class create CA {variable X; method inspect {} ",
+                        "{list [info consts] [info constant X] $X}}; set oa [CA new]; ",
+                        "namespace eval [info object namespace $oa] ",
+                        "{namespace upvar :: G X}; oo::class create CP ",
+                        "{method inspect {} {info consts}}; CP create op; ",
+                        "oo::objdefine op {variable Q; method init {} {const Q 3}}; ",
+                        "op init; list [$o inspect] [$o retarget] [$o shadow formal] ",
+                        "[O inspect] [$oa inspect] [op inspect] ",
+                        "[info constant [info object namespace op]::Q]"
+                    )
+                    .as_bytes(),
+                ),
+                b"{X 1 1} {{} 1} {formal {}} P {{} 1 9} {} 1"
+            );
         });
     }
 

--- a/runtime/rust/src/cmd_oo.rs
+++ b/runtime/rust/src/cmd_oo.rs
@@ -5770,6 +5770,10 @@ impl Interp {
                 }
             }
         }
+        // TclOO's automatic instance-variable resolver yields to a method
+        // formal of the same name. Explicit `my variable X` still uses the
+        // ordinary link path and reports a collision.
+        vars.retain(|(local, _)| !params.iter().any(|param| param.name == *local));
         let name = if method.is_empty() {
             b"<constructor>".to_vec()
         } else {

--- a/runtime/rust/src/frame.rs
+++ b/runtime/rust/src/frame.rs
@@ -20,7 +20,7 @@
 //!
 //! Canonical model: `tclInt.h`'s `Var` is a tagged union
 //! `{ scalar objPtr | array tablePtr | linkPtr }` held in a hash table
-//! (`tmp/tcl9.0.3/generic/tclVar.c`). In C every variable lives in *some*
+//! (`tmp/tcl9.0.4/generic/tclVar.c`). In C every variable lives in *some*
 //! [`VarTable`]: a proc call frame's locals, or a **namespace** var table
 //! (`Namespace.varTable`) — the global frame's table *is* the global
 //! namespace's. This module owns the cell mechanics ([`Var`], [`VarTable`]) and
@@ -46,6 +46,8 @@
 //! overwriting/unsetting/dropping releases. Links own nothing.
 
 use std::collections::BTreeMap;
+
+use tcl_runtime_api::FrameLinkOrigin;
 
 use crate::namespace::NsId;
 use crate::obj::{self, TclObj};
@@ -142,6 +144,9 @@ struct Cell {
     /// constant`. On the cell rather than in a side set so a compiled slot's
     /// write check is the same O(1) index as the write itself.
     constant: bool,
+    /// Why a link occupies this frame cell. `TclOO`'s automatic instance
+    /// projections participate in `info consts`; ordinary aliases do not.
+    link_origin: FrameLinkOrigin,
     /// **The per-cell trace bit**: whether a variable trace can observe this
     /// cell, together with the variable-trace epoch that answer was computed
     /// for.
@@ -197,6 +202,7 @@ impl VarTable {
             name: name.to_vec(),
             var: None,
             constant: false,
+            link_origin: FrameLinkOrigin::Ordinary,
             traced: core::cell::Cell::new((0, false)),
         });
         self.slots.insert(name.to_vec(), slot);
@@ -240,6 +246,7 @@ impl VarTable {
     /// Store `var` under `name`, returning the variable it displaced.
     fn put(&mut self, name: &[u8], var: Var) -> Option<Var> {
         let slot = self.slot_for(name);
+        self.cells[slot].link_origin = FrameLinkOrigin::Ordinary;
         self.cells[slot].var.replace(var)
     }
 
@@ -274,6 +281,24 @@ impl VarTable {
             .iter()
             .filter(|(_, slot)| self.cells[**slot].constant)
             .map(|(name, _)| name.as_slice())
+            .collect()
+    }
+
+    /// Automatic `TclOO` instance links in this table. The variable coordinator
+    /// resolves their targets because those may live in another table.
+    pub(crate) fn tcloo_instance_links(&self) -> Vec<(&[u8], &Link)> {
+        self.slots
+            .iter()
+            .filter_map(|(name, slot)| {
+                let cell = &self.cells[*slot];
+                if cell.link_origin != FrameLinkOrigin::TclOoInstance {
+                    return None;
+                }
+                match cell.var.as_ref()? {
+                    Var::Link(link) => Some((name.as_slice(), link)),
+                    Var::Scalar(_) | Var::Array(_) => None,
+                }
+            })
             .collect()
     }
 
@@ -459,7 +484,19 @@ impl VarTable {
 
     /// Install `link` under `name`, releasing any cell it replaces.
     pub(crate) fn insert_link(&mut self, name: &[u8], link: Link) {
-        if let Some(old) = self.put(name, Var::Link(link)) {
+        self.insert_link_with_origin(name, link, FrameLinkOrigin::Ordinary);
+    }
+
+    /// Install a link with its typed frame-binding origin.
+    pub(crate) fn insert_link_with_origin(
+        &mut self,
+        name: &[u8],
+        link: Link,
+        origin: FrameLinkOrigin,
+    ) {
+        let slot = self.slot_for(name);
+        self.cells[slot].link_origin = origin;
+        if let Some(old) = self.cells[slot].var.replace(Var::Link(link)) {
             old.release();
         }
     }
@@ -817,6 +854,34 @@ impl FrameStack {
                     .non_link_names()
                     .into_iter()
                     .map(<[u8]>::to_vec)
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    /// Direct `const` bindings in the active frame (`info consts`).
+    pub(crate) fn const_names(&self) -> Vec<Vec<u8>> {
+        self.index_of_level(self.active_level)
+            .map(|i| {
+                self.frames[i]
+                    .table
+                    .const_names()
+                    .into_iter()
+                    .map(<[u8]>::to_vec)
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    /// Automatic `TclOO` instance links in the active method frame.
+    pub(crate) fn tcloo_instance_links(&self) -> Vec<(Vec<u8>, Link)> {
+        self.index_of_level(self.active_level)
+            .map(|i| {
+                self.frames[i]
+                    .table
+                    .tcloo_instance_links()
+                    .into_iter()
+                    .map(|(name, link)| (name.to_vec(), link.clone()))
                     .collect()
             })
             .unwrap_or_default()

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -3259,6 +3259,16 @@ impl Interp {
         )
     }
 
+    /// Whether `name`, resolved as if `level` were active, is a `const` cell.
+    pub(crate) fn is_constant_at(&self, name: &[u8], level: usize) -> bool {
+        crate::vars::is_constant_at(
+            &self.frames.borrow(),
+            &self.namespaces.borrow(),
+            name,
+            level,
+        )
+    }
+
     /// `array default set arrayName value` — set the array's TIP 508 default
     /// (creating an empty array if needed). `Err` if the name is a scalar / its
     /// namespace is missing.
@@ -4311,6 +4321,24 @@ impl Interp {
         );
     }
 
+    /// Install an automatic `TclOO` instance-variable projection in the active
+    /// method frame.
+    pub(crate) fn make_tcloo_variable_mapped(
+        &mut self,
+        target_ns: NsId,
+        local: &[u8],
+        target: &[u8],
+    ) {
+        crate::vars::make_tcloo_variable_mapped(
+            &mut self.frames.borrow_mut(),
+            &mut self.namespaces.borrow_mut(),
+            self.current_ns.get(),
+            target_ns,
+            local,
+            target,
+        );
+    }
+
     /// The fully-qualified name of an existing namespace `name` (absolute or
     /// relative to the current namespace), or `None` if it does not exist —
     /// for `definitionnamespace`, which requires the namespace to exist.
@@ -4807,66 +4835,6 @@ impl Interp {
             .words_at(level)
             .filter(|w| !w.is_empty())
             .map(<[Vec<u8>]>::to_vec)
-    }
-
-    /// Variable names visible in the current scope (`info vars`): the active
-    /// frame's locals in a proc, else the current namespace's variables.
-    pub(crate) fn visible_var_names(&self) -> Vec<Vec<u8>> {
-        if self.frames.borrow().in_proc() {
-            self.frames.borrow().local_names()
-        } else {
-            self.namespaces.borrow().var_names(self.current_ns.get())
-        }
-    }
-
-    /// `info consts` — the `const` scalar names visible in the current scope.
-    /// Filters the visible variables by constness (following links), so an OO
-    /// instance variable linked to a `const` namespace variable is included.
-    pub(crate) fn visible_const_names(&self) -> Vec<Vec<u8>> {
-        self.visible_var_names()
-            .into_iter()
-            .filter(|n| self.is_constant(n))
-            .collect()
-    }
-
-    /// `info consts ns::pat` — the `const` scalar names in the namespace named
-    /// `qualifier` (absolute or relative to the current namespace).
-    pub(crate) fn consts_in_namespace(&self, qualifier: &[u8]) -> Vec<Vec<u8>> {
-        let ns = self.namespaces.borrow();
-        let target = if qualifier.is_empty() {
-            Some(GLOBAL)
-        } else {
-            ns.find_namespace(self.current_ns.get(), qualifier)
-        };
-        match target {
-            Some(id) => {
-                let mut v = ns.const_names(id);
-                v.sort();
-                v
-            }
-            None => Vec::new(),
-        }
-    }
-
-    /// The canonical fully-qualified prefix (ending in `::`) of the namespace a
-    /// pattern qualifier addresses (`info vars ns::pat`): `::` for the global
-    /// namespace, `::a::b::` otherwise. Resolves a *relative* qualifier against
-    /// the current namespace, so results are always absolute (matching C, where
-    /// names are re-qualified through the namespace's `fullName`). `None` if the
-    /// namespace doesn't exist. (Used by [`set_list_qualified`] for `info
-    /// vars`/`consts`; command/proc re-qualification moved to the shared core.)
-    pub(crate) fn canonical_ns_prefix(&self, qualifier: &[u8]) -> Option<Vec<u8>> {
-        let ns = self.namespaces.borrow();
-        let id = if qualifier.is_empty() {
-            GLOBAL
-        } else {
-            ns.find_namespace(self.current_ns.get(), qualifier)?
-        };
-        let mut p = ns.qualified_name(id);
-        if id != GLOBAL {
-            p.extend_from_slice(b"::"); // global's qualified_name is already `::`
-        }
-        Some(p)
     }
 
     /// Simple command names in the namespace named `qualifier` (absolute or
@@ -8168,7 +8136,7 @@ impl Interp {
         // the frame becomes a link to the object's namespace variable (`ns`), so
         // the method sees instance state without an explicit `variable`.
         for (local, target) in meta.link_vars {
-            self.make_variable_mapped(ns, local, target);
+            self.make_tcloo_variable_mapped(ns, local, target);
         }
 
         // Bind positionals left-to-right: the supplied arg, else the default.

--- a/runtime/rust/src/state_traits.rs
+++ b/runtime/rust/src/state_traits.rs
@@ -28,7 +28,7 @@
 
 use tcl_runtime_api::{
     CommandId, Commands, Completion, FrameId, Frames, Introspect, Namespaces, NsId, ProcInfo,
-    ProcParam, Procs, Traces, VarStore,
+    ProcParam, Procs, Traces, VarStore, VarUnsetError,
 };
 
 use crate::frame::Link;
@@ -73,6 +73,13 @@ impl VarStore for Interp {
         } else {
             self.var_unset_at(name.as_bytes(), frame.0)
         }
+    }
+
+    fn unset_command(&mut self, frame: FrameId, name: &str) -> Result<bool, VarUnsetError> {
+        if self.is_constant_at(name.as_bytes(), frame.0) {
+            return Err(VarUnsetError::IsConstant);
+        }
+        Ok(self.unset(frame, name))
     }
 
     fn exists(&self, frame: FrameId, name: &str) -> bool {
@@ -362,6 +369,17 @@ impl Frames for Interp {
             .map(|s| String::from_utf8_lossy(s).into_owned())
             .collect()
     }
+
+    fn const_names(&self) -> Vec<String> {
+        crate::vars::const_names(&self.frames.borrow(), &self.namespaces())
+            .iter()
+            .map(|name| String::from_utf8_lossy(name).into_owned())
+            .collect()
+    }
+
+    fn const_names_bytes(&self) -> Vec<Vec<u8>> {
+        crate::vars::const_names(&self.frames.borrow(), &self.namespaces())
+    }
 }
 
 /// Namespace name resolution. `NsId` is native (the contract's `u32` newtype
@@ -451,6 +469,14 @@ impl Namespaces for Interp {
             .collect()
     }
 
+    fn consts_in(&self, ns: NsId) -> Vec<String> {
+        self.namespaces()
+            .const_names(ns.0 as usize)
+            .iter()
+            .map(|name| String::from_utf8_lossy(name).into_owned())
+            .collect()
+    }
+
     // `Tcl_FindNamespaceVar`'s single probe: the namespace's own `varTable`,
     // including a `variable`-declared but as-yet-unset cell, and never a call
     // frame.
@@ -489,6 +515,14 @@ impl Namespaces for Interp {
 
     fn command_name_bytes(&self, cmd: CommandId) -> Option<Vec<u8>> {
         self.command_fqn(cmd.0)
+    }
+
+    fn vars_in_bytes(&self, ns: NsId) -> Vec<Vec<u8>> {
+        self.namespaces().var_names(ns.0 as usize)
+    }
+
+    fn consts_in_bytes(&self, ns: NsId) -> Vec<Vec<u8>> {
+        self.namespaces().const_names(ns.0 as usize)
     }
 
     fn command_origin(&self, cmd: CommandId) -> Option<CommandId> {

--- a/runtime/rust/src/vars.rs
+++ b/runtime/rust/src/vars.rs
@@ -42,6 +42,7 @@
 //! [`make_upvar`]). The coordinator borrows both the frame stack and the
 //! namespace tree (the two var-table owners) from the interp.
 
+use tcl_runtime_api::FrameLinkOrigin;
 use tcl_syntax::naming::is_qualified;
 
 use crate::frame::{FrameStack, Link, Var, VarError, VarHome, VarTable};
@@ -737,6 +738,38 @@ pub(crate) fn is_constant(
     }
 }
 
+/// Frame-addressed [`is_constant`]: resolve `name` as if `level` were active.
+pub(crate) fn is_constant_at(
+    frames: &FrameStack,
+    ns: &Namespaces,
+    name: &[u8],
+    level: usize,
+) -> bool {
+    match resolve_at(frames, ns, name, level) {
+        Resolved::Place(p) if p.elem.is_none() => {
+            table(frames, ns, p.home).is_some_and(|t| t.is_constant(&p.name))
+        }
+        _ => false,
+    }
+}
+
+/// `info consts` candidates in the active frame: direct constant cells plus
+/// automatic `TclOO` instance projections whose resolved namespace target is
+/// constant. Ordinary `global`/`upvar`/`variable` aliases are excluded.
+pub(crate) fn const_names(frames: &FrameStack, ns: &Namespaces) -> Vec<Vec<u8>> {
+    let mut names = frames.const_names();
+    for (name, link) in frames.tcloo_instance_links() {
+        if link.elem.is_none()
+            && table(frames, ns, link.home).is_some_and(|table| table.is_constant(&link.name))
+        {
+            names.push(name);
+        }
+    }
+    names.sort();
+    names.dedup();
+    names
+}
+
 /// Whether `name` resolves to an array variable (the `set a` array-vs-scalar
 /// diagnostic; `array exists`).
 pub(crate) fn is_array(
@@ -839,11 +872,29 @@ fn link_local(
     local: &[u8],
     target: Link,
 ) {
+    link_local_with_origin(
+        frames,
+        ns,
+        current_ns,
+        local,
+        target,
+        FrameLinkOrigin::Ordinary,
+    );
+}
+
+fn link_local_with_origin(
+    frames: &mut FrameStack,
+    ns: &mut Namespaces,
+    current_ns: NsId,
+    local: &[u8],
+    target: Link,
+    origin: FrameLinkOrigin,
+) {
     let here = current_home(frames, current_ns);
     if target.home == here && target.elem.is_none() && target.name == local {
         return; // already the same variable — `global`/`variable` is a no-op
     }
-    table_mut(frames, ns, here).insert_link(local, target);
+    table_mut(frames, ns, here).insert_link_with_origin(local, target, origin);
 }
 
 /// `variable tail` / `global tail` — link the current context's `tail` to the
@@ -871,6 +922,46 @@ pub(crate) fn make_variable_mapped(
     local: &[u8],
     target: &[u8],
 ) {
+    make_variable_mapped_with_origin(
+        frames,
+        ns,
+        current_ns,
+        target_ns,
+        local,
+        target,
+        FrameLinkOrigin::Ordinary,
+    );
+}
+
+/// Install one automatic `TclOO` instance-variable projection.
+pub(crate) fn make_tcloo_variable_mapped(
+    frames: &mut FrameStack,
+    ns: &mut Namespaces,
+    current_ns: NsId,
+    target_ns: NsId,
+    local: &[u8],
+    target: &[u8],
+) {
+    make_variable_mapped_with_origin(
+        frames,
+        ns,
+        current_ns,
+        target_ns,
+        local,
+        target,
+        FrameLinkOrigin::TclOoInstance,
+    );
+}
+
+fn make_variable_mapped_with_origin(
+    frames: &mut FrameStack,
+    ns: &mut Namespaces,
+    current_ns: NsId,
+    target_ns: NsId,
+    local: &[u8],
+    target: &[u8],
+    origin: FrameLinkOrigin,
+) {
     // C's `variable` (`TclLookupSimpleVar` with create) materialises the
     // namespace variable itself as an *undefined Var* before any value is
     // set.  The self-link cell is our stand-in: persistent in the namespace
@@ -888,7 +979,7 @@ pub(crate) fn make_variable_mapped(
             },
         );
     }
-    link_local(
+    link_local_with_origin(
         frames,
         ns,
         current_ns,
@@ -898,6 +989,7 @@ pub(crate) fn make_variable_mapped(
             name: target.to_vec(),
             elem: None,
         },
+        origin,
     );
 }
 

--- a/rust/tcl-cmd-core/src/array.rs
+++ b/rust/tcl-cmd-core/src/array.rs
@@ -36,7 +36,7 @@
 //!
 //! Semantics verified against tclsh 9.0.
 
-use tcl_runtime_api::{Frames, VarStore};
+use tcl_runtime_api::{ArrayTarget, Frames, VarStore, VarUnsetError};
 use tcl_syntax::glob::string_match;
 use tcl_syntax::value::ValueOps;
 
@@ -50,52 +50,73 @@ pub fn dispatch<O, V>(ops: &mut O, sub: &str, rest: &[V]) -> Option<Result<V, Cm
 where
     O: ValueOps<Value = V> + VarStore<Value = V> + Frames,
 {
+    dispatch_at(ops, sub, rest, None)
+}
+
+/// [`dispatch`] with an array target located before the operation trace fired.
+/// Tcl retains that cell for existence/key enumeration, while value reads and
+/// whole-array mutation deliberately continue through the live spelling.
+pub fn dispatch_at<O, V>(
+    ops: &mut O,
+    sub: &str,
+    rest: &[V],
+    located: Option<&ArrayTarget>,
+) -> Option<Result<V, CmdError>>
+where
+    O: ValueOps<Value = V> + VarStore<Value = V> + Frames,
+{
     match sub {
         "exists" => Some(match rest {
             [n] => {
-                let here = Frames::current(ops);
                 let name = ops.as_str(n);
-                Ok(ops.new_bool(ops.array_keys(here, &name).is_some()))
+                let target = locate(ops, &name, located);
+                Ok(ops.new_bool(ops.array_keys_at(&target).is_some()))
             }
             _ => Err(CmdError::wrong_args("array exists arrayName")),
         }),
         "size" => Some(match rest {
             [n] => {
-                let here = Frames::current(ops);
                 let name = ops.as_str(n);
-                let count = ops.array_keys(here, &name).map_or(0, |k| k.len());
+                let target = locate(ops, &name, located);
+                let count = ops.array_keys_at(&target).map_or(0, |k| k.len());
                 Ok(ops.new_int(i64::try_from(count).unwrap_or(i64::MAX)))
             }
             _ => Err(CmdError::wrong_args("array size arrayName")),
         }),
         "names" => Some(match rest {
-            [n] => Ok(names(ops, n, None)),
-            [n, p] => Ok(names(ops, n, Some(p))),
+            [n] => Ok(names(ops, n, None, located)),
+            [n, p] => Ok(names(ops, n, Some(p), located)),
             _ => Err(CmdError::wrong_args("array names arrayName ?pattern?")),
         }),
         "get" => Some(match rest {
-            [n] => Ok(get(ops, n, None)),
-            [n, p] => Ok(get(ops, n, Some(p))),
+            [n] => Ok(get(ops, n, None, located)),
+            [n, p] => Ok(get(ops, n, Some(p), located)),
             _ => Err(CmdError::wrong_args("array get arrayName ?pattern?")),
         }),
         "unset" => Some(match rest {
-            [n] => Ok(unset(ops, n, None)),
-            [n, p] => Ok(unset(ops, n, Some(p))),
+            [n] => unset(ops, n, None, located),
+            [n, p] => unset(ops, n, Some(p), located),
             _ => Err(CmdError::wrong_args("array unset arrayName ?pattern?")),
         }),
         _ => None,
     }
 }
 
+fn locate<O: VarStore + Frames>(ops: &O, name: &str, located: Option<&ArrayTarget>) -> ArrayTarget {
+    located
+        .cloned()
+        .unwrap_or_else(|| ops.array_target(Frames::current(ops), name))
+}
+
 /// `array names arrayName ?pattern?` — element names (glob-filtered).
-fn names<O, V>(ops: &mut O, name: &V, pattern: Option<&V>) -> V
+fn names<O, V>(ops: &mut O, name: &V, pattern: Option<&V>, located: Option<&ArrayTarget>) -> V
 where
     O: ValueOps<Value = V> + VarStore<Value = V> + Frames,
 {
-    let here = Frames::current(ops);
     let name = ops.as_str(name);
     let pattern = pattern.map(|p| ops.as_str(p).to_string());
-    let keys = ops.array_keys(here, &name).unwrap_or_default();
+    let target = locate(ops, &name, located);
+    let keys = ops.array_keys_at(&target).unwrap_or_default();
     let items: Vec<V> = keys
         .iter()
         .filter(|k| pattern.as_deref().is_none_or(|p| string_match(p, k)))
@@ -106,14 +127,15 @@ where
 
 /// `array get arrayName ?pattern?` — a flat `key value …` list (glob-filtered on
 /// the key).
-fn get<O, V>(ops: &mut O, name: &V, pattern: Option<&V>) -> V
+fn get<O, V>(ops: &mut O, name: &V, pattern: Option<&V>, located: Option<&ArrayTarget>) -> V
 where
     O: ValueOps<Value = V> + VarStore<Value = V> + Frames,
 {
     let here = Frames::current(ops);
     let name = ops.as_str(name);
     let pattern = pattern.map(|p| ops.as_str(p).to_string());
-    let keys = ops.array_keys(here, &name).unwrap_or_default();
+    let target = locate(ops, &name, located);
+    let keys = ops.array_keys_at(&target).unwrap_or_default();
     let mut items: Vec<V> = Vec::with_capacity(keys.len() * 2);
     for k in &keys {
         if pattern.as_deref().is_some_and(|p| !string_match(p, k)) {
@@ -129,7 +151,12 @@ where
 
 /// `array unset arrayName ?pattern?` — remove matching elements, or (no pattern)
 /// the whole array.
-fn unset<O, V>(ops: &mut O, name: &V, pattern: Option<&V>) -> V
+fn unset<O, V>(
+    ops: &mut O,
+    name: &V,
+    pattern: Option<&V>,
+    located: Option<&ArrayTarget>,
+) -> Result<V, CmdError>
 where
     O: ValueOps<Value = V> + VarStore<Value = V> + Frames,
 {
@@ -138,15 +165,25 @@ where
     match pattern.map(|p| ops.as_str(p).to_string()) {
         // No pattern: remove the whole array variable (ignore "didn't exist").
         None => {
-            ops.unset(here, &name);
+            let target = locate(ops, &name, located);
+            if ops.array_keys_at(&target).is_some() {
+                ops.unset_command(here, &name)
+                    .map_err(|error| match error {
+                        VarUnsetError::IsConstant => CmdError::with_error_code(
+                            format!("can't unset \"{name}\": variable is a constant"),
+                            "TCL UNSET CONST",
+                        ),
+                    })?;
+            }
         }
         Some(pattern) => {
-            for k in ops.array_keys(here, &name).unwrap_or_default() {
+            let target = locate(ops, &name, located);
+            for k in ops.array_keys_at(&target).unwrap_or_default() {
                 if string_match(&pattern, &k) {
-                    ops.unset_elem(here, &name, &k);
+                    ops.unset_elem_at(&target, &k);
                 }
             }
         }
     }
-    ops.empty()
+    Ok(ops.empty())
 }

--- a/rust/tcl-cmd-core/src/error.rs
+++ b/rust/tcl-cmd-core/src/error.rs
@@ -29,14 +29,14 @@
 use tcl_platform::HostError;
 use tcl_syntax::value::ValueError;
 
-/// A failed Tcl command: the error message that becomes the interpreter result.
+/// A failed Tcl command: its result message and optional structured error code.
 ///
-/// Carries the rendered message only for now; `-errorcode`/`-errorinfo`
-/// threading is added with the catch/return work (Family-B), where the per-frame
-/// `CmdFrame` accumulation lives.
+/// The shared command core owns the semantic error identity; each runtime
+/// adapter publishes it through its native completion/error state.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CmdError {
     message: String,
+    error_code: Option<String>,
 }
 
 impl CmdError {
@@ -44,6 +44,15 @@ impl CmdError {
     pub fn new(message: impl Into<String>) -> Self {
         Self {
             message: message.into(),
+            error_code: None,
+        }
+    }
+
+    /// A command error carrying Tcl's structured `-errorcode` list.
+    pub fn with_error_code(message: impl Into<String>, error_code: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            error_code: Some(error_code.into()),
         }
     }
 
@@ -53,11 +62,23 @@ impl CmdError {
         &self.message
     }
 
+    /// Tcl's structured `-errorcode` list, when the command supplied one.
+    #[must_use]
+    pub fn error_code(&self) -> Option<&str> {
+        self.error_code.as_deref()
+    }
+
     /// Consume the error, yielding its message (what an adapter sets as the
     /// interpreter result).
     #[must_use]
     pub fn into_message(self) -> String {
         self.message
+    }
+
+    /// Consume the error, yielding its message and optional error code.
+    #[must_use]
+    pub fn into_parts(self) -> (String, Option<String>) {
+        (self.message, self.error_code)
     }
 
     /// `wrong # args: should be "…"` — the canonical Tcl arity error.
@@ -118,5 +139,11 @@ mod tests {
             r#"wrong # args: should be "x""#
         );
         assert_eq!(CmdError::new("z").into_message(), "z");
+        let coded = CmdError::with_error_code("constant", "TCL UNSET CONST");
+        assert_eq!(coded.error_code(), Some("TCL UNSET CONST"));
+        assert_eq!(
+            coded.into_parts(),
+            ("constant".to_string(), Some("TCL UNSET CONST".to_string()))
+        );
     }
 }

--- a/rust/tcl-cmd-core/src/info.rs
+++ b/rust/tcl-cmd-core/src/info.rs
@@ -26,7 +26,7 @@
 //! bound and wrap the `Result<V, CmdError>` in their own command ABI.
 
 use tcl_runtime_api::{Frames, Introspect, Namespaces, NsId, Procs, ROOT_NS, VarStore};
-use tcl_syntax::glob::string_match;
+use tcl_syntax::glob::{is_literal_bytes, string_match, string_match_bytes};
 use tcl_syntax::value::ValueOps;
 
 use crate::error::CmdError;
@@ -309,6 +309,91 @@ where
     build_name_list(ops, names)
 }
 
+/// `info consts ?pattern?` — enumerate constant **bindings**, not variables
+/// reached through links. Qualified patterns select exactly one namespace;
+/// a procedure lists its direct local bindings; namespace scope also exposes
+/// unshadowed global constants, matching Tcl's `InfoConstsCmd`.
+///
+/// This path stays byte-valued through enumeration, pattern matching, and
+/// result construction so a byte-native runtime does not corrupt a Tcl name.
+pub fn consts<O, V>(ops: &mut O, pattern: Option<&V>) -> V
+where
+    O: ValueOps<Value = V> + Namespaces + Frames,
+{
+    let pat = pattern.map(|p| ops.as_bytes(p).to_vec());
+    let cur = Namespaces::current(ops);
+    let names = if let Some((prefix, tail)) = pat.as_deref().and_then(split_last_qualifier_bytes) {
+        qualified_listing_bytes(ops, prefix, tail, cur, Namespaces::consts_in_bytes)
+    } else {
+        let mut names = if Frames::in_proc(ops) {
+            ops.const_names_bytes()
+        } else {
+            let mut current = ops.consts_in_bytes(cur);
+            if cur != ROOT_NS {
+                let global = ops.consts_in_bytes(ROOT_NS);
+                if let Some(exact) = pat.as_deref().filter(|pat| is_literal_bytes(pat)) {
+                    // `TclInfoConstsCmd` preserves its direct-lookup fast path
+                    // as observable behaviour: a non-constant local binding
+                    // hides a global constant from a glob scan, but an exact
+                    // unqualified lookup falls through to that global.
+                    current = current
+                        .into_iter()
+                        .find(|name| name.as_slice() == exact)
+                        .or_else(|| global.into_iter().find(|name| name.as_slice() == exact))
+                        .into_iter()
+                        .collect();
+                } else {
+                    let shadowed = ops.vars_in_bytes(cur);
+                    current.extend(global.into_iter().filter(|name| !shadowed.contains(name)));
+                }
+            }
+            current
+        };
+        names.sort();
+        names.dedup();
+        if let Some(pattern) = pat.as_deref() {
+            names.retain(|name| string_match_bytes(pattern, name));
+        }
+        names
+    };
+    build_name_list_bytes(ops, names)
+}
+
+fn qualified_listing_bytes<O, F>(
+    ops: &O,
+    prefix: &[u8],
+    tail: &[u8],
+    cur: NsId,
+    enumerate: F,
+) -> Vec<Vec<u8>>
+where
+    O: Namespaces,
+    F: Fn(&O, NsId) -> Vec<Vec<u8>>,
+{
+    let target = if prefix.is_empty() {
+        Some(ROOT_NS)
+    } else {
+        ops.find_namespace_bytes(cur, prefix)
+    };
+    let Some(id) = target else {
+        return Vec::new();
+    };
+    let mut raw = enumerate(ops, id);
+    raw.sort();
+    let mut prefix_bytes = ops.name_bytes(id);
+    if id != ROOT_NS {
+        prefix_bytes.extend_from_slice(b"::");
+    }
+    raw.into_iter()
+        .filter(|name| string_match_bytes(tail, name))
+        .map(|name| {
+            let mut full_name = prefix_bytes.clone();
+            full_name.extend_from_slice(&name);
+            full_name
+        })
+        .collect()
+}
+
 /// The qualified-pattern listing path shared by `info commands`/`procs`/`vars`:
 /// resolve `prefix` (relative to `cur`, or the global root if empty) to a
 /// namespace, enumerate its members via `enumerate`, re-qualify each to an
@@ -368,13 +453,37 @@ where
     ops.new_list(vals)
 }
 
+fn build_name_list_bytes<O, V>(ops: &mut O, names: Vec<Vec<u8>>) -> V
+where
+    O: ValueOps<Value = V>,
+{
+    let vals: Vec<V> = names.into_iter().map(|name| ops.new_bytes(&name)).collect();
+    ops.new_list(vals)
+}
+
 /// Split a listing pattern on its **last** `::` into `(ns_prefix, tail_glob)`, or
 /// `None` when the pattern is unqualified. An empty prefix (a leading `::pat`)
 /// denotes the global namespace. Matches C's `TclGetNamespaceForQualName` split
-/// on colon runs (`foo:::bar` → prefix `foo:`, tail `bar`, like the runtime's
-/// `rposition` of `::`).
+/// on colon runs (`foo:::bar` → prefix `foo`, tail `bar`).
 fn split_last_qualifier(p: &str) -> Option<(&str, &str)> {
-    p.rfind("::").map(|i| (&p[..i], &p[i + 2..]))
+    split_last_qualifier_bytes(p.as_bytes()).map(|(prefix, tail)| {
+        (
+            std::str::from_utf8(prefix).expect("subslice of valid UTF-8"),
+            std::str::from_utf8(tail).expect("subslice of valid UTF-8"),
+        )
+    })
+}
+
+fn split_last_qualifier_bytes(p: &[u8]) -> Option<(&[u8], &[u8])> {
+    use crate::namespace::Qualifier;
+
+    match crate::namespace::qualifier(p) {
+        Qualifier::Absolute(b"::") => Some((b"", crate::namespace::tail(p))),
+        Qualifier::Absolute(prefix) | Qualifier::Relative(prefix) => {
+            Some((prefix, crate::namespace::tail(p)))
+        }
+        Qualifier::Unqualified => None,
+    }
 }
 
 #[cfg(test)]

--- a/rust/tcl-runtime-api/src/lib.rs
+++ b/rust/tcl-runtime-api/src/lib.rs
@@ -41,6 +41,87 @@ pub use tcl_core_types::{
     Code, CommandId, Completion, FrameId, GLOBAL_FRAME, NsId, ROOT_NS, VarId,
 };
 
+/// A command-level variable removal rejected by the store.
+///
+/// Storage-only consumers use [`VarStore::unset`] when they have already
+/// performed the Tcl command's policy checks. Command implementations use
+/// [`VarStore::unset_command`] so runtimes preserve structured failures such
+/// as Tcl 9's immutable-variable rejection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VarUnsetError {
+    /// The resolved variable cell is a Tcl 9 `const`.
+    IsConstant,
+}
+
+/// Why a call-frame link exists.
+///
+/// Tcl's `info consts` excludes ordinary `global`/`upvar`/`variable` aliases,
+/// but includes the automatic instance-variable projections installed for a
+/// `TclOO` method when their target is constant. Keeping this on the binding
+/// makes that distinction available to every runtime without teaching the
+/// shared `info` command core about `TclOO` command names.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum FrameLinkOrigin {
+    /// An ordinary Tcl variable alias.
+    #[default]
+    Ordinary,
+    /// An automatic `TclOO` method-frame instance-variable projection.
+    TclOoInstance,
+}
+
+/// One array name located for the duration of an `array` ensemble operation.
+///
+/// Tcl's `LocateArray` resolves the spelling once before firing an `array`
+/// trace. Enumeration continues against that exact cell even when the callback
+/// retargets an `upvar` alias; runtimes without stable variable identities use
+/// the name-addressed form until they acquire that capability.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ArrayTarget {
+    frame: FrameId,
+    name: String,
+    cell: Option<VarId>,
+}
+
+impl ArrayTarget {
+    /// Construct a name-addressed target.
+    #[must_use]
+    pub fn named(frame: FrameId, name: impl Into<String>) -> Self {
+        Self {
+            frame,
+            name: name.into(),
+            cell: None,
+        }
+    }
+
+    /// Construct a target backed by one stable variable cell.
+    #[must_use]
+    pub fn cell(frame: FrameId, name: impl Into<String>, cell: VarId) -> Self {
+        Self {
+            frame,
+            name: name.into(),
+            cell: Some(cell),
+        }
+    }
+
+    /// The frame in which the source spelling was resolved.
+    #[must_use]
+    pub const fn frame(&self) -> FrameId {
+        self.frame
+    }
+
+    /// The source spelling used for paths that Tcl deliberately re-resolves.
+    #[must_use]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// The stable reached cell, when the runtime provides one.
+    #[must_use]
+    pub const fn cell_id(&self) -> Option<VarId> {
+        self.cell
+    }
+}
+
 /// A compiler assumption about one runtime command binding.
 ///
 /// `resolution_namespace` is the unrooted constructed namespace key at the
@@ -513,6 +594,14 @@ pub trait VarStore {
     fn set(&mut self, frame: FrameId, name: &str, value: Self::Value);
     /// Remove a variable in `frame`; returns whether it existed.
     fn unset(&mut self, frame: FrameId, name: &str) -> bool;
+    /// Remove a variable as a Tcl command operation, preserving policy errors.
+    ///
+    /// An absent variable is not an error and returns `Ok(false)`. The default
+    /// keeps storage implementations source-compatible; runtimes with
+    /// immutable bindings override it to reject them before mutation.
+    fn unset_command(&mut self, frame: FrameId, name: &str) -> Result<bool, VarUnsetError> {
+        Ok(self.unset(frame, name))
+    }
     /// Whether a variable exists in `frame`.
     fn exists(&self, frame: FrameId, name: &str) -> bool;
 
@@ -539,6 +628,47 @@ pub trait VarStore {
     /// otherwise-deliberately-listing-free state traits expose for the `array`
     /// family (`names`/`get`/`size`/`exists`/`unset`).
     fn array_keys(&self, frame: FrameId, name: &str) -> Option<Vec<String>>;
+
+    /// Locate an array spelling before its operation trace fires. The default
+    /// remains name-addressed; a stable-cell runtime overrides this and the
+    /// `*_at` methods below so callbacks cannot steer enumeration elsewhere.
+    fn array_target(&self, frame: FrameId, name: &str) -> ArrayTarget {
+        ArrayTarget::named(frame, name)
+    }
+
+    /// Enumerate the cell captured by [`array_target`](Self::array_target).
+    fn array_keys_at(&self, target: &ArrayTarget) -> Option<Vec<String>> {
+        self.array_keys(target.frame(), target.name())
+    }
+
+    /// Physical element-table keys captured for an active array search.
+    /// Unlike [`array_keys_at`](Self::array_keys_at), this includes attached
+    /// undefined cells created by traces or links: Tcl's hash iterator sees
+    /// those entries and skips them only when each candidate is reached.
+    fn array_search_keys_at(&self, target: &ArrayTarget) -> Option<Vec<String>> {
+        self.array_keys_at(target)
+    }
+
+    /// Whether one candidate in the captured array currently has a value,
+    /// without firing its read trace.
+    fn array_elem_exists_at(&self, target: &ArrayTarget, key: &str) -> bool {
+        self.exists_elem(target.frame(), target.name(), key)
+    }
+
+    /// Structural revision of the captured array cell, when the runtime can
+    /// distinguish invalidation of an active Tcl array search. The value
+    /// changes on Tcl-level key insertion/removal or an explicit element
+    /// unset; defining or replacing an attached element does not invalidate
+    /// the search, nor does garbage-collecting an undefined trace shell.
+    fn array_revision_at(&self, _target: &ArrayTarget) -> Option<u64> {
+        None
+    }
+
+    /// Remove an element from the cell captured by
+    /// [`array_target`](Self::array_target).
+    fn unset_elem_at(&mut self, target: &ArrayTarget, key: &str) -> bool {
+        self.unset_elem(target.frame(), target.name(), key)
+    }
 }
 
 /// The call-frame stack: proc-call frames and the `uplevel` active-level dance.
@@ -566,6 +696,19 @@ pub trait Frames {
     /// included iff `include_links` — `info vars` lists links (by their local
     /// alias), `info locals` does not.
     fn var_names(&self, include_links: bool) -> Vec<String>;
+
+    /// The active frame's `info consts` bindings: direct constants plus typed
+    /// `TclOO` instance projections whose target is constant. Ordinary link
+    /// aliases are excluded even though `info constant alias` follows them.
+    fn const_names(&self) -> Vec<String>;
+
+    /// [`const_names`](Self::const_names) without a lossy UTF-8 round trip.
+    fn const_names_bytes(&self) -> Vec<Vec<u8>> {
+        self.const_names()
+            .into_iter()
+            .map(String::into_bytes)
+            .collect()
+    }
 }
 
 /// The command table and dispatch: builtins, procs, aliases, imports,
@@ -649,6 +792,8 @@ pub trait Namespaces {
     /// global namespace's variables). The variable analogue of
     /// [`commands_in`](Self::commands_in).
     fn vars_in(&self, ns: NsId) -> Vec<String>;
+    /// The direct `const` bindings in `ns`; link aliases are excluded.
+    fn consts_in(&self, ns: NsId) -> Vec<String>;
 
     // -- resolution accessors the shared `namespace which -variable` / `origin`
     // cores need beyond navigation (`tcl_cmd_core::namespace`).
@@ -708,6 +853,22 @@ pub trait Namespaces {
     /// actually keyed by.
     fn command_name_bytes(&self, cmd: CommandId) -> Option<Vec<u8>> {
         self.command_name(cmd).map(String::into_bytes)
+    }
+
+    /// [`vars_in`](Self::vars_in) without a lossy UTF-8 round trip.
+    fn vars_in_bytes(&self, ns: NsId) -> Vec<Vec<u8>> {
+        self.vars_in(ns)
+            .into_iter()
+            .map(String::into_bytes)
+            .collect()
+    }
+
+    /// [`consts_in`](Self::consts_in) without a lossy UTF-8 round trip.
+    fn consts_in_bytes(&self, ns: NsId) -> Vec<Vec<u8>> {
+        self.consts_in(ns)
+            .into_iter()
+            .map(String::into_bytes)
+            .collect()
     }
 }
 

--- a/rust/tcl-syntax/src/glob.rs
+++ b/rust/tcl-syntax/src/glob.rs
@@ -67,7 +67,19 @@ pub fn string_match_bytes(pattern: &[u8], text: &[u8]) -> bool {
 /// [`crate::glob`]'s `namespace export` consumers need (issue #1297).
 #[must_use]
 pub fn is_literal(pattern: &str) -> bool {
-    !pattern.contains(['*', '?', '[', '\\'])
+    is_literal_bytes(pattern.as_bytes())
+}
+
+/// [`is_literal`] for a byte-valued Tcl string.
+///
+/// This is the shared equivalent of C Tcl's `TclMatchIsTrivial`: the four
+/// ASCII metacharacters have the same byte representation in every valid Tcl
+/// string, and invalid UTF-8 must not be normalised before the decision.
+#[must_use]
+pub fn is_literal_bytes(pattern: &[u8]) -> bool {
+    !pattern
+        .iter()
+        .any(|byte| matches!(byte, b'*' | b'?' | b'[' | b'\\'))
 }
 
 /// Tcl `string match ?-nocase? pattern text`.
@@ -393,6 +405,19 @@ mod tests {
             assert!(!is_literal(pattern), "should not be literal: {pattern:?}");
             assert!(string_match(pattern, other), "{pattern:?} vs {other:?}");
             assert_ne!(pattern, other);
+        }
+    }
+
+    #[test]
+    fn byte_literal_detection_matches_tcl_match_is_trivial() {
+        for pattern in [&b""[..], &b"plain"[..], &b"raw\xff"[..], &b"]"[..]] {
+            assert!(is_literal_bytes(pattern), "should be literal: {pattern:?}");
+        }
+        for pattern in [&b"*"[..], &b"a?"[..], &b"[ab]"[..], &b"raw\xff\\x"[..]] {
+            assert!(
+                !is_literal_bytes(pattern),
+                "should not be literal: {pattern:?}"
+            );
         }
     }
 

--- a/rust/tcl-vm/src/cmd_array.rs
+++ b/rust/tcl-vm/src/cmd_array.rs
@@ -23,7 +23,8 @@
 //! VM's `array unset a` (no pattern), which used to iterate-and-unset elements
 //! (leaving an empty array) instead of removing the whole array.
 
-use tcl_runtime_api::{Code, Completion};
+use tcl_registry::ArgRole;
+use tcl_runtime_api::{ArrayTarget, Code, Completion, VarStore};
 
 use crate::interp::{Vm, err, ok};
 use crate::value::Value;
@@ -83,17 +84,44 @@ fn cmd_array(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
 }
 
 fn array_op(vm: &mut Vm, sub: &str, rest: &[Value]) -> Completion<Value> {
+    // `LocateArray` is the one semantic entry for every array subcommand,
+    // including the compiler-lowered `::tcl::array::*` commands above. Derive
+    // the target from the dialect-selected registry member: it is the unique
+    // VarRead/VarWrite argument, not a second command-name/index table.
+    let trace_target = array_trace_target(vm, sub, rest);
+    if sub == "for" {
+        return array_for(vm, rest, trace_target.as_deref());
+    }
+    if let Some(name) = trace_target {
+        return vm.with_array_trace_target(&name, |vm, target| {
+            array_op_after_trace(vm, sub, rest, Some(target))
+        });
+    }
+    array_op_after_trace(vm, sub, rest, None)
+}
+
+fn array_op_after_trace(
+    vm: &mut Vm,
+    sub: &str,
+    rest: &[Value],
+    target: Option<&ArrayTarget>,
+) -> Completion<Value> {
     // The read-side + `unset` live in the shared core.
-    if let Some(result) = tcl_cmd_core::array::dispatch(vm, sub, rest) {
+    if let Some(result) = tcl_cmd_core::array::dispatch_at(vm, sub, rest, target) {
         return match result {
             Ok(v) => ok(v),
-            Err(e) => err(e.into_message()),
+            Err(e) => {
+                let (message, error_code) = e.into_parts();
+                match error_code {
+                    Some(code) => crate::command::err_with_code(message, &code),
+                    None => err(message),
+                }
+            }
         };
     }
     // Per-runtime: `array set` (its per-element write traces must fail the
     // command), `array for` (iterates a body), and the unknown-subcommand message.
     match sub {
-        "for" => array_for(vm, rest),
         "set" => match rest {
             [n, list] => {
                 // C's `Tcl_ArrayObjCmd` set path resolves the target through
@@ -175,11 +203,50 @@ fn array_op(vm: &mut Vm, sub: &str, rest: &[Value]) -> Completion<Value> {
     }
 }
 
+fn array_trace_target(vm: &Vm, sub: &str, rest: &[Value]) -> Option<String> {
+    let profile = vm.command_surface_profile();
+    let registry = crate::environment::store_for_profile(profile);
+    let words: Vec<String> = std::iter::once(sub.to_owned())
+        .chain(rest.iter().map(|value| value.to_str().to_string()))
+        .collect();
+    let spellings: Vec<&str> = words.iter().map(String::as_str).collect();
+    let resolved = registry.resolve_invocation(
+        "array",
+        &spellings,
+        Some(crate::environment::surface_point(profile)),
+    )?;
+    if resolved.subcommand.resolved()?.canonical_name != sub {
+        return None;
+    }
+    let facts = resolved.facts();
+    let supplied = spellings.len().checked_sub(facts.argument_offset)?;
+    if !facts
+        .arity
+        .accepts(u16::try_from(supplied).unwrap_or(u16::MAX))
+        || !facts.arg_roles_complete
+    {
+        return None;
+    }
+    let mut targets: Vec<usize> = facts
+        .arg_roles
+        .iter()
+        .filter_map(|&(index, role)| {
+            matches!(role, ArgRole::VarRead | ArgRole::VarWrite)
+                .then_some(usize::from(index) + facts.argument_offset)
+        })
+        .collect();
+    targets.sort_unstable();
+    targets.dedup();
+    debug_assert!(targets.len() <= 1, "array member has one variable target");
+    let index = targets.into_iter().next()?.checked_sub(1)?;
+    rest.get(index).map(|value| value.to_str().to_string())
+}
+
 /// `array for {keyVar valueVar} arrayName script` — iterate the array's elements,
 /// binding the two vars and running the body once per pair (mirrors `dict for`;
 /// `break`/`continue` apply, an error/return propagates). The element set is
 /// snapshotted up front so body mutations don't perturb the walk.
-fn array_for(vm: &mut Vm, rest: &[Value]) -> Completion<Value> {
+fn array_for(vm: &mut Vm, rest: &[Value], trace_target: Option<&str>) -> Completion<Value> {
     let [vars, arrname, body] = rest else {
         return err("wrong # args: should be \"array for {key value} arrayName script\"");
     };
@@ -192,30 +259,56 @@ fn array_for(vm: &mut Vm, rest: &[Value]) -> Completion<Value> {
     };
     let kvar = kvar.to_str().to_string();
     let vvar = vvar.to_str().to_string();
-    let name = arrname.to_str();
-    if !vm.array_is(&name) {
-        return err(format!("\"{name}\" isn't an array"));
+    let name = arrname.to_str().to_string();
+    let body = body.to_str().to_string();
+    // C validates the loop-variable list before `LocateArray`; all later
+    // validation happens after the array operation trace.
+    if let Some(located_name) = trace_target {
+        return vm.with_array_trace_target(located_name, |vm, target| {
+            array_for_after_trace(vm, &kvar, &vvar, &name, &body, target)
+        });
     }
-    let body_src = body.to_str();
-    // Snapshot the key set, but read each value live: C's enumeration walks the
-    // hash by key and reports the element's *current* value, so a body that
-    // rewrites an as-yet-unvisited element is observed (var-23.12). Adding or
-    // removing an element, by contrast, perturbs the hash and C aborts the walk
-    // with "array changed during iteration" (var-23.10 / var-23.11) — detected
-    // here by the key set diverging from the snapshot.
-    let keys: Vec<String> = vm.array_pairs(&name).into_iter().map(|(k, _)| k).collect();
-    let orig: std::collections::BTreeSet<&str> = keys.iter().map(String::as_str).collect();
+    let target = VarStore::array_target(vm, tcl_runtime_api::Frames::current(vm), &name);
+    array_for_after_trace(vm, &kvar, &vvar, &name, &body, &target)
+}
+
+fn array_for_after_trace(
+    vm: &mut Vm,
+    kvar: &str,
+    vvar: &str,
+    name: &str,
+    body: &str,
+    target: &ArrayTarget,
+) -> Completion<Value> {
+    let Some(keys) = VarStore::array_search_keys_at(vm, target) else {
+        return crate::command::lookup_error(format!("\"{name}\" isn't an array"), "ARRAY", name);
+    };
+    let revision = VarStore::array_revision_at(vm, target);
+    // Snapshot the physical hash keys, including undefined shells created by a
+    // trace or link. C skips a candidate only when the iterator reaches it, so
+    // defining an existing shell during an earlier body makes it a later row;
+    // insertion/removal and unsetting a value invalidate the search revision.
     for k in &keys {
-        let Some(v) = vm.get_array_elem(&name, k) else {
+        if !same_array_target(vm, name, target, revision) {
+            return array_for_changed();
+        }
+        if !VarStore::array_elem_exists_at(vm, target, k) {
             continue;
-        };
-        if let Err(e) = vm.set_var(&kvar, Value::string(k.clone())) {
+        }
+        let value = vm.read_elem_swallowing_trace_error(name, k);
+        // The read trace runs before Tcl assigns either loop variable. If it
+        // deletes this element, the key is still assigned, the value variable
+        // retains its previous value, and the body runs once; the structural
+        // revision is diagnosed after that body unless it breaks the search.
+        if let Err(e) = vm.set_var(kvar, Value::string(k.clone())) {
             return e;
         }
-        if let Err(e) = vm.set_var(&vvar, v) {
+        if let Some(value) = value
+            && let Err(e) = vm.set_var(vvar, value)
+        {
             return e;
         }
-        match vm.eval_source(&body_src) {
+        match vm.eval_source(body) {
             Ok(c) => match c.code {
                 Code::Ok | Code::Continue => {}
                 Code::Break => break,
@@ -225,11 +318,48 @@ fn array_for(vm: &mut Vm, rest: &[Value]) -> Completion<Value> {
         }
         // The body may have added/removed elements (a structural change), which
         // invalidates the enumeration — abort as C does.
-        let cur: std::collections::BTreeSet<String> =
-            vm.array_pairs(&name).into_iter().map(|(k, _)| k).collect();
-        if cur.len() != orig.len() || !cur.iter().all(|k| orig.contains(k.as_str())) {
-            return err("array changed during iteration");
+        if !same_array_target(vm, name, target, revision) {
+            return array_for_changed();
         }
     }
     ok(Value::empty())
+}
+
+fn same_array_target(vm: &Vm, name: &str, original: &ArrayTarget, revision: Option<u64>) -> bool {
+    let current = VarStore::array_target(vm, tcl_runtime_api::Frames::current(vm), name);
+    current.cell_id() == original.cell_id()
+        && VarStore::array_keys_at(vm, original).is_some()
+        && revision
+            .is_none_or(|expected| VarStore::array_revision_at(vm, original) == Some(expected))
+}
+
+fn array_for_changed() -> Completion<Value> {
+    crate::command::err_with_code("array changed during iteration", "TCL READ array for")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn whole_array_unset_preserves_constant_error_identity() {
+        let mut vm = Vm::new();
+        vm.ensure_array("a").expect("array");
+        vm.mark_constant("a");
+
+        let completion = array_op_after_trace(&mut vm, "unset", &[Value::string("a")], None);
+
+        assert_eq!(completion.code, Code::Error);
+        assert_eq!(
+            completion.result.to_str().as_ref(),
+            r#"can't unset "a": variable is a constant"#
+        );
+        assert_eq!(
+            crate::command::resolved_error_code(&completion)
+                .to_str()
+                .as_ref(),
+            "TCL UNSET CONST"
+        );
+        assert!(VarStore::array_keys(&vm, tcl_runtime_api::Frames::current(&vm), "a").is_some());
+    }
 }

--- a/rust/tcl-vm/src/cmd_control.rs
+++ b/rust/tcl-vm/src/cmd_control.rs
@@ -246,7 +246,7 @@ fn cmd_lmap(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
 /// is appended to the result list; without, the result is the empty string.
 ///
 /// Parses the grammar up front (same validation, same errors) then defers the
-/// actual iteration to the explicit stack via `vm.pending_each_loop`
+/// actual iteration to the explicit stack via `vm.pending.each_loop`
 /// (`crate::exec::EachLoopReq`/`Frame::each_loop`), so each iteration's body
 /// runs as a yieldable child script frame instead of through
 /// `Vm::eval_source`'s nested drive — issue #1311: a value-consumed `lmap`
@@ -289,12 +289,12 @@ fn each_loop(vm: &mut Vm, args: &[Value], collect: bool) -> Completion<Value> {
     // longer runs via a nested nested-drive nested-native re-entry (it is
     // deferred to the explicit stack below), so it does not need
     // `enter_control_fallback`'s native-stack recursion guard — matching
-    // `eval`/`uplevel`'s own `pending_eval` deferral, which likewise has none.
+    // `eval`/`uplevel`'s own pending deferral, which likewise has none.
     let script = match vm.compile_script_cached(&body.to_str()) {
         Ok(script) => script,
         Err(e) => return err(e.message),
     };
-    vm.pending_each_loop = Some(crate::exec::EachLoopReq {
+    vm.pending.each_loop = Some(crate::exec::EachLoopReq {
         name,
         collect,
         groups,

--- a/rust/tcl-vm/src/cmd_info.rs
+++ b/rust/tcl-vm/src/cmd_info.rs
@@ -116,8 +116,7 @@ fn cmd_info(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
                 // `info exists` fires read traces first (a trace may create the
                 // variable — tcltest's lazy `SafeFetch` constraint init relies
                 // on this); a trace error does not abort the existence check.
-                let _ = vm.fire_var_traces(&name.to_str(), "read");
-                ok(tcl_cmd_core::info::exists(vm, name))
+                ok(Value::bool(vm.exists_var_traced(&name.to_str())))
             }
             _ => err("wrong # args: should be \"info exists varName\""),
         },
@@ -160,13 +159,10 @@ fn cmd_info(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
             [name] => ok(Value::bool(vm.is_constant(&name.to_str()))),
             _ => err("wrong # args: should be \"info constant varname\""),
         },
-        "consts" => {
-            let names = vm.constant_names().into_iter().filter(|n| {
-                rest.first()
-                    .is_none_or(|p| tcl_syntax::glob::string_match(&p.to_str(), n))
-            });
-            ok(Value::list(names.map(Value::string).collect()))
-        }
+        "consts" => match rest {
+            [] | [_] => ok(tcl_cmd_core::info::consts(vm, rest.first())),
+            _ => err("wrong # args: should be \"info consts ?pattern?\""),
+        },
         // body/args/default route through the shared `info` core over the `Procs`
         // role trait; the var-write for `default` stays here (it is trace-aware).
         "body" => match rest {

--- a/rust/tcl-vm/src/cmd_oo.rs
+++ b/rust/tcl-vm/src/cmd_oo.rs
@@ -1372,8 +1372,9 @@ fn run_step_inner(
         .get(obj_key)
         .map(|o| o.ns.clone())
         .unwrap_or_default();
-    // Instance variables to auto-link: the providing entity's declared vars,
-    // plus the object's own declared vars.
+    // Instance variables to auto-link belong to the method's declaring
+    // provider. An object-defined method sees the object's declarations; a
+    // class-defined method sees that class's declarations.
     let mut decl: Vec<String> = Vec::new();
     if step.is_object {
         if let Some(o) = vm.oo.objects.get(&step.provider) {
@@ -1382,15 +1383,12 @@ fn run_step_inner(
     } else if let Some(c) = vm.oo.classes.get(&step.provider) {
         decl.extend(c.variables.iter().cloned());
     }
-    if let Some(o) = vm.oo.objects.get(obj_key) {
-        for v in &o.variables {
-            if !decl.contains(v) {
-                decl.push(v.clone());
-            }
-        }
-    }
     let link_vars: Vec<(String, String)> = decl
         .into_iter()
+        // TclOO's automatic instance-variable resolver yields to a method
+        // formal of the same name. Explicit `my variable x` still reaches the
+        // ordinary link installer and reports the collision.
+        .filter(|v| !m.params.iter().any(|param| param.name == *v))
         .map(|v| {
             let storage = format!("{obj_ns}::{v}");
             (v, storage)
@@ -1475,7 +1473,13 @@ fn builtin_method(vm: &mut Vm, obj_key: &str, method: &str, args: &[Value]) -> C
                         "variable name \"{name}\" illegal: must not contain namespace separator"
                     ));
                 }
-                vm.add_link(&name, 0, &format!("{ns}::{name}"));
+                if let Err(error) = vm.add_link(&name, 0, &format!("{ns}::{name}")) {
+                    return crate::command::upvar_link_error(
+                        error,
+                        &format!("{ns}::{name}"),
+                        &name,
+                    );
+                }
             }
             ok(Value::empty())
         }

--- a/rust/tcl-vm/src/cmd_string.rs
+++ b/rust/tcl-vm/src/cmd_string.rs
@@ -511,12 +511,10 @@ fn cmd_append(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
         // current value, erroring if the variable is unset (matching tclsh —
         // the old VM wrongly created an empty variable here). `var_get` parses
         // `a(k)`.
-        if let Err(c) = vm.fire_var_traces(&n, "read") {
-            return c;
-        }
-        return match vm.var_get(&n) {
-            Some(v) => ok(v),
-            None => err(format!("can't read \"{n}\": no such variable")),
+        return match vm.read_var_traced(&n) {
+            Err(c) => c,
+            Ok(Some(v)) => ok(v),
+            Ok(None) => err(format!("can't read \"{n}\": no such variable")),
         };
     }
     // The byte-exact concatenation is shared with the WASM runtime via

--- a/rust/tcl-vm/src/cmd_try.rs
+++ b/rust/tcl-vm/src/cmd_try.rs
@@ -99,7 +99,7 @@ pub(crate) struct TryState {
 
 /// One phase of a `try` deferred to the explicit stack: the phase's compiled
 /// script plus the state to resume from once it completes. Parked in
-/// `Vm.pending_try` by `cmd_try`/[`advance_try`], drained into a try activation
+/// `Vm.pending.try_phase` by `cmd_try`/[`advance_try`], drained into a try activation
 /// (see [`Frame::new_try`](crate::exec::Frame::new_try)).
 pub(crate) struct TryReq {
     pub(crate) script: crate::compiled::CompiledUnit,
@@ -287,7 +287,7 @@ fn parse_clauses(rest: &[Value]) -> Result<(Vec<Handler>, Option<Value>), Comple
 /// `try body ?handler ...? ?finally script?` — structured exception handling.
 ///
 /// Parses and validates the grammar synchronously (unchanged), then defers the
-/// body to the explicit stack via `vm.pending_try` (issue #1311) instead of
+/// body to the explicit stack via `vm.pending.try_phase` (issue #1311) instead of
 /// running it through `Vm::eval_source`. [`advance_try`] carries the
 /// handler-matching / `finally` logic forward from there, one phase per
 /// `Vm::unwind` fold.
@@ -303,7 +303,7 @@ fn cmd_try(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     let plan = Rc::new(TryPlan { handlers, finally });
     match vm.prepare_script_commands(&body.to_str()) {
         Ok(prepared) if prepared.prefix.is_some() => {
-            vm.pending_try = Some(TryReq {
+            vm.pending.try_phase = Some(TryReq {
                 script: prepared.prefix.expect("checked above"),
                 state: TryState {
                     plan,
@@ -317,7 +317,7 @@ fn cmd_try(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
             let body_completion = prepared.fatal_tail.map_or_else(|| ok(Value::empty()), err);
             match advance_after_body(vm, &plan, body_completion) {
                 TryOutcome::Push(req) => {
-                    vm.pending_try = Some(req);
+                    vm.pending.try_phase = Some(req);
                     ok(Value::empty())
                 }
                 TryOutcome::Deliver(c) => c,
@@ -331,7 +331,7 @@ fn cmd_try(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
         // failure that skips it (try-body-parse-error tclsh-pinned test).
         Err(e) => match advance_after_body(vm, &plan, err(e.message)) {
             TryOutcome::Push(req) => {
-                vm.pending_try = Some(req);
+                vm.pending.try_phase = Some(req);
                 ok(Value::empty())
             }
             TryOutcome::Deliver(c) => c,

--- a/rust/tcl-vm/src/command.rs
+++ b/rust/tcl-vm/src/command.rs
@@ -264,10 +264,11 @@ fn cmd_set(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
             // the `$var` opcode path) — and a trace may create the variable
             // before the read resolves (tcltest's `SafeFetch` lazily
             // initialises a constraint this way).
-            if let Err(c) = vm.fire_var_traces(&n, "read") {
-                return c;
+            match vm.read_var_traced(&n) {
+                Ok(Some(value)) => ok(value),
+                Ok(None) => err(vm.read_miss_msg(&n)),
+                Err(c) => c,
             }
-            vm.var_get(&n).map_or_else(|| err(vm.read_miss_msg(&n)), ok)
         }
         [name, value] => match vm.store_var_result(&name.to_str(), value.clone()) {
             Ok(stored) => ok(stored),
@@ -351,12 +352,12 @@ fn cmd_eval(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     };
     // Defer the body to the *explicit* stack so a `yield` inside it stays
     // yieldable: compile it and hand it to the trampoline via
-    // `pending_eval`, which pushes a transparent script frame whose result
+    // the pending eval request, which pushes a transparent script frame whose result
     // replaces this placeholder. The script frame adds the `("eval" body line N)`
     // errorInfo frame itself on error (eval-2.5; see `Frame::body_label`).
     match vm.compile_script_cached(&script) {
         Ok(script) => {
-            vm.pending_eval = Some((script, Some("eval"), None));
+            vm.pending.eval = Some((script, Some("eval"), None));
             ok(Value::empty())
         }
         Err(e) => err(e.message),
@@ -443,7 +444,7 @@ pub(crate) fn build_lambda_proc(vm: &mut Vm, lambda: &Value) -> Result<String, C
 /// Implemented by binding the lambda to a temporary command and evaluating a
 /// call, so parameter binding and `return` semantics match a normal proc.
 ///
-/// Defers the call to the *explicit* stack via `pending_eval` (like
+/// Defers the call to the *explicit* stack via the pending eval request (like
 /// `eval`/`uplevel`) rather than `Vm::eval_source`'s nested drive, so a `yield`
 /// inside the lambda body stays yieldable — `coroutine c apply {lambda}`
 /// already got this treatment (`cmd_coroutine` binds the lambda to an internal
@@ -466,7 +467,7 @@ fn cmd_apply(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     let script = tcl_syntax::list::join_list(words.iter().map(Value::to_str));
     match vm.compile_script_cached(&script) {
         Ok(script) => {
-            vm.pending_eval = Some((script, None, Some(name)));
+            vm.pending.eval = Some((script, None, Some(name)));
             ok(Value::empty())
         }
         Err(e) => {
@@ -1167,12 +1168,12 @@ fn cmd_subst(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
         }
     }
     // Defer to the *explicit* stack so a `yield` inside a `[…]` stays yieldable:
-    // park the template + switches in `pending_subst`, drained by
+    // park the template + switches in the pending subst request, drained by
     // the trampoline into a scanner-driven subst frame (mirrors `cmd_catch`'s
-    // `pending_catch`). The frame's accumulated result replaces this builtin's
+    // the pending catch request). The frame's accumulated result replaces this builtin's
     // placeholder; on the native `invoke_command` fallback it runs via a nested
     // drive (not yieldable, as before).
-    vm.pending_subst = Some(crate::exec::SubstReq {
+    vm.pending.subst = Some(crate::exec::SubstReq {
         template: string.to_str().to_string(),
         backslashes,
         commands,
@@ -1489,6 +1490,31 @@ pub(crate) fn with_return_level(options: &Value, new_level: i64) -> Value {
     Value::list(items)
 }
 
+/// Rebuild a return-options dict with one key replaced, preserving every
+/// unrelated option. A missing key is appended.
+pub(crate) fn with_return_option(options: &Value, key: &str, value: Value) -> Value {
+    let mut items = Vec::new();
+    let mut replaced = false;
+    if let Ok(list) = options.as_list() {
+        let mut i = 0;
+        while i + 1 < list.len() {
+            items.push(list[i].clone());
+            if &*list[i].to_str() == key {
+                items.push(value.clone());
+                replaced = true;
+            } else {
+                items.push(list[i + 1].clone());
+            }
+            i += 2;
+        }
+    }
+    if !replaced {
+        items.push(Value::string(key));
+        items.push(value);
+    }
+    Value::list(items)
+}
+
 /// Look up a key in an options-dict value, returning the following element.
 pub(crate) fn opt_get(options: &Value, key: &str) -> Option<Value> {
     let items = options.as_list().ok()?;
@@ -1795,13 +1821,13 @@ fn cmd_catch(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     };
     // Defer the body to the *explicit* stack so a `yield` inside it stays
     // yieldable: compile it and hand it to the trampoline via
-    // `pending_catch`. A catch frame runs the body and its completion — of any
+    // the pending catch request. A catch frame runs the body and its completion — of any
     // code — is absorbed by `finish_catch` (which binds the result/options vars
-    // and yields the status code). Mirrors `cmd_eval`'s `pending_eval`, but
+    // and yields the status code). Mirrors `cmd_eval`'s pending request, but
     // catch's completion is caught rather than propagated.
     match vm.prepare_script_commands(&script.to_str()) {
         Ok(prepared) if prepared.prefix.is_some() => {
-            vm.pending_catch = Some(crate::exec::CatchReq {
+            vm.pending.catch = Some(crate::exec::CatchReq {
                 script: prepared.prefix.expect("checked above"),
                 resvar: resvar.map(|v| (*v).clone()),
                 optvar: optvar.map(|v| (*v).clone()),
@@ -2064,6 +2090,14 @@ pub(crate) fn upvar_link_error(
             format!("can't create \"{local}\": parent namespace doesn't exist"),
             &lookup_var_error_code(local),
         ),
+        crate::interp::UpvarLinkError::Exists => err_with_code(
+            format!("variable \"{local}\" already exists"),
+            "TCL UPVAR EXISTS",
+        ),
+        crate::interp::UpvarLinkError::Traced => err_with_code(
+            format!("variable \"{local}\" has traces: can't use for upvar"),
+            "TCL UPVAR TRACED",
+        ),
     }
 }
 
@@ -2076,22 +2110,25 @@ pub(crate) fn upvar_link_error(
 /// `global a(b)` are accepted. Verified on 8.6.16 and 9.0.4, which agree.
 fn cmd_global(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     let in_proc = vm.in_proc_frame();
+    if !in_proc {
+        return ok(Value::empty());
+    }
     for n in args {
         let nm = n.to_str();
-        if in_proc {
-            // Namespace resolution comes first: `global ::nosuch::v(k)` is a
-            // missing-namespace error, not an element one.
-            if let Some(e) = missing_parent_ns(vm, "access", &nm) {
-                return e;
-            }
-            // C links under the *tail* and reports the tail: `global ::x::a(b)`
-            // says `bad variable name "a(b)"`. Verified on 8.6.16 and 9.0.4.
-            let tail = name_tail(&nm);
-            if looks_like_element(tail) {
-                return bad_link_name(tail);
-            }
+        // Namespace resolution comes first: `global ::nosuch::v(k)` is a
+        // missing-namespace error, not an element one.
+        if let Some(e) = missing_parent_ns(vm, "access", &nm) {
+            return e;
         }
-        vm.add_link(&nm, 0, &nm);
+        // C links under the *tail* and reports the tail: `global ::x::a(b)`
+        // says `bad variable name "a(b)"`. Verified on 8.6.16 and 9.0.4.
+        let tail = name_tail(&nm);
+        if looks_like_element(tail) {
+            return bad_link_name(tail);
+        }
+        if let Err(error) = vm.add_link(&nm, 0, &nm) {
+            return upvar_link_error(error, &nm, name_tail(&nm));
+        }
     }
     ok(Value::empty())
 }
@@ -2226,7 +2263,7 @@ fn cmd_uplevel(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     if target == cur {
         return match vm.compile_script_cached(&script) {
             Ok(script) => {
-                vm.pending_eval = Some((script, Some("uplevel"), None));
+                vm.pending.eval = Some((script, Some("uplevel"), None));
                 ok(Value::empty())
             }
             Err(e) => err(e.message),
@@ -2248,9 +2285,7 @@ pub(crate) fn cmd_variable(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     let mut i = 0;
     while i < args.len() {
         let name = args[i].to_str();
-        // Namespace variables live in the global frame keyed by their canonical
-        // qualified name; alias the unqualified local the body uses to it.
-        let qual = vm.qualify_name(&name);
+        // Alias the unqualified local spelling to the stable namespace cell.
         let local = name_tail(&name).to_owned();
         // C's `TclNRVariableObjCmd` rejects an element-looking target, checking
         // the tail but naming the *given* spelling: `variable ::x::v(k)` says
@@ -2273,8 +2308,9 @@ pub(crate) fn cmd_variable(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
                 "TCL UPVAR LOCAL_ELEMENT",
             );
         }
-        vm.declare_namespace_variable(&qual);
-        vm.add_link(&local, 0, &qual);
+        if let Err(error) = vm.link_namespace_variable(&local, &name) {
+            return upvar_link_error(error, &name, &local);
+        }
         if i + 1 < args.len() {
             // `set_var` follows the alias just installed to the real cell.
             if let Err(e) = vm.set_var(&local, args[i + 1].clone()) {

--- a/rust/tcl-vm/src/exec.rs
+++ b/rust/tcl-vm/src/exec.rs
@@ -266,7 +266,7 @@ pub(crate) struct CatchReq {
 }
 
 /// A `subst` deferred to the explicit stack: the template plus its three
-/// substitution switches. Parked in `Vm.pending_subst` by `cmd_subst` and drained
+/// substitution switches. Parked in `Vm.pending.subst` by `cmd_subst` and drained
 /// into a subst activation (see [`Frame::subst`]), so a `yield` inside a `[…]`
 /// stays yieldable.
 pub(crate) struct SubstReq {
@@ -288,7 +288,7 @@ pub(crate) struct EachLoopGroup {
 /// — this is what a value-consumed `lmap`, e.g. `set r [lmap x {1 2} { yield
 /// $x }]`, needs: reached via generic command dispatch rather than the
 /// compiler's inline `LMAP_COLLECT` loop, its body used to run through
-/// `Vm::eval_source`'s nested drive). Parked in `Vm.pending_each_loop` by
+/// `Vm::eval_source`'s nested drive). Parked in `Vm.pending.each_loop` by
 /// `each_loop` and drained into an each-loop activation (see
 /// [`Frame::each_loop`]).
 pub(crate) struct EachLoopReq {
@@ -547,22 +547,22 @@ enum Tick {
     },
     /// Run a `catch` body on the explicit stack (yieldable) via a catch
     /// activation ([`Frame::new_catch`]); its completion is absorbed by the catch
-    /// epilogue. Drained from `Vm.pending_catch`, mirroring `PushScript`.
+    /// epilogue. Drained from `Vm.pending.catch`, mirroring `PushScript`.
     PushCatch(CatchReq),
     /// Run a `subst` on the explicit stack (yieldable) via a subst activation
     /// ([`Frame::new_subst`]); its `[…]` bodies run as child script frames and are
-    /// folded back by subst rules. Drained from `Vm.pending_subst`.
+    /// folded back by subst rules. Drained from `Vm.pending.subst`.
     PushSubst(SubstReq),
     /// Run a `foreach`/`lmap` runtime-fallback loop on the explicit stack
     /// (yieldable) via an each-loop activation ([`Frame::new_each_loop`]); each
     /// iteration's body runs as a child script frame and is folded back by
     /// `each_loop`'s collect/continue/break rules. Drained from
-    /// `Vm.pending_each_loop` (issue #1311).
+    /// `Vm.pending.each_loop` (issue #1311).
     PushEachLoop(EachLoopReq),
     /// Run one phase (body/handler/`finally`) of a `try` on the explicit stack
     /// (yieldable) via a try-phase activation ([`Frame::new_try`]); its
     /// completion decides the next phase via `cmd_try::advance_try`. Drained
-    /// from `Vm.pending_try` (issue #1311).
+    /// from `Vm.pending.try_phase` (issue #1311).
     PushTry(crate::cmd_try::TryReq),
     /// `tailcall cmd ?arg …?` — the current proc finishes and `cmd args` runs in
     /// its place (in the caller's activation), its result becoming the proc's.
@@ -2550,8 +2550,7 @@ impl Vm {
             // to carry no `(index)` part), so they are the same arm here.
             Op::LOAD_STK | Op::LOAD_SCALAR_STK => {
                 let name = pop(f).to_str();
-                try_op!(self.fire_var_traces(&name, "read"));
-                match self.get_var(&name) {
+                match try_op!(self.read_var_traced(&name)) {
                     Some(v) => f.stack.push(v),
                     None => {
                         return Tick::Return(err(format!(
@@ -2582,8 +2581,7 @@ impl Vm {
             // -- variables (LVT form, proc bodies) --
             Op::LOAD_SCALAR1 | Op::LOAD_SCALAR4 => {
                 let name = lvt_name(imm0(instr));
-                try_op!(self.fire_var_traces(&name, "read"));
-                match self.get_var(&name) {
+                match try_op!(self.read_var_traced(&name)) {
                     Some(v) => f.stack.push(v),
                     None => {
                         return Tick::Return(err(format!(
@@ -2649,13 +2647,11 @@ impl Vm {
                 let name = lvt_name(imm0(instr));
                 // `info exists` fires read traces (a trace may create the
                 // variable); a trace error does not abort the existence check.
-                let _ = self.fire_var_traces(&name, "read");
-                f.stack.push(Value::bool(self.exists_var(&name)));
+                f.stack.push(Value::bool(self.exists_var_traced(&name)));
             }
             Op::EXIST_STK => {
                 let name = pop(f).to_str();
-                let _ = self.fire_var_traces(&name, "read");
-                f.stack.push(Value::bool(self.exists_var(&name)));
+                f.stack.push(Value::bool(self.exists_var_traced(&name)));
             }
             // The array-element existence tests fire the element's read traces
             // first (C `INST_EXIST_ARRAY`: a trace may create it) and never
@@ -2664,23 +2660,20 @@ impl Vm {
                 let name = lvt_name(imm0(instr));
                 let key = pop(f).to_str();
                 let full = format!("{name}({key})");
-                let _ = self.fire_var_traces(&full, "read");
-                f.stack.push(Value::bool(self.exists_var(&full)));
+                f.stack.push(Value::bool(self.exists_var_traced(&full)));
             }
             Op::EXIST_ARRAY_STK => {
                 let key = pop(f).to_str();
                 let name = pop(f).to_str();
                 let full = format!("{name}({key})");
-                let _ = self.fire_var_traces(&full, "read");
-                f.stack.push(Value::bool(self.exists_var(&full)));
+                f.stack.push(Value::bool(self.exists_var_traced(&full)));
             }
 
             // -- arrays --
             Op::LOAD_ARRAY_STK => {
                 let key = pop(f).to_str();
                 let name = pop(f).to_str();
-                try_op!(self.fire_var_traces(&format!("{name}({key})"), "read"));
-                match self.get_array_elem(&name, &key) {
+                match try_op!(self.read_elem_traced(&name, &key)) {
                     Some(v) => f.stack.push(v),
                     None => {
                         return Tick::Return(err(format!(
@@ -2699,8 +2692,7 @@ impl Vm {
             Op::LOAD_ARRAY1 | Op::LOAD_ARRAY4 => {
                 let name = lvt_name(imm0(instr));
                 let key = pop(f).to_str();
-                try_op!(self.fire_var_traces(&format!("{name}({key})"), "read"));
-                match self.get_array_elem(&name, &key) {
+                match try_op!(self.read_elem_traced(&name, &key)) {
                     Some(v) => f.stack.push(v),
                     None => {
                         return Tick::Return(err(format!(
@@ -2718,13 +2710,29 @@ impl Vm {
             }
             Op::ARRAY_EXISTS_IMM => {
                 let name = lvt_name(imm0(instr));
-                f.stack.push(Value::bool(self.array_is(&name)));
+                let completion = self.with_array_trace_target(&name, |vm, target| {
+                    ok(Value::bool(
+                        tcl_runtime_api::VarStore::array_keys_at(vm, target).is_some(),
+                    ))
+                });
+                if completion.code != Code::Ok {
+                    return Tick::Return(completion);
+                }
+                f.stack.push(completion.result);
             }
             Op::ARRAY_EXISTS_STK => {
                 // The stack form resolves an arbitrary (possibly qualified) name,
                 // so it honours the namespace-variable fallback `array_is` skips.
                 let name = pop(f).to_str();
-                f.stack.push(Value::bool(self.var_is_array(&name)));
+                let completion = self.with_array_trace_target(&name, |vm, target| {
+                    ok(Value::bool(
+                        tcl_runtime_api::VarStore::array_keys_at(vm, target).is_some(),
+                    ))
+                });
+                if completion.code != Code::Ok {
+                    return Tick::Return(completion);
+                }
+                f.stack.push(completion.result);
             }
             // `array set`'s materialising half (C `INST_ARRAY_MAKE_*`): make the
             // variable an empty array when undefined, no-op when it already is
@@ -3120,13 +3128,14 @@ impl Vm {
             }
             // `variable` (C `INST_VARIABLE`): link the local slot to the
             // namespace variable named by the popped name. The link machinery is
-            // the `variable` command's (`cmd_variable`) — namespace variables
-            // live in the global frame under their canonical qualified name.
+            // the `variable` command's (`cmd_variable`) and resolves the exact
+            // namespace token once.
             Op::VARIABLE => {
                 let local = lvt_name(imm0(instr));
                 let var = pop(f).to_str();
-                let target = self.qualify_name(&var);
-                self.add_link(&local, 0, &target);
+                if let Err(error) = self.link_namespace_variable(&local, &var) {
+                    return Tick::Return(crate::command::upvar_link_error(error, &var, &local));
+                }
             }
 
             // -- concat (stack form): Tcl-concat the top N values. --
@@ -4989,7 +4998,7 @@ impl Vm {
         // An `eval`/`uplevel`/`apply`-style builtin defers its body to the
         // explicit stack (yieldable): drain it into a `PushScript`, whose
         // frame result replaces this builtin's placeholder (as for yield).
-        if let Some((script, label, cleanup_proc)) = self.pending_eval.take() {
+        if let Some((script, label, cleanup_proc)) = self.pending.eval.take() {
             return Ok(Some(Tick::PushScript {
                 script,
                 label,
@@ -4999,24 +5008,24 @@ impl Vm {
         }
         // A `catch` defers its body the same way, but into a catch frame
         // whose completion the epilogue absorbs (see `Frame::catch`).
-        if let Some(req) = self.pending_catch.take() {
+        if let Some(req) = self.pending.catch.take() {
             return Ok(Some(Tick::PushCatch(req)));
         }
         // A `subst` defers to a scanner-driven subst frame, whose `[…]`
         // bodies run yieldably as child frames (see `Frame::subst`).
-        if let Some(req) = self.pending_subst.take() {
+        if let Some(req) = self.pending.subst.take() {
             return Ok(Some(Tick::PushSubst(req)));
         }
         // A `foreach`/`lmap` runtime-fallback loop defers to a
         // scanner-driven each-loop frame, whose iterations run yieldably
         // as child frames (see `Frame::each_loop`, issue #1311).
-        if let Some(req) = self.pending_each_loop.take() {
+        if let Some(req) = self.pending.each_loop.take() {
             return Ok(Some(Tick::PushEachLoop(req)));
         }
         // A `try` defers its body (and, from `advance_try`, each
         // subsequent phase) to a try-phase frame (see `Frame::try_ctx`,
         // issue #1311).
-        if let Some(req) = self.pending_try.take() {
+        if let Some(req) = self.pending.try_phase.take() {
             return Ok(Some(Tick::PushTry(req)));
         }
         Self::deliver_sync(f, res)
@@ -5332,11 +5341,11 @@ impl Vm {
     /// only in having a trampoline to push onto.
     fn settle_native_invoke(&mut self, res: Completion<Value>) -> Completion<Value> {
         // An `eval`/`uplevel`/`apply`-style builtin deferred its body to
-        // `pending_eval`. This call site is on the native Rust stack (no
+        // the pending eval request. This call site is on the native Rust stack (no
         // trampoline to push onto), so run the body via a nested drive —
         // a `yield` inside cannot cross it, exactly like every other
         // `invoke_command` re-entry.
-        if let Some((script, label, cleanup_proc)) = self.pending_eval.take() {
+        if let Some((script, label, cleanup_proc)) = self.pending.eval.take() {
             let comp = self.run_activation(Frame::new_script(script, label));
             if let Some(name) = cleanup_proc {
                 self.take_command_unchecked(&name);
@@ -5346,7 +5355,7 @@ impl Vm {
         // A `catch` deferred its body: run it via a nested drive (a `yield`
         // inside cannot cross this native re-entry), then absorb its
         // completion with the catch epilogue.
-        if let Some(req) = self.pending_catch.take() {
+        if let Some(req) = self.pending.catch.take() {
             let mut comp = self.run_activation(Frame::new_script(req.script, None));
             if comp.code == Code::Ok
                 && let Some(message) = req.fatal_tail
@@ -5358,7 +5367,7 @@ impl Vm {
         // A `subst` deferred: run the scanner-driven subst frame via a
         // nested drive (its `[…]` bodies can't yield across this native
         // re-entry), returning its accumulated result.
-        if let Some(req) = self.pending_subst.take() {
+        if let Some(req) = self.pending.subst.take() {
             let namespace = self.current_ns().to_owned();
             let placeholder = self.compiled_unit(Rc::new(FunctionAsm::default()), namespace);
             return self.run_activation(Frame::new_subst(req, placeholder));
@@ -5366,7 +5375,7 @@ impl Vm {
         // A `foreach`/`lmap` runtime-fallback loop deferred: run the
         // scanner-driven each-loop frame via a nested drive (a `yield` in
         // its body can't cross this native re-entry either).
-        if let Some(req) = self.pending_each_loop.take() {
+        if let Some(req) = self.pending.each_loop.take() {
             let namespace = self.current_ns().to_owned();
             let placeholder = self.compiled_unit(Rc::new(FunctionAsm::default()), namespace);
             return self.run_activation(Frame::new_each_loop(req, placeholder));
@@ -5378,7 +5387,7 @@ impl Vm {
         // next phase onto the same nested `acts`, so one
         // `run_activation` call carries the whole construct through to
         // its final completion.
-        if let Some(req) = self.pending_try.take() {
+        if let Some(req) = self.pending.try_phase.take() {
             return self.run_activation(Frame::new_try(req));
         }
         res
@@ -5490,9 +5499,8 @@ impl Vm {
     /// instance-variable linking the runtime's `run_proc` does.
     ///
     /// `link_vars` are `(local, storage-fqn)` pairs: each links a method-local
-    /// name to the object namespace's variable of that FQN (namespace variables
-    /// live in the global frame keyed by their qualified name, so the link is at
-    /// level 0). The `frame` carries the resolved method chain that `self`/`my`/
+    /// name to the object namespace's variable of that FQN. The `frame` carries
+    /// the resolved method chain that `self`/`my`/
     /// `next` consult while the body runs.
     pub(crate) fn oo_run_method(
         &mut self,
@@ -5505,7 +5513,11 @@ impl Vm {
             return c;
         }
         for (local, storage) in link_vars {
-            self.add_link(local, 0, storage);
+            if let Err(error) = self.add_tcloo_instance_link(local, 0, storage) {
+                self.pop_call_frame();
+                self.pop_ns();
+                return crate::command::upvar_link_error(error, storage, local);
+            }
         }
         self.oo.call_stack.push(frame);
         let result = self.run_activation(Frame::new(proc.body.clone(), true));

--- a/rust/tcl-vm/src/expr.rs
+++ b/rust/tcl-vm/src/expr.rs
@@ -853,12 +853,13 @@ impl ExprOps for ExprEval<'_> {
     }
 
     fn var(&mut self, name: &str) -> Result<Value, TclError> {
-        if let Err(c) = self.vm.fire_var_traces(name, "read") {
-            return Err(TclError::new(c.result.to_str().to_string()));
+        match self.vm.read_var_traced(name) {
+            Err(c) => Err(TclError::new(c.result.to_str().to_string())),
+            Ok(Some(value)) => Ok(value),
+            Ok(None) => Err(TclError::new(format!(
+                "can't read \"{name}\": no such variable"
+            ))),
         }
-        self.vm
-            .get_var(name)
-            .ok_or_else(|| TclError::new(format!("can't read \"{name}\": no such variable")))
     }
 
     fn command(&mut self, script: &str) -> Result<Value, TclError> {

--- a/rust/tcl-vm/src/frame.rs
+++ b/rust/tcl-vm/src/frame.rs
@@ -18,45 +18,18 @@
 
 //! The call-frame stack and per-frame variable storage.
 //!
-//! Frame 0 is the global scope. Each frame holds local variables; a [`Local`]
-//! is either a scalar value or a cross-frame [`Local::Link`] (the
-//! `upvar`/`global`/`variable` alias). Name resolution follows links to the
-//! owning frame.
-
-use std::collections::{BTreeMap, HashMap};
+//! Frame 0 is the global call level. Procedure frames own local name tables;
+//! namespace variables instead belong to the stable namespace token's table.
 
 use tcl_runtime_api::NsId;
 
 use crate::value::Value;
-
-/// A variable cell in a frame: a scalar, an array, or a link to another frame's
-/// variable.
-pub(crate) enum Local {
-    /// A materialised, but unset, variable cell. `trace add variable` creates
-    /// this state: it is not visible to `info exists`, yet a later scalar or
-    /// array write defines it with the appropriate shape.
-    Undefined,
-    /// A scalar value owned by this frame.
-    Scalar(Value),
-    /// An associative array (element key → value). `BTreeMap` gives a
-    /// deterministic `array names`/`array get` order.
-    Array(BTreeMap<String, Value>),
-    /// An alias to `name` in frame `level` (`upvar`/`global`/`variable`).
-    Link {
-        /// Target frame level.
-        level: usize,
-        /// Target variable name within that frame.
-        name: String,
-    },
-}
+use crate::vars::VarTable;
 
 /// One call frame.
 pub(crate) struct CallFrame {
     /// Local variables by name.
-    pub locals: HashMap<String, Local>,
-    /// Names (within this frame) declared `const` — immutable scalars (TIP 677).
-    /// Dropped with the frame, so a proc-local constant lasts one activation.
-    pub consts: std::collections::HashSet<String>,
+    pub locals: VarTable,
     /// The namespace this frame executes in (currently global-only).
     #[allow(dead_code)]
     pub ns: NsId,
@@ -71,8 +44,8 @@ pub(crate) struct CallFrame {
     /// runs in (no leading `::`; `""` = global). `None` for proc activations and
     /// the global frame. An unqualified variable accessed in such a frame is a
     /// *namespace* variable (`ns::name` in the global frame), not a local — see
-    /// [`Vm::locate_from`](crate::interp::Vm). This is what makes `uplevel`/
-    /// `upvar` into a namespace-eval body resolve to namespace variables.
+    /// the shared variable resolver. This is what makes `uplevel`/`upvar` into
+    /// a namespace-eval body resolve to namespace variables.
     pub ns_eval: Option<String>,
 }
 
@@ -80,8 +53,7 @@ impl CallFrame {
     /// A fresh frame at `level` in namespace `ns`.
     pub fn new(level: usize, ns: NsId, proc_name: Option<String>, call_argv: Vec<Value>) -> Self {
         Self {
-            locals: HashMap::new(),
-            consts: std::collections::HashSet::new(),
+            locals: VarTable::new(),
             ns,
             level,
             proc_name,

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -27,7 +27,7 @@
 //! model does (issue #946).
 
 use std::cell::RefCell;
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::io::{self, Write};
 use std::rc::{Rc, Weak};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -40,9 +40,9 @@ use tcl_runtime_api::guard::{
     GuardDomain, GuardDomains, GuardError, GuardIdentity, GuardManager, GuardToken,
 };
 use tcl_runtime_api::{
-    Code, CommandId, Commands, CompileService, Completion, FrameId, Frames, Introspect, Namespaces,
-    NsId, ProcInfo, ProcParam, ProcedureCompileTarget, ProcedureDispatch, Procs, ROOT_NS,
-    ScriptCompileTarget, Traces, VarStore,
+    ArrayTarget, Code, CommandId, Commands, CompileService, Completion, FrameId, FrameLinkOrigin,
+    Frames, Introspect, Namespaces, NsId, ProcInfo, ProcParam, ProcedureCompileTarget,
+    ProcedureDispatch, Procs, ROOT_NS, ScriptCompileTarget, Traces, VarId, VarStore, VarUnsetError,
 };
 use tcl_syntax::expr::{eval, parse_expr};
 
@@ -52,7 +52,7 @@ use crate::command::{
 use crate::compiled::{CompiledUnit, CompilerProvenance};
 use crate::error::TclError;
 use crate::expr::ExprEval;
-use crate::frame::{CallFrame, Local};
+use crate::frame::CallFrame;
 // The default capability host, picked by target. Everywhere with an operating
 // system under it — including `wasm32-wasip1`, where `std::time` and `std::env`
 // both work — that is the full-capability std-backed `NativeHost`. On
@@ -65,6 +65,7 @@ use crate::host_native::NativeHost as DefaultHost;
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use crate::host_wasm::BrowserHost as DefaultHost;
 use crate::value::Value;
+use crate::vars::{VarArena, VarState as Local, VarState, VarTable};
 
 /// The proc-call recursion bound (C Tcl's default `interp recursionlimit`).
 /// A deeper nesting is a catchable error, not a native stack overflow.
@@ -83,6 +84,10 @@ pub(crate) enum UpvarLinkError {
     LocalElement,
     /// The alias names an absent namespace.
     LocalNamespace,
+    /// The alias already names a defined scalar or array cell.
+    Exists,
+    /// The alias owns traces, which cannot be discarded by link installation.
+    Traced,
 }
 
 /// A typed failure while moving a command between an interpreter's visible
@@ -822,6 +827,21 @@ enum CommandSemantics {
     Tracking,
 }
 
+/// Deferred control requests handed from builtins to the explicit VM stack.
+#[derive(Default)]
+pub(crate) struct PendingControl {
+    /// Compiled script, error-info label, and optional temporary command cleanup.
+    pub(crate) eval: Option<(CompiledUnit, Option<&'static str>, Option<String>)>,
+    /// Catch body whose completion is absorbed by the catch epilogue.
+    pub(crate) catch: Option<crate::exec::CatchReq>,
+    /// Scanner-driven substitution request.
+    pub(crate) subst: Option<crate::exec::SubstReq>,
+    /// Runtime `foreach`/`lmap` request.
+    pub(crate) each_loop: Option<crate::exec::EachLoopReq>,
+    /// Next body, handler, or `finally` phase of a `try`.
+    pub(crate) try_phase: Option<crate::cmd_try::TryReq>,
+}
+
 /// One interpreter's complete state: command table, namespaces, call frames,
 /// error state, traces, coroutines, channels, children. The engine ([`Vm`])
 /// executes with exactly one of these current at a time and swaps between
@@ -871,6 +891,14 @@ pub struct InterpState {
     compiler_generation: u64,
     /// Call-frame stack; `frames[0]` is the global scope.
     frames: Vec<CallFrame>,
+    /// Variable cells outlive the name table that currently binds them. This
+    /// is interpreter-global so parked coroutine frames retain their `VarId`s.
+    var_arena: VarArena,
+    /// Variable name tables belong to namespace tokens, not their reusable
+    /// spellings. A retained and recreated `::N` therefore remain disjoint.
+    ns_vars: HashMap<NsId, VarTable>,
+    /// Stable cells declared through TIP 677 `const`.
+    const_vars: HashSet<VarId>,
     /// Command table (builtins + user procs), keyed by canonical name — a
     /// builtin's simple name, or a proc's namespace-qualified name without the
     /// leading `::` (e.g. `foo::bar`; a global proc is just `bar`).
@@ -905,7 +933,7 @@ pub struct InterpState {
     /// namespace is already non-existent to Tcl callbacks, but its command
     /// table remains live until token deletion completes. Descendants are not
     /// marked dying until their own recursive teardown begins.
-    dying_namespaces: HashSet<String>,
+    dying_namespaces: HashSet<NsId>,
     /// Namespace-owned ensemble tokens in C's intrusive-list order: oldest at
     /// the front, newest at the back. `Tcl_CreateEnsemble` pushes at the head
     /// and `Tcl_DeleteNamespace` repeatedly removes that live head, so a token
@@ -1001,10 +1029,9 @@ pub struct InterpState {
     /// stable mode unless the process opted into latest mode, and the latter
     /// is a one-way latch for the lifetime of the interpreter.
     package_prefer: PackagePrefer,
-    /// Variable traces, keyed by a resolved-owner key (frame level + name) so a
-    /// trace fires regardless of the access path (`upvar` alias, qualified
-    /// name, …). Newest trace last; fired newest-first.
-    var_traces: HashMap<String, Vec<VarTrace>>,
+    /// Variable traces keyed by the stable variable-cell identity. Newest
+    /// trace last; fired newest-first.
+    var_traces: HashMap<VarId, Vec<VarTrace>>,
     /// Source of [`VarTrace::id`]s; never reused within an interpreter.
     next_var_trace_id: u64,
     /// `trace add command` registrations (`rename`/`delete` ops), keyed by the
@@ -1084,8 +1111,9 @@ pub struct InterpState {
     /// Stable semantic identities explicitly attached to guardable builtins.
     /// Ordinary command registration cannot authorise a fast path.
     guarded_commands: std::cell::RefCell<HashMap<String, BTreeSet<GuardIdentity>>>,
-    /// Re-entrancy guard: `"<key>\0<op>"` entries for traces currently firing.
-    active_traces: std::collections::HashSet<String>,
+    /// Resolved variable cells whose traces are currently firing. Tcl's guard
+    /// lives on each `Var`, so distinct elements of one array remain distinct.
+    active_traces: Vec<VarId>,
     /// Frame depths at which the currently-executing `namespace eval`/`inscope`
     /// bodies started (innermost last). A namespace body runs in the frame that
     /// invoked it, so when the current frame depth matches the innermost entry
@@ -1267,41 +1295,8 @@ pub struct InterpState {
     /// `[info coroutine]` + the yield-boundary check), and the pending
     /// `yield`/`yieldto` request. See [`crate::cmd_coro`].
     pub(crate) coro: crate::cmd_coro::CoroSystem,
-    /// A script an `eval`/`uplevel`/`apply`-style builtin wants run on the
-    /// *explicit* stack (so a `yield` in it stays yieldable): the compiled body,
-    /// its `errorInfo` body label, and an optional command name to delete once
-    /// the pushed frame completes (`apply`'s temporary lambda proc — issue
-    /// #1311). Set by the builtin and drained by `dispatch_words` into a
-    /// [`Tick::PushScript`](crate::exec) (or run via a nested drive on the
-    /// `invoke_command` fallback path), mirroring how `coro.pending` becomes a
-    /// `Tick::Suspend`.
-    pub(crate) pending_eval: Option<(CompiledUnit, Option<&'static str>, Option<String>)>,
-    /// A `catch` body an about-to-run `catch` wants evaluated on the *explicit*
-    /// stack (so a `yield` in it stays yieldable). Unlike `pending_eval`, the
-    /// body's completion is **absorbed** (not propagated): a catch frame runs it
-    /// and its epilogue records the result/options and yields the status code.
-    /// Set by `cmd_catch`, drained by `dispatch_words` into a
-    /// [`Tick::PushCatch`](crate::exec) (or run via a nested drive on the
-    /// `invoke_command` fallback).
-    pub(crate) pending_catch: Option<crate::exec::CatchReq>,
-    /// A `subst` an about-to-run `subst` command wants performed on the *explicit*
-    /// stack (so a `yield` in a `[…]` stays yieldable). Set by `cmd_subst`, drained
-    /// by `dispatch_words` into a [`Tick::PushSubst`](crate::exec) (or run via a
-    /// nested drive on the `invoke_command` fallback). See [`Frame::subst`].
-    pub(crate) pending_subst: Option<crate::exec::SubstReq>,
-    /// A `foreach`/`lmap` runtime-fallback loop an about-to-run `each_loop` wants
-    /// driven on the *explicit* stack (so a `yield` in its body stays yieldable —
-    /// issue #1311). Set by `each_loop`, drained by `dispatch_words` into a
-    /// [`Tick::PushEachLoop`](crate::exec) (or run via a nested drive on the
-    /// `invoke_command` fallback). See [`Frame::each_loop`].
-    pub(crate) pending_each_loop: Option<crate::exec::EachLoopReq>,
-    /// A `try`'s next phase (body/handler/finally) an about-to-run `try` wants
-    /// driven on the *explicit* stack (so a `yield` anywhere in it stays
-    /// yieldable — issue #1311). Set by `cmd_try`/`advance_try`, drained by
-    /// `dispatch_words` into a [`Tick::PushTry`](crate::exec) (or run via a
-    /// nested drive loop on the `invoke_command` fallback). See
-    /// [`Frame::try_ctx`].
-    pub(crate) pending_try: Option<crate::cmd_try::TryReq>,
+    /// Requests staged by control builtins and drained into stack ticks.
+    pub(crate) pending: PendingControl,
     /// The event loop's pending timer/idle events (`after`/`vwait`/`update`).
     /// The scheduler half of the coroutine subsystem. See [`crate::cmd_event`].
     pub(crate) events: crate::cmd_event::EventQueue,
@@ -1422,6 +1417,36 @@ struct CmdArena {
     fqns: Vec<String>,
 }
 
+/// The name table containing one variable binding.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum VarTableOwner {
+    Frame(usize),
+    Namespace(NsId),
+}
+
+/// A resolved name-table slot. The bound cell may still be absent.
+#[derive(Clone, Debug)]
+struct VarBinding {
+    owner: VarTableOwner,
+    name: String,
+}
+
+/// One resolved variable access, including an optional array element cell.
+#[derive(Clone, Debug)]
+struct ResolvedVar {
+    binding: VarBinding,
+    base_id: Option<VarId>,
+    id: Option<VarId>,
+    elem: Option<String>,
+}
+
+/// The direct name-table slot retained by an array operation reference.
+#[derive(Clone, Debug)]
+enum ArrayOperationBinding {
+    Variable(VarBinding),
+    Element,
+}
+
 /// A single registered variable trace.
 #[derive(Clone)]
 struct VarTrace {
@@ -1445,10 +1470,36 @@ struct VarTrace {
     old_style: bool,
 }
 
+/// The resolved storage cell used by both trace registration and firing.
+///
+/// Tcl marks the reached `Var` active, not its whole variable table entry: an
+/// array and each one of its elements therefore have separate identities.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct VarTraceCell {
+    id: Option<VarId>,
+    array: Option<VarId>,
+    elem: Option<String>,
+}
+
+impl VarTraceCell {
+    fn array_id(&self) -> Option<VarId> {
+        self.array
+    }
+}
+
+/// A trace list detached from a variable before unset callbacks run.
+struct TakenVarTraces {
+    cell: VarTraceCell,
+    entries: Vec<VarTrace>,
+    /// Whether an element access may also walk its containing array's live
+    /// traces. Whole-array destruction disables this for its element pass.
+    include_array: bool,
+}
+
 /// One group of variable traces a firing walks: the array's or the variable's
 /// own list, still in the table, or a list an unset has already taken out of it.
 enum TraceGroup {
-    Live(String),
+    Live(VarId),
     Taken(Vec<VarTrace>),
 }
 
@@ -1927,6 +1978,9 @@ impl InterpState {
             profile_generation: 0,
             compiler_generation: 0,
             frames: vec![CallFrame::new(0, ROOT_NS, None, Vec::new())],
+            var_arena: VarArena::default(),
+            ns_vars: HashMap::new(),
+            const_vars: HashSet::new(),
             commands: HashMap::new(),
             command_generations: HashMap::new(),
             next_command_generation: 0,
@@ -1971,7 +2025,7 @@ impl InterpState {
             cmd_epoch: std::cell::Cell::new(0),
             guards: std::cell::RefCell::new(guards),
             guarded_commands: std::cell::RefCell::new(HashMap::new()),
-            active_traces: std::collections::HashSet::new(),
+            active_traces: Vec::new(),
             ns_script_frames: Vec::new(),
             out,
             compiler: None,
@@ -2006,17 +2060,11 @@ impl InterpState {
             limits: LimitSet::default(),
             commands_run: 0,
             limit_tick: 0,
-            // A fixed non-zero default so an un-`srand`'d `rand()` is still
-            // deterministic; Tcl auto-seeds from the clock, but reproducibility
-            // is more useful for the VM and every test seeds explicitly.
+            // Keep an unseeded VM deterministic; tests seed explicitly.
             rand_seed: 1,
             oo: crate::cmd_oo::OoState::default(),
             coro: crate::cmd_coro::CoroSystem::default(),
-            pending_eval: None,
-            pending_catch: None,
-            pending_subst: None,
-            pending_each_loop: None,
-            pending_try: None,
+            pending: PendingControl::default(),
             events: crate::cmd_event::EventQueue::default(),
             thread: crate::cmd_thread::ThreadSystem::default(),
         }
@@ -2329,9 +2377,13 @@ impl Vm {
 
     fn unset_global_raw(&mut self, name: &str) {
         let key = name.strip_prefix("::").unwrap_or(name);
-        if let Some(global) = self.frames.first_mut() {
-            global.locals.remove(key);
-            global.consts.remove(key);
+        let id = self
+            .frames
+            .first_mut()
+            .and_then(|global| global.locals.remove(key));
+        if let Some(id) = id {
+            self.purge_variable_cell(id);
+            self.var_arena.unbind(id);
         }
     }
 
@@ -4954,6 +5006,7 @@ impl Vm {
         let id = NsId(u32::try_from(self.ns_arena.len()).expect("namespace count fits u32"));
         self.ns_arena.push(name.to_string());
         self.ns_intern.insert(name.to_string(), id);
+        self.ns_vars.entry(id).or_default();
         id
     }
 
@@ -5434,7 +5487,9 @@ impl Vm {
 
     /// Whether the exact namespace token is currently being torn down.
     pub(crate) fn namespace_is_dying(&self, ns: &str) -> bool {
-        self.dying_namespaces.contains(ns)
+        self.ns_intern
+            .get(ns)
+            .is_some_and(|id| self.dying_namespaces.contains(id))
     }
 
     /// Whether `ns` lies at or below a namespace whose token is currently
@@ -5442,13 +5497,20 @@ impl Vm {
     /// teardown reaches them, but Tcl must reject attempts to create a new
     /// namespace anywhere below a dying ancestor.
     fn namespace_in_dying_subtree(&self, ns: &str) -> bool {
-        self.dying_namespaces.iter().any(|dying| {
-            dying.is_empty()
-                || ns == dying
-                || ns
-                    .strip_prefix(dying)
-                    .is_some_and(|tail| tail.starts_with("::"))
-        })
+        let mut candidate = ns.to_owned();
+        loop {
+            if self
+                .ns_intern
+                .get(&candidate)
+                .is_some_and(|id| self.dying_namespaces.contains(id))
+            {
+                return true;
+            }
+            if candidate.is_empty() {
+                return false;
+            }
+            candidate = key_holder_and_tail_unrooted(&candidate).0;
+        }
     }
 
     /// Whether a qualified command definition may name `namespace` (C's
@@ -6381,6 +6443,67 @@ impl Vm {
         true
     }
 
+    /// Destroy one namespace's variable cells in Tcl's trace-visible order.
+    ///
+    /// `TclDeleteNamespaceVars` removes one old cell, fires its unset traces,
+    /// then forcibly purges any same-name value or traces recreated by those
+    /// callbacks before selecting the next cell. A callback-created *different*
+    /// variable remains in the table and receives its own teardown pass.
+    fn teardown_namespace_variables(&mut self, canonical: &str, id: NsId) {
+        loop {
+            let mut names: Vec<String> = self
+                .var_table(VarTableOwner::Namespace(id))
+                .into_iter()
+                .flat_map(|table| table.keys().cloned())
+                .collect();
+            names.sort();
+            let Some(simple) = names.into_iter().next() else {
+                break;
+            };
+            let binding = VarBinding {
+                owner: VarTableOwner::Namespace(id),
+                name: simple.clone(),
+            };
+            let raw = self
+                .var_table(binding.owner)
+                .and_then(|table| table.get(&simple))
+                .copied();
+            let written = if canonical.is_empty() {
+                format!("::{simple}")
+            } else {
+                format!("::{canonical}::{simple}")
+            };
+            if let Some(raw) = raw
+                && !matches!(
+                    self.var_arena.get(raw).map(crate::vars::VarCell::state),
+                    Some(Local::Link(_))
+                )
+            {
+                let resolved = ResolvedVar {
+                    binding: binding.clone(),
+                    base_id: self.var_arena.resolve(raw),
+                    id: self.var_arena.resolve(raw),
+                    elem: None,
+                };
+                let _ = self.unset_resolved(&written, &resolved);
+            }
+
+            // An unset callback may have recreated this exact cell and added a
+            // new trace. The dying namespace owns both, and C discards them
+            // without a second callback before continuing its table walk.
+            let recreated = self
+                .var_table_mut(binding.owner)
+                .and_then(|table| table.remove(&simple));
+            if let Some(recreated) = recreated {
+                self.purge_variable_cell(recreated);
+                self.var_arena.unbind(recreated);
+            }
+        }
+        if id != ROOT_NS {
+            self.ns_vars.remove(&id);
+        }
+    }
+
     /// Tear down one exact namespace token in Tcl's recursive order. C drains
     /// `nsPtr->ensembles` while the token is live, marks this namespace dying,
     /// tears down this token's commands and state, and only then recursively
@@ -6403,10 +6526,9 @@ impl Vm {
         // commands remain table-visible while their delete callbacks run, and
         // existing child namespace tokens remain live until recursion reaches
         // each child.
-        self.dying_namespaces.insert(canonical.to_owned());
-        if let Some(id) = self.ns_intern.get(canonical).copied()
-            && id != ROOT_NS
-        {
+        let id = self.ns_intern.get(canonical).copied().unwrap_or(ROOT_NS);
+        self.dying_namespaces.insert(id);
+        if id != ROOT_NS {
             self.dead_namespaces.insert(id);
         }
         if !deleting_root {
@@ -6416,6 +6538,12 @@ impl Vm {
                 order.remove(tail.as_bytes());
             }
         }
+
+        // Tcl destroys the variable table before the command table. Variable
+        // unset callbacks see this namespace as dying but can still address
+        // its cells; each cell is removed separately so later variables remain
+        // visible until their own turn. Issue #1575.
+        self.teardown_namespace_variables(canonical, id);
 
         // Delete this namespace's command table to a fixed point. A command
         // callback may replace the dying command or install another owned
@@ -6436,12 +6564,6 @@ impl Vm {
                 // map ever disagrees with the order owner.
                 break;
             }
-        }
-
-        if let Some(global) = self.frames.first_mut() {
-            global
-                .locals
-                .retain(|key, _| key_holder_and_tail_unrooted(key).0 != canonical);
         }
 
         // Drop this token's path/unknown state and remove it from every other
@@ -6476,7 +6598,7 @@ impl Vm {
         } else {
             self.ns_intern.remove(canonical);
         }
-        self.dying_namespaces.remove(canonical);
+        self.dying_namespaces.remove(&id);
     }
 
     // -- deferred teardown: retaining a token for its live frames ------------
@@ -6613,7 +6735,15 @@ impl Vm {
     /// One retained token's teardown, mirroring [`Self::delete_namespace_token`]
     /// over the record's tables.
     fn delete_retained_token(&mut self, record: &mut RetainedNamespace, canonical: &str) {
-        self.dying_namespaces.insert(canonical.to_owned());
+        // Variable tables remain attached to their stable namespace tokens,
+        // so this final teardown cannot touch a same-spelled live recreation.
+        let id = record
+            .subtree
+            .get(canonical)
+            .copied()
+            .unwrap_or(record.root);
+        self.dying_namespaces.insert(id);
+        self.teardown_namespace_variables(canonical, id);
         loop {
             let frontier = retained_command_hash_order(record, canonical);
             if frontier.is_empty() {
@@ -6636,14 +6766,6 @@ impl Vm {
         } else {
             format!("{canonical}::")
         };
-        // M1 gap: a retained token's variables stay in the global storage
-        // frame under their canonical names, so a same-named recreation shares
-        // them. Only the commands moved into the record.
-        if let Some(global) = self.frames.first_mut() {
-            global
-                .locals
-                .retain(|key, _| key_holder_and_tail_unrooted(key).0 != canonical);
-        }
         record.paths.remove(canonical);
         record.unknowns.remove(canonical);
         for path in self.ns_paths.values_mut() {
@@ -6669,7 +6791,7 @@ impl Vm {
         record.exports.remove(canonical);
         record.child_orders.remove(canonical);
         record.command_orders.remove(canonical);
-        self.dying_namespaces.remove(canonical);
+        self.dying_namespaces.remove(&id);
     }
 
     /// Retire one retained command token. The shared lifecycle
@@ -6857,20 +6979,33 @@ impl Vm {
 
     // -- variable traces (`trace add|remove|info variable`) --
 
-    /// The resolved-owner key a variable name's traces are stored under, so a
-    /// trace fires regardless of access path (alias / qualified name). An array
-    /// *element* reference (`arr(key)`) keys on the resolved element so element
-    /// traces are distinct from each other and from whole-array traces.
-    fn trace_key(&self, name: &str) -> String {
-        if let Some((base, key)) = elem_ref(name) {
-            let base = self.trace_qualify(base);
-            let (lvl, nm) = self.locate(&base);
-            format!("{lvl}\u{0}{nm}({key})")
-        } else {
-            let name = self.trace_qualify(name);
-            let (lvl, nm) = self.locate(&name);
-            format!("{lvl}\u{0}{nm}")
+    /// Resolve the stable variable cell reached by `name`. This is the identity owner
+    /// for trace storage, firing, re-entrancy and destructive lifecycle paths.
+    fn trace_cell(&self, name: &str) -> Option<VarTraceCell> {
+        let lookup = self.trace_qualify(name);
+        let resolved = self.resolve_var_from(&lookup, self.current_level())?;
+        self.trace_cell_from_resolved(&resolved)
+    }
+
+    fn trace_cell_from_resolved(&self, resolved: &ResolvedVar) -> Option<VarTraceCell> {
+        if let Some(elem) = &resolved.elem {
+            resolved.base_id?;
+            return Some(VarTraceCell {
+                id: resolved.id,
+                array: resolved.base_id,
+                elem: Some(elem.clone()),
+            });
         }
+        let id = resolved.id?;
+        let parent = self
+            .var_arena
+            .element_parent(id)
+            .map(|(array, key)| (array, key.to_owned()));
+        Some(VarTraceCell {
+            id: Some(id),
+            array: parent.as_ref().map(|(array, _)| *array),
+            elem: parent.map(|(_, key)| key),
+        })
     }
 
     /// Resolve a bare variable name to its namespace-qualified form when the
@@ -6918,10 +7053,15 @@ impl Vm {
     /// wrong variable (issue #1328).
     fn ns_fallback_targets_global(&self, qualified: &str, name: &str) -> bool {
         let qualified = qualified.strip_prefix("::").unwrap_or(qualified);
-        self.ns_var_global_fallback()
-            && self.frames.first().is_some_and(|global| {
-                !global.locals.contains_key(qualified) && global.locals.contains_key(name)
-            })
+        let (parent, simple) = key_holder_and_tail_unrooted(qualified);
+        let namespace_has = self
+            .namespace_var_token(self.current_level(), &parent, false)
+            .and_then(|id| self.var_table(VarTableOwner::Namespace(id)))
+            .is_some_and(|table| table.contains_key(&simple));
+        let global_has = self
+            .var_table(VarTableOwner::Namespace(ROOT_NS))
+            .is_some_and(|table| table.contains_key(name));
+        self.ns_var_global_fallback() && !namespace_has && global_has
     }
 
     /// Register a `trace add variable` callback. `old_style` marks the
@@ -6933,9 +7073,17 @@ impl Vm {
         command: String,
         old_style: bool,
     ) {
-        let key = self.trace_key(name);
+        if self.trace_cell(name).is_none() {
+            let _ = self.ensure_trace_variable(name);
+        }
+        let Some(key) = self.trace_cell(name).and_then(|cell| cell.id) else {
+            return;
+        };
         self.next_var_trace_id += 1;
         let id = self.next_var_trace_id;
+        if !self.var_traces.contains_key(&key) {
+            self.var_arena.pin(key);
+        }
         self.var_traces.entry(key).or_default().push(VarTrace {
             id,
             ops,
@@ -6953,8 +7101,11 @@ impl Vm {
     /// The old-style flag is deliberately not part of the match (C masks
     /// `TCL_TRACE_OLD_STYLE` out here), so either spelling removes the other's.
     pub(crate) fn remove_var_trace(&mut self, name: &str, ops: &[String], command: &str) {
-        let key = self.trace_key(name);
+        let Some(key) = self.trace_cell(name).and_then(|cell| cell.id) else {
+            return;
+        };
         let mut removed = false;
+        let mut emptied = false;
         if let Some(list) = self.var_traces.get_mut(&key) {
             if let Some(index) = list
                 .iter()
@@ -6965,6 +7116,17 @@ impl Vm {
             }
             if list.is_empty() {
                 self.var_traces.remove(&key);
+                emptied = true;
+            }
+        }
+        if emptied {
+            self.var_arena.unpin(key);
+            if let Some((parent, element)) = self
+                .var_arena
+                .element_parent(key)
+                .map(|(parent, element)| (parent, element.to_owned()))
+            {
+                self.discard_undefined_array_shell(parent, &element, key);
             }
         }
         if removed {
@@ -7430,7 +7592,9 @@ impl Vm {
     /// The traces on `name` as `(ops, command)` pairs (newest first), for
     /// `trace info variable`.
     pub(crate) fn var_trace_info(&self, name: &str) -> Vec<(Vec<String>, String)> {
-        let key = self.trace_key(name);
+        let Some(key) = self.trace_cell(name).and_then(|cell| cell.id) else {
+            return Vec::new();
+        };
         self.var_traces.get(&key).map_or_else(Vec::new, |list| {
             list.iter()
                 .rev()
@@ -7440,15 +7604,211 @@ impl Vm {
     }
 
     /// Fire the variable traces for `name` on operation `op`, running each
-    /// callback as `command name1 name2 op`. A read/write callback error aborts
-    /// the access (`can't read`/`can't set "name": …`); unset errors are
-    /// ignored. Re-entrant firing of the same variable+op is suppressed.
+    /// callback as `command name1 name2 op`. A read/write/array callback error
+    /// aborts the access; unset errors are ignored. Re-entrant firing of the
+    /// same resolved variable cell is suppressed.
     pub(crate) fn fire_var_traces(
         &mut self,
         name: &str,
         op: &str,
     ) -> Result<(), Completion<Value>> {
         self.fire_var_traces_reporting(name, op, None)
+    }
+
+    /// Read through one stable variable identity across a callback. If no cell
+    /// existed before the read trace, the callback may create it and the name
+    /// is resolved once afterwards; otherwise deletion/recreation of the same
+    /// spelling must not steer the pending read to the replacement cell.
+    pub(crate) fn read_var_traced(
+        &mut self,
+        name: &str,
+    ) -> Result<Option<Value>, Completion<Value>> {
+        let cell = self.trace_cell(name).and_then(|cell| cell.id);
+        self.fire_var_traces(name, "read")?;
+        Ok(cell.map_or_else(|| self.var_get(name), |id| self.read_resolved_cell(id)))
+    }
+
+    /// Element form of [`Self::read_var_traced`]. Keeping the already-split
+    /// base/key pair avoids recomposing names whose array base contains an
+    /// opening parenthesis, while the captured cell keeps post-trace lookup on
+    /// the original identity.
+    pub(crate) fn read_elem_traced(
+        &mut self,
+        name: &str,
+        key: &str,
+    ) -> Result<Option<Value>, Completion<Value>> {
+        let full = format!("{name}({key})");
+        let cell = self.trace_cell(&full).and_then(|cell| cell.id);
+        self.fire_var_traces(&full, "read")?;
+        Ok(cell.map_or_else(
+            || self.get_array_elem(name, key),
+            |id| self.read_resolved_cell(id),
+        ))
+    }
+
+    /// `info exists` form of a traced lookup. Trace errors are deliberately
+    /// ignored, but a same-name replacement created by a callback must not
+    /// change the answer for a cell that existed before the callback.
+    pub(crate) fn exists_var_traced(&mut self, name: &str) -> bool {
+        let cell = self.trace_cell(name).and_then(|cell| cell.id);
+        let _ = self.fire_var_traces(name, "read");
+        cell.map_or_else(
+            || self.exists_var(name),
+            |id| {
+                self.var_arena
+                    .get(id)
+                    .is_some_and(|cell| matches!(cell.state(), Local::Scalar(_) | Local::Array(_)))
+            },
+        )
+    }
+
+    /// Fire the `array` operation traces checked by every `array` subcommand.
+    /// Tcl's `LocateArray` does this when the exact reached cell has an array
+    /// trace and is an array or undefined, but not for a defined scalar. A
+    /// direct undefined element walks its parent then its own trace list; an
+    /// alias to that element walks only the element list. Callback errors abort
+    /// the subcommand and retain the callback's errorCode.
+    fn fire_array_trace_at(
+        &mut self,
+        name: &str,
+        id: Option<VarId>,
+    ) -> Result<(), Completion<Value>> {
+        if self.var_traces.is_empty() {
+            return Ok(());
+        }
+        let Some(id) = id else {
+            return Ok(());
+        };
+        let parent = self
+            .var_arena
+            .element_parent(id)
+            .map(|(array, key)| (array, key.to_owned()));
+        let cell = VarTraceCell {
+            id: Some(id),
+            array: parent.as_ref().map(|(array, _)| *array),
+            elem: parent.map(|(_, key)| key),
+        };
+        let has_array_trace = self.var_traces.get(&id).is_some_and(|traces| {
+            traces
+                .iter()
+                .any(|trace| trace.ops.iter().any(|op| op == "array"))
+        });
+        let traceable_state = self
+            .var_arena
+            .get(id)
+            .is_some_and(|cell| matches!(cell.state(), Local::Undefined | Local::Array(_)));
+        if !has_array_trace || !traceable_state {
+            return Ok(());
+        }
+        self.fire_var_traces_from_cell(name, "array", None, None, Some(cell))
+    }
+
+    /// Locate and pin one array cell across its operation trace and command.
+    /// This is the VM's `LocateArray` boundary: callbacks may remove the last
+    /// binding or retarget the source alias, but the shared array core can
+    /// still enumerate the cell Tcl originally reached.
+    pub(crate) fn with_array_trace_target(
+        &mut self,
+        name: &str,
+        operation: impl FnOnce(&mut Self, &ArrayTarget) -> Completion<Value>,
+    ) -> Completion<Value> {
+        let here = FrameId(self.current_level());
+        let target = VarStore::array_target(self, here, name);
+        let id = target.cell_id();
+        let protected_binding = id.and_then(|id| self.array_operation_binding(id));
+        if let Some(id) = id {
+            self.var_arena.retain_operation(id);
+        }
+        let result = match self.fire_array_trace_at(name, id) {
+            Ok(()) => operation(self, &target),
+            Err(completion) => completion,
+        };
+        if let Some(id) = id {
+            if let Some(binding) = protected_binding {
+                self.release_array_operation_binding(&binding, id);
+            }
+            self.var_arena.release_operation(id);
+        }
+        result
+    }
+
+    /// Drop the undefined name-table shell retained for a direct array
+    /// operation once its final operation reference leaves. Keeping that shell
+    /// during the callback lets an unset-and-recreate refill the same Tcl
+    /// variable cell; a namespace token that is deleted and recreated owns a
+    /// different table and therefore remains a distinct identity.
+    fn array_operation_binding(&self, id: VarId) -> Option<ArrayOperationBinding> {
+        if let Some((parent, key)) = self.var_arena.element_parent(id)
+            && matches!(
+                self.var_arena.get(parent).map(crate::vars::VarCell::state),
+                Some(Local::Array(elements)) if elements.get(key) == Some(&id)
+            )
+        {
+            return Some(ArrayOperationBinding::Element);
+        }
+        for (level, frame) in self.frames.iter().enumerate() {
+            if let Some((name, _)) = frame.locals.iter().find(|(_, raw)| **raw == id) {
+                return Some(ArrayOperationBinding::Variable(VarBinding {
+                    owner: VarTableOwner::Frame(level),
+                    name: name.clone(),
+                }));
+            }
+        }
+        for (&ns, table) in &self.ns_vars {
+            if let Some((name, _)) = table.iter().find(|(_, raw)| **raw == id) {
+                return Some(ArrayOperationBinding::Variable(VarBinding {
+                    owner: VarTableOwner::Namespace(ns),
+                    name: name.clone(),
+                }));
+            }
+        }
+        None
+    }
+
+    fn release_array_operation_binding(&mut self, binding: &ArrayOperationBinding, id: VarId) {
+        let ArrayOperationBinding::Variable(binding) = binding else {
+            // If the final trace was removed while this element operation held
+            // the cell, Tcl leaves the undefined hash shell attached. It stays
+            // a candidate for later array searches until an explicit unset or
+            // parent teardown removes it.
+            return;
+        };
+        let discard = self.var_arena.is_final_operation_ref(id)
+            && matches!(
+                self.var_arena.get(id).map(crate::vars::VarCell::state),
+                Some(Local::Undefined)
+            )
+            && !self.var_arena.has_link_refs(id)
+            && !self.var_traces.contains_key(&id);
+        if !discard {
+            return;
+        }
+        let removed = self
+            .var_table_mut(binding.owner)
+            .and_then(|table| {
+                (table.get(&binding.name) == Some(&id)).then(|| table.remove(&binding.name))
+            })
+            .flatten();
+        if let Some(raw) = removed {
+            self.const_vars.remove(&id);
+            self.var_arena.unbind(raw);
+        }
+    }
+
+    /// Remove one unreferenced undefined element shell when its final trace is
+    /// removed outside an operation that retains that element. An operation-
+    /// retained shell deliberately survives its eventual release.
+    fn discard_undefined_array_shell(&mut self, parent: VarId, key: &str, id: VarId) {
+        let discard = matches!(
+            self.var_arena.get(id).map(crate::vars::VarCell::state),
+            Some(Local::Undefined)
+        ) && !self.var_arena.has_link_refs(id)
+            && !self.var_arena.has_operation_refs(id)
+            && !self.var_traces.contains_key(&id);
+        if discard && let Some(raw) = self.var_arena.array_discard_if(parent, key, id) {
+            self.const_vars.remove(&id);
+            self.var_arena.unbind(raw);
+        }
     }
 
     /// [`fire_var_traces`](Self::fire_var_traces) with an explicit `name1` for
@@ -7474,7 +7834,18 @@ impl Vm {
         name: &str,
         op: &str,
         reported_name1: Option<&str>,
-        taken: Option<Vec<VarTrace>>,
+        taken: Option<TakenVarTraces>,
+    ) -> Result<(), Completion<Value>> {
+        self.fire_var_traces_from_cell(name, op, reported_name1, taken, None)
+    }
+
+    fn fire_var_traces_from_cell(
+        &mut self,
+        name: &str,
+        op: &str,
+        reported_name1: Option<&str>,
+        taken: Option<TakenVarTraces>,
+        located: Option<VarTraceCell>,
     ) -> Result<(), Completion<Value>> {
         if self.var_traces.is_empty() && taken.is_none() {
             return Ok(());
@@ -7483,22 +7854,88 @@ impl Vm {
             || (name.to_string(), String::new()),
             |(b, k)| (b.to_string(), k.to_string()),
         );
-        // Tcl suppresses *all* of a variable's traces while any one of them is
-        // being handled (the documented "traces are disabled during the
-        // handling of other traces" behaviour — see tcltest's outputChannel
-        // notes). The unit of suppression is the whole variable (every array
-        // element, every operation), so a read trace that writes the same
-        // variable won't re-enter its write trace, and a whole-array read trace
-        // fires only once per top-level access rather than per element.
-        let (base_lvl, base_nm) = self.locate(&base);
-        let active_key = format!("{base_lvl}\u{0}{base_nm}");
-        if self.active_traces.contains(&active_key) {
+        // C's `VAR_TRACE_ACTIVE` belongs to the reached `Var`: the whole array
+        // and every element are separate cells. A callback may therefore enter
+        // a different element, while a recursive access to this exact cell is
+        // suppressed regardless of operation. Issue #1574.
+        let Some(cell) = located.or_else(|| {
+            taken
+                .as_ref()
+                .map_or_else(|| self.trace_cell(name), |taken| Some(taken.cell.clone()))
+        }) else {
+            return Ok(());
+        };
+        // Unset moves the trace list to a dummy `Var` and clears its active
+        // bit, so unsetting the cell from its own write callback still fires
+        // that taken list. Other recursive operations on the cell stay gated.
+        let taken_unset = op == "unset" && taken.is_some();
+        if cell.id.is_some_and(|id| self.active_traces.contains(&id)) && !taken_unset {
             return Ok(());
         }
-        self.active_traces.insert(active_key.clone());
-        let r = self.fire_var_traces_inner(name, op, reported_name1.unwrap_or(&base), &elem, taken);
-        self.active_traces.remove(&active_key);
+        let array_active = cell
+            .array_id()
+            .is_some_and(|array| self.active_traces.contains(&array));
+        if let Some(id) = cell.id {
+            self.active_traces.push(id);
+        }
+        let r = self.fire_var_traces_inner(
+            name,
+            op,
+            (reported_name1.unwrap_or(&base), &elem),
+            &cell,
+            array_active,
+            taken,
+        );
+        if let Some(id) = cell.id {
+            let popped = self.active_traces.pop();
+            debug_assert_eq!(popped, Some(id));
+        }
         r
+    }
+
+    /// Select the parent-array and reached-cell trace groups in Tcl order.
+    /// Tcl 9 also recovers the parent and element name through a scalar-looking
+    /// alias to an array element; the release policy owns that distinction.
+    fn variable_trace_groups(
+        &self,
+        name: &str,
+        elem: &str,
+        cell: &VarTraceCell,
+        array_active: bool,
+        taken: Option<TakenVarTraces>,
+        op: &str,
+    ) -> (Vec<TraceGroup>, String) {
+        let mut groups = Vec::with_capacity(2);
+        let mut name2 = elem.to_string();
+        let include_array = taken.as_ref().is_none_or(|taken| taken.include_array);
+        if elem_ref(name).is_some() {
+            if include_array
+                && !array_active
+                && let Some(array) = cell.array_id()
+            {
+                groups.push(TraceGroup::Live(array));
+            }
+        } else if self.runtime_version.traces_recover_linked_array_element()
+            && let Some(rkey) = &cell.elem
+        {
+            if op != "array"
+                && include_array
+                && !array_active
+                && let Some(array) = cell.array_id()
+            {
+                groups.push(TraceGroup::Live(array));
+            }
+            name2.clone_from(rkey);
+        }
+        match taken {
+            Some(taken) => groups.push(TraceGroup::Taken(taken.entries)),
+            None => {
+                if let Some(id) = cell.id {
+                    groups.push(TraceGroup::Live(id));
+                }
+            }
+        }
+        (groups, name2)
     }
 
     /// Inner firing loop for [`Self::fire_var_traces`]: run the whole-array
@@ -7508,38 +7945,20 @@ impl Vm {
         &mut self,
         name: &str,
         op: &str,
-        name1: &str,
-        elem: &str,
-        taken: Option<Vec<VarTrace>>,
+        reported: (&str, &str),
+        cell: &VarTraceCell,
+        array_active: bool,
+        taken: Option<TakenVarTraces>,
     ) -> Result<(), Completion<Value>> {
+        let (name1, elem) = reported;
         // For an element access C walks the containing array's trace list
         // first and the element's own list second (`TclCallVarTraces`,
         // tclTrace.c 9.0.4: the `arrayPtr` loop at :2581 precedes the
         // `varPtr` loop at :2623) — regardless of which was registered first.
         // Issue #1440.
-        let mut groups = Vec::with_capacity(2);
-        let mut name2 = elem.to_string();
-        if let Some((base, _)) = elem_ref(name) {
-            let (lvl, nm) = self.locate(base);
-            groups.push(TraceGroup::Live(format!("{lvl}\u{0}{nm}")));
-        } else if self.runtime_version.traces_recover_linked_array_element() {
-            // From Tcl 9.0 an access whose spelling names no element but whose
-            // resolved variable *is* one (`upvar #0 a(k) e; set e 5`) recovers
-            // the containing array — so the array's traces run too — and the
-            // element's key, reported as `name2`. Issue #1633 row 7.
-            let (lvl, nm) = self.locate(name);
-            if let Some((rbase, rkey)) = elem_ref(&nm) {
-                let (blvl, bnm) = self.locate_key_from(rbase, lvl);
-                groups.push(TraceGroup::Live(format!("{blvl}\u{0}{bnm}")));
-                name2 = rkey.to_string();
-            }
-        }
-        groups.push(match taken {
-            Some(list) => TraceGroup::Taken(list),
-            None => TraceGroup::Live(self.trace_key(name)),
-        });
+        let (groups, name2) = self.variable_trace_groups(name, elem, cell, array_active, taken, op);
         for group in groups {
-            // Walk newest-first (the Vec is oldest-last), by identity: a
+            // Walk newest-first (the Vec is oldest-first), by identity: a
             // callback's `trace remove` unlinks its record from the live list
             // at once, and C's walk then skips it — so the id is re-found in
             // the table before every callback rather than trusting a snapshot.
@@ -7556,14 +7975,14 @@ impl Vm {
                     .collect(),
             };
             let live_key = match &group {
-                TraceGroup::Live(key) => key.as_str(),
-                TraceGroup::Taken(_) => "",
+                TraceGroup::Live(key) => Some(*key),
+                TraceGroup::Taken(_) => None,
             };
             for step in steps {
                 let entry = match step {
                     Step::Live(id) => self
                         .var_traces
-                        .get(live_key)
+                        .get(&live_key.expect("live trace group has a key"))
                         .and_then(|list| list.iter().find(|t| t.id == id))
                         .filter(|t| t.ops.iter().any(|o| o == op))
                         .map(|t| (t.command.clone(), t.old_style)),
@@ -7579,23 +7998,40 @@ impl Vm {
                     tcl_brace(&name2),
                     tcl_cmd_core::trace::callback_op_word(op, old_style)
                 );
-                let r = self.eval_source(&script);
-                let failed = match r {
+                let failed = match self.eval_source(&script) {
                     Ok(c) if c.code.is_ok() => None,
-                    Ok(c) => Some(c.result.to_str().to_string()),
-                    Err(e) => Some(e.message),
+                    Ok(c) => Some(c),
+                    Err(error) => Some(crate::command::completion_from_tcl_error(error)),
                 };
-                if let Some(msg) = failed {
+                if let Some(mut failure) = failed {
                     match op {
-                        "write" | "read" => {
+                        "write" | "read" | "array" => {
                             // C's `TclCallVarTraces` logs a `(write|read trace
                             // on "name")` frame, then clears ERR_ALREADY_LOGGED
                             // so the command that triggered the trace logs its
                             // own `invoked from within` frame as the error
                             // unwinds (set-2.4 / set-4.4).
                             self.append_var_trace_frame(op, name);
-                            let verb = if op == "write" { "set" } else { "read" };
-                            return Err(err(format!("can't {verb} \"{name}\": {msg}")));
+                            let verb = match op {
+                                "write" => "set",
+                                "array" => "trace array",
+                                _ => "read",
+                            };
+                            let message = failure.result.to_str().to_string();
+                            failure.code = Code::Error;
+                            failure.result =
+                                Value::string(format!("can't {verb} \"{name}\": {message}"));
+                            if op != "array" {
+                                let kind = if op == "write" { "WRITE" } else { "READ" };
+                                let code =
+                                    tcl_syntax::list::join_list(["TCL", kind, "VARNAME", name]);
+                                failure.options = crate::command::with_return_option(
+                                    &crate::command::completion_options(&failure),
+                                    "-errorcode",
+                                    Value::string(code),
+                                );
+                            }
+                            return Err(failure);
                         }
                         _ => {} // unset trace errors are ignored
                     }
@@ -8009,9 +8445,32 @@ impl Vm {
 
     pub(crate) fn pop_call_frame(&mut self) {
         if self.frames.len() > 1 {
-            self.fire_frame_unset_traces();
-            self.frames.pop();
+            let frame = self.frames.pop().expect("non-global frame exists");
             self.recursion_depth = self.recursion_depth.saturating_sub(1);
+            // Tcl switches to the caller before firing a departing frame's
+            // unset callbacks. The namespace stacks are retired separately by
+            // the activation owner, so hide their top entry only for this walk.
+            let has_departing_ns = self.ns_stack.len() > self.frames.len();
+            let departing_ns = has_departing_ns.then(|| self.ns_stack.pop()).flatten();
+            let departing_ns_id = has_departing_ns.then(|| self.ns_id_stack.pop()).flatten();
+            self.destroy_call_frame(frame);
+            if let Some(ns) = departing_ns {
+                self.ns_stack.push(ns);
+            }
+            if let Some(ns_id) = departing_ns_id {
+                self.ns_id_stack.push(ns_id);
+            }
+        }
+    }
+
+    /// Destroy every live activation above `len`, running the same variable
+    /// lifecycle as an ordinary return. Error unwinding and `uplevel` cleanup
+    /// must not bypass trace firing, link unbinding, or arena collection by
+    /// truncating the frame vector directly.
+    fn drain_call_frames_to(&mut self, len: usize) {
+        while self.frames.len() > len {
+            self.pop_call_frame();
+            self.pop_ns();
         }
     }
 
@@ -8022,30 +8481,18 @@ impl Vm {
     /// owned by another frame, whose trace fires when *that* frame goes. The
     /// fired traces are then dropped, since their variables no longer exist.
     /// Guarded on `var_traces` being non-empty, so it is free in the common case.
-    fn fire_frame_unset_traces(&mut self) {
-        if self.var_traces.is_empty() {
-            return;
+    fn destroy_call_frame(&mut self, frame: CallFrame) {
+        for (name, raw) in frame.locals {
+            if matches!(
+                self.var_arena.get(raw).map(crate::vars::VarCell::state),
+                Some(Local::Link(_))
+            ) {
+                self.purge_variable_cell(raw);
+                self.var_arena.unbind(raw);
+                continue;
+            }
+            self.destroy_owned_variable(&name, raw, None);
         }
-        let Some(frame) = self.frames.last() else {
-            return;
-        };
-        let level = frame.level;
-        // Genuine locals (scalars/arrays), sorted for a deterministic order.
-        let mut names: Vec<String> = frame
-            .locals
-            .iter()
-            .filter(|(_, l)| matches!(l, Local::Scalar(_) | Local::Array(_)))
-            .map(|(n, _)| n.clone())
-            .collect();
-        names.sort();
-        for nm in &names {
-            // The frame is still on the stack, so the name resolves to this
-            // level; C ignores errors from unset traces, as does `fire_var_traces`.
-            let _ = self.fire_var_traces(nm, "unset");
-        }
-        // Drop every trace scoped to this frame level — those variables are gone.
-        let prefix = format!("{level}\u{0}");
-        self.var_traces.retain(|k, _| !k.starts_with(&prefix));
     }
 
     /// Fire `unset` traces on a suspended coroutine's parked locals as the
@@ -8053,11 +8500,8 @@ impl Vm {
     /// parked flow in, unwind it frame by frame (each `pop_call_frame` fires that
     /// frame's unset traces), then swap the caller's flow back (`parked` is left
     /// emptied for the caller to drop). Matches C Tcl unsetting a deleted
-    /// coroutine's variables (coroutine-4.3). Free when no traces are registered.
+    /// coroutine's variables (coroutine-4.3).
     pub(crate) fn fire_parked_unset_traces(&mut self, parked: &mut ParkedFlow) {
-        if self.var_traces.is_empty() {
-            return;
-        }
         self.swap_flow(parked);
         while self.frames.len() > 1 {
             self.pop_call_frame();
@@ -8190,12 +8634,9 @@ impl Vm {
         let saved_ns_ids = self.ns_id_stack.split_off(ns_cut);
         let saved_depth = self.recursion_depth;
         let result = self.eval_source(src);
-        // Restore any frames the script left in place, then re-attach the ones
-        // we set aside (the script's own proc activations are already balanced).
-        // `truncate` may drop frames the script left unbalanced (an error mid
-        // proc), which `pop_call_frame` never saw — so reset the recursion depth
-        // to its pre-eval value rather than leak it.
-        self.frames.truncate(target + 1);
+        // Destroy any activation the script left in place through the ordinary
+        // lifecycle, then re-attach the frames set aside above.
+        self.drain_call_frames_to(target + 1);
         self.frames.extend(saved);
         self.ns_stack.truncate(ns_cut);
         self.ns_stack.extend(saved_ns);
@@ -8278,91 +8719,135 @@ impl Vm {
         self.frames.last().map_or_else(Vec::new, |f| {
             f.locals
                 .iter()
-                .filter(|(_, l)| include_links || matches!(l, Local::Scalar(_) | Local::Array(_)))
-                .map(|(n, _)| n.clone())
-                .collect()
-        })
-    }
-
-    /// The variables defined **directly** in namespace `canonical` (unrooted; `""`
-    /// = global) — the `Namespaces::vars_in` enumeration. Namespace variables live
-    /// in the global frame keyed by their qualified name (`foo::v`), so this is the
-    /// variable analogue of [`names_directly_in`](Self::names_directly_in): the
-    /// global frame's genuine variables (scalars/arrays, not links) whose key is a
-    /// direct member of `canonical`.
-    pub(crate) fn vars_directly_in(&self, canonical: &str) -> Vec<String> {
-        self.frames.first().map_or_else(Vec::new, |f| {
-            f.locals
-                .iter()
-                // A namespace-scoped `Link` is a real cell in the namespace's
-                // table — see `namespace_var_exists` for why C's
-                // `CompiledLocal` exclusion does not apply to it.
-                .filter(|(_, local)| {
-                    matches!(
-                        local,
-                        Local::Undefined | Local::Scalar(_) | Local::Array(_) | Local::Link { .. }
-                    )
+                .filter(|(_, id)| {
+                    include_links
+                        || matches!(
+                            self.var_arena.get(**id).map(crate::vars::VarCell::state),
+                            Some(Local::Scalar(_) | Local::Array(_))
+                        )
                 })
-                .filter_map(|(key, _)| direct_member_tail(key, canonical).map(str::to_owned))
+                .map(|(n, _)| n.clone())
                 .collect()
         })
     }
 
     /// Set a local directly in the current frame (proc argument binding).
     pub(crate) fn set_local(&mut self, name: &str, value: Value) {
-        if let Some(f) = self.frames.last_mut() {
-            f.locals.insert(name.to_owned(), Local::Scalar(value));
-        }
+        let binding = VarBinding {
+            owner: VarTableOwner::Frame(self.current_level()),
+            name: name.to_owned(),
+        };
+        let _ = self.bind_new_var(&binding, Local::Scalar(value));
     }
 
     /// Install a cross-frame link in the current frame (`upvar`/`global`).
-    pub(crate) fn add_link(&mut self, local: &str, level: usize, target: &str) {
-        if let Some(f) = self.frames.last_mut() {
-            f.locals.insert(
-                local.to_owned(),
-                Local::Link {
-                    level,
-                    name: target.to_owned(),
-                },
-            );
-        }
+    pub(crate) fn add_link(
+        &mut self,
+        local: &str,
+        level: usize,
+        target: &str,
+    ) -> Result<(), UpvarLinkError> {
+        self.add_link_with_origin(local, level, target, FrameLinkOrigin::Ordinary)
     }
 
-    /// Materialise an unset namespace-variable cell in the global storage
-    /// frame. `variable name` creates this table entry even without assigning a
-    /// value: namespace introspection sees it while `info exists` remains false.
-    pub(crate) fn declare_namespace_variable(&mut self, key: &str) {
-        let key = key.strip_prefix("::").unwrap_or(key);
-        if let Some(global) = self.frames.first_mut() {
-            global
-                .locals
-                .entry(key.to_owned())
-                .or_insert(Local::Undefined);
-        }
+    /// Install the automatic instance-variable projection for a `TclOO` method.
+    pub(crate) fn add_tcloo_instance_link(
+        &mut self,
+        local: &str,
+        level: usize,
+        target: &str,
+    ) -> Result<(), UpvarLinkError> {
+        self.add_link_with_origin(local, level, target, FrameLinkOrigin::TclOoInstance)
     }
 
-    /// Install a link in the global frame keyed by `alias` (a canonical,
-    /// namespace-qualified name). Used for namespace-level `upvar` aliases so
-    /// they coincide with the `variable`-resolved namespace variable.
-    pub(crate) fn add_global_link(&mut self, alias: &str, level: usize, target: &str) {
-        if let Some(f) = self.frames.first_mut() {
-            f.locals.insert(
-                alias.to_owned(),
-                Local::Link {
-                    level,
-                    name: target.to_owned(),
-                },
-            );
+    fn add_link_with_origin(
+        &mut self,
+        local: &str,
+        level: usize,
+        target: &str,
+        origin: FrameLinkOrigin,
+    ) -> Result<(), UpvarLinkError> {
+        let target = if origin == FrameLinkOrigin::TclOoInstance {
+            self.ensure_tcloo_storage_var_from(target, level)
+        } else {
+            self.ensure_target_var_from(target, level)
+        };
+        let Some(target) = target else {
+            return Err(UpvarLinkError::TargetNamespace);
+        };
+        let binding = VarBinding {
+            owner: VarTableOwner::Frame(self.current_level()),
+            name: local.to_owned(),
+        };
+        self.bind_link_var_with_origin(&binding, target, origin)
+    }
+
+    /// Materialise the direct object-namespace storage cell used by a `TclOO`
+    /// projection without collapsing a link it contains. Reads through the
+    /// method-local link still resolve transitively, while `info consts` can
+    /// test whether the declared storage binding itself is constant.
+    fn ensure_tcloo_storage_var_from(&mut self, name: &str, start: usize) -> Option<VarId> {
+        if elem_ref(name).is_some() {
+            return None;
         }
+        let binding = self.var_binding_from(name, start)?;
+        self.var_table(binding.owner)
+            .and_then(|table| table.get(&binding.name))
+            .copied()
+            .or_else(|| self.bind_new_var(&binding, Local::Undefined))
+    }
+
+    /// Materialise and link the namespace cell named by `variable`. Relative
+    /// names use the exact namespace token of the current activation, including
+    /// one retained after its public spelling was deleted and recreated.
+    pub(crate) fn link_namespace_variable(
+        &mut self,
+        local: &str,
+        written: &str,
+    ) -> Result<(), UpvarLinkError> {
+        let key = self.qualify_name(written);
+        let unrooted = key.strip_prefix("::").unwrap_or(&key);
+        let (parent, tail) = key_holder_and_tail_unrooted(unrooted);
+        let current = self.ns_id_stack.last().copied().unwrap_or(ROOT_NS);
+        let owner = if !written.starts_with("::") && self.ns_name(current) == parent {
+            Some(current)
+        } else if !written.starts_with("::") {
+            self.retained_record_of(current)
+                .and_then(|record| record.subtree.get(&parent).copied())
+                .or_else(|| self.ns_intern.get(&parent).copied())
+        } else {
+            self.ns_intern.get(&parent).copied()
+        };
+        let Some(owner) = owner else {
+            return Err(UpvarLinkError::TargetNamespace);
+        };
+        let target_binding = VarBinding {
+            owner: VarTableOwner::Namespace(owner),
+            name: tail,
+        };
+        let target = self
+            .bound_var_id(&target_binding)
+            .or_else(|| self.bind_new_var(&target_binding, Local::Undefined));
+        let Some(target) = target else {
+            return Err(UpvarLinkError::TargetNamespace);
+        };
+        if self.current_level() == 0 && owner == ROOT_NS && local == target_binding.name {
+            return Ok(());
+        }
+        let binding = VarBinding {
+            owner: VarTableOwner::Frame(self.current_level()),
+            name: local.to_owned(),
+        };
+        self.bind_link_var(&binding, target)
     }
 
     /// Resolve and install one `upvar` link, preserving Tcl's semantic homes.
     ///
-    /// Namespace variables are stored in frame zero in this VM, so resolving
-    /// the target before installing the link gives a representation-independent
-    /// answer to the lifetime check: any final non-zero procedure frame is a
-    /// procedure local. The check precedes alias shape/namespace validation, as
-    /// C's `MakeUpvar` does (`TCL UPVAR INVERTED`).
+    /// Resolving the target to its stable frame/namespace owner before
+    /// installing the link gives a representation-independent answer to the
+    /// lifetime check: any final non-zero procedure frame is a procedure local.
+    /// The check precedes alias shape/namespace validation, as C's `MakeUpvar`
+    /// does (`TCL UPVAR INVERTED`).
     pub(crate) fn link_upvar(
         &mut self,
         target_level: usize,
@@ -8375,25 +8860,22 @@ impl Vm {
             return Err(UpvarLinkError::TargetNamespace);
         }
 
-        // A direct namespace script executes in its caller's frame, but its
-        // unqualified variables live in the active namespace. Frame-only
-        // lookup cannot infer that home for frame zero (there is no synthetic
-        // namespace frame), so resolve this one written-name case before
-        // following links. Other target levels retain their own frame homes.
-        let target_base = if target_level == self.current_level()
-            && self.in_ns_script()
-            && !tcl_syntax::naming::is_qualified(other_base.as_bytes())
-        {
-            tcl_syntax::naming::qualify(self.current_ns(), other_base)
-        } else {
-            other_base.to_owned()
+        let Some(binding) = self.var_binding_from(other_base, target_level) else {
+            return Err(UpvarLinkError::TargetNamespace);
         };
-        let (owner_level, owner_base) = self.locate_from(&target_base, target_level);
-        // Link targets are internal keys after this boundary. Element aliases
-        // retain the already-split key while the base is resolved exactly once.
+        let owner_is_proc = match binding.owner {
+            VarTableOwner::Frame(level) => self
+                .frames
+                .get(level)
+                .is_some_and(|frame| frame.proc_name.is_some()),
+            VarTableOwner::Namespace(_) => false,
+        };
         let target_name =
-            other_key.map_or(owner_base.clone(), |key| format!("{owner_base}({key})"));
-        self.link_upvar_key(owner_level, &target_name, local)
+            other_key.map_or_else(|| other.to_owned(), |key| format!("{other_base}({key})"));
+        let Some(target) = self.ensure_target_var_from(&target_name, target_level) else {
+            return Err(UpvarLinkError::TargetNamespace);
+        };
+        self.install_upvar_link(target, owner_is_proc, local)
     }
 
     /// Install an `upvar`-family link to an already-resolved internal key.
@@ -8414,6 +8896,18 @@ impl Vm {
             .frames
             .get(owner_level)
             .is_some_and(|frame| frame.proc_name.is_some());
+        let Some(target) = self.ensure_target_var_from(target_name, owner_level) else {
+            return Err(UpvarLinkError::TargetNamespace);
+        };
+        self.install_upvar_link(target, owner_is_proc, local)
+    }
+
+    fn install_upvar_link(
+        &mut self,
+        target: VarId,
+        owner_is_proc: bool,
+        local: &str,
+    ) -> Result<(), UpvarLinkError> {
         let alias_is_namespace =
             tcl_syntax::naming::is_qualified(local.as_bytes()) || !self.in_proc_frame();
         if owner_is_proc && alias_is_namespace {
@@ -8428,20 +8922,73 @@ impl Vm {
 
         if alias_is_namespace {
             let alias = tcl_syntax::naming::qualify(self.current_ns(), local);
-            let alias = alias.strip_prefix("::").unwrap_or(&alias).to_owned();
-            self.add_global_link(&alias, owner_level, target_name);
+            let Some(binding) = self.var_binding_from(&alias, self.current_level()) else {
+                return Err(UpvarLinkError::LocalNamespace);
+            };
+            self.bind_link_var(&binding, target)?;
         } else {
-            self.add_link(local, owner_level, target_name);
+            let binding = VarBinding {
+                owner: VarTableOwner::Frame(self.current_level()),
+                name: local.to_owned(),
+            };
+            self.bind_link_var(&binding, target)?;
         }
         Ok(())
+    }
+
+    /// Install a link without discarding observable local state. Tcl reuses an
+    /// untraced undefined shell, and it may retarget an existing link, but a
+    /// defined scalar/array or a trace-only shell is an `upvar` error.
+    fn bind_link_var(&mut self, binding: &VarBinding, target: VarId) -> Result<(), UpvarLinkError> {
+        self.bind_link_var_with_origin(binding, target, FrameLinkOrigin::Ordinary)
+    }
+
+    fn bind_link_var_with_origin(
+        &mut self,
+        binding: &VarBinding,
+        target: VarId,
+        origin: FrameLinkOrigin,
+    ) -> Result<(), UpvarLinkError> {
+        if let Some(raw) = self
+            .var_table(binding.owner)
+            .and_then(|table| table.get(&binding.name))
+            .copied()
+        {
+            match self.var_arena.get(raw).map(crate::vars::VarCell::state) {
+                Some(Local::Link(_)) => {}
+                Some(Local::Undefined) => {
+                    if self
+                        .var_arena
+                        .resolve(raw)
+                        .is_some_and(|id| self.var_traces.contains_key(&id))
+                    {
+                        return Err(UpvarLinkError::Traced);
+                    }
+                }
+                Some(Local::Scalar(_) | Local::Array(_)) => {
+                    let traced = self
+                        .var_arena
+                        .resolve(raw)
+                        .is_some_and(|id| self.var_traces.contains_key(&id));
+                    return Err(if traced {
+                        UpvarLinkError::Traced
+                    } else {
+                        UpvarLinkError::Exists
+                    });
+                }
+                None => return Err(UpvarLinkError::Exists),
+            }
+        }
+        self.bind_new_link(binding, target, origin)
+            .map(|_| ())
+            .ok_or(UpvarLinkError::TargetNamespace)
     }
 
     /// Whether a `namespace eval`/`inscope` body is *directly* executing in the
     /// current frame. Returns `false` inside a proc called from such a body —
     /// a proc activation has its own scope where unqualified names are locals,
-    /// not namespace variables. We test this by recording the frame depth at
-    /// which each namespace script started and checking the innermost against
-    /// the current depth.
+    /// not namespace variables. Equality with the innermost recorded entry
+    /// distinguishes direct execution from a nested activation.
     pub(crate) fn in_ns_script(&self) -> bool {
         self.ns_script_frames.last() == Some(&self.frames.len())
     }
@@ -8456,13 +9003,265 @@ impl Vm {
         self.ns_script_frames.pop();
     }
 
-    /// Resolve `name` to the (frame level, owning name) that actually owns it,
-    /// following `upvar`/`global`/`variable` links. Any namespace-qualified name
-    /// (containing `::`, including a plain `::global`) lives in the global frame
-    /// keyed by its canonical name (leading `::` stripped) — this is where
-    /// namespace variables (`tcltest::numTests`) are stored.
-    fn locate(&self, name: &str) -> (usize, String) {
-        self.locate_from(name, self.frames.len().saturating_sub(1))
+    fn var_table(&self, owner: VarTableOwner) -> Option<&VarTable> {
+        match owner {
+            VarTableOwner::Frame(level) => self.frames.get(level).map(|frame| &frame.locals),
+            VarTableOwner::Namespace(ROOT_NS) => self.frames.first().map(|frame| &frame.locals),
+            VarTableOwner::Namespace(id) => self.ns_vars.get(&id),
+        }
+    }
+
+    fn var_table_mut(&mut self, owner: VarTableOwner) -> Option<&mut VarTable> {
+        match owner {
+            VarTableOwner::Frame(level) => {
+                self.frames.get_mut(level).map(|frame| &mut frame.locals)
+            }
+            VarTableOwner::Namespace(ROOT_NS) => {
+                self.frames.first_mut().map(|frame| &mut frame.locals)
+            }
+            VarTableOwner::Namespace(id) => self.ns_vars.get_mut(&id),
+        }
+    }
+
+    fn namespace_var_token(&self, start: usize, parent: &str, absolute: bool) -> Option<NsId> {
+        if parent.is_empty() {
+            return Some(ROOT_NS);
+        }
+        if absolute {
+            return self.ns_intern.get(parent).copied();
+        }
+        let current_id = self.ns_id_stack.get(start).copied().unwrap_or(ROOT_NS);
+        if self.ns_name(current_id) == parent {
+            return Some(current_id);
+        }
+        if let Some(record) = self.retained_record_of(current_id)
+            && let Some(id) = record.subtree.get(parent)
+        {
+            return Some(*id);
+        }
+        self.ns_intern.get(parent).copied()
+    }
+
+    /// Resolve a written base name to the frame or namespace-token table that
+    /// owns its binding. No cell is created here.
+    fn var_binding_from(&self, name: &str, start: usize) -> Option<VarBinding> {
+        if tcl_syntax::naming::is_qualified(name.as_bytes()) {
+            let canonical = self.canonical_var_name_from(name, start);
+            let unrooted = canonical.strip_prefix("::").unwrap_or(&canonical);
+            let (parent, tail) = key_holder_and_tail_unrooted(unrooted);
+            let id = self.namespace_var_token(start, &parent, name.starts_with("::"))?;
+            return Some(VarBinding {
+                owner: VarTableOwner::Namespace(id),
+                name: tail,
+            });
+        }
+
+        if start == 0 {
+            return Some(VarBinding {
+                owner: VarTableOwner::Namespace(ROOT_NS),
+                name: name.to_owned(),
+            });
+        }
+        let frame = self.frames.get(start)?;
+        if frame.locals.contains_key(name) {
+            return Some(VarBinding {
+                owner: VarTableOwner::Frame(start),
+                name: name.to_owned(),
+            });
+        }
+        if frame.ns_eval.is_some() {
+            let id = self.ns_id_stack.get(start).copied().unwrap_or(ROOT_NS);
+            let ns_has = self
+                .var_table(VarTableOwner::Namespace(id))
+                .is_some_and(|table| table.contains_key(name));
+            let global_has = self
+                .var_table(VarTableOwner::Namespace(ROOT_NS))
+                .is_some_and(|table| table.contains_key(name));
+            let owner = if self.ns_var_global_fallback() && !ns_has && global_has {
+                VarTableOwner::Namespace(ROOT_NS)
+            } else {
+                VarTableOwner::Namespace(id)
+            };
+            return Some(VarBinding {
+                owner,
+                name: name.to_owned(),
+            });
+        }
+        Some(VarBinding {
+            owner: VarTableOwner::Frame(start),
+            name: name.to_owned(),
+        })
+    }
+
+    fn bound_var_id(&self, binding: &VarBinding) -> Option<VarId> {
+        let id = *self.var_table(binding.owner)?.get(&binding.name)?;
+        self.var_arena.resolve(id)
+    }
+
+    fn resolve_var_from(&self, name: &str, start: usize) -> Option<ResolvedVar> {
+        let (base, elem) = elem_ref(name).map_or((name, None), |(base, key)| (base, Some(key)));
+        let binding = self.var_binding_from(base, start)?;
+        let base_id = self.bound_var_id(&binding);
+        let id = match (base_id, elem) {
+            (Some(base_id), Some(key)) => match self.var_arena.get(base_id)?.state() {
+                VarState::Array(elements) => elements
+                    .get(key)
+                    .copied()
+                    .and_then(|id| self.var_arena.resolve(id)),
+                _ => None,
+            },
+            (id, None) => id,
+            (None, Some(_)) => None,
+        };
+        Some(ResolvedVar {
+            binding,
+            base_id,
+            id,
+            elem: elem.map(str::to_owned),
+        })
+    }
+
+    fn bind_new_var(&mut self, binding: &VarBinding, state: VarState) -> Option<VarId> {
+        let id = self.var_arena.alloc(state)?;
+        self.install_new_var(binding, id);
+        Some(id)
+    }
+
+    fn bind_new_link(
+        &mut self,
+        binding: &VarBinding,
+        target: VarId,
+        origin: FrameLinkOrigin,
+    ) -> Option<VarId> {
+        let id = self.var_arena.alloc_link(target, origin)?;
+        self.install_new_var(binding, id);
+        Some(id)
+    }
+
+    fn install_new_var(&mut self, binding: &VarBinding, id: VarId) {
+        let old = self
+            .var_table_mut(binding.owner)
+            .expect("resolved variable owner has a table")
+            .insert(binding.name.clone(), id);
+        self.var_arena.bind(id);
+        if let Some(old) = old {
+            self.purge_variable_cell(old);
+            self.var_arena.unbind(old);
+        }
+    }
+
+    fn ensure_base_var_from(&mut self, name: &str, start: usize) -> Option<(VarBinding, VarId)> {
+        let binding = self.var_binding_from(name, start)?;
+        let id = self
+            .bound_var_id(&binding)
+            .or_else(|| self.bind_new_var(&binding, VarState::Undefined))?;
+        Some((binding, id))
+    }
+
+    /// Resolve an upvar target once and materialise its undefined cell. An
+    /// element target creates the containing array and its own stable element
+    /// cell, just as Tcl's `MakeUpvar` does.
+    fn ensure_target_var_from(&mut self, name: &str, start: usize) -> Option<VarId> {
+        let (base, elem) = elem_ref(name).map_or((name, None), |(base, key)| (base, Some(key)));
+        let (_, base_id) = self.ensure_base_var_from(base, start)?;
+        let Some(key) = elem else {
+            return Some(base_id);
+        };
+        match self.var_arena.get(base_id).map(crate::vars::VarCell::state) {
+            Some(Local::Undefined) => {
+                if !self
+                    .var_arena
+                    .replace_state(base_id, Local::Array(VarTable::new()))
+                {
+                    return None;
+                }
+            }
+            Some(Local::Array(_)) => {}
+            Some(Local::Scalar(_) | Local::Link(_)) | None => return None,
+        }
+        if let Some(id) = match self.var_arena.get(base_id).map(crate::vars::VarCell::state) {
+            Some(Local::Array(elements)) => elements.get(key).copied(),
+            _ => None,
+        } {
+            return self.var_arena.resolve(id);
+        }
+        let element_id = self
+            .var_arena
+            .alloc_element(Local::Undefined, base_id, key.to_owned())?;
+        let inserted = self
+            .var_arena
+            .array_insert(base_id, key.to_owned(), element_id);
+        if inserted {
+            self.var_arena.bind(element_id);
+            Some(element_id)
+        } else {
+            self.var_arena.discard_unbound(element_id);
+            None
+        }
+    }
+
+    /// Remove the binding reached by a resolved access while preserving a
+    /// target cell that still has `upvar` links. Linked cells become undefined
+    /// in place so every alias continues to share the same identity.
+    fn unbind_resolved(&mut self, resolved: &ResolvedVar) -> bool {
+        let Some(id) = resolved.id else {
+            return false;
+        };
+        let existed = self.var_arena.get(id).is_some_and(|cell| {
+            matches!(
+                cell.state(),
+                Local::Undefined | Local::Scalar(_) | Local::Array(_)
+            )
+        });
+        if !existed {
+            return false;
+        }
+        self.drop_array_descendant_traces(id);
+        if matches!(
+            self.var_arena.get(id).map(crate::vars::VarCell::state),
+            Some(Local::Array(_))
+        ) {
+            // This storage-only path runs no child unset callbacks, so release
+            // the detached table and its bindings immediately.
+            let _ = self.var_arena.replace_state(id, Local::Undefined);
+        } else {
+            let _ = self.var_arena.unset_state(id);
+        }
+
+        let raw = if let Some(key) = &resolved.elem {
+            let Some(base_id) = resolved.base_id else {
+                return existed;
+            };
+            match self.var_arena.get(base_id).map(crate::vars::VarCell::state) {
+                Some(Local::Array(elements)) => elements.get(key).copied(),
+                _ => None,
+            }
+        } else {
+            self.var_table(resolved.binding.owner)
+                .and_then(|table| table.get(&resolved.binding.name))
+                .copied()
+        };
+        let Some(raw) = raw else {
+            return existed;
+        };
+        if matches!(
+            self.var_arena.get(raw).map(crate::vars::VarCell::state),
+            Some(Local::Link(_))
+        ) || self.var_arena.has_link_refs(id)
+            || self.var_arena.has_operation_refs(id)
+        {
+            return existed;
+        }
+        if let Some(key) = &resolved.elem {
+            if let Some(base_id) = resolved.base_id {
+                let _ = self.var_arena.array_remove(base_id, key);
+            }
+        } else if let Some(table) = self.var_table_mut(resolved.binding.owner) {
+            table.remove(&resolved.binding.name);
+        }
+        self.const_vars.remove(&id);
+        self.var_arena.unbind(raw);
+        existed
     }
 
     /// Canonicalise a written qualified variable name using the shared Tcl
@@ -8477,8 +9276,7 @@ impl Vm {
     /// Canonicalise a written variable name in the namespace belonging to
     /// explicit frame `level`. This is the frame-addressed half of the shared
     /// variable resolver: `upvar 1 rel::x` resolves `rel` in the caller's
-    /// namespace, not the active callee's, and the same rule reaches scalar and
-    /// array-element storage through [`Self::locate_from`].
+    /// namespace, not the active callee's.
     fn canonical_var_name_from(&self, name: &str, level: usize) -> String {
         if !tcl_syntax::naming::is_qualified(name.as_bytes()) {
             return name.to_owned();
@@ -8497,7 +9295,13 @@ impl Vm {
         let rooted = self.canonical_var_name(name);
         let (parent, _) = tcl_syntax::naming::key_holder_and_tail(&rooted);
         let parent = parent.strip_prefix("::").unwrap_or(parent);
-        if !self.namespace_exists(parent) {
+        // A namespace being torn down is unpublished (`namespace exists` is
+        // false) but its variable table remains addressable from unset trace
+        // callbacks until `TclDeleteNamespaceVars` finishes.
+        let exact_dying_parent = self
+            .namespace_var_token(self.current_level(), parent, name.starts_with("::"))
+            .is_some_and(|id| self.dying_namespaces.contains(&id));
+        if !self.namespace_exists(parent) && !exact_dying_parent {
             return Err(err(format!(
                 "can't set \"{name}\": parent namespace doesn't exist"
             )));
@@ -8525,83 +9329,14 @@ impl Vm {
         self.namespace_exists(parent.strip_prefix("::").unwrap_or(parent))
     }
 
-    /// Like [`Self::locate`] but begins link resolution at frame `start` (used
-    /// by frame-addressed public storage operations). Written qualified names
-    /// are canonicalised once at this boundary; link targets are already
-    /// internal keys and must not be qualified again.
-    fn locate_from(&self, name: &str, start: usize) -> (usize, String) {
-        let canonical = self.canonical_var_name_from(name, start);
-        let stripped = canonical.strip_prefix("::").unwrap_or(&canonical);
-        let qualified = tcl_syntax::naming::is_qualified(canonical.as_bytes());
-        let level = if qualified { 0 } else { start };
-        let key = if qualified { stripped } else { name };
-        self.locate_key_from(key, level)
-    }
-
-    /// Follow links from an already-canonical internal variable key. Unlike
-    /// [`Self::locate_from`], this never interprets a relative qualified key in
-    /// the current namespace a second time.
-    fn locate_key_from(&self, name: &str, start: usize) -> (usize, String) {
-        let mut level = start;
-        let mut nm = name.to_owned();
-        for _ in 0..64 {
-            match self.frames.get(level).and_then(|f| f.locals.get(&nm)) {
-                Some(Local::Link {
-                    level: tl,
-                    name: tn,
-                }) => {
-                    level = *tl;
-                    nm.clone_from(tn);
-                }
-                _ => break,
-            }
-        }
-        // A bare name landing on a `namespace eval` body frame (no genuine local
-        // there) is a *namespace* variable: redirect it to `ns::name` in the
-        // global frame, where namespace variables live. This mirrors what
-        // `ns_var_fallback` does for the current frame, but also covers an
-        // `upvar`/`uplevel` link that reaches a namespace-eval frame — so a proc's
-        // `upvar 1 v` into a `namespace eval` body resolves the namespace variable,
-        // and a plain `set x` at namespace-script level *creates* `ns::x`.
-        if !nm.contains("::")
-            && let Some(f) = self.frames.get(level)
-            && let Some(ns) = &f.ns_eval
-            && !ns.is_empty()
-            && !f.locals.contains_key(&nm)
-        {
-            let qualified = format!("{ns}::{nm}");
-            // Tcl 8.x namespace-scope fallback (M11): when the namespace has
-            // no such variable but the global namespace does, the bare name
-            // resolves to the GLOBAL variable — reads and writes both (a
-            // `variable` declaration installs a link above, so a declared
-            // name never reaches this redirect and correctly blocks the
-            // fallback).  9.0 always binds in the namespace (TIP 278).
-            if self.ns_fallback_targets_global(&qualified, &nm) {
-                return (0, nm);
-            }
-            return (0, qualified);
-        }
-        (level, nm)
-    }
-
     /// Read a scalar (following links). A link may resolve to an array element
     /// name (`upvar 0 arr(key) alias`), in which case the element is read.
     #[must_use]
     pub fn get_var(&self, name: &str) -> Option<Value> {
-        let resolved = self.ns_var_fallback(name);
-        let name = resolved.as_deref().unwrap_or(name);
-        let (lvl, nm) = self.locate(name);
-        if let Some((base, key)) = elem_ref(&nm) {
-            // The base may itself be a link (`variable`/`upvar` to a namespace
-            // array), so resolve it onward from the frame it landed on.
-            let (blvl, bnm) = self.locate_key_from(base, lvl);
-            return match self.frames.get(blvl)?.locals.get(&bnm) {
-                Some(Local::Array(m)) => m.get(key).cloned(),
-                _ => None,
-            };
-        }
-        match self.frames.get(lvl)?.locals.get(&nm) {
-            Some(Local::Scalar(v)) => Some(v.clone()),
+        let resolved = self.resolve_var_from(name, self.current_level())?;
+        let id = resolved.id?;
+        match self.var_arena.get(id)?.state() {
+            Local::Scalar(value) => Some(value.clone()),
             _ => None,
         }
     }
@@ -8609,34 +9344,29 @@ impl Vm {
     /// Write a scalar with no trace firing (frame argument binding, rollback).
     /// A link resolving to an array element name writes that element.
     fn write_scalar_raw(&mut self, name: &str, value: Value) {
-        let resolved = self.ns_var_fallback(name);
-        let name = resolved.as_deref().unwrap_or(name);
-        let (lvl, nm) = self.locate(name);
-        if let Some((base, key)) = elem_ref(&nm) {
-            // Resolve the array base onward (it may be a link to a namespace
-            // array) before writing the element.
-            let key = key.to_owned();
-            let (blvl, bnm) = self.locate_key_from(base, lvl);
-            if let Some(f) = self.frames.get_mut(blvl) {
-                match f.locals.get_mut(&bnm) {
-                    Some(Local::Array(m)) => {
-                        m.insert(key, value);
-                    }
-                    Some(Local::Undefined) => {
-                        f.locals.insert(bnm, Local::Scalar(value));
-                    }
-                    Some(_) => {}
-                    None => {
-                        let mut m = BTreeMap::new();
-                        m.insert(key, value);
-                        f.locals.insert(bnm, Local::Array(m));
-                    }
+        let Some(resolved) = self.resolve_var_from(name, self.current_level()) else {
+            return;
+        };
+        if let Some(id) = resolved.id {
+            self.drop_array_descendant_traces(id);
+            let _ = self.var_arena.replace_state(id, Local::Scalar(value));
+        } else if let Some(key) = resolved.elem {
+            if let Some(base_id) = resolved.base_id {
+                let Some(element_id) =
+                    self.var_arena
+                        .alloc_element(Local::Scalar(value), base_id, key.clone())
+                else {
+                    return;
+                };
+                let inserted = self.var_arena.array_insert(base_id, key, element_id);
+                if inserted {
+                    self.var_arena.bind(element_id);
+                } else {
+                    self.var_arena.discard_unbound(element_id);
                 }
             }
-            return;
-        }
-        if let Some(f) = self.frames.get_mut(lvl) {
-            f.locals.insert(nm, Local::Scalar(value));
+        } else {
+            let _ = self.bind_new_var(&resolved.binding, Local::Scalar(value));
         }
     }
 
@@ -8644,46 +9374,39 @@ impl Vm {
     /// — a `can't set "x": variable is array` error rather than a silent
     /// overwrite (the resolution mirrors [`write_scalar_raw`](Self::write_scalar_raw)).
     fn scalar_write_hits_array(&self, name: &str) -> bool {
-        let resolved = self.ns_var_fallback(name);
-        let name = resolved.as_deref().unwrap_or(name);
-        let (lvl, nm) = self.locate(name);
-        if elem_ref(&nm).is_some() {
-            return false; // an element write resolves the array base separately
-        }
-        matches!(
-            self.frames.get(lvl).and_then(|f| f.locals.get(&nm)),
-            Some(Local::Array(_))
-        )
-    }
-
-    /// Resolve `name` to the `(frame, local-name)` owning its cell, mirroring
-    /// the scalar write path — the key for constant tracking (TIP 677).
-    fn const_slot(&self, name: &str) -> (usize, String) {
-        let resolved = self.ns_var_fallback(name);
-        self.locate(resolved.as_deref().unwrap_or(name))
+        let Some(resolved) = self.resolve_var_from(name, self.current_level()) else {
+            return false;
+        };
+        resolved.elem.is_none()
+            && matches!(
+                resolved
+                    .id
+                    .and_then(|id| self.var_arena.get(id))
+                    .map(crate::vars::VarCell::state),
+                Some(Local::Array(_))
+            )
     }
 
     /// Mark `name`'s scalar cell as a `const` (immutable).
     pub(crate) fn mark_constant(&mut self, name: &str) {
-        let (lvl, nm) = self.const_slot(name);
-        if let Some(f) = self.frames.get_mut(lvl) {
-            f.consts.insert(nm);
+        if let Some(id) = self
+            .resolve_var_from(name, self.current_level())
+            .and_then(|resolved| resolved.id)
+        {
+            self.const_vars.insert(id);
         }
     }
 
     /// Whether `name` resolves to a `const` cell.
     pub(crate) fn is_constant(&self, name: &str) -> bool {
-        let (lvl, nm) = self.const_slot(name);
-        self.frames.get(lvl).is_some_and(|f| f.consts.contains(&nm))
+        self.is_constant_from(self.current_level(), name)
     }
 
-    /// The `const` names visible in the current frame matching `info consts`.
-    pub(crate) fn constant_names(&self) -> Vec<String> {
-        let lvl = self.frames.len().saturating_sub(1);
-        self.frames
-            .get(lvl)
-            .map(|f| f.consts.iter().cloned().collect())
-            .unwrap_or_default()
+    /// Whether `name`, resolved as if `start` were active, is a `const` cell.
+    fn is_constant_from(&self, start: usize, name: &str) -> bool {
+        self.resolve_var_from(name, start)
+            .and_then(|resolved| resolved.id)
+            .is_some_and(|id| self.const_vars.contains(&id))
     }
 
     /// Write a scalar, firing `write` traces afterwards. A callback error
@@ -8695,6 +9418,17 @@ impl Vm {
     /// cell the write created therefore survives too. Issue #1438.
     pub fn set_var(&mut self, name: &str, value: Value) -> Result<(), Completion<Value>> {
         self.validate_var_parent(name)?;
+        if self
+            .resolve_var_from(name, self.current_level())
+            .filter(|resolved| resolved.elem.is_none())
+            .and_then(|resolved| resolved.id)
+            .is_some_and(|id| !self.var_arena.element_is_attached(id))
+        {
+            return Err(crate::command::err_with_code(
+                format!("can't set \"{name}\": upvar refers to element in deleted array"),
+                "TCL WRITE VARNAME",
+            ));
+        }
         if self.is_constant(name) {
             return Err(err(format!("can't set \"{name}\": variable is a constant")));
         }
@@ -8719,37 +9453,217 @@ impl Vm {
     /// the removal: resolution can depend on the cell still existing (issue
     /// #1328). Issue #1633 row 10.
     pub fn unset_var(&mut self, name: &str) -> bool {
-        let key = (!self.var_traces.is_empty()).then(|| self.trace_key(name));
-        let (lvl, nm) = self.locate(name);
-        let existed = if let Some((rbase, rkey)) = elem_ref(&nm) {
-            // The name resolved through a link into an array element
-            // (`upvar #0 a(k) e; unset e`): remove that element, not a cell
-            // spelled `a(k)`, which is what C's resolved `Var` does.
-            let (blvl, bnm) = self.locate_key_from(rbase, lvl);
-            match self
-                .frames
-                .get_mut(blvl)
-                .and_then(|f| f.locals.get_mut(&bnm))
-            {
-                Some(Local::Array(m)) => m.remove(rkey).is_some(),
-                _ => false,
+        let Some(resolved) = self.resolve_var_from(name, self.current_level()) else {
+            return false;
+        };
+        self.unset_resolved(name, &resolved)
+    }
+
+    fn unset_resolved(&mut self, name: &str, resolved: &ResolvedVar) -> bool {
+        let traced_cell = self.trace_cell_from_resolved(resolved);
+        let Some((existed, old_state)) = self.detach_variable_state(resolved) else {
+            return false;
+        };
+
+        if let Some(cell) = traced_cell {
+            self.fire_taken_unset(name, None, cell, true);
+        }
+
+        // An array's old element table is detached from the parent before its
+        // callback, then visited one cell at a time. Later old elements remain
+        // live while an earlier callback runs, and callback-created elements
+        // belong to the revived array rather than this destruction pass.
+        if let Local::Array(elements) = old_state {
+            for (element, raw_id) in elements {
+                let Some(id) = self.var_arena.resolve(raw_id) else {
+                    self.var_arena.unbind(raw_id);
+                    continue;
+                };
+                let _ = self.var_arena.take_state(id);
+                let cell = VarTraceCell {
+                    id: Some(id),
+                    array: resolved.id,
+                    elem: Some(element.clone()),
+                };
+                let spelling = format!("{name}({element})");
+                self.fire_taken_unset(&spelling, Some(name), cell, false);
+                // A whole-array destruction retires the old element even when
+                // its callback wrote through an alias. A surviving alias keeps
+                // this identity as a detached, undefined element; it cannot
+                // retarget a later same-name element.
+                let _ = self.var_arena.replace_state(id, Local::Undefined);
+                self.const_vars.remove(&id);
+                self.var_arena.unbind(raw_id);
             }
-        } else {
-            self.frames
-                .get_mut(lvl)
-                .is_some_and(|f| f.locals.remove(&nm).is_some())
+        }
+        existed
+    }
+
+    /// Retire one binding whose frame/namespace owner has already been
+    /// detached. The stable cell identity remains available while callbacks
+    /// run, but any value or trace recreated through an alias is forcibly
+    /// discarded because the owner itself is dying.
+    fn destroy_owned_variable(&mut self, name: &str, raw_id: VarId, reported_name1: Option<&str>) {
+        let Some(id) = self.var_arena.resolve(raw_id) else {
+            self.purge_variable_cell(raw_id);
+            self.var_arena.unbind(raw_id);
+            return;
         };
-        // A variable's traces go with it, and the taken list is what fires.
-        let Some(key) = key else {
-            return existed;
+        let old_state = self.var_arena.take_state(id).unwrap_or(Local::Undefined);
+        let cell = VarTraceCell {
+            id: Some(id),
+            array: None,
+            elem: None,
         };
-        let taken = self.var_traces.remove(&key);
-        if taken.is_some() {
+        self.fire_taken_unset(name, reported_name1, cell, true);
+
+        if let Local::Array(elements) = old_state {
+            for (element, raw_element) in elements {
+                let Some(element_id) = self.var_arena.resolve(raw_element) else {
+                    self.var_arena.unbind(raw_element);
+                    continue;
+                };
+                let _ = self.var_arena.take_state(element_id);
+                let cell = VarTraceCell {
+                    id: Some(element_id),
+                    array: Some(id),
+                    elem: Some(element.clone()),
+                };
+                let spelling = format!("{name}({element})");
+                self.fire_taken_unset(&spelling, reported_name1.or(Some(name)), cell, false);
+                self.purge_variable_cell(raw_element);
+                self.var_arena.unbind(raw_element);
+            }
+        }
+        self.purge_variable_cell(raw_id);
+        self.var_arena.unbind(raw_id);
+    }
+
+    /// Discard one cell owned by a dying frame/namespace without firing newly
+    /// installed traces. Array children are purged recursively; link cells are
+    /// unbound without touching their targets.
+    fn purge_variable_cell(&mut self, raw_id: VarId) {
+        if matches!(
+            self.var_arena.get(raw_id).map(crate::vars::VarCell::state),
+            Some(Local::Link(_))
+        ) {
+            let _ = self.var_arena.replace_state(raw_id, Local::Undefined);
+            return;
+        }
+        let Some(id) = self.var_arena.resolve(raw_id) else {
+            let _ = self.var_arena.replace_state(raw_id, Local::Undefined);
+            return;
+        };
+        self.drop_var_traces(id);
+        if let Some(Local::Array(elements)) = self.var_arena.take_state(id) {
+            for child in elements.into_values() {
+                self.purge_variable_cell(child);
+                self.var_arena.unbind(child);
+            }
+        }
+        let _ = self.var_arena.replace_state(id, Local::Undefined);
+        self.const_vars.remove(&id);
+    }
+
+    /// Remove every callback pinned to one stable variable cell. Lifecycle
+    /// paths that intentionally do not execute callbacks still must release
+    /// their pin before the final binding is dropped.
+    fn drop_var_traces(&mut self, id: VarId) {
+        if self.var_traces.remove(&id).is_some() {
+            self.var_arena.unpin(id);
             self.invalidate_guard_domain(GuardDomain::VariableTrace);
         }
-        // Unset-trace errors are ignored.
-        let _ = self.fire_var_traces_taken(name, "unset", None, taken);
-        existed
+    }
+
+    /// Retire trace pins below an array before a no-callback storage mutation
+    /// releases the element bindings. The arena owns state/bindings and this
+    /// VM owner owns callbacks, so every raw replacement funnels through this
+    /// bridge instead of leaving trace-pinned, unreachable element cells.
+    fn drop_array_descendant_traces(&mut self, id: VarId) {
+        let children: Vec<VarId> = match self.var_arena.get(id).map(crate::vars::VarCell::state) {
+            Some(Local::Array(elements)) => elements.values().copied().collect(),
+            Some(Local::Undefined | Local::Scalar(_) | Local::Link(_)) | None => Vec::new(),
+        };
+        for raw in children {
+            if let Some(child) = self.var_arena.resolve(raw) {
+                self.drop_array_descendant_traces(child);
+                self.drop_var_traces(child);
+                self.const_vars.remove(&child);
+            }
+        }
+    }
+
+    fn detach_variable_state(&mut self, resolved: &ResolvedVar) -> Option<(bool, VarState)> {
+        let id = resolved.id?;
+        let raw = if let Some(key) = &resolved.elem {
+            let base_id = resolved.base_id?;
+            match self.var_arena.get(base_id).map(crate::vars::VarCell::state) {
+                Some(Local::Array(elements)) => elements.get(key).copied(),
+                _ => None,
+            }
+        } else {
+            self.var_table(resolved.binding.owner)
+                .and_then(|table| table.get(&resolved.binding.name))
+                .copied()
+        }?;
+        let raw_is_link = matches!(
+            self.var_arena.get(raw).map(crate::vars::VarCell::state),
+            Some(Local::Link(_))
+        );
+        let old = self.var_arena.unset_state(id)?;
+        let existed = matches!(old, Local::Scalar(_) | Local::Array(_));
+        if !raw_is_link
+            && !self.var_arena.has_link_refs(id)
+            && !self.var_arena.has_operation_refs(id)
+        {
+            if let Some(key) = &resolved.elem {
+                if let Some(base_id) = resolved.base_id {
+                    let _ = self.var_arena.array_remove(base_id, key);
+                }
+            } else if let Some(table) = self.var_table_mut(resolved.binding.owner) {
+                table.remove(&resolved.binding.name);
+            }
+            self.const_vars.remove(&id);
+            self.var_arena.unbind(raw);
+        }
+        Some((existed, old))
+    }
+
+    fn fire_taken_unset(
+        &mut self,
+        name: &str,
+        reported_name1: Option<&str>,
+        cell: VarTraceCell,
+        include_array: bool,
+    ) {
+        let Some(id) = cell.id else {
+            return;
+        };
+        let taken = self.var_traces.remove(&id);
+        let has_array_trace = include_array
+            && cell
+                .array_id()
+                .is_some_and(|array| self.var_traces.contains_key(&array));
+        let had_taken = taken.is_some();
+        if !had_taken && !has_array_trace {
+            return;
+        }
+        if had_taken {
+            self.invalidate_guard_domain(GuardDomain::VariableTrace);
+        }
+        let _ = self.fire_var_traces_taken(
+            name,
+            "unset",
+            reported_name1,
+            Some(TakenVarTraces {
+                cell,
+                entries: taken.unwrap_or_default(),
+                include_array,
+            }),
+        );
+        if had_taken {
+            self.var_arena.unpin(id);
+        }
     }
 
     /// Unset a single variable by name, the shared core of the `unset` command
@@ -8757,15 +9671,25 @@ impl Vm {
     /// [`array_unset_elem`](Self::array_unset_elem) (which splits the base/key);
     /// a scalar/array variable is removed via [`unset_var`](Self::unset_var).
     /// When `complain` is set and the variable did not exist, this returns the
-    /// Tcl `can't unset "name": no such variable` error (array-element removal
-    /// never complains, matching C Tcl / `cmd_unset`).
+    /// Tcl diagnostic that distinguishes a missing variable, a scalar used as
+    /// an array, and a missing array element.
     pub(crate) fn unset_one(
         &mut self,
         name: &str,
         complain: bool,
     ) -> Result<(), Completion<Value>> {
         if let Some((array, key)) = elem_ref(name) {
-            self.array_unset_elem_spelled(array, key);
+            let existed = self.array_unset_elem_spelled(array, key);
+            if !existed && complain {
+                let what = if self.var_is_array(array) {
+                    "no such element in array"
+                } else if self.exists_var(array) {
+                    "variable isn't array"
+                } else {
+                    "no such variable"
+                };
+                return Err(err(format!("can't unset \"{name}\": {what}")));
+            }
             return Ok(());
         }
         // A constant cannot be unset; `-nocomplain` leaves it intact (var-26.12).
@@ -8794,16 +9718,9 @@ impl Vm {
 
     /// Frame-addressed scalar read (the storage half of [`get_var`](Self::get_var)).
     pub(crate) fn get_var_from(&self, start: usize, name: &str) -> Option<Value> {
-        let (lvl, nm) = self.locate_from(name, start);
-        if let Some((base, key)) = elem_ref(&nm) {
-            let (blvl, bnm) = self.locate_key_from(base, lvl);
-            return match self.frames.get(blvl)?.locals.get(&bnm) {
-                Some(Local::Array(m)) => m.get(key).cloned(),
-                _ => None,
-            };
-        }
-        match self.frames.get(lvl)?.locals.get(&nm) {
-            Some(Local::Scalar(v)) => Some(v.clone()),
+        let id = self.resolve_var_from(name, start)?.id?;
+        match self.var_arena.get(id)?.state() {
+            Local::Scalar(value) => Some(value.clone()),
             _ => None,
         }
     }
@@ -8811,69 +9728,61 @@ impl Vm {
     /// Frame-addressed scalar write (the storage half of
     /// [`write_scalar_raw`](Self::write_scalar_raw)).
     pub(crate) fn write_scalar_from(&mut self, start: usize, name: &str, value: Value) {
-        let (lvl, nm) = self.locate_from(name, start);
-        if let Some((base, key)) = elem_ref(&nm) {
-            let key = key.to_owned();
-            let (blvl, bnm) = self.locate_key_from(base, lvl);
-            if let Some(f) = self.frames.get_mut(blvl) {
-                match f.locals.get_mut(&bnm) {
-                    Some(Local::Array(m)) => {
-                        m.insert(key, value);
-                    }
-                    Some(Local::Undefined) => {
-                        f.locals.insert(bnm, Local::Scalar(value));
-                    }
-                    Some(_) => {}
-                    None => {
-                        let mut m = BTreeMap::new();
-                        m.insert(key, value);
-                        f.locals.insert(bnm, Local::Array(m));
-                    }
-                }
-            }
+        let Some(resolved) = self.resolve_var_from(name, start) else {
             return;
-        }
-        if let Some(f) = self.frames.get_mut(lvl) {
-            f.locals.insert(nm, Local::Scalar(value));
+        };
+        if let Some(id) = resolved.id {
+            self.drop_array_descendant_traces(id);
+            let _ = self.var_arena.replace_state(id, Local::Scalar(value));
+        } else if resolved.elem.is_none() {
+            let _ = self.bind_new_var(&resolved.binding, Local::Scalar(value));
         }
     }
 
     /// Frame-addressed scalar existence (the storage half of
     /// [`var_exists`](Self::var_exists)).
     pub(crate) fn exists_from(&self, start: usize, name: &str) -> bool {
-        let (lvl, nm) = self.locate_from(name, start);
-        self.frames
-            .get(lvl)
-            .is_some_and(|f| matches!(f.locals.get(&nm), Some(Local::Scalar(_))))
+        self.resolve_var_from(name, start)
+            .and_then(|resolved| resolved.id)
+            .and_then(|id| self.var_arena.get(id))
+            .is_some_and(|cell| matches!(cell.state(), Local::Scalar(_) | Local::Array(_)))
     }
 
     /// Frame-addressed unset (storage only — no unset-trace firing).
     pub(crate) fn unset_from(&mut self, start: usize, name: &str) -> bool {
-        let (lvl, nm) = self.locate_from(name, start);
-        self.frames
-            .get_mut(lvl)
-            .is_some_and(|f| f.locals.remove(&nm).is_some())
+        let Some(resolved) = self.resolve_var_from(name, start) else {
+            return false;
+        };
+        self.unbind_storage_resolved(&resolved)
+    }
+
+    /// Storage-only destruction shared by frame-addressed whole-variable and
+    /// element façades. No callback runs, so the reached cell's trace pin is
+    /// retired after the binding/state transition.
+    fn unbind_storage_resolved(&mut self, resolved: &ResolvedVar) -> bool {
+        let id = resolved.id;
+        let existed = self.unbind_resolved(resolved);
+        if existed && let Some(id) = id {
+            self.drop_var_traces(id);
+        }
+        existed
     }
 
     /// Whether a scalar or array variable named `name` exists (`info exists`).
     pub(crate) fn has_var(&self, name: &str) -> bool {
-        let (lvl, nm) = self.locate(name);
-        matches!(
-            self.frames.get(lvl).and_then(|f| f.locals.get(&nm)),
-            Some(Local::Scalar(_) | Local::Array(_))
-        )
+        self.resolve_var_from(name, self.current_level())
+            .and_then(|resolved| resolved.id)
+            .and_then(|id| self.var_arena.get(id))
+            .is_some_and(|cell| matches!(cell.state(), Local::Scalar(_) | Local::Array(_)))
     }
 
     /// Whether `name` resolves to an array variable (the `set a` array/scalar
     /// diagnostic; `array exists`).
     pub(crate) fn var_is_array(&self, name: &str) -> bool {
-        let resolved = self.ns_var_fallback(name);
-        let lookup = resolved.as_deref().unwrap_or(name);
-        let (lvl, nm) = self.locate(lookup);
-        matches!(
-            self.frames.get(lvl).and_then(|f| f.locals.get(&nm)),
-            Some(Local::Array(_))
-        )
+        self.resolve_var_from(name, self.current_level())
+            .and_then(|resolved| resolved.id)
+            .and_then(|id| self.var_arena.get(id))
+            .is_some_and(|cell| matches!(cell.state(), Local::Array(_)))
     }
 
     /// C's three-way read-miss message (`tclVar.c`): a scalar read of an array
@@ -8902,20 +9811,25 @@ impl Vm {
     /// empty-list path, which C words under the command (`can't array set "n"`),
     /// unlike the per-element write that names `n(key)`.
     pub(crate) fn ensure_array(&mut self, name: &str) -> Result<(), Completion<Value>> {
-        let resolved = self.ns_var_fallback(name);
-        let lookup = resolved.as_deref().unwrap_or(name).to_string();
-        let (lvl, nm) = self.locate(&lookup);
-        if let Some(f) = self.frames.get_mut(lvl) {
-            match f.locals.get(&nm) {
-                Some(Local::Array(_) | Local::Link { .. }) => {}
-                Some(Local::Undefined) | None => {
-                    f.locals.insert(nm, Local::Array(BTreeMap::new()));
-                }
-                Some(Local::Scalar(_)) => {
-                    return Err(err(format!(
-                        "can't array set \"{name}\": variable isn't array"
-                    )));
-                }
+        let Some((binding, id)) = self.ensure_base_var_from(name, self.current_level()) else {
+            return Err(err(format!(
+                "can't array set \"{name}\": parent namespace doesn't exist"
+            )));
+        };
+        match self.var_arena.get(id).map(crate::vars::VarCell::state) {
+            Some(Local::Array(_)) => {}
+            Some(Local::Undefined) => {
+                let _ = self
+                    .var_arena
+                    .replace_state(id, Local::Array(VarTable::new()));
+            }
+            Some(Local::Scalar(_)) => {
+                return Err(err(format!(
+                    "can't array set \"{name}\": variable isn't array"
+                )));
+            }
+            Some(Local::Link(_)) | None => {
+                let _ = self.bind_new_var(&binding, Local::Array(VarTable::new()));
             }
         }
         Ok(())
@@ -8928,18 +9842,14 @@ impl Vm {
         if let Some((base, _)) = elem_ref(name) {
             let base = self.trace_qualify(base);
             self.ensure_trace_namespace(name, &base)?;
-            return self
-                .ensure_array(&base)
-                .map_err(|_| err(format!("can't trace \"{name}\": variable isn't array")));
+            self.ensure_array(&base)
+                .map_err(|_| err(format!("can't trace \"{name}\": variable isn't array")))?;
+            let _ = self.ensure_target_var_from(name, self.current_level());
+            return Ok(());
         }
         let lookup = self.trace_qualify(name);
         self.ensure_trace_namespace(name, &lookup)?;
-        let (lvl, nm) = self.locate(&lookup);
-        if let Some(frame) = self.frames.get_mut(lvl)
-            && !frame.locals.contains_key(&nm)
-        {
-            frame.locals.insert(nm, Local::Undefined);
-        }
+        let _ = self.ensure_base_var_from(&lookup, self.current_level());
         Ok(())
     }
 
@@ -9020,31 +9930,24 @@ impl Vm {
         // different variable. Measured on tclsh 8.6.16. Issue #1633 row 1.
         let cell = self.resolved_cell(name);
         self.set_var(name, value)?;
-        Ok(self.read_resolved_cell(&cell).unwrap_or_else(Value::empty))
+        Ok(cell
+            .and_then(|id| self.read_resolved_cell(id))
+            .unwrap_or_else(Value::empty))
     }
 
     /// The frame + key a scalar name resolves to **right now** — C's `Var *`.
     /// Mirrors the resolution [`write_scalar_raw`](Self::write_scalar_raw) and
     /// [`write_array_raw`](Self::write_array_raw) perform, so a cell captured
     /// before a store is exactly the one the store wrote.
-    fn resolved_cell(&self, name: &str) -> (usize, String) {
-        let resolved = self.ns_var_fallback(name);
-        self.locate(resolved.as_deref().unwrap_or(name))
+    fn resolved_cell(&mut self, name: &str) -> Option<VarId> {
+        self.ensure_target_var_from(name, self.current_level())
     }
 
     /// Read the scalar at an already-resolved [`resolved_cell`](Self::resolved_cell) —
     /// the tail of [`get_var`](Self::get_var) with the name lookup already done.
-    fn read_resolved_cell(&self, (lvl, nm): &(usize, String)) -> Option<Value> {
-        if let Some((base, key)) = elem_ref(nm) {
-            // The resolved name is itself an element (a link into an array).
-            let (blvl, bnm) = self.locate_key_from(base, *lvl);
-            return match self.frames.get(blvl)?.locals.get(&bnm) {
-                Some(Local::Array(m)) => m.get(key).cloned(),
-                _ => None,
-            };
-        }
-        match self.frames.get(*lvl)?.locals.get(nm) {
-            Some(Local::Scalar(v)) => Some(v.clone()),
+    fn read_resolved_cell(&self, id: VarId) -> Option<Value> {
+        match self.var_arena.get(id)?.state() {
+            Local::Scalar(value) => Some(value.clone()),
             _ => None,
         }
     }
@@ -9052,11 +9955,12 @@ impl Vm {
     /// [`read_resolved_cell`](Self::read_resolved_cell) for element `key` of an
     /// already-resolved array cell — the tail of
     /// [`get_array_elem`](Self::get_array_elem).
-    fn read_resolved_elem(&self, (lvl, nm): &(usize, String), key: &str) -> Option<Value> {
-        match self.frames.get(*lvl)?.locals.get(nm) {
-            Some(Local::Array(m)) => m.get(key).cloned(),
-            _ => None,
-        }
+    fn read_resolved_elem(&self, base_id: VarId, key: &str) -> Option<Value> {
+        let Local::Array(elements) = self.var_arena.get(base_id)?.state() else {
+            return None;
+        };
+        let id = self.var_arena.resolve(*elements.get(key)?)?;
+        self.read_resolved_cell(id)
     }
 
     /// [`store_var_result`](Self::store_var_result) for an already-split
@@ -9076,8 +9980,8 @@ impl Vm {
         // [`store_var_result`](Self::store_var_result) explains.
         let cell = self.resolved_cell(name);
         self.set_array_elem(name, key, value)?;
-        Ok(self
-            .read_resolved_elem(&cell, key)
+        Ok(cell
+            .and_then(|id| self.read_resolved_elem(id, key))
             .unwrap_or_else(Value::empty))
     }
 
@@ -9091,25 +9995,35 @@ impl Vm {
     /// ending in the `(read trace on "x")` frame while the `incr` succeeds.
     /// Mirror of the runtime's `Interp::read_for_update`. Issue #1633 rows 3/4.
     pub(crate) fn read_for_update(&mut self, name: &str) -> Option<Value> {
-        if !self.var_traces.is_empty() && self.fire_var_traces(name, "read").is_err() {
+        if let Ok(value) = self.read_var_traced(name) {
+            value
+        } else {
             self.publish_swallowed_trace_error();
-            return None;
+            None
         }
-        self.var_get(name)
     }
 
     /// [`read_for_update`](Self::read_for_update) for an already-split
     /// `name(key)` element.
     pub(crate) fn read_elem_for_update(&mut self, name: &str, key: &str) -> Option<Value> {
-        if !self.var_traces.is_empty()
-            && self
-                .fire_var_traces(&format!("{name}({key})"), "read")
-                .is_err()
-        {
+        self.read_elem_swallowing_trace_error(name, key)
+    }
+
+    /// Read one array element while retaining but not propagating a read-trace
+    /// error. Tcl uses this both for read-modify-write commands and `array for`:
+    /// the access behaves as missing, while `::errorInfo` keeps the callback's
+    /// trace stack.
+    pub(crate) fn read_elem_swallowing_trace_error(
+        &mut self,
+        name: &str,
+        key: &str,
+    ) -> Option<Value> {
+        if let Ok(value) = self.read_elem_traced(name, key) {
+            value
+        } else {
             self.publish_swallowed_trace_error();
-            return None;
+            None
         }
-        self.get_array_elem(name, key)
     }
 
     /// Publish the `errorInfo` a read trace left behind when the
@@ -9127,48 +10041,16 @@ impl Vm {
     // -- arrays (link-aware via `locate`) --
 
     pub(crate) fn get_array_elem(&self, name: &str, key: &str) -> Option<Value> {
-        let resolved = self.ns_var_fallback(name);
-        let lookup = resolved.as_deref().unwrap_or(name);
-        let (lvl, nm) = self.locate(lookup);
-        match self.frames.get(lvl)?.locals.get(&nm) {
-            Some(Local::Array(m)) => m.get(key).cloned(),
-            _ => None,
-        }
+        self.get_array_elem_from(self.current_level(), name, key)
     }
 
-    /// When an unqualified `name` is not a local in the current frame but the
-    /// current namespace has a variable `ns::name`, resolve to that qualified
-    /// name. This is the namespace-variable fallback (a namespace script or an
-    /// undeclared access reaching an existing namespace variable). Only
-    /// resolves to variables that already exist, so frame locals are unaffected.
-    fn ns_var_fallback(&self, name: &str) -> Option<String> {
-        if name.contains("::") {
+    fn get_array_elem_from(&self, start: usize, name: &str, key: &str) -> Option<Value> {
+        let base_id = self.resolve_var_from(name, start)?.base_id?;
+        let Local::Array(elements) = self.var_arena.get(base_id)?.state() else {
             return None;
-        }
-        // Only a namespace-eval body resolves a bare name to a namespace
-        // variable. Inside a proc (even one defined in the namespace), an
-        // unqualified name is a local unless declared via `variable`/`global`.
-        if !self.in_ns_script() {
-            return None;
-        }
-        let cur = self.current_ns();
-        if cur.is_empty() {
-            return None;
-        }
-        let top = self.frames.last()?;
-        if top.locals.contains_key(name) {
-            return None;
-        }
-        let q = format!("{cur}::{name}");
-        if self
-            .frames
-            .first()
-            .is_some_and(|g| g.locals.contains_key(&q))
-        {
-            Some(format!("::{q}"))
-        } else {
-            None
-        }
+        };
+        let id = self.var_arena.resolve(*elements.get(key)?)?;
+        self.read_resolved_cell(id)
     }
 
     /// Write an array element with no trace firing.
@@ -9178,30 +10060,56 @@ impl Vm {
         key: &str,
         value: Value,
     ) -> Result<(), Completion<Value>> {
+        self.write_array_raw_from(self.current_level(), name, key, value)
+    }
+
+    fn write_array_raw_from(
+        &mut self,
+        start: usize,
+        name: &str,
+        key: &str,
+        value: Value,
+    ) -> Result<(), Completion<Value>> {
         self.validate_var_parent(name)?;
-        let resolved = self.ns_var_fallback(name);
-        let name = resolved.as_deref().unwrap_or(name);
-        let (lvl, nm) = self.locate(name);
-        let frame = self
-            .frames
-            .get_mut(lvl)
-            .expect("locate returns a valid level");
-        match frame.locals.get_mut(&nm) {
-            Some(Local::Array(m)) => {
-                m.insert(key.to_owned(), value);
-                Ok(())
+        let Some((_, base_id)) = self.ensure_base_var_from(name, start) else {
+            return Err(err(format!(
+                "can't set \"{name}({key})\": no such variable"
+            )));
+        };
+        match self.var_arena.get(base_id).map(crate::vars::VarCell::state) {
+            Some(Local::Scalar(_)) => {
+                return Err(err(format!(
+                    "can't set \"{name}({key})\": variable isn't array"
+                )));
             }
-            Some(Local::Scalar(_)) => Err(err(format!(
-                "can't set \"{name}({key})\": variable isn't array"
-            ))),
-            Some(Local::Undefined) | None => {
-                let mut m = BTreeMap::new();
-                m.insert(key.to_owned(), value);
-                frame.locals.insert(nm, Local::Array(m));
-                Ok(())
+            Some(Local::Undefined) => {
+                let _ = self
+                    .var_arena
+                    .replace_state(base_id, Local::Array(VarTable::new()));
             }
-            Some(Local::Link { .. }) => unreachable!("locate resolves links"),
+            Some(Local::Array(_)) => {}
+            Some(Local::Link(_)) | None => return Ok(()),
         }
+        let existing = match self.var_arena.get(base_id).map(crate::vars::VarCell::state) {
+            Some(Local::Array(elements)) => elements.get(key).copied(),
+            _ => None,
+        };
+        if let Some(id) = existing.and_then(|id| self.var_arena.resolve(id)) {
+            let _ = self.var_arena.replace_state(id, Local::Scalar(value));
+            return Ok(());
+        }
+        let Some(id) = self
+            .var_arena
+            .alloc_element(Local::Scalar(value), base_id, key.to_owned())
+        else {
+            return Err(err("too many variable cells"));
+        };
+        if self.var_arena.array_insert(base_id, key.to_owned(), id) {
+            self.var_arena.bind(id);
+        } else {
+            self.var_arena.discard_unbound(id);
+        }
+        Ok(())
     }
 
     /// Write an array element, firing `write` traces afterwards. Like
@@ -9220,27 +10128,11 @@ impl Vm {
         self.fire_var_traces(&format!("{name}({key})"), "write")
     }
 
-    pub(crate) fn array_is(&self, name: &str) -> bool {
-        let (lvl, nm) = self.locate(name);
-        matches!(
-            self.frames.get(lvl).and_then(|f| f.locals.get(&nm)),
-            Some(Local::Array(_))
-        )
-    }
-
-    pub(crate) fn array_pairs(&self, name: &str) -> Vec<(String, Value)> {
-        let (lvl, nm) = self.locate(name);
-        match self.frames.get(lvl).and_then(|f| f.locals.get(&nm)) {
-            Some(Local::Array(m)) => m.iter().map(|(k, v)| (k.clone(), v.clone())).collect(),
-            _ => Vec::new(),
-        }
-    }
-
     /// Remove array element `name(key)` through a **two-part** access — C's
     /// `TclObjUnsetVar2(part1, part2, …)`, which `array unset` and the
     /// `INST_UNSET_ARRAY*` opcodes use. The traces report `name1 = name`.
-    pub(crate) fn array_unset_elem(&mut self, name: &str, key: &str) {
-        self.array_unset_elem_reporting(name, key, None);
+    pub(crate) fn array_unset_elem(&mut self, name: &str, key: &str) -> bool {
+        self.array_unset_elem_reporting(name, key, None)
     }
 
     /// Remove array element `name(key)` named by the **one-part** `a(k)`
@@ -9249,39 +10141,165 @@ impl Vm {
     /// (`tclVar.c` 9.0.4:2638-2642), which stops `TclCallVarTraces` splitting
     /// the spelling, so the callbacks see `name1 = a(k)`; 8.4/8.5/8.6 split it
     /// and see `name1 = a`. Issue #1633 row 6.
-    pub(crate) fn array_unset_elem_spelled(&mut self, name: &str, key: &str) {
-        if self.runtime_version.traces_recover_linked_array_element() {
-            let spelling = format!("{name}({key})");
-            self.array_unset_elem_reporting(name, key, Some(&spelling));
+    pub(crate) fn array_unset_elem_spelled(&mut self, name: &str, key: &str) -> bool {
+        let spelling = format!("{name}({key})");
+        let active = self
+            .trace_cell(&spelling)
+            .and_then(|cell| cell.id)
+            .is_some_and(|id| self.active_traces.contains(&id));
+        if self.runtime_version.traces_recover_linked_array_element() && !active {
+            self.array_unset_elem_reporting(name, key, Some(&spelling))
         } else {
-            self.array_unset_elem_reporting(name, key, None);
+            self.array_unset_elem_reporting(name, key, None)
         }
     }
 
-    fn array_unset_elem_reporting(&mut self, name: &str, key: &str, reported: Option<&str>) {
+    fn array_unset_elem_reporting(
+        &mut self,
+        name: &str,
+        key: &str,
+        reported: Option<&str>,
+    ) -> bool {
+        let Some(base_id) = self
+            .resolve_var_from(name, self.current_level())
+            .and_then(|resolved| resolved.base_id)
+        else {
+            return false;
+        };
+        self.array_unset_elem_reporting_at(base_id, name, key, reported)
+    }
+
+    fn array_unset_elem_reporting_at(
+        &mut self,
+        base_id: VarId,
+        name: &str,
+        key: &str,
+        reported: Option<&str>,
+    ) -> bool {
         // As for a scalar: the element goes, and its own traces come out of the
         // table, before the callbacks run. The *array's* traces stay — C leaves
         // them on the array's own `Var` — so they are still live in the walk and
         // still visible to `trace info`. The trace key is resolved while the
         // element is still present (issue #1328).
-        let traced = (!self.var_traces.is_empty()).then(|| {
-            let spelling = format!("{name}({key})");
-            let trace_key = self.trace_key(&spelling);
-            (spelling, trace_key)
-        });
-        let (lvl, nm) = self.locate(name);
-        if let Some(Local::Array(m)) = self.frames.get_mut(lvl).and_then(|f| f.locals.get_mut(&nm))
-        {
-            m.remove(key);
-        }
-        let Some((spelling, trace_key)) = traced else {
-            return;
+        let raw = match self.var_arena.get(base_id).map(crate::vars::VarCell::state) {
+            Some(Local::Array(elements)) => elements.get(key).copied(),
+            _ => None,
         };
-        let taken = self.var_traces.remove(&trace_key);
-        if taken.is_some() {
-            self.invalidate_guard_domain(GuardDomain::VariableTrace);
+        let id = raw.and_then(|raw| self.var_arena.resolve(raw));
+        let spelling = format!("{name}({key})");
+        let traced = (!self.var_traces.is_empty()).then(|| {
+            id.map(|id| VarTraceCell {
+                id: Some(id),
+                array: Some(base_id),
+                elem: Some(key.to_owned()),
+            })
+        });
+        let existed = match (raw, id) {
+            (Some(raw), Some(id)) => self.unbind_array_element(base_id, key, raw, id),
+            _ => false,
+        };
+        let Some(Some(cell)) = traced else {
+            return existed;
+        };
+        self.fire_taken_unset(&spelling, reported, cell, true);
+        existed
+    }
+
+    fn unbind_array_element(&mut self, base_id: VarId, key: &str, raw: VarId, id: VarId) -> bool {
+        let existed = self.var_arena.get(id).is_some_and(|cell| {
+            matches!(
+                cell.state(),
+                Local::Undefined | Local::Scalar(_) | Local::Array(_)
+            )
+        });
+        if !existed {
+            return false;
         }
-        let _ = self.fire_var_traces_taken(&spelling, "unset", reported, taken);
+        self.drop_array_descendant_traces(id);
+        let _ = self.var_arena.unset_state(id);
+        if matches!(
+            self.var_arena.get(raw).map(crate::vars::VarCell::state),
+            Some(Local::Link(_))
+        ) || self.var_arena.has_link_refs(id)
+            || self.var_arena.has_operation_refs(id)
+        {
+            return true;
+        }
+        let _ = self.var_arena.array_remove(base_id, key);
+        self.const_vars.remove(&id);
+        self.var_arena.unbind(raw);
+        true
+    }
+
+    fn resolve_array_elem_from(&self, start: usize, name: &str, key: &str) -> Option<ResolvedVar> {
+        let base = self.resolve_var_from(name, start)?;
+        let base_id = base.base_id?;
+        let raw = match self.var_arena.get(base_id).map(crate::vars::VarCell::state) {
+            Some(Local::Array(elements)) => elements.get(key).copied(),
+            _ => None,
+        };
+        let raw = raw?;
+        Some(ResolvedVar {
+            binding: base.binding,
+            base_id: Some(base_id),
+            id: self.var_arena.resolve(raw),
+            elem: Some(key.to_owned()),
+        })
+    }
+
+    fn unset_array_elem_from(&mut self, start: usize, name: &str, key: &str) -> bool {
+        let Some(resolved) = self.resolve_array_elem_from(start, name, key) else {
+            return false;
+        };
+        self.unbind_storage_resolved(&resolved)
+    }
+
+    /// Frame-addressed array-key enumeration. The explicit frame selects both
+    /// proc-local and namespace-token ownership before the stable array cell is
+    /// read, so equal spellings in two frames never collapse.
+    fn array_keys_from(&self, start: usize, name: &str) -> Option<Vec<String>> {
+        let resolved = self.resolve_var_from(name, start)?;
+        if resolved.elem.is_some() {
+            return None;
+        }
+        let id = resolved.id?;
+        self.array_keys_at_id(id)
+    }
+
+    fn array_keys_at_id(&self, id: VarId) -> Option<Vec<String>> {
+        let Local::Array(elements) = self.var_arena.get(id)?.state() else {
+            return None;
+        };
+        Some(
+            elements
+                .iter()
+                .filter_map(|(key, raw)| {
+                    self.var_arena
+                        .resolve(*raw)
+                        .and_then(|id| self.read_resolved_cell(id))
+                        .map(|_| key.clone())
+                })
+                .collect(),
+        )
+    }
+
+    fn array_search_keys_at_id(&self, id: VarId) -> Option<Vec<String>> {
+        let Local::Array(elements) = self.var_arena.get(id)?.state() else {
+            return None;
+        };
+        Some(elements.keys().cloned().collect())
+    }
+
+    fn array_elem_exists_at_id(&self, id: VarId, key: &str) -> bool {
+        let Some(Local::Array(elements)) = self.var_arena.get(id).map(crate::vars::VarCell::state)
+        else {
+            return false;
+        };
+        elements
+            .get(key)
+            .and_then(|raw| self.var_arena.resolve(*raw))
+            .and_then(|element| self.read_resolved_cell(element))
+            .is_some()
     }
 
     /// Append one `while executing` / `invoked from within` frame for the
@@ -9448,18 +10466,12 @@ impl Vm {
     /// Publish `errorInfo` / `errorCode` into the global frame.
     pub(crate) fn publish_error(&mut self, info: &str, code: &Value) {
         self.publish_error_info(info);
-        if let Some(g) = self.frames.first_mut() {
-            g.locals
-                .insert("errorCode".to_owned(), Local::Scalar(code.clone()));
-        }
+        self.write_scalar_from(0, "::errorCode", code.clone());
     }
 
     /// Publish the `errorInfo` global alone, leaving `errorCode` as it is.
     pub(crate) fn publish_error_info(&mut self, info: &str) {
-        if let Some(g) = self.frames.first_mut() {
-            g.locals
-                .insert("errorInfo".to_owned(), Local::Scalar(Value::string(info)));
-        }
+        self.write_scalar_from(0, "::errorInfo", Value::string(info));
     }
 
     pub(crate) fn write_output(&mut self, s: &str, newline: bool) {
@@ -9758,6 +10770,13 @@ impl VarStore for Vm {
         }
     }
 
+    fn unset_command(&mut self, frame: FrameId, name: &str) -> Result<bool, VarUnsetError> {
+        if self.is_constant_from(frame.0, name) {
+            return Err(VarUnsetError::IsConstant);
+        }
+        Ok(self.unset(frame, name))
+    }
+
     fn exists(&self, frame: FrameId, name: &str) -> bool {
         if frame.0 == self.current_level() {
             // The *complete* existence check: a scalar, an array, or an array
@@ -9780,11 +10799,7 @@ impl VarStore for Vm {
         if frame.0 == self.current_level() {
             self.get_array_elem(name, key)
         } else {
-            let (level, base) = self.locate_from(name, frame.0);
-            match self.frames.get(level)?.locals.get(&base) {
-                Some(Local::Array(elements)) => elements.get(key).cloned(),
-                _ => None,
-            }
+            self.get_array_elem_from(frame.0, name, key)
         }
     }
 
@@ -9793,21 +10808,7 @@ impl VarStore for Vm {
             let _ = self.set_array_elem(name, key, value);
             return;
         }
-        let (level, base) = self.locate_from(name, frame.0);
-        let Some(owner) = self.frames.get_mut(level) else {
-            return;
-        };
-        match owner.locals.get_mut(&base) {
-            Some(Local::Array(elements)) => {
-                elements.insert(key.to_owned(), value);
-            }
-            Some(Local::Undefined) | None => {
-                let mut elements = BTreeMap::new();
-                elements.insert(key.to_owned(), value);
-                owner.locals.insert(base, Local::Array(elements));
-            }
-            Some(Local::Scalar(_) | Local::Link { .. }) => {}
-        }
+        let _ = self.write_array_raw_from(frame.0, name, key, value);
     }
 
     fn unset_elem(&mut self, frame: FrameId, name: &str, key: &str) -> bool {
@@ -9816,28 +10817,61 @@ impl VarStore for Vm {
             self.array_unset_elem(name, key);
             return existed;
         }
-        let (level, base) = self.locate_from(name, frame.0);
-        match self
-            .frames
-            .get_mut(level)
-            .and_then(|owner| owner.locals.get_mut(&base))
-        {
-            Some(Local::Array(elements)) => elements.remove(key).is_some(),
-            _ => false,
-        }
+        self.unset_array_elem_from(frame.0, name, key)
     }
 
     fn exists_elem(&self, frame: FrameId, name: &str, key: &str) -> bool {
         self.get_elem(frame, name, key).is_some()
     }
 
-    fn array_keys(&self, _frame: FrameId, name: &str) -> Option<Vec<String>> {
-        // `array_is` distinguishes an (empty-or-not) array from a scalar/unset;
-        // `array_pairs` yields the keys (active frame — the cores pass current).
-        if self.array_is(name) {
-            Some(self.array_pairs(name).into_iter().map(|(k, _)| k).collect())
+    fn array_keys(&self, frame: FrameId, name: &str) -> Option<Vec<String>> {
+        self.array_keys_from(frame.0, name)
+    }
+
+    fn array_target(&self, frame: FrameId, name: &str) -> ArrayTarget {
+        self.resolve_var_from(name, frame.0)
+            .and_then(|resolved| resolved.id)
+            .map_or_else(
+                || ArrayTarget::named(frame, name),
+                |id| ArrayTarget::cell(frame, name, id),
+            )
+    }
+
+    fn array_keys_at(&self, target: &ArrayTarget) -> Option<Vec<String>> {
+        target.cell_id().map_or_else(
+            || self.array_keys_from(target.frame().0, target.name()),
+            |id| self.array_keys_at_id(id),
+        )
+    }
+
+    fn array_search_keys_at(&self, target: &ArrayTarget) -> Option<Vec<String>> {
+        target.cell_id().map_or_else(
+            || self.array_keys_from(target.frame().0, target.name()),
+            |id| self.array_search_keys_at_id(id),
+        )
+    }
+
+    fn array_elem_exists_at(&self, target: &ArrayTarget, key: &str) -> bool {
+        target.cell_id().map_or_else(
+            || {
+                self.get_array_elem_from(target.frame().0, target.name(), key)
+                    .is_some()
+            },
+            |id| self.array_elem_exists_at_id(id, key),
+        )
+    }
+
+    fn array_revision_at(&self, target: &ArrayTarget) -> Option<u64> {
+        target
+            .cell_id()
+            .and_then(|id| self.var_arena.array_revision(id))
+    }
+
+    fn unset_elem_at(&mut self, target: &ArrayTarget, key: &str) -> bool {
+        if let Some(id) = target.cell_id() {
+            self.array_unset_elem_reporting_at(id, target.name(), key, None)
         } else {
-            None
+            self.unset_array_elem_from(target.frame().0, target.name(), key)
         }
     }
 }
@@ -9953,7 +10987,8 @@ impl Frames for Vm {
             self.current_level(),
             "upvar installs in the current frame"
         );
-        self.add_link(local, target.0, target_name);
+        let linked = self.add_link(local, target.0, target_name);
+        debug_assert!(linked.is_ok(), "validated frame link must install");
     }
 
     fn in_proc(&self) -> bool {
@@ -9964,6 +10999,30 @@ impl Frames for Vm {
 
     fn var_names(&self, include_links: bool) -> Vec<String> {
         self.frame_var_names(include_links)
+    }
+
+    fn const_names(&self) -> Vec<String> {
+        self.frames.last().map_or_else(Vec::new, |frame| {
+            frame
+                .locals
+                .iter()
+                .filter(|(_, raw)| {
+                    let Some(cell) = self.var_arena.get(**raw) else {
+                        return false;
+                    };
+                    match cell.state() {
+                        Local::Link(target) => {
+                            cell.link_origin() == FrameLinkOrigin::TclOoInstance
+                                && self.const_vars.contains(target)
+                        }
+                        Local::Undefined | Local::Scalar(_) | Local::Array(_) => {
+                            self.const_vars.contains(raw)
+                        }
+                    }
+                })
+                .map(|(name, _)| name.clone())
+                .collect()
+        })
     }
 }
 
@@ -10035,7 +11094,7 @@ impl Namespaces for Vm {
     }
 
     fn namespace_is_live(&self, ns: NsId) -> bool {
-        !self.dead_namespaces.contains(&ns) && !self.namespace_is_dying(&self.ns_name(ns))
+        !self.dead_namespaces.contains(&ns) && !self.dying_namespaces.contains(&ns)
     }
 
     fn parent(&self, ns: NsId) -> Option<NsId> {
@@ -10085,12 +11144,22 @@ impl Namespaces for Vm {
     }
 
     fn vars_in(&self, ns: NsId) -> Vec<String> {
-        self.vars_directly_in(&self.ns_name(ns))
+        self.var_table(VarTableOwner::Namespace(ns))
+            .map_or_else(Vec::new, |table| table.keys().cloned().collect())
     }
 
-    // `Tcl_FindNamespaceVar`'s single probe. The VM keeps namespace variables
-    // in the global frame keyed by their canonical (unrooted) FQN, so the
-    // namespace's own table is the set of `canonical::simple` cells.
+    fn consts_in(&self, ns: NsId) -> Vec<String> {
+        self.var_table(VarTableOwner::Namespace(ns))
+            .map_or_else(Vec::new, |table| {
+                table
+                    .iter()
+                    .filter(|(_, raw)| self.const_vars.contains(raw))
+                    .map(|(name, _)| name.clone())
+                    .collect()
+            })
+    }
+
+    // `Tcl_FindNamespaceVar`'s single probe over the namespace token's table.
     //
     // A `Link` counts. C's exclusion is of `CompiledLocal`s — a *proc*-local
     // `upvar`/`global` alias, which lives in the proc's compiled frame and is
@@ -10099,22 +11168,12 @@ impl Namespaces for Vm {
     // puts a real `VAR_LINK` cell in the namespace's own table, which
     // `Tcl_FindNamespaceVar` and `info vars` both see (tclsh 9.0.4:
     // `namespace which -variable y` → `::n::y`). Proc-locals cannot leak in
-    // here regardless, because this only ever probes `frames.first()` — the
-    // global frame — and a proc's locals live in its own frame.
+    // here regardless, because procedure locals live in frame tables.
     //
     fn namespace_var_exists(&self, ns: NsId, simple: &str) -> bool {
-        let canonical = self.ns_name(ns);
-        let key = if canonical.is_empty() {
-            simple.to_owned()
-        } else {
-            format!("{canonical}::{simple}")
-        };
-        self.frames.first().is_some_and(|frame| {
-            matches!(
-                frame.locals.get(&key),
-                Some(Local::Undefined | Local::Scalar(_) | Local::Array(_) | Local::Link { .. })
-            )
-        })
+        self.var_table(VarTableOwner::Namespace(ns))
+            .and_then(|table| table.get(simple))
+            .is_some_and(|id| self.var_arena.get(*id).is_some())
     }
 
     fn command_origin(&self, cmd: CommandId) -> Option<CommandId> {
@@ -10834,6 +11893,113 @@ mod family_b_tests {
             assert!(vm.exists_elem(GLOBAL_FRAME, base, "a"));
             assert!(vm.unset_elem(GLOBAL_FRAME, base, "a"));
         }
+    }
+
+    #[test]
+    fn raw_scalar_replacement_retires_array_element_trace_cells() {
+        let mut vm = Vm::new();
+        let baseline = vm.var_arena.len();
+        assert!(vm.set_array_elem("a", "k", Value::string("old")).is_ok());
+        vm.add_var_trace(
+            "a(k)",
+            vec!["unset".to_owned()],
+            "callback".to_owned(),
+            false,
+        );
+        assert_eq!(vm.var_arena.len(), baseline + 2);
+
+        vm.write_scalar_raw("a", Value::string("scalar"));
+
+        assert_eq!(vm.get_var("a").unwrap().to_str().as_ref(), "scalar");
+        assert!(vm.var_traces.is_empty());
+        assert_eq!(vm.var_arena.len(), baseline + 1);
+    }
+
+    #[test]
+    fn noncurrent_varstore_unset_retires_array_element_trace_cells() {
+        let mut vm = Vm::new();
+        let baseline = vm.var_arena.len();
+        assert!(vm.set_array_elem("a", "k", Value::string("old")).is_ok());
+        vm.add_var_trace(
+            "a(k)",
+            vec!["unset".to_owned()],
+            "callback".to_owned(),
+            false,
+        );
+        vm.push_call_frame(Some("p".to_owned()), vec![Value::string("p")]);
+        assert!(vm.unset(GLOBAL_FRAME, "a"));
+
+        assert!(vm.var_traces.is_empty());
+        assert_eq!(vm.var_arena.len(), baseline);
+        vm.pop_call_frame();
+    }
+
+    #[test]
+    fn noncurrent_varstore_unset_elem_retires_the_reached_trace_cell() {
+        let mut vm = Vm::new();
+        let baseline = vm.var_arena.len();
+        vm.set_elem(GLOBAL_FRAME, "a", "k", Value::string("old"));
+        vm.add_var_trace(
+            "a(k)",
+            vec!["unset".to_owned()],
+            "callback".to_owned(),
+            false,
+        );
+        vm.push_call_frame(Some("p".to_owned()), vec![Value::string("p")]);
+
+        assert!(vm.unset_elem(GLOBAL_FRAME, "a", "k"));
+        assert!(vm.var_traces.is_empty());
+        assert_eq!(vm.var_arena.len(), baseline + 1, "the empty array remains");
+        assert_eq!(vm.array_keys(GLOBAL_FRAME, "a"), Some(Vec::new()));
+        vm.pop_call_frame();
+    }
+
+    #[test]
+    fn varstore_array_keys_honours_the_requested_frame() {
+        let mut vm = Vm::new();
+        vm.set_elem(GLOBAL_FRAME, "same", "global-a", Value::string("A"));
+        vm.set_elem(GLOBAL_FRAME, "same", "global-b", Value::string("B"));
+        vm.push_call_frame(Some("p".to_owned()), vec![Value::string("p")]);
+        let local = FrameId(vm.current_level());
+        vm.set_elem(local, "same", "local", Value::string("L"));
+
+        assert!(vm.exists(GLOBAL_FRAME, "same"));
+        assert!(vm.exists(local, "same"));
+        assert_eq!(
+            vm.array_keys(GLOBAL_FRAME, "same"),
+            Some(vec!["global-a".to_owned(), "global-b".to_owned()])
+        );
+        assert_eq!(vm.array_keys(local, "same"), Some(vec!["local".to_owned()]));
+        vm.pop_call_frame();
+    }
+
+    #[test]
+    fn namespace_var_enumeration_uses_the_exact_retained_token() {
+        let mut vm = Vm::new();
+        vm.set_compiler(Box::new(BytecodeCompileService::default()));
+        assert_eq!(
+            eval_value(
+                &mut vm,
+                "namespace eval N {\
+                     variable old OLD;\
+                     proc p {} {\
+                         namespace delete ::N;\
+                         namespace eval ::N {variable fresh NEW};\
+                         yield paused\
+                     }\
+                 }",
+            ),
+            ""
+        );
+        let old = Namespaces::find_namespace(&vm, ROOT_NS, "::N").unwrap();
+        assert_eq!(eval_value(&mut vm, "coroutine c ::N::p"), "paused");
+        let fresh = Namespaces::find_namespace(&vm, ROOT_NS, "::N").unwrap();
+
+        assert_ne!(old, fresh);
+        assert_eq!(Namespaces::vars_in(&vm, old), vec!["old".to_owned()]);
+        assert_eq!(Namespaces::vars_in(&vm, fresh), vec!["fresh".to_owned()]);
+
+        assert_eq!(eval_value(&mut vm, "c"), "");
     }
 
     #[test]

--- a/rust/tcl-vm/src/lib.rs
+++ b/rust/tcl-vm/src/lib.rs
@@ -76,6 +76,7 @@ mod expr;
 mod frame;
 mod interp;
 mod subst;
+mod vars;
 
 pub use cmd_thread::{CompileFactory, ThreadedOutput};
 pub use command::NativeCommand;

--- a/rust/tcl-vm/src/subst.rs
+++ b/rust/tcl-vm/src/subst.rs
@@ -89,11 +89,13 @@ fn command_end(
 }
 
 fn read_var(vm: &mut Vm, name: &str) -> Result<Value, TclError> {
-    if let Err(c) = vm.fire_var_traces(name, "read") {
-        return Err(TclError::new(c.result.to_str().to_string()));
+    match vm.read_var_traced(name) {
+        Err(c) => Err(TclError::new(c.result.to_str().to_string())),
+        Ok(Some(value)) => Ok(value),
+        Ok(None) => Err(TclError::new(format!(
+            "can't read \"{name}\": no such variable"
+        ))),
     }
-    vm.get_var(name)
-        .ok_or_else(|| TclError::new(format!("can't read \"{name}\": no such variable")))
 }
 
 /// Compile + run a command-substitution body, surfacing a non-`OK` completion
@@ -408,11 +410,13 @@ fn subst_index(vm: &mut Vm, idx: &str) -> Result<IndexFlow, TclError> {
 /// Read an array element `base(key)` (firing read traces) with the standard
 /// "no such variable" error. `var_get` resolves the `base(key)` form.
 fn read_elem(vm: &mut Vm, full: &str) -> Result<Value, TclError> {
-    if let Err(c) = vm.fire_var_traces(full, "read") {
-        return Err(TclError::new(c.result.to_str().to_string()));
+    match vm.read_var_traced(full) {
+        Err(c) => Err(TclError::new(c.result.to_str().to_string())),
+        Ok(Some(value)) => Ok(value),
+        Ok(None) => Err(TclError::new(format!(
+            "can't read \"{full}\": no such variable"
+        ))),
     }
-    vm.var_get(full)
-        .ok_or_else(|| TclError::new(format!("can't read \"{full}\": no such variable")))
 }
 
 /// A parsed `$`-reference split into its base name and optional raw array index.

--- a/rust/tcl-vm/src/vars.rs
+++ b/rust/tcl-vm/src/vars.rs
@@ -1,0 +1,495 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Stable variable-cell storage shared by frames and namespace tokens.
+
+use std::collections::{BTreeMap, HashMap, HashSet};
+
+use tcl_core_types::VarId;
+use tcl_runtime_api::FrameLinkOrigin;
+
+use crate::value::Value;
+
+/// A name table owns bindings, while the arena owns the cells they identify.
+/// Removing a binding never makes its `VarId` identify a later variable.
+pub(crate) type VarTable = BTreeMap<String, VarId>;
+
+/// The mutable state carried by one Tcl `Var` cell.
+pub(crate) enum VarState {
+    /// Materialised but unset (for `variable` and `trace add variable`).
+    Undefined,
+    /// A scalar value.
+    Scalar(Value),
+    /// An array whose element names bind stable cells of their own.
+    Array(VarTable),
+    /// An `upvar`/`global`/`variable` alias to its target cell.
+    Link(VarId),
+}
+
+/// One stable variable cell. Cells are never reused for a later binding.
+pub(crate) struct VarCell {
+    state: VarState,
+    /// The containing array cell and element key, for Tcl's alias reporting.
+    /// This remains on a detached element so an `upvar` alias cannot silently
+    /// retarget a later same-name element.
+    parent: Option<(VarId, String)>,
+    bindings: u64,
+    link_refs: u64,
+    pins: u64,
+    operation_refs: u64,
+    array_revision: u64,
+    link_origin: FrameLinkOrigin,
+}
+
+impl VarCell {
+    pub(crate) const fn state(&self) -> &VarState {
+        &self.state
+    }
+
+    pub(crate) const fn link_origin(&self) -> FrameLinkOrigin {
+        self.link_origin
+    }
+}
+
+/// Monotonic arena for every variable cell in one interpreter.
+#[derive(Default)]
+pub(crate) struct VarArena {
+    next: u64,
+    cells: HashMap<VarId, VarCell>,
+}
+
+impl VarArena {
+    #[cfg(test)]
+    pub(crate) fn len(&self) -> usize {
+        self.cells.len()
+    }
+
+    pub(crate) fn alloc(&mut self, state: VarState) -> Option<VarId> {
+        self.alloc_with_parent(state, None, FrameLinkOrigin::Ordinary)
+    }
+
+    pub(crate) fn alloc_link(&mut self, target: VarId, origin: FrameLinkOrigin) -> Option<VarId> {
+        self.alloc_with_parent(VarState::Link(target), None, origin)
+    }
+
+    pub(crate) fn alloc_element(
+        &mut self,
+        state: VarState,
+        parent: VarId,
+        key: String,
+    ) -> Option<VarId> {
+        self.alloc_with_parent(state, Some((parent, key)), FrameLinkOrigin::Ordinary)
+    }
+
+    fn alloc_with_parent(
+        &mut self,
+        state: VarState,
+        parent: Option<(VarId, String)>,
+        link_origin: FrameLinkOrigin,
+    ) -> Option<VarId> {
+        if let VarState::Link(target) = &state
+            && self.resolve(*target).is_none()
+        {
+            return None;
+        }
+        let raw = u32::try_from(self.next).ok()?;
+        self.next = self.next.checked_add(1)?;
+        let id = VarId(raw);
+        let link = match &state {
+            VarState::Link(target) => Some(*target),
+            _ => None,
+        };
+        self.cells.insert(
+            id,
+            VarCell {
+                state,
+                parent,
+                bindings: 0,
+                link_refs: 0,
+                pins: 0,
+                operation_refs: 0,
+                array_revision: 0,
+                link_origin,
+            },
+        );
+        if let Some(target) = link
+            && let Some(cell) = self.cells.get_mut(&target)
+        {
+            cell.link_refs = cell
+                .link_refs
+                .checked_add(1)
+                .expect("variable link reference count overflow");
+        }
+        Some(id)
+    }
+
+    pub(crate) fn get(&self, id: VarId) -> Option<&VarCell> {
+        self.cells.get(&id)
+    }
+
+    pub(crate) fn array_insert(&mut self, id: VarId, key: String, element: VarId) -> bool {
+        let Some(cell) = self.cells.get_mut(&id) else {
+            return false;
+        };
+        let VarState::Array(elements) = &mut cell.state else {
+            return false;
+        };
+        if elements.contains_key(&key) {
+            return false;
+        }
+        elements.insert(key, element);
+        cell.array_revision = cell.array_revision.wrapping_add(1);
+        true
+    }
+
+    pub(crate) fn array_remove(&mut self, id: VarId, key: &str) -> Option<VarId> {
+        let cell = self.cells.get_mut(&id)?;
+        let VarState::Array(elements) = &mut cell.state else {
+            return None;
+        };
+        let removed = elements.remove(key)?;
+        cell.array_revision = cell.array_revision.wrapping_add(1);
+        Some(removed)
+    }
+
+    /// Discard an element only while its table slot still names `expected`.
+    /// Garbage-collecting an undefined trace shell is not a Tcl-level array
+    /// mutation and therefore does not invalidate an active search.
+    pub(crate) fn array_discard_if(
+        &mut self,
+        id: VarId,
+        key: &str,
+        expected: VarId,
+    ) -> Option<VarId> {
+        let cell = self.cells.get_mut(&id)?;
+        let VarState::Array(elements) = &mut cell.state else {
+            return None;
+        };
+        if elements.get(key) != Some(&expected) {
+            return None;
+        }
+        elements.remove(key)
+    }
+
+    pub(crate) fn array_revision(&self, id: VarId) -> Option<u64> {
+        let cell = self.cells.get(&id)?;
+        matches!(cell.state, VarState::Array(_)).then_some(cell.array_revision)
+    }
+
+    pub(crate) fn has_link_refs(&self, id: VarId) -> bool {
+        self.cells.get(&id).is_some_and(|cell| cell.link_refs != 0)
+    }
+
+    pub(crate) fn element_parent(&self, id: VarId) -> Option<(VarId, &str)> {
+        self.cells
+            .get(&id)?
+            .parent
+            .as_ref()
+            .map(|(parent, key)| (*parent, key.as_str()))
+    }
+
+    pub(crate) fn element_is_attached(&self, id: VarId) -> bool {
+        let Some((parent, key)) = self.element_parent(id) else {
+            return true;
+        };
+        let Some(VarState::Array(elements)) = self.get(parent).map(VarCell::state) else {
+            return false;
+        };
+        elements
+            .get(key)
+            .copied()
+            .and_then(|element| self.resolve(element))
+            == Some(id)
+    }
+
+    pub(crate) fn replace_state(&mut self, id: VarId, state: VarState) -> bool {
+        let new_link = match &state {
+            VarState::Link(target) => Some(*target),
+            _ => None,
+        };
+        if let Some(target) = new_link
+            && self.resolve(target).is_none_or(|resolved| resolved == id)
+        {
+            return false;
+        }
+        let Some(cell) = self.cells.get_mut(&id) else {
+            return false;
+        };
+        let old_was_array = matches!(cell.state, VarState::Array(_));
+        let new_is_array = matches!(state, VarState::Array(_));
+        let old = std::mem::replace(&mut cell.state, state);
+        cell.link_origin = FrameLinkOrigin::Ordinary;
+        if old_was_array || new_is_array {
+            cell.array_revision = cell.array_revision.wrapping_add(1);
+        }
+        if let Some(target) = new_link
+            && let Some(target_cell) = self.cells.get_mut(&target)
+        {
+            target_cell.link_refs = target_cell
+                .link_refs
+                .checked_add(1)
+                .expect("variable link reference count overflow");
+        }
+        match old {
+            VarState::Link(target) => {
+                if let Some(target_cell) = self.cells.get_mut(&target) {
+                    target_cell.link_refs = target_cell
+                        .link_refs
+                        .checked_sub(1)
+                        .expect("variable link reference count underflow");
+                }
+                self.collect(target);
+            }
+            VarState::Array(elements) => {
+                for element in elements.into_values() {
+                    self.unbind(element);
+                }
+            }
+            VarState::Undefined | VarState::Scalar(_) => {}
+        }
+        true
+    }
+
+    /// Apply Tcl's unset transition and invalidate an active parent-array
+    /// search whenever this is an attached element. Even an already undefined
+    /// trace/link shell cancels the search; a generic state replacement does
+    /// not carry that operation-level meaning.
+    pub(crate) fn unset_state(&mut self, id: VarId) -> Option<VarState> {
+        let attached_parent = self
+            .element_is_attached(id)
+            .then(|| self.element_parent(id).map(|(parent, _)| parent))
+            .flatten();
+        let old = self.take_state(id)?;
+        if let Some(parent) = attached_parent
+            && let Some(parent_cell) = self.cells.get_mut(&parent)
+        {
+            parent_cell.array_revision = parent_cell.array_revision.wrapping_add(1);
+        }
+        Some(old)
+    }
+
+    /// Detach a cell's current state without releasing bindings owned by an
+    /// array table inside it. Destructive lifecycle code walks those element
+    /// bindings one at a time because callbacks can observe and mutate the
+    /// remaining old cells.
+    pub(crate) fn take_state(&mut self, id: VarId) -> Option<VarState> {
+        let cell = self.cells.get_mut(&id)?;
+        let old = std::mem::replace(&mut cell.state, VarState::Undefined);
+        if matches!(old, VarState::Array(_)) {
+            cell.array_revision = cell.array_revision.wrapping_add(1);
+        }
+        Some(old)
+    }
+
+    /// Follow link cells to the storage cell Tcl operations observe.
+    pub(crate) fn resolve(&self, mut id: VarId) -> Option<VarId> {
+        let mut visited = HashSet::new();
+        while visited.insert(id) {
+            match self.get(id).map(|cell| &cell.state) {
+                Some(VarState::Link(target)) => id = *target,
+                Some(_) => return Some(id),
+                None => return None,
+            }
+        }
+        None
+    }
+
+    pub(crate) fn bind(&mut self, id: VarId) {
+        let cell = self
+            .cells
+            .get_mut(&id)
+            .expect("binding must refer to a live variable cell");
+        cell.bindings = cell
+            .bindings
+            .checked_add(1)
+            .expect("variable binding count overflow");
+    }
+
+    pub(crate) fn unbind(&mut self, id: VarId) {
+        let cell = self
+            .cells
+            .get_mut(&id)
+            .expect("binding must refer to a live variable cell");
+        cell.bindings = cell
+            .bindings
+            .checked_sub(1)
+            .expect("variable binding count underflow");
+        self.collect(id);
+    }
+
+    /// Discard a cell that was allocated but never inserted into a name table.
+    /// This is deliberately distinct from [`Self::unbind`]: no binding count
+    /// exists to decrement on the failed-installation path.
+    pub(crate) fn discard_unbound(&mut self, id: VarId) {
+        let cell = self
+            .cells
+            .get(&id)
+            .expect("discard must refer to a live variable cell");
+        assert_eq!(cell.bindings, 0, "bound variable cell cannot be discarded");
+        self.collect(id);
+    }
+
+    pub(crate) fn pin(&mut self, id: VarId) {
+        let cell = self
+            .cells
+            .get_mut(&id)
+            .expect("pin must refer to a live variable cell");
+        cell.pins = cell
+            .pins
+            .checked_add(1)
+            .expect("variable pin count overflow");
+    }
+
+    pub(crate) fn unpin(&mut self, id: VarId) {
+        let cell = self
+            .cells
+            .get_mut(&id)
+            .expect("pin must refer to a live variable cell");
+        cell.pins = cell
+            .pins
+            .checked_sub(1)
+            .expect("variable pin count underflow");
+        self.collect(id);
+    }
+
+    pub(crate) fn retain_operation(&mut self, id: VarId) {
+        let cell = self
+            .cells
+            .get_mut(&id)
+            .expect("operation reference must refer to a live variable cell");
+        cell.operation_refs = cell
+            .operation_refs
+            .checked_add(1)
+            .expect("variable operation reference count overflow");
+    }
+
+    pub(crate) fn release_operation(&mut self, id: VarId) {
+        let cell = self
+            .cells
+            .get_mut(&id)
+            .expect("operation reference must refer to a live variable cell");
+        cell.operation_refs = cell
+            .operation_refs
+            .checked_sub(1)
+            .expect("variable operation reference count underflow");
+        self.collect(id);
+    }
+
+    pub(crate) fn has_operation_refs(&self, id: VarId) -> bool {
+        self.cells
+            .get(&id)
+            .is_some_and(|cell| cell.operation_refs != 0)
+    }
+
+    pub(crate) fn is_final_operation_ref(&self, id: VarId) -> bool {
+        self.cells
+            .get(&id)
+            .is_some_and(|cell| cell.operation_refs == 1)
+    }
+
+    fn collect(&mut self, id: VarId) {
+        let collectable = self.cells.get(&id).is_some_and(|cell| {
+            cell.bindings == 0 && cell.link_refs == 0 && cell.pins == 0 && cell.operation_refs == 0
+        });
+        if !collectable {
+            return;
+        }
+        let Some(cell) = self.cells.remove(&id) else {
+            return;
+        };
+        match cell.state {
+            VarState::Link(target) => {
+                if let Some(target_cell) = self.cells.get_mut(&target) {
+                    target_cell.link_refs = target_cell
+                        .link_refs
+                        .checked_sub(1)
+                        .expect("variable link reference count underflow");
+                }
+                self.collect(target);
+            }
+            VarState::Array(elements) => {
+                for element in elements.into_values() {
+                    self.unbind(element);
+                }
+            }
+            VarState::Undefined | VarState::Scalar(_) => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{VarArena, VarState, VarTable};
+    use crate::value::Value;
+
+    #[test]
+    fn replacing_an_array_releases_its_element_bindings() {
+        let mut arena = VarArena::default();
+        let child = arena
+            .alloc(VarState::Scalar(Value::string("child")))
+            .expect("child cell");
+        arena.bind(child);
+        let mut elements = VarTable::new();
+        elements.insert("key".to_owned(), child);
+        let parent = arena.alloc(VarState::Array(elements)).expect("parent cell");
+        arena.bind(parent);
+
+        assert!(arena.replace_state(parent, VarState::Scalar(Value::string("scalar"))));
+        assert!(arena.get(child).is_none());
+    }
+
+    #[test]
+    fn a_link_keeps_its_unbound_target_alive_then_releases_it() {
+        let mut arena = VarArena::default();
+        let target = arena.alloc(VarState::Undefined).expect("target cell");
+        arena.bind(target);
+        let link = arena.alloc(VarState::Link(target)).expect("link cell");
+        arena.bind(link);
+
+        arena.unbind(target);
+        assert_eq!(arena.resolve(link), Some(target));
+        arena.unbind(link);
+        assert!(arena.get(link).is_none());
+        assert!(arena.get(target).is_none());
+    }
+
+    #[test]
+    fn link_cycles_and_missing_targets_are_rejected() {
+        let mut arena = VarArena::default();
+        let first = arena.alloc(VarState::Undefined).expect("first cell");
+        arena.bind(first);
+        let second = arena.alloc(VarState::Link(first)).expect("second cell");
+        arena.bind(second);
+
+        assert!(!arena.replace_state(first, VarState::Link(second)));
+        assert!(
+            arena
+                .alloc(VarState::Link(tcl_core_types::VarId(u32::MAX)))
+                .is_none()
+        );
+        assert_eq!(arena.resolve(second), Some(first));
+    }
+
+    #[test]
+    fn an_uninstalled_allocation_has_a_distinct_discard_path() {
+        let mut arena = VarArena::default();
+        let id = arena.alloc(VarState::Undefined).expect("cell");
+        arena.discard_unbound(id);
+        assert!(arena.get(id).is_none());
+    }
+}

--- a/rust/tcl-vm/tests/cmd_info_prefix_e2e.rs
+++ b/rust/tcl-vm/tests/cmd_info_prefix_e2e.rs
@@ -1116,10 +1116,114 @@ fn info_constant_and_consts() {
     );
     // tclsh9.0: info consts c* -> the constant name.
     assert_eq!(run("const c 5; info consts c*").1, "c");
+    // Namespace-qualified and current-namespace listings resolve through the
+    // same stable namespace-variable tables as `info vars`.
+    assert_eq!(
+        run(concat!(
+            "namespace eval N {const c 5}; ",
+            "list [info constant ::N::c] [info consts N::*] ",
+            "[namespace eval N {info consts}]",
+        ))
+        .1,
+        "1 ::N::c c"
+    );
     // wrong # args on `info constant`.
     let (ok, msg, _) = run("info constant");
     assert!(!ok);
     assert_eq!(msg, r#"wrong # args: should be "info constant varname""#);
+    let (ok, msg, _) = run("info consts * extra");
+    assert!(!ok);
+    assert_eq!(msg, r#"wrong # args: should be "info consts ?pattern?""#);
+}
+
+#[test]
+fn info_consts_enumerates_bindings_and_namespace_global_fallback() {
+    // Exact Tcl 9.0.4 results. `info constant` follows links, but `info consts`
+    // enumerates only cells directly marked const. At namespace scope a scan
+    // includes only unshadowed global constants, while a trivial exact pattern
+    // retains Tcl's direct-lookup fallback past a non-constant local binding.
+    assert_eq!(
+        run(concat!(
+            "const G 1; namespace eval N {const C 2; set ordinary 0}; ",
+            "list [lsort [info consts]] [info consts G] ",
+            "[info consts N::*] [info consts ::N::*]",
+        ))
+        .1,
+        "G G ::N::C ::N::C"
+    );
+    assert_eq!(
+        run(concat!(
+            "const G 1; namespace eval N {const C 2; set ordinary 0; ",
+            "list [lsort [info consts]] [lsort [info consts *]] ",
+            "[info consts G] [info consts C] [info consts ::*]}"
+        ))
+        .1,
+        "{C G} {C G} G C ::G"
+    );
+    assert_eq!(
+        run(concat!(
+            "const G 1; namespace eval N {const C 2}; ",
+            "proc p {} {const L 3; set ordinary 0; global G; ",
+            "upvar #0 ::N::C U; list [lsort [info vars]] ",
+            "[lsort [info consts]] [info constant L] [info constant G] ",
+            "[info constant U] [info consts ::*] [info consts N::*]}; p"
+        ))
+        .1,
+        "{G L U ordinary} L 1 1 1 ::G ::N::C"
+    );
+    assert_eq!(
+        run(concat!(
+            "const G 1; namespace eval M {const C 4; namespace upvar :: G A; ",
+            "list [lsort [info vars]] [lsort [info consts]] ",
+            "[info constant A] [info consts A] [info consts G]}"
+        ))
+        .1,
+        "{A C} {C G} 1 {} G"
+    );
+    assert_eq!(
+        run(concat!(
+            "const G 1; namespace eval S {const C 5; set G shadow; ",
+            "list [lsort [info consts]] [info consts G] [info consts G*] ",
+            "[info constant G] [info constant ::G]}"
+        ))
+        .1,
+        "C G {} 0 1"
+    );
+    assert_eq!(
+        run("const ::x 1; list [info consts :::x] [info consts ::::x] [info consts ::::::*]").1,
+        "::x ::x ::x"
+    );
+}
+
+#[test]
+fn info_consts_includes_only_tcloo_instance_links() {
+    // Tcl 9.0.4's method-frame enumeration includes automatic instance
+    // projections, but excludes ordinary aliases. A formal shadows
+    // the automatic projection, and an ordinary upvar retarget removes its
+    // TclOO origin for that activation. The object's direct storage binding
+    // must itself be constant, and object-declared variables are not projected
+    // into a method provided by its class.
+    assert_eq!(
+        run(concat!(
+            "const G 9; oo::class create C {variable X; constructor {} {const X 1}; ",
+            "method inspect {} {global G; upvar #0 ::G U; ",
+            "list [info consts] [info constant G] [info constant U]}; ",
+            "method retarget {} {upvar #0 ::G X; list [info consts] [info constant X]}; ",
+            "method shadow {X} {list $X [info consts]}}; set o [C new]; ",
+            "oo::object create O; oo::objdefine O {variable P; ",
+            "method init {} {const P 2}; method inspect {} {info consts}}; O init; ",
+            "oo::class create CA {variable X; method inspect {} ",
+            "{list [info consts] [info constant X] $X}}; set oa [CA new]; ",
+            "namespace eval [info object namespace $oa] {namespace upvar :: G X}; ",
+            "oo::class create CP {method inspect {} {info consts}}; CP create op; ",
+            "oo::objdefine op {variable Q; method init {} {const Q 3}}; op init; ",
+            "list [$o inspect] [$o retarget] [$o shadow formal] [O inspect] ",
+            "[$oa inspect] [op inspect] ",
+            "[info constant [info object namespace op]::Q]"
+        ))
+        .1,
+        "{X 1 1} {{} 1} {formal {}} P {{} 1 9} {} 1"
+    );
 }
 
 /// `info cmdtype commandName` — Tcl 9.0 (8.6 lacks it). `proc` for a user proc,

--- a/rust/tcl-vm/tests/cmd_oo_e2e.rs
+++ b/rust/tcl-vm/tests/cmd_oo_e2e.rs
@@ -783,6 +783,23 @@ fn my_variable_links_instance_state() {
     );
 }
 
+#[test]
+fn automatic_instance_variable_link_yields_to_a_formal_local() {
+    // Exact Tcl 9.0.4 transcript. Declaring x as an instance variable does not
+    // replace the method's already-bound formal x.
+    assert_eq!(
+        result("oo::class create C {variable x; method m {x} {return $x}}; [C new] m ARG"),
+        "ARG"
+    );
+
+    // Explicit linking is different: it still reaches the shared upvar
+    // collision check and refuses to replace the formal.
+    let (ok, message, _) =
+        run("oo::class create D {variable x; method m {x} {my variable x}}; [D new] m ARG");
+    assert!(!ok);
+    assert_eq!(message, "variable \"x\" already exists");
+}
+
 // Export / unexport, unknown-method errors
 
 #[test]

--- a/rust/tcl-vm/tests/language_e2e.rs
+++ b/rust/tcl-vm/tests/language_e2e.rs
@@ -542,6 +542,15 @@ fn global_element_guard_applies_only_inside_a_proc() {
     assert_eq!(r, format!("bad variable name \"(v)\": {SCALAR}"));
 }
 
+#[test]
+fn global_at_top_level_does_not_rebind_an_existing_cell() {
+    // Exact Tcl 9.0.4 transcript. The global-frame fast return precedes all
+    // link creation, including the collision checks for an existing scalar.
+    let (ok, result, _) = run("set x 1; global x; set x");
+    assert!(ok, "top-level global must be a no-op: {result}");
+    assert_eq!(result, "1");
+}
+
 /// A qualified name's **parent namespace is resolved before** the element-name
 /// guard, so a missing namespace is reported as such rather than as an element
 /// error (closes a slice of #1588; the `upvar` surface of that issue remains).

--- a/rust/tcl-vm/tests/namespace_surface_e2e.rs
+++ b/rust/tcl-vm/tests/namespace_surface_e2e.rs
@@ -2556,10 +2556,8 @@ fn a_retained_token_keeps_its_children() {
 fn a_retained_token_keeps_its_variables() {
     // The token's variables ride with it; every name-addressed probe fails
     // because the name is gone. Exact Tcl 9.0.4 oracle result (identical on
-    // 8.6.16). (`catch {set ::N::v}` is not pinned here: the VM keeps namespace
-    // variables in one flat global table, so the retained token's cells are
-    // still addressable by their canonical name — see the milestone note in
-    // `interp.rs`.)
+    // 8.6.16). The relative link still addresses the retained token's exact
+    // variable cell even though neither absolute glob can reach it.
     assert_eq!(
         run(r"namespace eval N {
                  variable v V
@@ -2571,6 +2569,106 @@ fn a_retained_token_keeps_its_variables() {
              }
              ::N::p"),
         r"V {} {}"
+    );
+}
+
+#[test]
+fn retained_and_recreated_namespace_variables_have_distinct_cells() {
+    // Exact Tcl 9.0.4 oracle from #1753. This pins the variable-table half of
+    // stable namespace identity; command-token retirement has separate
+    // coverage and remains tracked independently.
+    assert_eq!(
+        run(r"set answer [namespace eval N {
+                 variable v OLD
+                 proc q {} {return OLDQ}
+                 proc p {} {
+                     namespace delete ::N
+                     namespace eval ::N {variable v NEW; proc q {} {return NEWQ}}
+                     variable v
+                     list [q] [::N::q] $v [set v OLD2] [set ::N::v] \
+                          [info commands q] [info commands ::N::q] \
+                          [namespace current] [namespace exists {}] [namespace exists ::N]
+                 }
+                 p
+             }]
+             list $answer [set ::N::v] [::N::q]"),
+        "{OLDQ NEWQ OLD OLD2 NEW q ::N::q ::N 0 1} NEW NEWQ"
+    );
+}
+
+#[test]
+fn retained_and_recreated_namespace_variable_traces_are_isolated() {
+    // Exact Tcl 9.0.4 oracle. Final teardown of the old token fires only its
+    // old trace; its callback sees the same-spelled recreation as live, and
+    // that new token keeps both its value and trace.
+    assert_eq!(
+        run(r"proc rec {tag n1 n2 op} {
+                 lappend ::events [list $tag [namespace exists ::N] $n1 $n2 $op]
+             }
+             set events {}
+             namespace eval N {
+                 variable v old
+                 trace add variable v unset {::rec old}
+                 proc p {} {
+                     namespace delete ::N
+                     namespace eval ::N {
+                         variable v new
+                         trace add variable v unset {::rec new}
+                     }
+                     variable v
+                     list [namespace exists {}] $v [set ::N::v]
+                 }
+             }
+             set inside [::N::p]
+             set after [list [namespace exists ::N] [set ::N::v] $events \
+                             [trace info variable ::N::v]]
+             namespace delete ::N
+             list $inside $after $events"),
+        "{0 old new} {1 new {{old 1 ::N::v {} unset}} {{unset {::rec new}}}} {{old 1 ::N::v {} unset} {new 0 ::N::v {} unset}}"
+    );
+}
+
+#[test]
+fn namespace_teardown_fires_trace_only_undefined_cells() {
+    // Tcl 9.0.4 trace-18.3: registration itself materialises an undefined
+    // namespace cell, which still participates in namespace destruction.
+    assert_eq!(
+        run(r"set events {}
+             proc rec {n1 n2 op} {lappend ::events [list $n1 $n2 $op]}
+             namespace eval N {}
+             trace add variable ::N::var unset rec
+             namespace delete ::N
+             set events"),
+        "{::N::var {} unset}"
+    );
+}
+
+#[test]
+fn namespace_teardown_removes_one_cell_then_purges_its_recreation() {
+    // Exact Tcl 9.0.4 oracle. Each callback sees its own cell absent and the
+    // namespace already unpublished. The remaining-count multiset proves the
+    // cells are removed one at a time without pinning the hash-table order.
+    // Recreating either removed name and attaching a new trace does not give it
+    // a second callback during the dying token's fixed-point purge.
+    assert_eq!(
+        run(r"set events {}
+             set remaining {}
+             proc R {n1 n2 op} {
+                 lappend ::events [list $n1 [info exists $n1] [namespace exists ::N]]
+                 lappend ::remaining [expr {[info exists ::N::a] + [info exists ::N::b]}]
+                 set $n1 revived
+                 trace add variable $n1 unset {lappend ::events NEW;#}
+             }
+             namespace eval N {
+                 variable a A
+                 variable b B
+                 trace add variable a unset R
+                 trace add variable b unset R
+             }
+             namespace delete ::N
+             list [lsort $events] [lsort -integer $remaining] \
+                  [namespace exists ::N] [info exists ::N::a] [info exists ::N::b]"),
+        "{{::N::a 0 0} {::N::b 0 0}} {0 1} 0 0 0"
     );
 }
 

--- a/rust/tcl-vm/tests/opcode_c_parity.rs
+++ b/rust/tcl-vm/tests/opcode_c_parity.rs
@@ -107,6 +107,7 @@ fn run(vm: &mut Vm, asm: Asm) -> Completion<Value> {
 /// Run a hand-built function on a fresh `Vm`, returning `(vm, completion)`.
 fn run_fresh(asm: Asm) -> (Vm, Completion<Value>) {
     let mut vm = Vm::new();
+    vm.set_compiler(Box::new(compiler::svc()));
     let c = run(&mut vm, asm);
     (vm, c)
 }
@@ -519,13 +520,35 @@ fn variable_links_local_to_namespace_var() {
     let slot = a.slot("v");
     a.push("ns::v").op(Op::VARIABLE, &[slot]);
     a.push("42").op(Op::STORE_SCALAR1, &[slot]);
-    let (vm, c) = run_fresh(a);
+    let mut vm = Vm::new();
+    vm.set_compiler(Box::new(compiler::svc()));
+    assert_eq!(ok_str(&eval(&mut vm, "namespace eval ns {}")), "");
+    let c = run(&mut vm, a);
     assert_eq!(ok_str(&c), "42");
     assert_eq!(
         vm.get_var("ns::v").map(|v| v.to_str().to_string()),
         Some("42".into()),
         "the write must reach the namespace variable"
     );
+}
+
+/// `variable` resolves only through a namespace token that already exists.
+/// The opcode must not manufacture the missing parent as a side effect of
+/// creating its local link.
+#[test]
+fn variable_rejects_a_missing_parent_namespace() {
+    let mut a = Asm::new();
+    let slot = a.slot("v");
+    a.push("::missing::v").op(Op::VARIABLE, &[slot]);
+    let mut vm = Vm::new();
+    vm.set_compiler(Box::new(compiler::svc()));
+    let c = run(&mut vm, a);
+    assert_eq!(
+        err_str(&c),
+        "can't access \"::missing::v\": parent namespace doesn't exist"
+    );
+    assert_eq!(err_code(&c), "TCL LOOKUP VARNAME ::missing::v");
+    assert_eq!(ok_str(&eval(&mut vm, "namespace exists ::missing")), "0");
 }
 
 // -- currentNamespace / infoLevelNumber / infoLevelArgs -------------------

--- a/rust/tcl-vm/tests/variable_name_resolution_e2e.rs
+++ b/rust/tcl-vm/tests/variable_name_resolution_e2e.rs
@@ -490,6 +490,29 @@ puts "element=[catch {upvar #0 x local(k)} m]:$m:$::errorCode"
                   local=1:can't create \"::missing::local\": parent namespace doesn't exist:TCL LOOKUP VARNAME ::missing::local\n\
                   element=1:bad variable name \"local(k)\": can't create a scalar variable that looks like an array element:TCL UPVAR LOCAL_ELEMENT",
     },
+    Vector {
+        name: "upvar preserves defined and traced locals while reusing undefined shells",
+        script: r"set ::one 1
+set ::two 2
+proc p {} {
+    set x value
+    set c1 [catch {upvar #0 one x} m]
+    set r1 [list $c1 $m $::errorCode]
+    unset x
+    trace add variable x unset {apply {{n1 n2 op} {}}}
+    set c2 [catch {upvar #0 one x} m]
+    set r2 [list $c2 $m $::errorCode]
+    upvar #0 one y
+    upvar #0 two y
+    variable z
+    upvar #0 one z
+    list $r1 $r2 $y $z
+}
+puts [p]
+",
+        want_8x: "{1 {variable \"x\" already exists} {TCL UPVAR EXISTS}} {1 {variable \"x\" has traces: can't use for upvar} {TCL UPVAR TRACED}} 2 1",
+        want_90: "{1 {variable \"x\" already exists} {TCL UPVAR EXISTS}} {1 {variable \"x\" has traces: can't use for upvar} {TCL UPVAR TRACED}} 2 1",
+    },
 ];
 
 #[test]

--- a/rust/tcl-vm/tests/variable_trace_semantics_e2e.rs
+++ b/rust/tcl-vm/tests/variable_trace_semantics_e2e.rs
@@ -510,6 +510,618 @@ fn vm_matches_the_pinned_trace_vectors() {
     }
 }
 
+#[test]
+fn array_operations_fire_the_registry_resolved_array_trace() {
+    // Exact Tcl 9.0.4 transcript. This covers all seven members implemented
+    // and advertised by this VM adapter; Tcl 9's `default` is not implemented
+    // by the adapter yet.
+    // Wrong arity and array-for's malformed variable list fail before
+    // LocateArray; callback errors retain their Tcl message and error code.
+    let script = r"
+set events {}
+proc A {tag n1 n2 op} {lappend ::events [list $tag $n1 $n2 $op]}
+array set exists {x 1}
+trace add variable exists array {A exists}
+array exists exists
+array set forvar {x 1}
+trace add variable forvar array {A for}
+array for {k v} forvar {}
+array set get {x 1}
+trace add variable get array {A get}
+array get get
+array set names {x 1}
+trace add variable names array {A names}
+array names names
+array set setvar {x 1}
+trace add variable setvar array {A set}
+array set setvar {y 2}
+array set size {x 1}
+trace add variable size array {A size}
+array size size
+array set unsetvar {x 1}
+trace add variable unsetvar array {A unset}
+array unset unsetvar nomatch
+set before $events
+catch {array exists exists extra} m
+set wrong [expr {$before eq $events}]
+catch {array for x forvar {}} fm
+set forbad [expr {$before eq $events}]
+puts [list $events $wrong $forbad $m $fm]
+array set a {x 1}
+proc B {n1 n2 op} {return -code error -errorcode {APP ARRAY} boom}
+trace add variable a array B
+catch {array exists a} em eo
+puts [list $em [dict get $eo -errorcode]]
+";
+    assert_eq!(
+        vm_output(script),
+        "{{exists exists {} array} {for forvar {} array} {get get {} array} {names names {} array} {set setvar {} array} {size size {} array} {unset unsetvar {} array}} 1 1 {wrong # args: should be \"array exists arrayName\"} {must have two variable names}\n{can't trace array \"a\": boom} {APP ARRAY}"
+    );
+}
+
+#[test]
+fn read_and_write_trace_wrappers_publish_their_lookup_error_codes() {
+    // Exact Tcl 9.0.4 transcript. Unlike the array operation, scalar
+    // read/write wrapping replaces the callback's code with the variable
+    // lookup class while still committing a write before its callback.
+    let script = r"
+proc R {n1 n2 op} {return -code error -errorcode {APP READ} nope}
+set x 1
+trace add variable x read R
+catch {set x} rm ro
+proc W {n1 n2 op} {return -code error -errorcode {APP WRITE} bad}
+set y 1
+trace add variable y write W
+catch {set y 2} wm wo
+puts [list $rm [dict get $ro -errorcode] $wm [dict get $wo -errorcode] $y]
+";
+    assert_eq!(
+        vm_output(script),
+        "{can't read \"x\": nope} {TCL READ VARNAME x} {can't set \"y\": bad} {TCL WRITE VARNAME y} 2"
+    );
+}
+
+#[test]
+fn array_trace_resolution_handles_undefined_scalar_and_alias_cells() {
+    // Exact Tcl 9.0.4 transcript. LocateArray reaches an undefined traced
+    // shell, rejects a scalar without tracing, and reports an upvar's spelling
+    // while retaining the target array's stable trace identity.
+    let script = r"
+set events {}
+proc A {tag n1 n2 op} {lappend ::events [list $tag $n1 $n2 $op]}
+trace add variable absent array {A absent}
+set ae [array exists absent]
+set scalar value
+trace add variable scalar array {A scalar}
+set se [array exists scalar]
+proc aliasprobe {} {upvar #0 target a; return [array size a]}
+array set target {x 1}
+trace add variable target array {A alias}
+set av [aliasprobe]
+puts [list $ae $se $av $events]
+";
+    assert_eq!(
+        vm_output(script),
+        "0 0 1 {{absent absent {} array} {alias a {} array}}"
+    );
+}
+
+#[test]
+fn array_trace_resolution_distinguishes_direct_and_linked_elements() {
+    // Exact Tcl 9.0.4 transcript. LocateArray gates on the reached cell's own
+    // trace and state. A direct undefined element walks parent then element,
+    // while an alias reaches only that element; scalar elements and an
+    // untraced element under a traced parent do not fire.
+    let script = r"
+set events {}
+proc A {tag n1 n2 op} {lappend ::events [list $tag $n1 $n2 $op]}
+array set a {}
+trace add variable a array {A parent}
+trace add variable a(k) array {A elem}
+set direct [array exists a(k)]
+set directevents $events
+set events {}
+proc aliasprobe {} {upvar #0 a(k) e; array exists e}
+set alias [aliasprobe]
+set aliasevents $events
+set events {}
+set a(k) value
+set defined [array exists a(k)]
+set definedevents $events
+array set b {}
+trace add variable b array {A onlyparent}
+set parentonly [array exists b(k)]
+puts [list $direct $directevents $alias $aliasevents $defined $definedevents $parentonly $events]
+";
+    assert_eq!(
+        vm_output(script),
+        "0 {{parent a k array} {elem a k array}} 0 {{elem e k array}} 0 {} 0 {}"
+    );
+}
+
+#[test]
+fn array_trace_alias_retarget_uses_located_cell_policy() {
+    // Tcl 9.0.4's LocateArray retains the original cell for key enumeration,
+    // while set and whole-array unset deliberately re-resolve the spelling.
+    // `get` combines the two (old keys, live values), patterned unset stays on
+    // the located cell, and `for` detects a changed search identity.
+    let script = r"
+proc R {target n1 n2 op} {uplevel 1 [list upvar #0 $target x]}
+array set as {a 1}
+array set bs {b1 1 b2 2}
+proc PS {} {
+    upvar #0 as x
+    trace add variable x array {R bs}
+    list [array size x] [array size x]
+}
+set size [PS]
+array set an {a 1}
+array set bn {b1 1 b2 2}
+proc PN {} {
+    upvar #0 an x
+    trace add variable x array {R bn}
+    list [array exists x] [lsort [array names x]] [array size x]
+}
+set names [PN]
+array set ag {a 1}
+array set bg {b 2}
+proc PG {} {
+    upvar #0 ag x
+    trace add variable x array {R bg}
+    array get x
+}
+set get [PG]
+array set aset {a 1}
+array set bset {b 2}
+proc PSET {} {
+    upvar #0 aset x
+    trace add variable x array {R bset}
+    array set x {new 3}
+}
+PSET
+set setrow [list [info exists aset(new)] [info exists bset(new)]]
+array set au {a 1}
+array set bu {b 2}
+proc PU {} {
+    upvar #0 au x
+    trace add variable x array {R bu}
+    array unset x
+}
+PU
+set unsetrow [list [array exists au] [array exists bu]]
+array set ap {a 1}
+array set bp {b 2}
+proc PP {} {
+    upvar #0 ap x
+    trace add variable x array {R bp}
+    array unset x a
+}
+PP
+set pattern [list [array size ap] [array size bp]]
+array set af {a 1}
+array set bf {b 2}
+proc PF {} {
+    upvar #0 af x
+    trace add variable x array {R bf}
+    catch {array for {k v} x {}} msg
+    list $msg
+}
+set forrow [PF]
+puts [list $size $names $get $setrow $unsetrow $pattern $forrow]
+";
+    assert_eq!(
+        vm_output(script),
+        "{1 2} {1 {b1 b2} 2} {} {0 1} {1 0} {0 1} {{array changed during iteration}}"
+    );
+}
+
+#[test]
+fn whole_array_unset_retargets_live_alias_and_preserves_const_error() {
+    // Exact Tcl 9.0.4 transcript. LocateArray retains `old` for the array
+    // operation, but whole-array mutation re-resolves the live spelling after
+    // its array trace retargets `x`. The scalar constant rejects that unset;
+    // both it and the originally located array remain unchanged.
+    let script = r"
+proc RCONST {n1 n2 op} {uplevel 1 {upvar #0 c x}}
+array set old {k v}
+const c locked
+proc P {} {
+    upvar #0 old x
+    trace add variable x array RCONST
+    set code [catch {array unset x} message options]
+    list $code $message [dict get $options -errorcode] [array get ::old] $::c
+}
+puts [P]
+";
+    assert_eq!(
+        vm_output(script),
+        r#"1 {can't unset "x": variable is a constant} {TCL UNSET CONST} {k v} locked"#
+    );
+}
+
+#[test]
+fn array_operation_reference_preserves_same_binding_recreation() {
+    // Tcl's LocateArray operation reference keeps the direct binding shell,
+    // not merely the allocation, so a callback's same-name recreation refills
+    // the cell observed by both command and compiler-opcode paths. The target
+    // binding is retained through an alias too, nested operations release only
+    // the final reference, and final cleanup never removes a replacement array
+    // element. A scalar recreation is not removed by whole-array `unset`.
+    let script = r"
+proc R {n1 n2 op} {
+    trace remove variable ::a array R
+    unset ::a
+    array set ::a {new1 2 new2 3}
+}
+array set a {old 1}
+trace add variable a array R
+set direct [list [lsort [array names a]] [lsort [array names a]]]
+proc RI {n1 n2 op} {
+    uplevel 1 [list trace remove variable $n1 array RI]
+    uplevel 1 [list unset $n1]
+    uplevel 1 [list array set $n1 {x 1}]
+}
+proc compiled {} {
+    array set local {old 1}
+    trace add variable local array RI
+    list [array exists local] [lsort [array names local]]
+}
+proc RS {n1 n2 op} {
+    trace remove variable ::s array RS
+    unset ::s
+    set ::s scalar
+}
+array set s {old 1}
+trace add variable s array RS
+array unset s
+array set aa {old 1}
+array set bb {new 2}
+proc RA {n1 n2 op} {
+    trace remove variable ::aa array RA
+    uplevel 1 {upvar #0 bb x}
+    unset ::aa
+}
+proc PA {} {
+    upvar #0 aa x
+    trace add variable x array RA
+    list [array names x] [info vars ::aa] [array names x]
+}
+set aliasrow [PA]
+array set nestedA {old 1}
+set nestedResult unset
+proc RN {n1 n2 op} {
+    trace remove variable ::nestedA array RN
+    unset ::nestedA
+    set ::nestedResult [array exists ::nestedA]
+    array set ::nestedA {new 2}
+}
+trace add variable nestedA array RN
+set nestedrow [list [array names nestedA] [array names nestedA] $nestedResult]
+array set elem {}
+upvar #0 elem keep
+proc RELEM {n1 n2 op} {
+    trace remove variable ::elem(missing) array RELEM
+    unset ::elem
+    array set ::elem {missing fresh}
+}
+trace add variable elem(missing) array RELEM
+set elemrow [list [array exists elem(missing)] [array get elem] [array get keep]]
+puts [list $direct [compiled] [info exists s] [array exists s] $s \
+    $aliasrow $nestedrow $elemrow]
+";
+    assert_eq!(
+        vm_output(script),
+        "{{new1 new2} {new1 new2}} {1 x} 1 0 scalar {{} {} new} {new new 0} {0 {missing fresh} {missing fresh}}"
+    );
+}
+
+#[test]
+fn array_for_tracks_structural_revision_and_read_trace_deletion() {
+    // A delete/recreate of the same key invalidates Tcl's active search even
+    // though the final key set is unchanged. A read trace that deletes the
+    // current value still leaves the key assigned, preserves the prior value
+    // variable, and runs the body once before that invalidation is reported.
+    // Defining a physical-but-undefined trace/link shell does not invalidate
+    // the search and makes that candidate visible if it has not been visited.
+    let script = r#"
+array set a {x 1}
+set churnCode [catch {array for {k v} a {unset a($k); set a($k) 2}} churnMsg churnOpts]
+array set b {x 1}
+set k oldk
+set v oldv
+set events {}
+proc RD {n1 n2 op} {
+    trace remove variable ::b($n2) read RD
+    unset ::b($n2)
+}
+trace add variable b(x) read RD
+set readCode [catch {array for {k v} b {lappend ::events [list $k $v]}} readMsg readOpts]
+array set c {x 1}
+set errEvents {}
+set ek oldk
+set ev oldv
+proc RE {n1 n2 op} {error boom}
+trace add variable c(x) read RE
+set errCode [catch {array for {ek ev} c {lappend ::errEvents [list $ek $ev]}} errMsg]
+set keptErrorInfo [string match {*read trace on "c(x)"*} $::errorInfo]
+proc N args {}
+array set d {x 1}
+trace add variable d(y) read N
+set dEvents {}
+set dCode [catch {array for {dk dv} d {
+    lappend ::dEvents [list $dk $dv]
+    if {$dk eq "x"} {set d(y) 2}
+}} dMsg]
+array set e {x 1}
+upvar #0 e(y) eAlias
+set eEvents {}
+set eCode [catch {array for {ekey eval} e {
+    lappend ::eEvents [list $ekey $eval]
+    if {$ekey eq "x"} {set eAlias 2}
+}} eMsg]
+array set f {x 1}
+upvar #0 f(y) fAlias
+set fCode [catch {array for {fkey fval} f {
+    if {$fkey eq "x"} {unset -nocomplain f(y)}
+}} fMsg]
+array set g {x 1}
+upvar #0 g(y) gAlias
+set gCode [catch {array for {gkey gval} g {
+    if {$gkey eq "x"} {unset -nocomplain gAlias}
+}} gMsg]
+proc RSEARCH {n1 n2 op} {trace remove variable ::h(y) array RSEARCH}
+array set h {x 1}
+trace add variable h(y) array RSEARCH
+set hEvents {}
+set hCode [catch {array for {hkey hval} h {
+    lappend ::hEvents [list $hkey $hval]
+    if {$hkey eq "x"} {array exists h(y); set h(y) 2}
+}} hMsg]
+array set i {x 1}
+trace add variable i(y) read N
+trace remove variable i(y) read N
+set iEvents {}
+set iCode [catch {array for {ikey ival} i {
+    lappend ::iEvents [list $ikey $ival]
+    if {$ikey eq "x"} {set i(y) 2}
+}} iMsg iOpts]
+proc RKEEP {n1 n2 op} {trace remove variable ::j(y) array RKEEP}
+array set j {x 1}
+trace add variable j(y) array RKEEP
+array for {jkey jval} j {
+    if {$jkey eq "x"} {array exists j(y)}
+}
+set jEvents {}
+set jCode [catch {array for {jkey jval} j {
+    lappend ::jEvents [list $jkey $jval]
+    if {$jkey eq "x"} {set j(y) 2}
+}} jMsg]
+array set z {x 1}
+trace add variable z(y) read N
+set zCode1 [catch {array for {zkey zval} z {
+    if {$zkey eq "x"} {trace remove variable z(y) read N}
+}} zMsg1]
+set zEvents {}
+set zCode2 [catch {array for {zkey zval} z {
+    lappend ::zEvents [list $zkey $zval]
+    if {$zkey eq "x"} {set z(y) 2}
+}} zMsg2 zOpts2]
+puts [list $churnCode $churnMsg [dict get $churnOpts -errorcode] [array get a] \
+    $readCode $readMsg [dict get $readOpts -errorcode] $events $k $v \
+    $errCode $errMsg $errEvents $ek $ev $keptErrorInfo \
+    $dCode $dMsg $dEvents [array get d] $eCode $eMsg $eEvents [array get e] \
+    $fCode $fMsg [array get f] $gCode $gMsg [array get g] \
+    $hCode $hMsg $hEvents [array get h] $iCode $iMsg \
+    [dict get $iOpts -errorcode] $iEvents [array get i] \
+    $jCode $jMsg $jEvents [array get j] $zCode1 $zMsg1 $zCode2 $zMsg2 \
+    [dict get $zOpts2 -errorcode] $zEvents [array get z]]
+"#;
+    assert_eq!(
+        vm_output(script),
+        "1 {array changed during iteration} {TCL READ array for} {x 2} 1 {array changed during iteration} {TCL READ array for} {{x oldv}} x oldv 0 {} {{x oldv}} x oldv 1 0 {} {{x 1} {y 2}} {x 1 y 2} 0 {} {{x 1} {y 2}} {x 1 y 2} 1 {array changed during iteration} {x 1} 1 {array changed during iteration} {x 1} 0 {} {{x 1} {y 2}} {x 1 y 2} 1 {array changed during iteration} {TCL READ array for} {{x 1}} {x 1 y 2} 0 {} {{x 1} {y 2}} {x 1 y 2} 0 {} 1 {array changed during iteration} {TCL READ array for} {{x 1}} {x 1 y 2}"
+    );
+}
+
+#[test]
+fn array_for_non_array_errors_have_the_lookup_identity() {
+    let script = r"
+set missingCode [catch {array for {k v} missing {}} missingMsg missingOpts]
+set scalar 1
+set scalarCode [catch {array for {k v} scalar {}} scalarMsg scalarOpts]
+proc RSF {n1 n2 op} {
+    trace remove variable ::traced array RSF
+    unset ::traced
+    set ::traced scalar
+}
+array set traced {x 1}
+trace add variable traced array RSF
+set tracedCode [catch {array for {k v} traced {}} tracedMsg tracedOpts]
+puts [list $missingCode $missingMsg [dict get $missingOpts -errorcode] \
+    $scalarCode $scalarMsg [dict get $scalarOpts -errorcode] \
+    $tracedCode $tracedMsg [dict get $tracedOpts -errorcode]]
+";
+    assert_eq!(
+        vm_output(script),
+        "1 {\"missing\" isn't an array} {TCL LOOKUP ARRAY missing} 1 {\"scalar\" isn't an array} {TCL LOOKUP ARRAY scalar} 1 {\"traced\" isn't an array} {TCL LOOKUP ARRAY traced}"
+    );
+}
+
+#[test]
+fn whole_array_teardown_visits_trace_only_undefined_elements() {
+    // TraceVarEx materialises an undefined element cell, and DeleteArray walks
+    // that cell even though it has no value and is absent from `array names`.
+    let script = r"
+set events {}
+proc U {n1 n2 op} {lappend ::events [list $n1 $n2 $op]}
+array set a {}
+trace add variable a(missing) unset U
+unset a
+puts $events
+";
+    assert_eq!(vm_output(script), "{a missing unset}");
+}
+
+#[test]
+fn every_advertised_array_member_validates_arity_before_tracing() {
+    // Exact Tcl 9.0.4 transcript for all seven members implemented by the VM.
+    // The registry arity check precedes LocateArray, so none reaches its trace.
+    let script = r"
+set events {}
+proc A {tag n1 n2 op} {lappend ::events [list $tag $n1 $n2 $op]}
+foreach n {exists forvar get names setvar size unsetvar} {
+    array set $n {x 1}
+    trace add variable $n array [list A $n]
+}
+set outcomes {}
+lappend outcomes [catch {array exists exists extra}] [expr {$events eq {}}]
+lappend outcomes [catch {array for {k v} forvar}] [expr {$events eq {}}]
+lappend outcomes [catch {array get get p extra}] [expr {$events eq {}}]
+lappend outcomes [catch {array names names -glob p extra}] [expr {$events eq {}}]
+lappend outcomes [catch {array set setvar}] [expr {$events eq {}}]
+lappend outcomes [catch {array size size extra}] [expr {$events eq {}}]
+lappend outcomes [catch {array unset unsetvar p extra}] [expr {$events eq {}}]
+puts $outcomes
+";
+    assert_eq!(vm_output(script), "1 1 1 1 1 1 1 1 1 1 1 1 1 1");
+}
+
+#[test]
+fn compiled_proc_local_array_exists_fires_the_array_trace() {
+    // Exact Tcl 9.0.4 transcript. A proc-local `array exists` lowers to the
+    // dedicated ARRAY_EXISTS_IMM opcode, which must share array_op's trace
+    // owner rather than query the local slot directly.
+    let script = r"
+set events {}
+proc A {n1 n2 op} {lappend ::events [list $n1 $n2 $op]}
+proc p {} {
+    array set a {k v}
+    trace add variable a array A
+    array exists a
+}
+puts [list [p] $events]
+";
+    assert_eq!(vm_output(script), "1 {{a {} array}}");
+}
+
+#[test]
+fn trace_reentrancy_is_per_resolved_variable_cell() {
+    // Exact Tcl 9.0.4 transcript: entering a sibling element from a write
+    // callback is not suppressed by the first element's active bit.
+    let script = r#"
+set events {}
+proc E {tag n1 n2 op} {
+    lappend ::events [list $tag $n1 $n2 $op]
+    if {$tag eq "x"} {set ::a(y) nested}
+}
+set a(x) old
+set a(y) old
+trace add variable a(x) write {E x}
+trace add variable a(y) write {E y}
+set a(x) outer
+puts $events
+"#;
+    assert_eq!(vm_output(script), "{x a x write} {y ::a y write}");
+}
+
+#[test]
+fn whole_array_write_trace_can_enter_a_sibling_element() {
+    // Exact Tcl 9.0.4 transcript. The parent trace list is selected for both
+    // writes, but activity belongs to each resolved element cell, so x does
+    // not suppress the nested write to y.
+    let script = r#"
+set events {}
+proc W {n1 n2 op} {
+    lappend ::events [list $n1 $n2 $op]
+    if {$n2 eq "x"} {set ::c(y) nested}
+}
+array set c {x old y old}
+trace add variable c write W
+set c(x) outer
+puts [list $c(x) $c(y) $events]
+"#;
+    assert_eq!(
+        vm_output(script),
+        "outer nested {{c x write} {::c y write}}"
+    );
+}
+
+#[test]
+fn array_operation_trace_self_gates_on_the_parent_cell() {
+    // Exact Tcl 9.0.4 transcript. Array operations resolve to the parent cell,
+    // so a callback's recursive operation on that same parent is suppressed.
+    let script = r"
+set events {}
+proc P {n1 n2 op} {lappend ::events [list $n1 $n2 $op]; array size ::p}
+array set p {x 1}
+trace add variable p array P
+puts [list [array exists p] $events]
+";
+    assert_eq!(vm_output(script), "1 {{p {} array}}");
+}
+
+#[test]
+fn unset_from_an_active_write_trace_fires_the_taken_unset_list() {
+    // Exact Tcl 9.0.4 transcript. Unset moves the trace list to a dummy cell
+    // whose active bit is clear, so the nested unset callback still runs.
+    let script = r#"
+set events {}
+proc W {n1 n2 op} {
+    lappend ::events [list W $n1 $n2 $op]
+    if {$op eq "write"} {unset ::a(k)}
+}
+trace add variable a(k) {write unset} W
+set a(k) v
+puts $events
+"#;
+    assert_eq!(vm_output(script), "{W a k write} {W ::a k unset}");
+}
+
+#[test]
+fn whole_array_unset_fires_each_old_element_cell() {
+    // Exact Tcl 9.0.4 transcript. The parent fires once, every old element
+    // fires even when an earlier callback errors, and unset-trace errors do not
+    // fail `unset`. Sorting removes only Tcl hash iteration order.
+    let script = r#"
+set events {}
+proc U {tag n1 n2 op} {
+    lappend ::events [list $tag $n1 $n2 $op]
+    if {$tag eq "x"} {error boom}
+}
+array set a {x X y Y}
+trace add variable a unset {U parent}
+trace add variable a(x) unset {U x}
+trace add variable a(y) unset {U y}
+set code [catch {unset a} message]
+puts [list $code $message [lsort $events] [info exists a]]
+"#;
+    assert_eq!(
+        vm_output(script),
+        "0 {} {{parent a {} unset} {x a x unset} {y a y unset}} 0"
+    );
+}
+
+#[test]
+fn whole_array_unset_detaches_old_element_aliases() {
+    // Exact Tcl 9.0.4 transcript. The alias keeps the old element identity and
+    // must not retarget the fresh same-name element created afterwards.
+    let script = r"
+set events {}
+proc U {n1 n2 op} {lappend ::events [list $n1 $n2 $op]}
+set x(k) old
+upvar #0 x(k) alias
+trace add variable x(k) unset U
+unset x
+set x(k) fresh
+set code [catch {set alias rewritten} msg opts]
+puts [list $events $code $msg [dict get $opts -errorcode] \
+           [set x(k)] [trace info variable x(k)]]
+";
+    assert_eq!(
+        vm_output(script),
+        "{{x k unset}} 1 {can't set \"alias\": upvar refers to element in deleted array} {TCL WRITE VARNAME} fresh {}"
+    );
+}
+
 /// The table itself is pinned to C Tcl (8.6.16 and 9.0.4 agree on every line).
 #[test]
 fn vectors_match_real_tclsh() {


### PR DESCRIPTION
## Summary

- introduce monotonic `VarId` cells shared by frame and namespace bindings, arrays, aliases, traces, and active operation scopes
- preserve old cells across callback re-entry, namespace recreation, aliases, parked frames, and teardown
- route native `array` operation targeting through registry argument roles and dialect facts, including compiled/opcode consumers
- centralise `info consts` over byte-preserving runtime APIs, typed TclOO instance-link origins, and Tcl 9.0.4 exact-pattern/global-fallback semantics
- add a fallible command-aware unset rung so whole-array mutation preserves `TCL UNSET CONST` after trace retargeting
- document the shared variable, trace, and introspection ownership contracts

## Issue scope

Closes #1928.

Advances #1569: the native VM now fires registry-resolved array traces with Tcl-compatible validation ordering; the standalone runtime residual remains.

Advances #1574: the native VM now gates trace re-entry by stable variable-cell identity; the standalone runtime stable-generation migration remains.

Advances #1575: the native VM now fires namespace-teardown and whole-array element unset traces; standalone runtime frame teardown and remaining per-element lifecycle work remain.

Advances #1753: retained and recreated namespaces now have independent variable tables and trace lifecycles; residual command-side stable ownership and the suspended-coroutine case remain.

## Tcl 9.0.4 coverage

- retained old and recreated live namespace variables coexist with distinct values and traces
- all native VM `array` members use registry-resolved targets and Tcl-compatible validation ordering
- whole-array unset fires old element cells individually and preserves a constant retarget refusal
- trace re-entry, sibling-element writes, taken unsets, aliases, trace-only undefined cells, array searches, and namespace teardown
- direct constant-binding enumeration, namespace/global fallback, exact versus wildcard patterns, TclOO projections, and byte-valued names in both engines
- focused upstream `trace.test` and `var.test` cases run through the real Tcl 9.0.4 `tcltest/init.tcl` harness

## Validation

- `make rust-check`
- `make prep-pr NPROC=1` — 30/30 smoke tests
- `make test-spectcl-compat` — 30/30 across SpecTcl 1.x and 2.0 paths
- focused native and standalone-runtime regressions
- full `cargo test -p tcl-vm`, including real WASM coroutine link cases, before the final docs-only base update