### PR TITLE
docs(ci): describe unaffected-path proof

### DIFF
--- a/docs/design/contracts/test-tiers-and-ci-gates.md
+++ b/docs/design/contracts/test-tiers-and-ci-gates.md
@@ -169,6 +169,10 @@ CI skips only what demonstrably did not change. The rules live in
   because no sccache executable exists when setup is skipped. This audited
   closure overrides the broad docs-only shape check: an executable or
   test-consumed input under `docs/` or `.claude/` still runs the suite.
+  Validate an unaffected-path change in Actions by checking that the required
+  `rust-tests` job succeeds after checkout while its setup and test steps are
+  absent; a skipped job is not equivalent because it does not report the
+  required successful check.
 - `runtime-rust-tests` runs the standalone `runtime/rust` unit suite
   (`make runtime-rust-test`) only when `runtime_rust_changed` is true — that
   crate plus the path-dependency closure its own lockfile resolves. It is its


### PR DESCRIPTION
## Summary

Document how to validate an unaffected-path CI run while preserving the required `rust-tests` check.

This one-file documentation change is the live experiment for #1918. Its base is #1925, so the run exercises the new trusted-base classifier with a change outside the root Rust-test dependency closure.

## Expected proof

- the channel reports `rust_tests_changed=false`
- the required `rust-tests` job succeeds rather than being skipped
- only checkout runs in that job; Rust setup, sccache, Tcl bootstrap, nextest, doctests, and sccache reporting are absent
- the elapsed wall time is recorded on #1925 before merge

## Local verification

- `make NPROC=1 rust-check`
- `make NPROC=1 prep-pr`
- smoke tier: 30 passed, 21,801 skipped by the committed smoke filter
