### PR TITLE
ci: skip unaffected root Rust test steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,10 @@ jobs:
   #                    PRs prove themselves on an isolated GitHub-hosted runner;
   #                    an unreviewed policy edit must not execute new dependency
   #                    code on, overload, or strand the protected host.
+  #   rust_tests_changed — the committed root Rust-test closure (nextest plus
+  #                    the full workspace doctest command) or one of its
+  #                    build/test inputs changed. Missing/ambiguous changed-file
+  #                    data fails closed to true.
   channel:
     runs-on: ubuntu-24.04
     permissions:
@@ -152,6 +156,7 @@ jobs:
       web_frontends_changed: ${{ steps.paths.outputs.web_frontends_changed }}
       runner_policy_changed: ${{ steps.paths.outputs.runner_policy_changed }}
       rust_tests_runner: ${{ steps.rust-runner.outputs.runner }}
+      rust_tests_changed: ${{ steps.paths.outputs.rust_tests_changed }}
       docs_only: ${{ steps.paths.outputs.docs_only }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -189,20 +194,11 @@ jobs:
         run: |
           ok=true
           files=""
-          if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
-            files="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files?per_page=100" \
-              --paginate --jq '.[].filename' 2>/dev/null)" || ok=false
-          elif [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" != refs/tags/* &&
-            -n "$BEFORE" && "$BEFORE" != 0000000000000000000000000000000000000000 ]]; then
-            # The compare API caps the file list at 300; a full list means
-            # "could be anything", not "exactly 300 files changed".
-            files="$(gh api "repos/$GITHUB_REPOSITORY/compare/$BEFORE...$GITHUB_SHA" \
-              --jq '.files[].filename' 2>/dev/null)" || ok=false
-            [ "$(printf '%s\n' "$files" | wc -l)" -ge 300 ] && ok=false
+          if files="$(scripts/dev/changed-paths.sh "$GITHUB_EVENT_NAME" "$GITHUB_REPOSITORY" "$PR_NUMBER" "$BEFORE" "$GITHUB_SHA" "$GITHUB_REF")"; then
+            :
           else
-            ok=false # tags, dispatch, branch creation: everything counts as changed
+            ok=false
           fi
-          [ -z "$files" ] && ok=false
 
           python_changed=false
           ext_changed=false
@@ -212,6 +208,7 @@ jobs:
           runtime_rust_changed=false
           web_frontends_changed=false
           runner_policy_changed=false
+          rust_tests_changed=false
           docs_only=true
           if [ "$ok" = "true" ]; then
             while IFS= read -r f; do
@@ -239,6 +236,15 @@ jobs:
                 .github/workflows/ci.yml | .github/dependabot.yml | scripts/dev/select-rust-tests-runner.sh | scripts/dev/test-rust-tests-runner.sh)
                   runner_policy_changed=true ;;
               esac
+              if scripts/dev/rust-tests-path.sh "$f"; then
+                rust_tests_changed=true
+              else
+                status=$?
+                if [ "$status" -ne 1 ]; then
+                  ok=false
+                  break
+                fi
+              fi
               if scripts/dev/spectcl-compat-path.sh "$f"; then
                 spectcl_compat_changed=true
               else
@@ -272,6 +278,7 @@ jobs:
             runtime_rust_changed=true
             web_frontends_changed=true
             runner_policy_changed=true
+            rust_tests_changed=true
             docs_only=false
           fi
           {
@@ -283,9 +290,10 @@ jobs:
             echo "runtime_rust_changed=$runtime_rust_changed"
             echo "web_frontends_changed=$web_frontends_changed"
             echo "runner_policy_changed=$runner_policy_changed"
+            echo "rust_tests_changed=$rust_tests_changed"
             echo "docs_only=$docs_only"
           } >>"$GITHUB_OUTPUT"
-          echo "python_changed=$python_changed ext_changed=$ext_changed lsp_wasm_changed=$lsp_wasm_changed wasm_cc_changed=$wasm_cc_changed spectcl_compat_changed=$spectcl_compat_changed runtime_rust_changed=$runtime_rust_changed web_frontends_changed=$web_frontends_changed runner_policy_changed=$runner_policy_changed docs_only=$docs_only"
+          echo "python_changed=$python_changed ext_changed=$ext_changed lsp_wasm_changed=$lsp_wasm_changed wasm_cc_changed=$wasm_cc_changed spectcl_compat_changed=$spectcl_compat_changed runtime_rust_changed=$runtime_rust_changed web_frontends_changed=$web_frontends_changed runner_policy_changed=$runner_policy_changed rust_tests_changed=$rust_tests_changed docs_only=$docs_only"
 
       - name: Select the broad Rust test runner
         id: rust-runner
@@ -880,6 +888,8 @@ jobs:
       queue: max
       cancel-in-progress: false
     steps:
+      # Keep this required job alive for unrelated changes; only the checkout
+      # runs when the channel says the root Rust test archive is unaffected.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
@@ -891,6 +901,7 @@ jobs:
       # The action installs the current stable and wires up the Swatinem cache
       # (keyed per job, so the concurrent cargo jobs don't race on save).
       - name: Set up Rust
+        if: needs.channel.outputs.rust_tests_changed == 'true'
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           toolchain: stable
@@ -901,11 +912,13 @@ jobs:
       # those expensive compilations reusable across runner registrations and
       # source revisions without weakening Cargo's freshness checks.
       - name: Set up sccache
+        if: needs.channel.outputs.rust_tests_changed == 'true'
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
         with:
           version: v0.17.0
 
       - name: Install cargo-nextest
+        if: needs.channel.outputs.rust_tests_changed == 'true'
         uses: taiki-e/install-action@e67fa11c4b9316fa714ddf0abed07a0c3143b95b # v2.87.4
         with:
           tool: nextest@0.9.143
@@ -915,7 +928,7 @@ jobs:
       # lane through the same tool entry point SpecTcl uses; distro Tcl and a
       # stale system tclsh9.0 must never decide which oracle CI exercises.
       - name: Install exact Tcl 9.0 reference interpreter
-        if: needs.channel.outputs.docs_only != 'true' && needs.channel.outputs.already_green != 'true'
+        if: needs.channel.outputs.rust_tests_changed == 'true' && needs.channel.outputs.docs_only != 'true' && needs.channel.outputs.already_green != 'true'
         env:
           TCL_LSP_TCL_BIN_DIR: ${{ runner.temp }}/tcl-reference-bin
         run: |
@@ -935,7 +948,7 @@ jobs:
       # used with '--no-fail-fast'"), and the flag is meaningless anyway when
       # no tests are executed.
       - name: cargo nextest run (workspace minus VM-sim heavies and lsp-e2e)
-        if: needs.channel.outputs.docs_only != 'true' && !(startsWith(github.ref, 'refs/tags/') && needs.channel.outputs.already_green == 'true')
+        if: needs.channel.outputs.rust_tests_changed == 'true' && needs.channel.outputs.docs_only != 'true' && !(startsWith(github.ref, 'refs/tags/') && needs.channel.outputs.already_green == 'true')
         env:
           ALREADY_GREEN: ${{ needs.channel.outputs.already_green }}
         run: |
@@ -950,8 +963,14 @@ jobs:
       # the crates excluded above — doctests are cheap) so the other jobs need
       # not duplicate them.  Deps are already built, so this is compile + run.
       - name: cargo test --doc
-        if: needs.channel.outputs.docs_only != 'true' && needs.channel.outputs.already_green != 'true'
+        if: needs.channel.outputs.rust_tests_changed == 'true' && needs.channel.outputs.docs_only != 'true' && needs.channel.outputs.already_green != 'true'
         run: cargo test --workspace --all-features --doc --no-fail-fast
+
+      # Setup is intentionally skipped when the root Rust-test closure is
+      # unaffected, so sccache is unavailable on those required no-op runs.
+      - name: Report sccache statistics
+        if: always() && needs.channel.outputs.rust_tests_changed == 'true'
+        run: sccache --show-stats
 
   # Fail-closed SpecTcl compatibility on every PR that changes its TclVM,
   # compiler, registry, runtime, pack, or exact-reference-toolchain closure.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,6 +268,12 @@ jobs:
                 *) docs_only=false ;;
               esac
             done <<<"$files"
+            # Some apparent documentation inputs are executable or consumed by
+            # root tests. The audited closure is authoritative over the broad
+            # docs-only shape check for those paths.
+            if [ "$rust_tests_changed" = "true" ]; then
+              docs_only=false
+            fi
           fi
           if [ "$ok" != "true" ]; then
             python_changed=true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,11 +190,45 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
           BEFORE: ${{ github.event.before }}
         run: |
           ok=true
           files=""
-          if files="$(scripts/dev/changed-paths.sh "$GITHUB_EVENT_NAME" "$GITHUB_REPOSITORY" "$PR_NUMBER" "$BEFORE" "$GITHUB_SHA" "$GITHUB_REF")"; then
+          changed_paths=scripts/dev/changed-paths.sh
+          rust_tests_path=scripts/dev/rust-tests-path.sh
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+            # The PR checkout is deliberately not trusted to decide whether
+            # its own root tests run. Read the parser and closure from the
+            # exact base commit; any shallow/missing object or missing helper
+            # fails closed below. The merge checkout has both parents at
+            # fetch-depth 2.
+            trusted="$RUNNER_TEMP/root-rust-test-classifier"
+            mkdir -p "$trusted"
+            if [[ ${#BASE_SHA} -ne 40 || "$BASE_SHA" == *[!0-9a-f]* ]]; then
+              ok=false
+            fi
+            if [[ "$ok" == "true" ]]; then
+              for path in \
+                scripts/dev/changed-paths.sh \
+                scripts/dev/rust-tests-path.sh \
+                scripts/dev/rust-tests-package-paths.txt \
+                scripts/dev/rust-tests-input-paths.txt; do
+                if ! git show "$BASE_SHA:$path" >"$trusted/${path##*/}"; then
+                  ok=false
+                  break
+                fi
+              done
+            fi
+            if [[ "$ok" == "true" ]]; then
+              chmod +x "$trusted/changed-paths.sh" "$trusted/rust-tests-path.sh"
+              changed_paths="$trusted/changed-paths.sh"
+              rust_tests_path="$trusted/rust-tests-path.sh"
+              export TCL_LSP_RUST_TESTS_PACKAGE_MANIFEST="$trusted/rust-tests-package-paths.txt"
+              export TCL_LSP_RUST_TESTS_INPUT_MANIFEST="$trusted/rust-tests-input-paths.txt"
+            fi
+          fi
+          if [[ "$ok" == "true" ]] && files="$("$changed_paths" "$GITHUB_EVENT_NAME" "$GITHUB_REPOSITORY" "$PR_NUMBER" "$BEFORE" "$GITHUB_SHA" "$GITHUB_REF")"; then
             :
           else
             ok=false
@@ -236,7 +270,7 @@ jobs:
                 .github/workflows/ci.yml | .github/dependabot.yml | scripts/dev/select-rust-tests-runner.sh | scripts/dev/test-rust-tests-runner.sh)
                   runner_policy_changed=true ;;
               esac
-              if scripts/dev/rust-tests-path.sh "$f"; then
+              if "$rust_tests_path" "$f"; then
                 rust_tests_changed=true
               else
                 status=$?

--- a/Makefile
+++ b/Makefile
@@ -210,7 +210,7 @@ TS_SRCS  := $(shell find $(EXT_DIR)/src -name '*.ts' 2>/dev/null)
 # Tests
 .PHONY: test test-ext test-emacs test-rust rust-server rust-tcl rust-f5 rust-mcp rust-clis ensure-server-cross-deps server-cross-build server-cross-build-all mcp-cross-build-all cli-cross-build-all server-cross-test server-cross-test-build print-server-targets-all print-server-targets-jetbrains
 .PHONY: xtask-check xtask-editor-extensions xtask-kcs-index-links xtask-diag-tables xtask-diag-emission-check xtask-gen-editor-catalogs xtask-gen-bundled-environments xtask-gen-editor-dialects xtask-gen-irule-test-data xtask-gen-zed-queries xtask-gen-editor-settings xtask-gen-vscode-package xtask-gen-jetbrains-catalog xtask-gen-ai-diagnostics xtask-owner-resolution xtask-command-backing xtask-audit-option-dialects xtask-registry-oracle xtask-sslictcl-data xtask-runtime-stdlib tcltest-sweep tcltest-sweep-check xtask-f5query-builtins-doc xtask-bigip-data-schema xtask-c-api-ownership check-c-api-ownership
-.PHONY: xtask-workflow-sync xtask-resolution-drift xtask-retired-api-gate xtask-pack-goldens xtask-number-drift xtask-gen-tmlanguage-keywords xtask-option-registry-drift xtask-callback-inventory check-tcl-reference-toolchains check-spectcl-compat-paths check-runtime-rust-paths check-rust-tests-runner check-lsp-e2e-partitions check-already-green check-monitoring-triggers check-smoke-targets check-wasm-cc-env check-homebrew-ci check-sign-and-upload xtask-dialect-drift xtask-segmentation-drift
+.PHONY: xtask-workflow-sync xtask-resolution-drift xtask-retired-api-gate xtask-pack-goldens xtask-number-drift xtask-gen-tmlanguage-keywords xtask-option-registry-drift xtask-callback-inventory check-tcl-reference-toolchains check-spectcl-compat-paths check-runtime-rust-paths check-rust-tests-runner check-rust-tests-paths check-lsp-e2e-partitions check-already-green check-monitoring-triggers check-smoke-targets check-wasm-cc-env check-homebrew-ci check-sign-and-upload xtask-dialect-drift xtask-segmentation-drift
 # Lint / format / typecheck
 .PHONY: lint format lint-ts format-ts typecheck-ts check-rust check-rust-pr _check-rust-pr rust-deny
 .PHONY: build-report-assets build-report-pyz lint-report-ts typecheck-report-ts check-report-assets lint-spec-studio-ts typecheck-spec-studio-ts
@@ -760,7 +760,7 @@ coverage-ext: compile $(NPM_STAMP) ensure-vscode-test-deps ## Run VS Code extens
 # --- Native (cargo xtask) check gates.  These need the Rust toolchain, so CI
 # runs them in the rust-tests job (rust-gate.yml / ci.yml).  `xtask-check` is
 # the CI aggregate.
-xtask-check: check-tcl-reference-toolchains check-spectcl-compat-paths check-runtime-rust-paths check-rust-tests-runner check-lsp-e2e-partitions check-already-green check-monitoring-triggers check-smoke-targets check-wasm-cc-env check-homebrew-ci check-sign-and-upload xtask-workflow-sync xtask-kcs-index-links xtask-diag-tables xtask-diag-emission-check xtask-gen-editor-catalogs xtask-gen-bundled-environments xtask-gen-editor-dialects xtask-gen-irule-test-data xtask-gen-zed-queries xtask-gen-tmlanguage-keywords xtask-gen-editor-settings xtask-gen-vscode-package xtask-gen-jetbrains-catalog xtask-gen-ai-diagnostics xtask-owner-resolution xtask-resolution-drift xtask-retired-api-gate xtask-pack-goldens xtask-number-drift xtask-segmentation-drift xtask-command-backing xtask-callback-inventory xtask-option-registry-drift xtask-sslictcl-data xtask-runtime-stdlib xtask-editor-extensions xtask-f5query-builtins-doc xtask-bigip-data-schema xtask-c-api-ownership ## Rust-side check gates (docs index coverage + generated-table/catalog drift) xtask-dialect-drift
+xtask-check: check-tcl-reference-toolchains check-spectcl-compat-paths check-runtime-rust-paths check-rust-tests-runner check-rust-tests-paths check-lsp-e2e-partitions check-already-green check-monitoring-triggers check-smoke-targets check-wasm-cc-env check-homebrew-ci check-sign-and-upload xtask-workflow-sync xtask-kcs-index-links xtask-diag-tables xtask-diag-emission-check xtask-gen-editor-catalogs xtask-gen-bundled-environments xtask-gen-editor-dialects xtask-gen-irule-test-data xtask-gen-zed-queries xtask-gen-tmlanguage-keywords xtask-gen-editor-settings xtask-gen-vscode-package xtask-gen-jetbrains-catalog xtask-gen-ai-diagnostics xtask-owner-resolution xtask-resolution-drift xtask-retired-api-gate xtask-pack-goldens xtask-number-drift xtask-segmentation-drift xtask-command-backing xtask-callback-inventory xtask-option-registry-drift xtask-sslictcl-data xtask-runtime-stdlib xtask-editor-extensions xtask-f5query-builtins-doc xtask-bigip-data-schema xtask-c-api-ownership ## Rust-side check gates (docs index coverage + generated-table/catalog drift) xtask-dialect-drift
 
 check-tcl-reference-toolchains: ## Verify pinned C Tcl patchlevels across shell setup and Rust oracle discovery
 	@echo "==> Checking C Tcl reference toolchain ownership"
@@ -774,6 +774,10 @@ check-spectcl-compat-paths: ## Verify CI's SpecTcl dependency closure and centra
 check-runtime-rust-paths: ## Verify CI's standalone-runtime dependency closure and job wiring (#1768)
 	@echo "==> Checking standalone runtime CI path ownership"
 	@bash scripts/dev/test-runtime-rust-paths.sh
+
+check-rust-tests-paths: ## Verify CI's root Rust test dependency closure and classifier wiring
+	@echo "==> Checking root Rust test path ownership"
+	@bash scripts/dev/test-rust-tests-paths.sh
 
 check-rust-tests-runner: ## Verify trusted rust-tests jobs serialize on the shared tank host
 	@echo "==> Checking self-hosted Rust test scheduling"

--- a/docs/design/contracts/test-tiers-and-ci-gates.md
+++ b/docs/design/contracts/test-tiers-and-ci-gates.md
@@ -162,11 +162,13 @@ CI skips only what demonstrably did not change. The rules live in
   `scripts/dev/rust-tests-package-paths.txt` and external-input closure in
   `scripts/dev/rust-tests-input-paths.txt` define that decision; `make
   check-rust-tests-paths` checks the manifests against locked Cargo metadata
-  and exercises the fail-closed GitHub changed-file parser. The sccache stats
-  step uses the same decision because no sccache executable exists when setup
-  is skipped. This audited closure overrides the broad docs-only shape check:
-  an executable or test-consumed input under `docs/` or `.claude/` still runs
-  the suite.
+  and exercises the fail-closed GitHub changed-file parser. Pull requests run
+  the parser and both closure manifests copied from the exact base commit, so
+  a proposed classifier change cannot exempt itself; a missing shallow object
+  or helper runs the full suite. The sccache stats step uses the same decision
+  because no sccache executable exists when setup is skipped. This audited
+  closure overrides the broad docs-only shape check: an executable or
+  test-consumed input under `docs/` or `.claude/` still runs the suite.
 - `runtime-rust-tests` runs the standalone `runtime/rust` unit suite
   (`make runtime-rust-test`) only when `runtime_rust_changed` is true — that
   crate plus the path-dependency closure its own lockfile resolves. It is its

--- a/docs/design/contracts/test-tiers-and-ci-gates.md
+++ b/docs/design/contracts/test-tiers-and-ci-gates.md
@@ -164,7 +164,9 @@ CI skips only what demonstrably did not change. The rules live in
   check-rust-tests-paths` checks the manifests against locked Cargo metadata
   and exercises the fail-closed GitHub changed-file parser. The sccache stats
   step uses the same decision because no sccache executable exists when setup
-  is skipped.
+  is skipped. This audited closure overrides the broad docs-only shape check:
+  an executable or test-consumed input under `docs/` or `.claude/` still runs
+  the suite.
 - `runtime-rust-tests` runs the standalone `runtime/rust` unit suite
   (`make runtime-rust-test`) only when `runtime_rust_changed` is true — that
   crate plus the path-dependency closure its own lockfile resolves. It is its

--- a/docs/design/contracts/test-tiers-and-ci-gates.md
+++ b/docs/design/contracts/test-tiers-and-ci-gates.md
@@ -156,6 +156,15 @@ CI skips only what demonstrably did not change. The rules live in
 - **Docs-only** changes skip the cargo test steps; `python`, `test-ext`, and
   `test-ext-web` run only when their input paths changed (`test-ext-web` on
   `ext_changed` or `lsp_wasm_changed`, since it consumes both).
+- The root `rust-tests` job keeps its required status for every change, but
+  step-skips Rust setup, sccache, nextest, the Tcl oracle, and doctests when
+  `rust_tests_changed` is false. The committed package closure in
+  `scripts/dev/rust-tests-package-paths.txt` and external-input closure in
+  `scripts/dev/rust-tests-input-paths.txt` define that decision; `make
+  check-rust-tests-paths` checks the manifests against locked Cargo metadata
+  and exercises the fail-closed GitHub changed-file parser. The sccache stats
+  step uses the same decision because no sccache executable exists when setup
+  is skipped.
 - `runtime-rust-tests` runs the standalone `runtime/rust` unit suite
   (`make runtime-rust-test`) only when `runtime_rust_changed` is true — that
   crate plus the path-dependency closure its own lockfile resolves. It is its

--- a/scripts/dev/changed-paths.sh
+++ b/scripts/dev/changed-paths.sh
@@ -1,0 +1,126 @@
+#!/bin/sh
+# tcl-lsp — a language server and toolchain for Tcl
+# Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+# Print the changed files for a supported CI event. Exit 0 with a complete
+# list, or 2 when the API/diff cannot prove the list is complete. Callers must
+# treat every non-zero result as "everything changed".
+set -eu
+
+if [ "$#" -ne 6 ]; then
+    echo "usage: scripts/dev/changed-paths.sh EVENT REPOSITORY PR_NUMBER BEFORE SHA REF" >&2
+    exit 2
+fi
+
+EVENT=$1
+REPOSITORY=$2
+PR_NUMBER=$3
+BEFORE=$4
+SHA=$5
+REF=$6
+GH_BIN=${GH_BIN:-gh}
+ZERO_SHA=0000000000000000000000000000000000000000
+
+canonical_sha() {
+    value=$1
+    [ "${#value}" -eq 40 ] || return 1
+    case "$value" in *[!0-9a-f]*|'') return 1 ;; esac
+    [ "$value" != "$ZERO_SHA" ]
+}
+
+# Validate the raw API response and print one or two repository paths per file
+# object.  The API's file-list limits apply to objects, not to emitted paths:
+# a renamed file contributes two paths but still counts as one object.  Keep
+# this parser here instead of trusting `--jq '.[].filename'`: a schema drift
+# that turns a missing field into `null` must fail closed.
+validate_files() {
+    cap=$1
+    shape=$2
+    python3 -c '
+import json
+import sys
+
+cap = int(sys.argv[1])
+shape = sys.argv[2]
+
+def fail():
+    raise SystemExit(2)
+
+try:
+    payload = json.load(sys.stdin)
+except (json.JSONDecodeError, TypeError, ValueError):
+    fail()
+
+if shape == "pull_request":
+    # --paginate --slurp returns one array per API page.
+    if not isinstance(payload, list) or not payload or not all(isinstance(page, list) for page in payload):
+        fail()
+    rows = [row for page in payload for row in page]
+else:
+    if not isinstance(payload, dict) or not isinstance(payload.get("files"), list):
+        fail()
+    rows = payload["files"]
+
+# GitHub truncates exactly at these boundaries.  Treat a full response as
+# ambiguous, and reject an empty response as an unproven changed-file list.
+if not rows or len(rows) >= cap:
+    fail()
+
+statuses = {"added", "modified", "deleted", "renamed", "copied", "changed", "unchanged"}
+
+def path(value):
+    # The downstream shell transport is line-oriented.  Refuse control-line
+    # characters rather than allowing one API field to masquerade as several.
+    if not isinstance(value, str) or not value or "\x00" in value or "\n" in value or "\r" in value:
+        fail()
+    if value.startswith("/") or any(part in ("", ".", "..") for part in value.split("/")):
+        fail()
+    return value
+
+for row in rows:
+    if not isinstance(row, dict):
+        fail()
+    status = row.get("status")
+    if not isinstance(status, str) or status not in statuses:
+        fail()
+    filename = path(row.get("filename"))
+    previous_present = "previous_filename" in row
+    previous = row.get("previous_filename")
+    if previous_present:
+        if status != "renamed":
+            fail()
+        previous = path(previous)
+    elif status == "renamed":
+        fail()
+    print(filename)
+    if previous_present:
+        print(previous)
+' "$cap" "$shape"
+}
+
+case "$EVENT" in
+    pull_request)
+        case "$PR_NUMBER" in
+            '' | *[!0-9]*) exit 2 ;;
+        esac
+        raw=$("$GH_BIN" api "repos/$REPOSITORY/pulls/$PR_NUMBER/files?per_page=100" \
+            --paginate --slurp 2>/dev/null) || exit 2
+        files=$(printf '%s' "$raw" | validate_files 3000 pull_request) || exit 2
+        ;;
+    push)
+        case "$REF" in refs/heads/rust) ;; *) exit 2 ;; esac
+        canonical_sha "$BEFORE" || exit 2
+        canonical_sha "$SHA" || exit 2
+        raw=$("$GH_BIN" api "repos/$REPOSITORY/compare/$BEFORE...$SHA" \
+            2>/dev/null) || exit 2
+        files=$(printf '%s' "$raw" | validate_files 300 push) || exit 2
+        ;;
+    *)
+        exit 2
+        ;;
+esac
+
+[ -n "$files" ] || exit 2
+printf '%s\n' "$files"

--- a/scripts/dev/rust-tests-input-paths.txt
+++ b/scripts/dev/rust-tests-input-paths.txt
@@ -33,6 +33,7 @@ docs/kcs/features
 docs/design/spec-dsl-examples
 docs/references/command-spec
 docs/references/f5_query
+docs/design/contracts/shared-utility-contracts-rust.md
 editors/vscode/package.json
 editors/vscode/src/chat/dialectCatalog.ts
 editors/vscode/src/compilerExplorerHtml.ts
@@ -40,6 +41,7 @@ editors/vscode/src/extension.ts
 editors/vscode/src/generated
 editors/vscode/src/languageIds.ts
 editors/vscode/syntaxes/tcl.tmLanguage.json
+editors/vscode/testFixture/variableContexts.tcl
 editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/TclFileType.kt
 editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/settings/TclLspSettings.kt
 editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/settings/TclLspSettingsPanel.kt
@@ -63,4 +65,9 @@ rust/tcl-spectcl/data/shipped-pack-dirs.txt
 rust/tcl-spectcl/tests/fixtures
 samples
 specs
+tests/external/backend_constraints.tcl
 tests/fixtures/spec-packs
+rust/bigip-report-gen/python/deploy/github-pages.yml
+rust/bigip-report-gen/python/deploy/report-pyz.yml
+.github/workflows/github-pages.yml
+.github/workflows/report-pyz.yml

--- a/scripts/dev/rust-tests-input-paths.txt
+++ b/scripts/dev/rust-tests-input-paths.txt
@@ -31,6 +31,8 @@ ai
 docs/generated
 docs/kcs/features
 docs/design/spec-dsl-examples
+docs/design/compiler/semantic-aot-optimisation.md
+docs/design/compiler/wasm-codegen.md
 docs/references/command-spec
 docs/references/f5_query
 docs/design/contracts/shared-utility-contracts-rust.md

--- a/scripts/dev/rust-tests-input-paths.txt
+++ b/scripts/dev/rust-tests-input-paths.txt
@@ -12,16 +12,21 @@
 # tcl-vm-wasm directly.
 .cargo/config.toml
 .config/nextest.toml
+.github/dependabot.yml
 .github/workflows/ci.yml
 Cargo.toml
 Cargo.lock
 Makefile
 rust-toolchain.toml
+.claude/skills/fetch-tcl-source/fetch_tcl_source.sh
 scripts/dev/ensure-test-deps.sh
+scripts/dev/already-green.sh
 scripts/dev/changed-paths.sh
 scripts/dev/rust-tests-path.sh
 scripts/dev/rust-tests-package-paths.txt
 scripts/dev/rust-tests-input-paths.txt
+scripts/dev/select-rust-tests-runner.sh
+scripts/dev/test-already-green.sh
 scripts/dev/test-rust-tests-paths.sh
 scripts/dev/test-rust-tests-runner.sh
 scripts/dev/tcl-reference-toolchains.sh

--- a/scripts/dev/rust-tests-input-paths.txt
+++ b/scripts/dev/rust-tests-input-paths.txt
@@ -1,0 +1,66 @@
+# Files and directories read by selected workspace crates, generated-data
+# checks, or archive/test bootstrap. Ordinary docs and unrelated lanes remain
+# no-ops.
+#
+# Audit method: package-owned include_str!/include_bytes!, filesystem reads,
+# scripts, fixtures, and tools are covered by the locked Cargo metadata path
+# closure in rust-tests-package-paths.txt.  We audited external inputs with:
+#   rg -n 'include_(str|bytes)!|env::var|var_os|read_to_string|read_to_end|File::open|Command::new|verify\.mjs|templates' rust --glob '*.rs' --glob '*.toml' --glob '*.mjs' --glob '*.sh'
+# The roots below are the resulting non-package inputs used by the root
+# rust-tests job; standalone wasm crates are listed even though Cargo excludes
+# them from the root workspace because tcl-vm's root tests build and verify
+# tcl-vm-wasm directly.
+.cargo/config.toml
+.config/nextest.toml
+.github/workflows/ci.yml
+Cargo.toml
+Cargo.lock
+Makefile
+rust-toolchain.toml
+scripts/dev/ensure-test-deps.sh
+scripts/dev/changed-paths.sh
+scripts/dev/rust-tests-path.sh
+scripts/dev/rust-tests-package-paths.txt
+scripts/dev/rust-tests-input-paths.txt
+scripts/dev/test-rust-tests-paths.sh
+scripts/dev/test-rust-tests-runner.sh
+scripts/dev/tcl-reference-toolchains.sh
+scripts/dev/test-reference-tcl-toolchains.sh
+scripts/dev/wasm-cc-env.sh
+ai
+docs/generated
+docs/kcs/features
+docs/design/spec-dsl-examples
+docs/references/command-spec
+docs/references/f5_query
+editors/vscode/package.json
+editors/vscode/src/chat/dialectCatalog.ts
+editors/vscode/src/compilerExplorerHtml.ts
+editors/vscode/src/extension.ts
+editors/vscode/src/generated
+editors/vscode/src/languageIds.ts
+editors/vscode/syntaxes/tcl.tmLanguage.json
+editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/TclFileType.kt
+editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/settings/TclLspSettings.kt
+editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/settings/TclLspSettingsPanel.kt
+editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/settings/generated
+editors/jetbrains/src/main/resources/META-INF/plugin.xml
+editors/jetbrains/src/main/resources/syntaxes/tcl.tmLanguage.json
+editors/sublime-text/plugin.py
+editors/sublime-text/sublime-package.json
+editors/zed/languages
+editors/helix/README.md
+INSTALL-editors.md
+rust/bigip-report-gen/frontend/src
+rust/bigip-report-gen/frontend/dist
+rust/bigip-report-gen/assets
+rust/bigip-report-gen/templates
+rust/bigip-report-gen/python/tests/data
+rust/tcl-cli/gui
+rust/tcl-cli/tests/fixtures
+rust/tcl-vm-wasm
+rust/tcl-spectcl/data/shipped-pack-dirs.txt
+rust/tcl-spectcl/tests/fixtures
+samples
+specs
+tests/fixtures/spec-packs

--- a/scripts/dev/rust-tests-package-paths.txt
+++ b/scripts/dev/rust-tests-package-paths.txt
@@ -1,0 +1,53 @@
+# Local package directories in the full root Cargo workspace. The root Rust
+# job's doctest command intentionally covers every workspace member, including
+# the four packages excluded from its nextest invocation, so this manifest is
+# the union of the nextest and doctest closures.
+rust/bigip-report-gen/rust
+rust/bpf-tcl
+rust/bpf-tcl-codegen
+rust/bpf-tcl-ir
+rust/f5-cli
+rust/f5-xc
+rust/tcl-bigip
+rust/tcl-bigip-io
+rust/tcl-bigip-query
+rust/tcl-bytecode
+rust/tcl-cli
+rust/tcl-cli-support
+rust/tcl-cmd-core
+rust/tcl-compiler
+rust/tcl-core-types
+rust/tcl-cshim
+rust/tcl-debugger
+rust/tcl-diagram
+rust/tcl-dialect
+rust/tcl-engine-api
+rust/tcl-engine-tclvm
+rust/tcl-explorer
+rust/tcl-f5mku
+rust/tcl-fuzz
+rust/tcl-host-native
+rust/tcl-irule-test
+rust/tcl-irules
+rust/tcl-lexer
+rust/tcl-lsp-core
+rust/tcl-lsp-db
+rust/tcl-lsp-server
+rust/tcl-mcp
+rust/tcl-pkg
+rust/tcl-platform
+rust/tcl-regex
+rust/tcl-registry
+rust/tcl-runtime-api
+rust/tcl-sandbox
+rust/tcl-spec-hooks
+rust/tcl-spec-studio
+rust/tcl-spectcl
+rust/tcl-sslictcl
+rust/tcl-syntax
+rust/tcl-test-support
+rust/tcl-userdirs
+rust/tcl-version
+rust/tcl-vm
+rust/tcl-vm-cli
+rust/xtask

--- a/scripts/dev/rust-tests-path.sh
+++ b/scripts/dev/rust-tests-path.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+# tcl-lsp — a language server and toolchain for Tcl
+# Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+# Exit 0 for a path in the root Rust-test closure (nextest plus the full
+# workspace doctest command), 1 for unrelated, and 2 for an unusable closure.
+# CI turns all errors into a broad test run.
+set -eu
+
+if [ "$#" -ne 1 ] || [ -z "$1" ]; then
+    echo "usage: scripts/dev/rust-tests-path.sh REPOSITORY_PATH" >&2
+    exit 2
+fi
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+REPO_ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/../.." && pwd)
+PACKAGE_MANIFEST=${TCL_LSP_RUST_TESTS_PACKAGE_MANIFEST:-$REPO_ROOT/scripts/dev/rust-tests-package-paths.txt}
+INPUT_MANIFEST=${TCL_LSP_RUST_TESTS_INPUT_MANIFEST:-$REPO_ROOT/scripts/dev/rust-tests-input-paths.txt}
+PATH_TO_CLASSIFY=$1
+
+for manifest in "$PACKAGE_MANIFEST" "$INPUT_MANIFEST"; do
+    [ -r "$manifest" ] || { echo "rust-tests-path: cannot read $manifest" >&2; exit 2; }
+    awk '
+        /^[[:space:]]*#/ || /^[[:space:]]*$/ { next }
+        $0 ~ /^[[:space:]]/ || $0 ~ /[[:space:]]$/ || $0 ~ /^\// || $0 ~ /\/$/ || $0 ~ /[*?]/ || index($0, "[") || seen[$0]++ {
+            printf "rust-tests-path: invalid row %d in %s: %s\n", NR, FILENAME, $0 > "/dev/stderr"; bad=1
+        }
+        { count++ }
+        END { if (count == 0) { print "rust-tests-path: empty manifest " FILENAME > "/dev/stderr"; bad=1 } exit bad }
+    ' "$manifest" || exit 2
+done
+
+while IFS= read -r directory; do
+    case "$directory" in ''|\#*) continue ;; esac
+    case "$PATH_TO_CLASSIFY" in "$directory"|"$directory"/*) exit 0 ;; esac
+done < "$PACKAGE_MANIFEST"
+
+while IFS= read -r path; do
+    case "$path" in ''|\#*) continue ;; esac
+    case "$PATH_TO_CLASSIFY" in "$path"|"$path"/*) exit 0 ;; esac
+done < "$INPUT_MANIFEST"
+
+exit 1

--- a/scripts/dev/test-rust-tests-paths.sh
+++ b/scripts/dev/test-rust-tests-paths.sh
@@ -53,8 +53,13 @@ expect_relevant specs/sdc_base.tclspec
 expect_relevant docs/generated/diagnostic_codes.md
 expect_relevant editors/vscode/src/extension.ts
 expect_relevant scripts/dev/already-green.sh
+expect_relevant scripts/dev/changed-paths.sh
+expect_relevant scripts/dev/rust-tests-input-paths.txt
+expect_relevant scripts/dev/rust-tests-package-paths.txt
+expect_relevant scripts/dev/rust-tests-path.sh
 expect_relevant scripts/dev/select-rust-tests-runner.sh
 expect_relevant scripts/dev/test-already-green.sh
+expect_relevant scripts/dev/test-rust-tests-paths.sh
 expect_relevant scripts/dev/test-rust-tests-runner.sh
 expect_relevant rust/bigip-report-gen/templates/report.html.j2
 expect_relevant rust/tcl-vm-wasm/Cargo.toml
@@ -235,10 +240,16 @@ expect_status_2 push-many push owner/repo 42 0123456789abcdef0123456789abcdef012
 # Verify channel wiring remains fail-closed and step-level.
 grep -Fq 'rust_tests_changed: ${{ steps.paths.outputs.rust_tests_changed }}' "$WORKFLOW" \
     || fail "channel output is missing rust_tests_changed"
-grep -Fq 'scripts/dev/changed-paths.sh' "$WORKFLOW" \
-    || fail "channel does not use the committed changed-file helper"
-grep -Fq 'scripts/dev/rust-tests-path.sh "$f"' "$WORKFLOW" \
-    || fail "channel does not invoke the committed path classifier"
+grep -Fq 'git show "$BASE_SHA:$path"' "$WORKFLOW" \
+    || fail "PR classification does not read its helpers from the trusted base commit"
+grep -Fq 'TCL_LSP_RUST_TESTS_PACKAGE_MANIFEST="$trusted/rust-tests-package-paths.txt"' "$WORKFLOW" \
+    || fail "trusted package closure is not wired into PR classification"
+grep -Fq 'TCL_LSP_RUST_TESTS_INPUT_MANIFEST="$trusted/rust-tests-input-paths.txt"' "$WORKFLOW" \
+    || fail "trusted external-input closure is not wired into PR classification"
+grep -Fq '"$changed_paths" "$GITHUB_EVENT_NAME"' "$WORKFLOW" \
+    || fail "channel does not invoke the selected changed-file helper"
+grep -Fq '"$rust_tests_path" "$f"' "$WORKFLOW" \
+    || fail "channel does not invoke the selected path classifier"
 grep -Fq 'rust_tests_changed=true' "$WORKFLOW" \
     || fail "channel has no fail-closed Rust-test fallback"
 rust_job=$(awk '

--- a/scripts/dev/test-rust-tests-paths.sh
+++ b/scripts/dev/test-rust-tests-paths.sh
@@ -1,0 +1,243 @@
+#!/bin/sh
+# tcl-lsp — a language server and toolchain for Tcl
+# Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+# Contract tests for the fail-closed root Rust test path closure and the
+# changed-file API boundary used by ci.yml.
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/../.." && pwd)
+CLASSIFIER=$ROOT/scripts/dev/rust-tests-path.sh
+CHANGED_FILES=$ROOT/scripts/dev/changed-paths.sh
+PACKAGES=$ROOT/scripts/dev/rust-tests-package-paths.txt
+INPUTS=$ROOT/scripts/dev/rust-tests-input-paths.txt
+WORKFLOW=$ROOT/.github/workflows/ci.yml
+
+fail() { echo "test-rust-tests-paths: $*" >&2; exit 1; }
+[ -x "$CLASSIFIER" ] || fail "classifier is not executable"
+[ -x "$CHANGED_FILES" ] || fail "changed-file helper is not executable"
+[ -r "$PACKAGES" ] || fail "package manifest is missing"
+[ -r "$INPUTS" ] || fail "input manifest is missing"
+
+expect_relevant() {
+    "$CLASSIFIER" "$1" || fail "expected relevant path: $1"
+}
+expect_unrelated() {
+    if "$CLASSIFIER" "$1"; then
+        fail "expected unrelated path: $1"
+    else
+        status=$?
+        [ "$status" -eq 1 ] || fail "unrelated path returned $status: $1"
+    fi
+}
+expect_invalid() {
+    if "$CLASSIFIER" "$1" 2>/dev/null; then
+        fail "invalid path unexpectedly passed: $1"
+    else
+        status=$?
+        [ "$status" -eq 2 ] || fail "invalid path returned $status: $1"
+    fi
+}
+
+expect_relevant rust/tcl-compiler/src/lib.rs
+expect_relevant rust/xtask/src/main.rs
+expect_relevant Cargo.lock
+expect_relevant Makefile
+expect_relevant .github/workflows/ci.yml
+expect_relevant specs/sdc_base.tclspec
+expect_relevant docs/generated/diagnostic_codes.md
+expect_relevant editors/vscode/src/extension.ts
+expect_relevant scripts/dev/test-rust-tests-runner.sh
+expect_relevant rust/bigip-report-gen/templates/report.html.j2
+expect_relevant rust/tcl-vm-wasm/Cargo.toml
+expect_relevant rust/tcl-vm-wasm/Cargo.lock
+expect_relevant rust/tcl-vm-wasm/src/lib.rs
+expect_relevant rust/tcl-vm-wasm/verify.mjs
+expect_unrelated README.md
+expect_unrelated docs/design/compiler/wasm-native-lowering-plan.md
+expect_relevant rust/tcl-lsp-server/src/lib.rs
+expect_unrelated runtime/rust/src/lib.rs
+expect_unrelated grammars/tree-sitter-tcl/grammar.js
+expect_unrelated editors/vscode/src/test/runTest.ts
+expect_invalid ""
+
+# A missing or malformed committed closure must never classify a path as
+# unrelated; CI converts status 2 into a broad Rust-test run.
+tmp=${TMPDIR:-/tmp}/tcl-lsp-rust-tests-paths.$$
+trap 'rm -rf "$tmp"' EXIT HUP INT TERM
+mkdir -p "$tmp"
+if TCL_LSP_RUST_TESTS_INPUT_MANIFEST="$tmp/missing" "$CLASSIFIER" README.md 2>/dev/null; then
+    fail "missing manifest unexpectedly passed"
+else
+    status=$?
+    [ "$status" -eq 2 ] || fail "missing manifest returned $status"
+fi
+if TCL_LSP_RUST_TESTS_PACKAGE_MANIFEST="$tmp/missing" "$CLASSIFIER" README.md 2>/dev/null; then
+    fail "missing package manifest unexpectedly passed"
+else
+    status=$?
+    [ "$status" -eq 2 ] || fail "missing package manifest returned $status"
+fi
+printf '%s\n' 'rust/' > "$tmp/bad"
+if TCL_LSP_RUST_TESTS_INPUT_MANIFEST="$tmp/bad" "$CLASSIFIER" README.md 2>/dev/null; then
+    fail "malformed manifest unexpectedly passed"
+else
+    status=$?
+    [ "$status" -eq 2 ] || fail "malformed manifest returned $status"
+fi
+
+# Re-derive the local package closure from locked cargo metadata so a new path
+# dependency cannot silently fall outside the committed classifier manifest.
+meta="$tmp/metadata.json"
+cargo metadata --locked --format-version 1 > "$meta" || fail "cargo metadata --locked failed"
+python3 - "$ROOT" "$PACKAGES" "$meta" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1]).resolve()
+manifest = Path(sys.argv[2])
+metadata = json.loads(Path(sys.argv[3]).read_text(encoding="utf-8"))
+packages = {package["id"]: package for package in metadata["packages"]}
+nodes = {node["id"]: node for node in metadata["resolve"]["nodes"]}
+pending = list(metadata["workspace_members"])
+seen = set(pending)
+while pending:
+    current = pending.pop()
+    for dependency in nodes[current]["deps"]:
+        dependency_id = dependency["pkg"]
+        if packages[dependency_id].get("source") is None and dependency_id not in seen:
+            seen.add(dependency_id)
+            pending.append(dependency_id)
+
+actual = set()
+for package_id in seen:
+    directory = Path(packages[package_id]["manifest_path"]).resolve().parent
+    actual.add(directory.relative_to(root).as_posix())
+expected = {line.strip() for line in manifest.read_text(encoding="utf-8").splitlines()
+            if line.strip() and not line.strip().startswith("#")}
+if actual != expected:
+    print("cargo metadata closure drift", file=sys.stderr)
+    print("missing:", sorted(actual - expected), file=sys.stderr)
+    print("extra:", sorted(expected - actual), file=sys.stderr)
+    raise SystemExit(1)
+print(f"cargo metadata closure contract passed ({len(actual)} local packages)")
+PY
+
+# Mock the GitHub CLI to exercise the changed-file API boundary without a
+# network call. A missing base, tag/unsupported event, empty result, compare
+# cap, or API error all return status 2 and therefore force a broad run.
+cat > "$tmp/gh" <<'EOF'
+#!/bin/sh
+set -eu
+case "${SCENARIO:-pr-negative}:$2" in
+    api-fail:*) exit 1 ;;
+    pr-negative:*) printf '%s\n' '[[{"filename":"README.md","status":"modified"}]]' ;;
+    pr-positive:*) printf '%s\n' '[[{"filename":"rust/tcl-compiler/src/lib.rs","status":"modified"}]]' ;;
+    pr-rename:*) printf '%s\n' '[[{"filename":"docs/moved.rs","previous_filename":"rust/tcl-compiler/tests/removed.rs","status":"renamed"}]]' ;;
+    pr-empty:*) printf '%s\n' '[[]]' ;;
+    pr-malformed-null:*) printf '%s\n' '[[{"filename":null,"status":"modified"}]]' ;;
+    pr-malformed-empty:*) printf '%s\n' '[[{"filename":"","status":"modified"}]]' ;;
+    pr-malformed-status:*) printf '%s\n' '[[{"filename":"README.md","status":"moved"}]]' ;;
+    pr-malformed-previous:*) printf '%s\n' '[[{"filename":"docs/moved.rs","previous_filename":null,"status":"renamed"}]]' ;;
+    pr-many:*) python3 -c 'import json; print(json.dumps([[{"filename": f"docs/file-{i}.md", "status": "modified"} for i in range(3000)]]))' ;;
+    push-positive:*) printf '%s\n' '{"files":[{"filename":"rust/xtask/src/main.rs","status":"modified"}]}' ;;
+    push-rename:*) printf '%s\n' '{"files":[{"filename":"docs/moved.rs","previous_filename":"rust/tcl-compiler/tests/removed.rs","status":"renamed"}]}' ;;
+    push-malformed-null:*) printf '%s\n' '{"files":[{"filename":null,"status":"modified"}]}' ;;
+    push-malformed-status:*) printf '%s\n' '{"files":[{"filename":"README.md","status":"moved"}]}' ;;
+    push-malformed-previous:*) printf '%s\n' '{"files":[{"filename":"docs/moved.rs","previous_filename":null,"status":"renamed"}]}' ;;
+    push-many:*) python3 -c 'import json; print(json.dumps({"files": [{"filename": f"docs/file-{i}.md", "status": "modified"} for i in range(300)]}))' ;;
+    *) printf '%s\n' '[[{"filename":"README.md","status":"modified"}]]' ;;
+esac
+EOF
+chmod +x "$tmp/gh"
+
+expect_files() {
+    scenario=$1
+    expected=$2
+    actual=$(SCENARIO=$scenario GH_BIN="$tmp/gh" PATH="$tmp:$PATH" \
+        "$CHANGED_FILES" "$3" owner/repo 42 "$4" "$5" "$6")
+    [ "$actual" = "$expected" ] || fail "$scenario returned unexpected files: $actual"
+}
+expect_files pr-negative README.md pull_request '' deadbeef refs/pull/42/merge
+expect_files pr-positive rust/tcl-compiler/src/lib.rs pull_request '' deadbeef refs/pull/42/merge
+expect_files push-positive rust/xtask/src/main.rs push 0123456789abcdef0123456789abcdef01234567 0123456789abcdef0123456789abcdef01234567 refs/heads/rust
+
+# A rename emits both API paths, while the cap still counts one file object.
+rename_paths=$(SCENARIO=pr-rename GH_BIN="$tmp/gh" PATH="$tmp:$PATH" \
+    "$CHANGED_FILES" pull_request owner/repo 42 '' deadbeef refs/pull/42/merge)
+expected_rename=$(printf '%s\n%s' docs/moved.rs rust/tcl-compiler/tests/removed.rs)
+[ "$rename_paths" = "$expected_rename" ] || fail "rename paths were not preserved: $rename_paths"
+rename_relevant=false
+while IFS= read -r path; do
+    if "$CLASSIFIER" "$path"; then
+        rename_relevant=true
+    fi
+done <<EOF
+$rename_paths
+EOF
+[ "$rename_relevant" = true ] || fail "relevant source rename did not trigger root tests"
+
+push_rename_paths=$(SCENARIO=push-rename GH_BIN="$tmp/gh" PATH="$tmp:$PATH" \
+    "$CHANGED_FILES" push owner/repo 42 0123456789abcdef0123456789abcdef01234567 0123456789abcdef0123456789abcdef01234567 refs/heads/rust)
+[ "$push_rename_paths" = "$expected_rename" ] || fail "compare rename paths were not preserved: $push_rename_paths"
+
+expect_status_2() {
+    scenario=$1
+    shift
+    if SCENARIO=$scenario GH_BIN="$tmp/gh" PATH="$tmp:$PATH" \
+        "$CHANGED_FILES" "$@"; then
+        fail "$scenario unexpectedly produced a complete file list"
+    else
+        status=$?
+        [ "$status" -eq 2 ] || fail "$scenario returned $status, expected 2"
+    fi
+}
+expect_status_2 api-fail pull_request owner/repo 42 '' deadbeef refs/pull/42/merge
+expect_status_2 pr-empty pull_request owner/repo 42 '' deadbeef refs/pull/42/merge
+expect_status_2 pr-malformed-null pull_request owner/repo 42 '' deadbeef refs/pull/42/merge
+expect_status_2 pr-malformed-empty pull_request owner/repo 42 '' deadbeef refs/pull/42/merge
+expect_status_2 pr-malformed-status pull_request owner/repo 42 '' deadbeef refs/pull/42/merge
+expect_status_2 pr-malformed-previous pull_request owner/repo 42 '' deadbeef refs/pull/42/merge
+expect_status_2 pr-many pull_request owner/repo 42 '' deadbeef refs/pull/42/merge
+expect_status_2 missing-base push owner/repo 42 '' 0123456789abcdef0123456789abcdef01234567 refs/heads/rust
+expect_status_2 tag-push push owner/repo 42 0123456789abcdef0123456789abcdef01234567 0123456789abcdef0123456789abcdef01234567 refs/tags/v1
+expect_status_2 wrong-ref push owner/repo 42 0123456789abcdef0123456789abcdef01234567 0123456789abcdef0123456789abcdef01234567 refs/heads/feature
+expect_status_2 abbreviated-before push owner/repo 42 0123456789abcdef 0123456789abcdef0123456789abcdef01234567 refs/heads/rust
+expect_status_2 abbreviated-sha push owner/repo 42 0123456789abcdef0123456789abcdef01234567 0123456789abcdef refs/heads/rust
+expect_status_2 uppercase-before push owner/repo 42 0123456789ABCDEF0123456789abcdef01234567 0123456789abcdef0123456789abcdef01234567 refs/heads/rust
+expect_status_2 uppercase-sha push owner/repo 42 0123456789abcdef0123456789abcdef01234567 0123456789ABCDEF0123456789abcdef01234567 refs/heads/rust
+expect_status_2 zero-before push owner/repo 42 0000000000000000000000000000000000000000 0123456789abcdef0123456789abcdef01234567 refs/heads/rust
+expect_status_2 zero-sha push owner/repo 42 0123456789abcdef0123456789abcdef01234567 0000000000000000000000000000000000000000 refs/heads/rust
+expect_status_2 unsupported-event schedule owner/repo 42 '' deadbeef refs/heads/rust
+expect_status_2 push-malformed-null push owner/repo 42 0123456789abcdef0123456789abcdef01234567 0123456789abcdef0123456789abcdef01234567 refs/heads/rust
+expect_status_2 push-malformed-status push owner/repo 42 0123456789abcdef0123456789abcdef01234567 0123456789abcdef0123456789abcdef01234567 refs/heads/rust
+expect_status_2 push-malformed-previous push owner/repo 42 0123456789abcdef0123456789abcdef01234567 0123456789abcdef0123456789abcdef01234567 refs/heads/rust
+expect_status_2 push-many push owner/repo 42 0123456789abcdef0123456789abcdef01234567 0123456789abcdef0123456789abcdef01234567 refs/heads/rust
+
+# Verify channel wiring remains fail-closed and step-level.
+grep -Fq 'rust_tests_changed: ${{ steps.paths.outputs.rust_tests_changed }}' "$WORKFLOW" \
+    || fail "channel output is missing rust_tests_changed"
+grep -Fq 'scripts/dev/changed-paths.sh' "$WORKFLOW" \
+    || fail "channel does not use the committed changed-file helper"
+grep -Fq 'scripts/dev/rust-tests-path.sh "$f"' "$WORKFLOW" \
+    || fail "channel does not invoke the committed path classifier"
+grep -Fq 'rust_tests_changed=true' "$WORKFLOW" \
+    || fail "channel has no fail-closed Rust-test fallback"
+rust_job=$(awk '
+    /^  rust-tests:/ { in_job = 1 }
+    in_job && /^  [A-Za-z0-9_-]+:/ && $1 != "rust-tests:" { exit }
+    in_job { print }
+' "$WORKFLOW")
+[ -n "$rust_job" ] || fail "ci.yml must define rust-tests"
+printf '%s\n' "$rust_job" | grep -Fq "if: needs.channel.outputs.rust_tests_changed == 'true'" \
+    || fail "rust-tests expensive steps are not path-gated"
+case "$rust_job" in
+    *'if: always() && needs.channel.outputs.rust_tests_changed == '\''true'\'''*'sccache --show-stats'*) ;;
+    *) fail "sccache statistics must be skipped when Rust setup is skipped" ;;
+esac
+
+echo "root Rust test path and changed-file contracts passed"

--- a/scripts/dev/test-rust-tests-paths.sh
+++ b/scripts/dev/test-rust-tests-paths.sh
@@ -59,6 +59,8 @@ expect_relevant rust/tcl-vm-wasm/verify.mjs
 expect_relevant editors/vscode/testFixture/variableContexts.tcl
 expect_relevant tests/external/backend_constraints.tcl
 expect_relevant docs/design/contracts/shared-utility-contracts-rust.md
+expect_relevant docs/design/compiler/semantic-aot-optimisation.md
+expect_relevant docs/design/compiler/wasm-codegen.md
 expect_relevant rust/bigip-report-gen/python/deploy/github-pages.yml
 expect_relevant rust/bigip-report-gen/python/deploy/report-pyz.yml
 expect_relevant .github/workflows/github-pages.yml

--- a/scripts/dev/test-rust-tests-paths.sh
+++ b/scripts/dev/test-rust-tests-paths.sh
@@ -56,6 +56,13 @@ expect_relevant rust/tcl-vm-wasm/Cargo.toml
 expect_relevant rust/tcl-vm-wasm/Cargo.lock
 expect_relevant rust/tcl-vm-wasm/src/lib.rs
 expect_relevant rust/tcl-vm-wasm/verify.mjs
+expect_relevant editors/vscode/testFixture/variableContexts.tcl
+expect_relevant tests/external/backend_constraints.tcl
+expect_relevant docs/design/contracts/shared-utility-contracts-rust.md
+expect_relevant rust/bigip-report-gen/python/deploy/github-pages.yml
+expect_relevant rust/bigip-report-gen/python/deploy/report-pyz.yml
+expect_relevant .github/workflows/github-pages.yml
+expect_relevant .github/workflows/report-pyz.yml
 expect_unrelated README.md
 expect_unrelated docs/design/compiler/wasm-native-lowering-plan.md
 expect_relevant rust/tcl-lsp-server/src/lib.rs

--- a/scripts/dev/test-rust-tests-paths.sh
+++ b/scripts/dev/test-rust-tests-paths.sh
@@ -46,10 +46,15 @@ expect_relevant rust/tcl-compiler/src/lib.rs
 expect_relevant rust/xtask/src/main.rs
 expect_relevant Cargo.lock
 expect_relevant Makefile
+expect_relevant .github/dependabot.yml
 expect_relevant .github/workflows/ci.yml
+expect_relevant .claude/skills/fetch-tcl-source/fetch_tcl_source.sh
 expect_relevant specs/sdc_base.tclspec
 expect_relevant docs/generated/diagnostic_codes.md
 expect_relevant editors/vscode/src/extension.ts
+expect_relevant scripts/dev/already-green.sh
+expect_relevant scripts/dev/select-rust-tests-runner.sh
+expect_relevant scripts/dev/test-already-green.sh
 expect_relevant scripts/dev/test-rust-tests-runner.sh
 expect_relevant rust/bigip-report-gen/templates/report.html.j2
 expect_relevant rust/tcl-vm-wasm/Cargo.toml

--- a/scripts/dev/test-rust-tests-runner.sh
+++ b/scripts/dev/test-rust-tests-runner.sh
@@ -162,5 +162,13 @@ esac
 require_path_gate_count "        if: needs.channel.outputs.rust_tests_changed == 'true'" 3
 require_path_gate_count "        if: needs.channel.outputs.rust_tests_changed == 'true' && needs.channel.outputs.docs_only != 'true' && needs.channel.outputs.already_green != 'true'" 2
 require_path_gate_count "        if: needs.channel.outputs.rust_tests_changed == 'true' && needs.channel.outputs.docs_only != 'true' && !(startsWith(github.ref, 'refs/tags/') && needs.channel.outputs.already_green == 'true')" 1
+case "$(cat "$WORKFLOW")" in
+    *'if [ "$rust_tests_changed" = "true" ]; then
+              docs_only=false'*) ;;
+    *)
+        echo "root Rust closure must override the broad docs-only path shape" >&2
+        exit 1
+        ;;
+esac
 
 echo "self-hosted Rust test scheduling contract passed"

--- a/scripts/dev/test-rust-tests-runner.sh
+++ b/scripts/dev/test-rust-tests-runner.sh
@@ -121,6 +121,16 @@ expect_selection() {
     fi
 }
 
+require_path_gate_count() {
+    expected=$1
+    required=$2
+    actual=$(printf '%s\n' "$rust_tests_job" | grep -Fxc "$expected" || true)
+    if [ "$actual" -ne "$required" ]; then
+        echo "rust-tests expected $required gated steps, found $actual: $expected" >&2
+        exit 1
+    fi
+}
+
 expect_selection idle tank
 expect_selection occupied hosted
 expect_selection hosted tank
@@ -144,5 +154,13 @@ case "$(cat "$WORKFLOW")" in
         exit 1
         ;;
 esac
+
+# Keep the required job alive for unrelated changes, but do not provision
+# toolchains, caches, interpreters, or test binaries when its archive is not
+# in the changed-path closure. These are step-level gates deliberately: a
+# job-level skip would leave the required status absent.
+require_path_gate_count "        if: needs.channel.outputs.rust_tests_changed == 'true'" 3
+require_path_gate_count "        if: needs.channel.outputs.rust_tests_changed == 'true' && needs.channel.outputs.docs_only != 'true' && needs.channel.outputs.already_green != 'true'" 2
+require_path_gate_count "        if: needs.channel.outputs.rust_tests_changed == 'true' && needs.channel.outputs.docs_only != 'true' && !(startsWith(github.ref, 'refs/tags/') && needs.channel.outputs.already_green == 'true')" 1
 
 echo "self-hosted Rust test scheduling contract passed"


### PR DESCRIPTION
## Summary

- derive and drift-check the complete 49-package root workspace closure used by nextest and workspace doctests
- commit the audited non-Cargo input closure, including generated data, spec packs, report templates, standalone tcl-vm-wasm verification, Tcl oracle bootstrap, runner policy, and classifier self-inputs
- preserve the required `rust-tests` job while step-skipping Rust setup, sccache, Tcl bootstrap, nextest, and doctests only when a complete changed-file list proves the closure is unaffected
- validate both rename paths and fail closed on API/schema errors, empty data, unsupported events, branch creation, tags, malformed SHAs, and the GitHub 300/3,000-file limits
- run pull-request classification from helpers and manifests copied from the exact trusted base commit, so a proposed classifier change cannot exempt itself
- make the audited closure authoritative over the broad docs-only shape check

## Verification

- `make NPROC=1 rust-check`
- `make NPROC=1 prep-pr`
- smoke tier: 30 passed, 21,801 skipped by the committed smoke filter
- focused classifier contract: all 49 local packages derived from locked Cargo metadata
- focused rename, truncation, malformed-schema, API-failure, tag/branch-creation, self-coverage, required-job, and workflow YAML checks
- two independent reviews of closure completeness and workflow fail-closed behaviour

After this implementation PR merges, #1926 will be retargeted to `rust` as a genuine docs-only PR. Its live run will provide the required wall-time proof that the unchanged required `rust-tests` check stays successful while all expensive steps skip; #1918 will remain open until that proof is recorded.
