### PR TITLE
ci: stabilise root Rust caches across Tank runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,7 +267,7 @@ jobs:
                   web_frontends_changed=true ;;
               esac
               case "$f" in
-                .github/workflows/ci.yml | .github/dependabot.yml | scripts/dev/select-rust-tests-runner.sh | scripts/dev/test-rust-tests-runner.sh)
+                .github/workflows/ci.yml | .github/dependabot.yml | scripts/dev/changed-paths.sh | scripts/dev/rust-tests-path.sh | scripts/dev/rust-tests-input-paths.txt | scripts/dev/rust-tests-package-paths.txt | scripts/dev/select-rust-tests-runner.sh | scripts/dev/test-rust-tests-paths.sh | scripts/dev/test-rust-tests-runner.sh)
                   runner_policy_changed=true ;;
               esac
               if "$rust_tests_path" "$f"; then
@@ -932,7 +932,6 @@ jobs:
     env:
       CARGO_HOME: /home/runner/.cargo
       RUSTUP_HOME: /home/runner/.rustup
-      RUSTC_WRAPPER: sccache
       SCCACHE_GHA_ENABLED: "true"
     concurrency:
       group: rust-tests-${{ ((github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]' || needs.channel.outputs.runner_policy_changed == 'true')) || needs.channel.outputs.rust_tests_runner == 'hosted') && format('hosted-{0}', github.run_id) || 'tank' }}
@@ -946,11 +945,13 @@ jobs:
           fetch-depth: 1
 
       - name: Verify canonical Rust homes
+        if: needs.channel.outputs.rust_tests_changed == 'true'
         shell: bash
         run: |
           set -euo pipefail
           root=/home/runner
-          test -d "$root" && test -w "$root"
+          test -d "$root" && test -w "$root" && test ! -L "$root"
+          test "$(readlink -f "$root")" = "$root"
           test "$(stat -c %u "$root")" = "$(id -u)"
           for dir in "$CARGO_HOME" "$RUSTUP_HOME"; do
             mkdir -p "$dir"
@@ -971,7 +972,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           toolchain: stable
-          cache-key: rust-tests
+          cache-key: rust-tests-v2
           # Swatinem's target archive is hundreds of MB and competes with the
           # per-object sccache backend for the repository cache quota. Cargo
           # rebuilds absent targets safely; registry/tool caches and sccache
@@ -984,10 +985,31 @@ jobs:
       # remapping here; measure cross-registration hits rather than assuming
       # that registrations with different absolute workspace paths share them.
       - name: Set up sccache
+        id: sccache
         if: needs.channel.outputs.rust_tests_changed == 'true'
+        continue-on-error: true
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
         with:
           version: v0.17.0
+          # The resilient reporting step below owns degradation warnings.
+          disable_annotations: true
+
+      # Compiler caching is an optimisation, never a condition of correctness.
+      # Do not export the wrapper until both action setup and the installed
+      # binary have succeeded; Cargo then falls back to rustc automatically.
+      - name: Enable sccache when available
+        if: needs.channel.outputs.rust_tests_changed == 'true'
+        shell: bash
+        env:
+          SCCACHE_SETUP_OUTCOME: ${{ steps.sccache.outcome }}
+        run: |
+          if [[ "$SCCACHE_SETUP_OUTCOME" == success ]] \
+              && command -v sccache >/dev/null 2>&1 \
+              && sccache --version >/dev/null 2>&1; then
+            echo 'RUSTC_WRAPPER=sccache' >> "$GITHUB_ENV"
+          else
+            echo '::warning::sccache is unavailable; continuing with uncached compilation'
+          fi
 
       - name: Install cargo-nextest
         if: needs.channel.outputs.rust_tests_changed == 'true'
@@ -1042,7 +1064,25 @@ jobs:
       # unaffected, so sccache is unavailable on those required no-op runs.
       - name: Report sccache statistics
         if: always() && needs.channel.outputs.rust_tests_changed == 'true'
-        run: sccache --show-stats
+        shell: bash
+        run: |
+          if ! command -v sccache >/dev/null 2>&1; then
+            echo '::warning::sccache statistics unavailable; compilation ran uncached'
+            exit 0
+          fi
+          set +e
+          stats=$(sccache --show-stats 2>&1)
+          status=$?
+          set -e
+          printf '%s\n' "$stats"
+          if [[ "$status" -ne 0 ]]; then
+            echo "::warning::sccache statistics failed with status $status"
+            exit 0
+          fi
+          write_errors=$(printf '%s\n' "$stats" | awk '$1 == "Cache" && $2 == "write" && $3 == "errors" { print $NF; exit }')
+          if [[ -n "$write_errors" && "$write_errors" != 0 ]]; then
+            echo "::warning::sccache reported $write_errors cache write errors"
+          fi
 
   # Fail-closed SpecTcl compatibility on every PR that changes its TclVM,
   # compiler, registry, runtime, pack, or exact-reference-toolchain closure.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -920,7 +920,18 @@ jobs:
     runs-on: ${{ ((github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]' || needs.channel.outputs.runner_policy_changed == 'true')) || needs.channel.outputs.rust_tests_runner == 'hosted') && 'ubuntu-26.04' || 'tank' }}
     # The action starts the sccache server during setup, so the backend must be
     # configured at job scope rather than only on the later Cargo steps.
+    # Self-hosted Tank has several runner registrations on one host. Their
+    # default CARGO_HOME/RUSTUP_HOME point below each registration directory,
+    # and Swatinem/rust-cache hashes those values, fragmenting an otherwise
+    # identical cache. Keep dependency/tool homes stable for Tank and hosted
+    # overflow jobs alike. The runner image contract is that /home/runner is
+    # owned and writable by the runner account; the preflight below proves it
+    # on every registration before setup writes there. Do not set
+    # CARGO_TARGET_DIR: Cargo's default workspace-local target/ remains
+    # isolated per checkout/job and is not shared between worktrees or runners.
     env:
+      CARGO_HOME: /home/runner/.cargo
+      RUSTUP_HOME: /home/runner/.rustup
       RUSTC_WRAPPER: sccache
       SCCACHE_GHA_ENABLED: "true"
     concurrency:
@@ -934,6 +945,21 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Verify canonical Rust homes
+        shell: bash
+        run: |
+          set -euo pipefail
+          root=/home/runner
+          test -d "$root" && test -w "$root"
+          test "$(stat -c %u "$root")" = "$(id -u)"
+          for dir in "$CARGO_HOME" "$RUSTUP_HOME"; do
+            mkdir -p "$dir"
+            test ! -L "$dir" && test -w "$dir"
+            test "$(stat -c %u "$dir")" = "$(id -u)"
+            probe=$(mktemp "$dir/.tcl-lsp-write-probe.XXXXXX")
+            rm -f "$probe"
+          done
+
       # Must install `stable` explicitly rather than lean on the runner's
       # preinstalled rustup: the image ships a pinned stable (e.g. 1.96.1) and
       # `rust-toolchain.toml`'s `channel = "stable"` resolves to *that*, not to
@@ -946,11 +972,17 @@ jobs:
         with:
           toolchain: stable
           cache-key: rust-tests
+          # Swatinem's target archive is hundreds of MB and competes with the
+          # per-object sccache backend for the repository cache quota. Cargo
+          # rebuilds absent targets safely; registry/tool caches and sccache
+          # remain enabled for dependency and compiler reuse.
+          cache-targets: false
 
       # rust-cache restores dependency artefacts, but intentionally removes
-      # workspace crates before saving.  This source-aware compiler cache keeps
-      # those expensive compilations reusable across runner registrations and
-      # source revisions without weakening Cargo's freshness checks.
+      # workspace crates before saving. sccache remains source-aware, but the
+      # pinned v0.17 Rust backend does not provide a proven cross-checkout-root
+      # remapping here; measure cross-registration hits rather than assuming
+      # that registrations with different absolute workspace paths share them.
       - name: Set up sccache
         if: needs.channel.outputs.rust_tests_changed == 'true'
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11

--- a/docs/design/contracts/test-tiers-and-ci-gates.md
+++ b/docs/design/contracts/test-tiers-and-ci-gates.md
@@ -211,8 +211,13 @@ cache optimisation; only trusted pushes and trusted pull requests may run
 there, while fork, Dependabot, runner-policy, and explicit hosted paths stay
 on hosted capacity. The job's preflight checks ownership, writability, and a
 temporary write on every registration. `CARGO_TARGET_DIR` is deliberately not
-shared. sccache v0.17 is also measured across registrations rather than
-assumed to normalize differing absolute checkout roots.
+shared, and the `rust-tests-v2` dependency-cache generation excludes Cargo
+targets so old target-heavy archives cannot be restored. sccache v0.17 is
+measured across registrations rather than assumed to normalize differing
+absolute checkout roots. Its setup, compiler cache, and statistics are
+performance-only: an unavailable cache falls back to direct rustc, while
+failed statistics and non-zero cache-write errors emit workflow warnings
+without changing the test result.
 
 Keep these properties: skips are **step-level** (jobs still report success so
 required checks and the release `needs:` graph hold), keyed on **content

--- a/docs/design/contracts/test-tiers-and-ci-gates.md
+++ b/docs/design/contracts/test-tiers-and-ci-gates.md
@@ -201,6 +201,19 @@ pull requests independently force hosted placement. A manual dispatch remains
 an explicit `tank` or `hosted` override. Placement never changes the test
 filter, skips coverage, or carries forward a result.
 
+The Tank job uses canonical `/home/runner/.cargo` and `/home/runner/.rustup`
+homes because each registration's default homes are rooted under its own
+checkout directory. These homes are shared mutable state: cancellation can
+interrupt Cargo or rustup writes, and any untrusted build script that reached
+Tank could persist configuration, credentials, or executable tools for a later
+job. The routing guards above are therefore a security boundary, not merely a
+cache optimisation; only trusted pushes and trusted pull requests may run
+there, while fork, Dependabot, runner-policy, and explicit hosted paths stay
+on hosted capacity. The job's preflight checks ownership, writability, and a
+temporary write on every registration. `CARGO_TARGET_DIR` is deliberately not
+shared. sccache v0.17 is also measured across registrations rather than
+assumed to normalize differing absolute checkout roots.
+
 Keep these properties: skips are **step-level** (jobs still report success so
 required checks and the release `needs:` graph hold), keyed on **content
 identity** (tree/SHA, never a label or commit message), and bounded in time.

--- a/scripts/dev/test-rust-tests-runner.sh
+++ b/scripts/dev/test-rust-tests-runner.sh
@@ -25,65 +25,109 @@ if [ -z "$rust_tests_job" ]; then
     exit 1
 fi
 
-case "$(cat "$WORKFLOW")" in
-    *'runner_policy_changed: ${{ steps.paths.outputs.runner_policy_changed }}'*) ;;
-    *)
-        echo "the channel job must publish its runner-policy path decision" >&2
-        exit 1
-        ;;
-esac
+# Parse the workflow rather than searching comments: the fork, Dependabot, and
+# runner-policy guards must be present in the values Actions actually consumes.
+python3 - "$WORKFLOW" <<'PY'
+import sys
 
-hosted_condition="(github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]' || needs.channel.outputs.runner_policy_changed == 'true')) || needs.channel.outputs.rust_tests_runner == 'hosted'"
+try:
+    import yaml
+except ModuleNotFoundError as error:
+    raise SystemExit(f"PyYAML is required for the CI contract test: {error}")
 
-case "$(cat "$WORKFLOW")" in
-    *'.github/workflows/ci.yml | .github/dependabot.yml | scripts/dev/select-rust-tests-runner.sh | scripts/dev/test-rust-tests-runner.sh)'*) ;;
-    *)
-        echo "runner and dependency-policy changes must classify themselves for hosted proof" >&2
-        exit 1
-        ;;
-esac
+with open(sys.argv[1], encoding="utf-8") as workflow_file:
+    workflow = yaml.safe_load(workflow_file)
 
-case "$(cat "$WORKFLOW")" in
-    *'rust_tests_runner:'*'type: choice'*'- tank'*'- hosted'*) ;;
-    *)
-        echo "manual CI dispatch must offer tank and hosted Rust runner choices" >&2
-        exit 1
-        ;;
-esac
 
-case "$(cat "$WORKFLOW")" in
-    *'rust_tests_runner: ${{ steps.rust-runner.outputs.runner }}'*) ;;
-    *)
-        echo "the channel job must publish its broad Rust runner decision" >&2
-        exit 1
-        ;;
-esac
+def require(condition, message):
+    if not condition:
+        raise SystemExit(message)
 
-case "$rust_tests_job" in
-    *"runs-on:"*"($hosted_condition)"*"&& 'ubuntu-26.04' || 'tank'"*) ;;
-    *)
-        echo "rust-tests must use the channel job's runner decision" >&2
-        exit 1
-        ;;
-esac
 
-case "$rust_tests_job" in
-    *"group: rust-tests-"*"($hosted_condition)"*"format('hosted-{0}', github.run_id)"*"|| 'tank'"*) ;;
-    *)
-        echo "rust-tests must serialize tank jobs and keep load-spilled hosted jobs unique" >&2
-        exit 1
-        ;;
-esac
+jobs = workflow.get("jobs", {})
+rust_tests = jobs.get("rust-tests")
+require(isinstance(rust_tests, dict), "ci.yml must define jobs.rust-tests as a mapping")
+require(
+    [name for name, job in jobs.items() if isinstance(job, dict) and "tank" in str(job.get("runs-on", ""))]
+    == ["rust-tests"],
+    "rust-tests must remain the only job that can reach Tank",
+)
+channel = jobs.get("channel")
+require(isinstance(channel, dict), "ci.yml must define jobs.channel as a mapping")
+outputs = channel.get("outputs", {})
+require(outputs.get("runner_policy_changed") == "${{ steps.paths.outputs.runner_policy_changed }}",
+        "channel must publish runner_policy_changed from the paths step")
+require(outputs.get("rust_tests_runner") == "${{ steps.rust-runner.outputs.runner }}",
+        "channel must publish the broad Rust runner decision")
 
-if ! printf '%s\n' "$rust_tests_job" | grep -Fqx '      cancel-in-progress: false'; then
-    echo "a new tank job must not cancel an already-running workspace suite" >&2
-    exit 1
-fi
+channel_steps = channel.get("steps", [])
+paths = next((step for step in channel_steps if step.get("id") == "paths"), {})
+path_list = ".github/workflows/ci.yml | .github/dependabot.yml | scripts/dev/select-rust-tests-runner.sh | scripts/dev/test-rust-tests-runner.sh)"
+require(path_list in paths.get("run", ""),
+        "runner and dependency-policy changes must classify themselves for hosted proof")
+runner = next((step for step in channel_steps if step.get("id") == "rust-runner"), {})
+runner_script = runner.get("run", "")
+require('"$PR_HEAD_REPOSITORY" != "$GITHUB_REPOSITORY"' in runner_script,
+        "fork pull requests must force hosted Rust tests")
+require('"$PR_AUTHOR" == \'dependabot[bot]\'' in runner_script,
+        "Dependabot pull requests must force hosted Rust tests")
+require('"$RUNNER_POLICY_CHANGED" == true' in runner_script,
+        "runner-policy pull requests must force hosted Rust tests")
+require('elif [[ "$EVENT_NAME" == workflow_dispatch ]]' in runner_script
+        and 'runner="$DISPATCH_RUNNER"' in runner_script,
+        "manual dispatch must remain an explicit runner override")
 
-if ! printf '%s\n' "$rust_tests_job" | grep -Fqx '      queue: max'; then
-    echo "the tank concurrency group must retain every pending workspace suite" >&2
-    exit 1
-fi
+triggers = workflow.get("on") or workflow.get(True, {})
+dispatch = triggers.get("workflow_dispatch", {})
+runner_input = dispatch.get("inputs", {}).get("rust_tests_runner", {})
+require(runner_input.get("type") == "choice", "manual dispatch must choose a Rust runner")
+require(runner_input.get("options") == ["tank", "hosted"],
+        "manual dispatch must offer exactly tank and hosted Rust runner choices")
+
+hosted = ("(github.event_name == 'pull_request' && ("
+          "github.event.pull_request.head.repo.full_name != github.repository || "
+          "github.event.pull_request.user.login == 'dependabot[bot]' || "
+          "needs.channel.outputs.runner_policy_changed == 'true')) || "
+          "needs.channel.outputs.rust_tests_runner == 'hosted'")
+runs_on = rust_tests.get("runs-on", "")
+group = rust_tests.get("concurrency", {}).get("group", "")
+require(hosted in runs_on, "runs-on must include all hosted guards")
+require(hosted in group, "concurrency group must include all hosted guards")
+require("&& 'ubuntu-26.04' || 'tank'" in runs_on, "rust-tests must retain the Tank fallback")
+require("format('hosted-{0}', github.run_id) || 'tank'" in group,
+        "hosted overflow must be unique while Tank remains one logical lane")
+
+concurrency = rust_tests.get("concurrency", {})
+require(concurrency.get("queue") == "max", "Tank concurrency must retain every pending suite")
+require(concurrency.get("cancel-in-progress") is False,
+        "a new Tank job must not cancel an already-running suite")
+
+env = rust_tests.get("env", {})
+require(env.get("CARGO_HOME") == "/home/runner/.cargo",
+        "rust-tests must use the canonical Cargo home")
+require(env.get("RUSTUP_HOME") == "/home/runner/.rustup",
+        "rust-tests must use the canonical rustup home")
+require("CARGO_TARGET_DIR" not in env, "rust-tests must not share CARGO_TARGET_DIR")
+require(env.get("RUSTC_WRAPPER") == "sccache", "rust-tests must retain sccache")
+require(env.get("SCCACHE_GHA_ENABLED") == "true", "rust-tests must enable GHA sccache")
+
+setup = next((step for step in rust_tests.get("steps", []) if step.get("name") == "Set up Rust"), {})
+require(setup.get("uses", "").startswith("actions-rust-lang/setup-rust-toolchain@"),
+        "rust-tests must use setup-rust-toolchain")
+require(setup.get("with", {}).get("cache-key") == "rust-tests",
+        "Rust cache key must stay stable")
+require(setup.get("with", {}).get("cache-targets") is False,
+        "Rust target archives must remain disabled")
+sccache = next((step for step in rust_tests.get("steps", []) if step.get("name") == "Set up sccache"), {})
+require(sccache.get("uses", "").startswith("mozilla-actions/sccache-action@")
+        and sccache.get("with", {}).get("version") == "v0.17.0",
+        "rust-tests must retain the pinned sccache setup")
+stats = next((step for step in rust_tests.get("steps", []) if step.get("name") == "Report sccache statistics"), {})
+require(stats.get("if") == "always()" and "sccache --show-stats" in stats.get("run", ""),
+        "cross-registration sccache reuse must be measured even after a test failure")
+require("SCCACHE_BASEDIRS" not in env,
+        "do not claim cross-checkout Rust remapping without pinned-source support")
+PY
 
 selector=$REPO_ROOT/scripts/dev/select-rust-tests-runner.sh
 tmp=${TMPDIR:-/tmp}/tcl-lsp-runner-policy.$$

--- a/scripts/dev/test-rust-tests-runner.sh
+++ b/scripts/dev/test-rust-tests-runner.sh
@@ -14,120 +14,218 @@ SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 REPO_ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/../.." && pwd)
 WORKFLOW=$REPO_ROOT/.github/workflows/ci.yml
 
-rust_tests_job=$(awk '
-    /^  rust-tests:/ { in_job = 1 }
-    in_job && /^  [A-Za-z0-9_-]+:/ && $1 != "rust-tests:" { exit }
-    in_job { print }
-' "$WORKFLOW")
-
-if [ -z "$rust_tests_job" ]; then
-    echo "ci.yml must define the rust-tests job" >&2
+# Parse the workflow without PyYAML or another unprovisioned dependency.  This
+# is a strict parser for the YAML subset used by the contract: mappings,
+# sequences, scalar values, and literal block scalars.  It records paths only
+# after walking indentation and list structure, so assertions cannot be
+# satisfied by a comment or an unrelated job/step with the same text.
+awk '
+function fail(message) {
+    print "ci.yml contract: " message > "/dev/stderr"
+    failed = 1
     exit 1
-fi
+}
+function trim(value) {
+    sub(/^[ \t]+/, "", value)
+    sub(/[ \t]+$/, "", value)
+    return value
+}
+function scalar(value,    i, c, quote, out) {
+    value = trim(value)
+    quote = ""
+    out = ""
+    for (i = 1; i <= length(value); i++) {
+        c = substr(value, i, 1)
+        if ((c == "\"" || c == "\047") && (i == 1 || substr(value, i - 1, 1) != "\\")) {
+            if (quote == "") quote = c
+            else if (quote == c) quote = ""
+        }
+        if (c == "#" && quote == "" && (i == 1 || substr(value, i - 1, 1) ~ /[ \t]/)) break
+        out = out c
+    }
+    out = trim(out)
+    if (length(out) >= 2 && ((substr(out, 1, 1) == "\"" && substr(out, length(out), 1) == "\"") ||
+                             (substr(out, 1, 1) == "\047" && substr(out, length(out), 1) == "\047")))
+        out = substr(out, 2, length(out) - 2)
+    return out
+}
+function put(path, value) {
+    if (values_seen[path]) fail("duplicate mapping key " path)
+    values_seen[path] = 1
+    seen[path] = 1
+    values[path] = value
+}
+function flush_block(    value) {
+    if (!block_active) return
+    sub(/\n$/, "", block_value)
+    put(block_path, block_value)
+    block_active = 0
+    block_path = ""
+    block_value = ""
+}
+function step(job, field, wanted,    parent, i, path) {
+    parent = job ".steps"
+    for (i = 0; i < seq_count[parent]; i++) {
+        path = parent "." i "." field
+        if (values[path] == wanted) return i
+    }
+    return -1
+}
+function need(condition, message) {
+    if (!condition) fail(message)
+}
+function contains(path, text, message) {
+    need(seen[path] && index(values[path], text) != 0, message)
+}
+{
+    line = $0
+    if (block_active) {
+        line_indent = 0
+        while (substr(line, line_indent + 1, 1) == " ") line_indent++
+        if (line ~ /^[ \t]*$/ || line_indent > block_indent) {
+            block_value = block_value line "\n"
+            next
+        }
+        flush_block()
+    }
+    if (line ~ /^[ \t]*$/ || line ~ /^[ \t]*#/) next
+    if (line ~ /\t/) fail("tabs are not valid indentation (line " NR ")")
+    indent = 0
+    while (substr(line, indent + 1, 1) == " ") indent++
+    while (stack_count > 0 && stack_indent[stack_count] >= indent) stack_count--
+    content = substr(line, indent + 1)
+    # YAML permits a flow sequence to continue on the line after its key
+    # (`needs:` in this workflow). It is a scalar for our purposes; consume it
+    # as the value of the pending mapping key rather than mistaking it for a
+    # malformed top-level line.
+    if (content ~ /^\[/ && stack_count > 0) {
+        path = stack_path[stack_count]
+        need(!values_seen[path], "duplicate mapping key " path)
+        values_seen[path] = 1
+        seen[path] = 1
+        values[path] = scalar(content)
+        stack_count--
+        next
+    }
+    if (content ~ /^-[ \t]*/) {
+        parent = (stack_count > 0 ? stack_path[stack_count] : "")
+        need(parent != "", "sequence without a mapping parent (line " NR ")")
+        sub(/^-/, "", content)
+        content = trim(content)
+        item = parent "." seq_count[parent]++
+        stack_count++
+        stack_indent[stack_count] = indent
+        stack_path[stack_count] = item
+        if (content == "") next
+        colon = index(content, ":")
+        if (colon == 0) {
+            put(item, scalar(content))
+            next
+        }
+        key = trim(substr(content, 1, colon - 1))
+        value = trim(substr(content, colon + 1))
+        path = item "." key
+    } else {
+        colon = index(content, ":")
+        need(colon != 0, "expected a mapping or sequence item (line " NR ")")
+        parent = (stack_count > 0 ? stack_path[stack_count] : "")
+        key = trim(substr(content, 1, colon - 1))
+        need(key != "", "empty mapping key (line " NR ")")
+        value = trim(substr(content, colon + 1))
+        path = (parent == "" ? key : parent "." key)
+    }
+    need(!nodes[path], "duplicate mapping key " path)
+    nodes[path] = 1
+    if (value == "") {
+        stack_count++
+        stack_indent[stack_count] = indent
+        stack_path[stack_count] = path
+    } else if (value == "|") {
+        block_active = 1
+        block_indent = indent
+        block_path = path
+        block_value = ""
+    } else if (value ~ /^[>|][+-]?$/) {
+        # Preserve folded scalars line-for-line. The contract only searches
+        # literal shell blocks, but accepting both YAML block styles keeps an
+        # unrelated workflow field from making this structural parser brittle.
+        block_active = 1
+        block_indent = indent
+        block_path = path
+        block_value = ""
+    } else {
+        put(path, scalar(value))
+    }
+}
+END {
+    if (failed) exit 1
+    flush_block()
+    need(values_seen["jobs.rust-tests.runs-on"], "ci.yml must define jobs.rust-tests as a mapping")
+    tank_jobs = 0
+    for (path in values) {
+        if (path ~ /^jobs\.[^.]+\.runs-on$/ && index(values[path], "tank") != 0) {
+            split(path, parts, ".")
+            tank_jobs++
+            tank_job = parts[2]
+        }
+    }
+    need(tank_jobs == 1 && tank_job == "rust-tests", "rust-tests must remain the only job that can reach Tank")
+    need(nodes["jobs.channel"], "ci.yml must define jobs.channel as a mapping")
+    need(values["jobs.channel.outputs.runner_policy_changed"] == "${{ steps.paths.outputs.runner_policy_changed }}",
+         "channel must publish runner_policy_changed from the paths step")
+    need(values["jobs.channel.outputs.rust_tests_runner"] == "${{ steps.rust-runner.outputs.runner }}",
+         "channel must publish the broad Rust runner decision")
 
-# Parse the workflow rather than searching comments: the fork, Dependabot, and
-# runner-policy guards must be present in the values Actions actually consumes.
-python3 - "$WORKFLOW" <<'PY'
-import sys
+    paths_step = step("jobs.channel", "id", "paths")
+    need(paths_step >= 0, "channel must define the paths step")
+    paths_run = "jobs.channel.steps." paths_step ".run"
+    path_list = ".github/workflows/ci.yml | .github/dependabot.yml | scripts/dev/select-rust-tests-runner.sh | scripts/dev/test-rust-tests-runner.sh)"
+    contains(paths_run, path_list, "runner and dependency-policy changes must classify themselves for hosted proof")
 
-try:
-    import yaml
-except ModuleNotFoundError as error:
-    raise SystemExit(f"PyYAML is required for the CI contract test: {error}")
+    runner_step = step("jobs.channel", "id", "rust-runner")
+    need(runner_step >= 0, "channel must define the rust-runner step")
+    runner_run = "jobs.channel.steps." runner_step ".run"
+    contains(runner_run, "\"$PR_HEAD_REPOSITORY\" != \"$GITHUB_REPOSITORY\"", "fork pull requests must force hosted Rust tests")
+    contains(runner_run, "\"$PR_AUTHOR\" == '\''dependabot[bot]'\''", "Dependabot pull requests must force hosted Rust tests")
+    contains(runner_run, "\"$RUNNER_POLICY_CHANGED\" == true", "runner-policy pull requests must force hosted Rust tests")
+    contains(runner_run, "elif [[ \"$EVENT_NAME\" == workflow_dispatch ]]", "manual dispatch must remain an explicit runner override")
+    contains(runner_run, "runner=\"$DISPATCH_RUNNER\"", "manual dispatch must remain an explicit runner override")
+    routing = "if [[ \"$EVENT_NAME\" == pull_request && (\"$PR_HEAD_REPOSITORY\" != \"$GITHUB_REPOSITORY\" || \"$PR_AUTHOR\" == '\''dependabot[bot]'\'' || \"$RUNNER_POLICY_CHANGED\" == true) ]]"
+    contains(runner_run, routing, "fork, Dependabot, policy-change, and manual-dispatch routing must stay outside the mutable selector")
+    contains(runner_run, "runner=hosted", "fork, Dependabot, policy-change, and manual-dispatch routing must stay outside the mutable selector")
 
-with open(sys.argv[1], encoding="utf-8") as workflow_file:
-    workflow = yaml.safe_load(workflow_file)
+    need(values["on.workflow_dispatch.inputs.rust_tests_runner.type"] == "choice", "manual dispatch must choose a Rust runner")
+    need(values["on.workflow_dispatch.inputs.rust_tests_runner.options.0"] == "tank" &&
+         values["on.workflow_dispatch.inputs.rust_tests_runner.options.1"] == "hosted" &&
+         seq_count["on.workflow_dispatch.inputs.rust_tests_runner.options"] == 2,
+         "manual dispatch must offer exactly tank and hosted Rust runner choices")
 
+    hosted = "(github.event_name == '\''pull_request'\'' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == '\''dependabot[bot]'\'' || needs.channel.outputs.runner_policy_changed == '\''true'\'')) || needs.channel.outputs.rust_tests_runner == '\''hosted'\''"
+    contains("jobs.rust-tests.runs-on", hosted, "runs-on must include all hosted guards")
+    contains("jobs.rust-tests.concurrency.group", hosted, "concurrency group must include all hosted guards")
+    contains("jobs.rust-tests.runs-on", "&& '\''ubuntu-26.04'\'' || '\''tank'\''", "rust-tests must retain the Tank fallback")
+    contains("jobs.rust-tests.concurrency.group", "format('\''hosted-{0}'\'', github.run_id) || '\''tank'\''", "hosted overflow must be unique while Tank remains one logical lane")
+    need(values["jobs.rust-tests.concurrency.queue"] == "max", "Tank concurrency must retain every pending suite")
+    need(values["jobs.rust-tests.concurrency.cancel-in-progress"] == "false", "a new Tank job must not cancel an already-running suite")
+    need(values["jobs.rust-tests.env.CARGO_HOME"] == "/home/runner/.cargo", "rust-tests must use the canonical Cargo home")
+    need(values["jobs.rust-tests.env.RUSTUP_HOME"] == "/home/runner/.rustup", "rust-tests must use the canonical rustup home")
+    need(!nodes["jobs.rust-tests.env.CARGO_TARGET_DIR"], "rust-tests must not share CARGO_TARGET_DIR")
+    need(values["jobs.rust-tests.env.RUSTC_WRAPPER"] == "sccache", "rust-tests must retain sccache")
+    need(values["jobs.rust-tests.env.SCCACHE_GHA_ENABLED"] == "true", "rust-tests must enable GHA sccache")
 
-def require(condition, message):
-    if not condition:
-        raise SystemExit(message)
-
-
-jobs = workflow.get("jobs", {})
-rust_tests = jobs.get("rust-tests")
-require(isinstance(rust_tests, dict), "ci.yml must define jobs.rust-tests as a mapping")
-require(
-    [name for name, job in jobs.items() if isinstance(job, dict) and "tank" in str(job.get("runs-on", ""))]
-    == ["rust-tests"],
-    "rust-tests must remain the only job that can reach Tank",
-)
-channel = jobs.get("channel")
-require(isinstance(channel, dict), "ci.yml must define jobs.channel as a mapping")
-outputs = channel.get("outputs", {})
-require(outputs.get("runner_policy_changed") == "${{ steps.paths.outputs.runner_policy_changed }}",
-        "channel must publish runner_policy_changed from the paths step")
-require(outputs.get("rust_tests_runner") == "${{ steps.rust-runner.outputs.runner }}",
-        "channel must publish the broad Rust runner decision")
-
-channel_steps = channel.get("steps", [])
-paths = next((step for step in channel_steps if step.get("id") == "paths"), {})
-path_list = ".github/workflows/ci.yml | .github/dependabot.yml | scripts/dev/select-rust-tests-runner.sh | scripts/dev/test-rust-tests-runner.sh)"
-require(path_list in paths.get("run", ""),
-        "runner and dependency-policy changes must classify themselves for hosted proof")
-runner = next((step for step in channel_steps if step.get("id") == "rust-runner"), {})
-runner_script = runner.get("run", "")
-require('"$PR_HEAD_REPOSITORY" != "$GITHUB_REPOSITORY"' in runner_script,
-        "fork pull requests must force hosted Rust tests")
-require('"$PR_AUTHOR" == \'dependabot[bot]\'' in runner_script,
-        "Dependabot pull requests must force hosted Rust tests")
-require('"$RUNNER_POLICY_CHANGED" == true' in runner_script,
-        "runner-policy pull requests must force hosted Rust tests")
-require('elif [[ "$EVENT_NAME" == workflow_dispatch ]]' in runner_script
-        and 'runner="$DISPATCH_RUNNER"' in runner_script,
-        "manual dispatch must remain an explicit runner override")
-
-triggers = workflow.get("on") or workflow.get(True, {})
-dispatch = triggers.get("workflow_dispatch", {})
-runner_input = dispatch.get("inputs", {}).get("rust_tests_runner", {})
-require(runner_input.get("type") == "choice", "manual dispatch must choose a Rust runner")
-require(runner_input.get("options") == ["tank", "hosted"],
-        "manual dispatch must offer exactly tank and hosted Rust runner choices")
-
-hosted = ("(github.event_name == 'pull_request' && ("
-          "github.event.pull_request.head.repo.full_name != github.repository || "
-          "github.event.pull_request.user.login == 'dependabot[bot]' || "
-          "needs.channel.outputs.runner_policy_changed == 'true')) || "
-          "needs.channel.outputs.rust_tests_runner == 'hosted'")
-runs_on = rust_tests.get("runs-on", "")
-group = rust_tests.get("concurrency", {}).get("group", "")
-require(hosted in runs_on, "runs-on must include all hosted guards")
-require(hosted in group, "concurrency group must include all hosted guards")
-require("&& 'ubuntu-26.04' || 'tank'" in runs_on, "rust-tests must retain the Tank fallback")
-require("format('hosted-{0}', github.run_id) || 'tank'" in group,
-        "hosted overflow must be unique while Tank remains one logical lane")
-
-concurrency = rust_tests.get("concurrency", {})
-require(concurrency.get("queue") == "max", "Tank concurrency must retain every pending suite")
-require(concurrency.get("cancel-in-progress") is False,
-        "a new Tank job must not cancel an already-running suite")
-
-env = rust_tests.get("env", {})
-require(env.get("CARGO_HOME") == "/home/runner/.cargo",
-        "rust-tests must use the canonical Cargo home")
-require(env.get("RUSTUP_HOME") == "/home/runner/.rustup",
-        "rust-tests must use the canonical rustup home")
-require("CARGO_TARGET_DIR" not in env, "rust-tests must not share CARGO_TARGET_DIR")
-require(env.get("RUSTC_WRAPPER") == "sccache", "rust-tests must retain sccache")
-require(env.get("SCCACHE_GHA_ENABLED") == "true", "rust-tests must enable GHA sccache")
-
-setup = next((step for step in rust_tests.get("steps", []) if step.get("name") == "Set up Rust"), {})
-require(setup.get("uses", "").startswith("actions-rust-lang/setup-rust-toolchain@"),
-        "rust-tests must use setup-rust-toolchain")
-require(setup.get("with", {}).get("cache-key") == "rust-tests",
-        "Rust cache key must stay stable")
-require(setup.get("with", {}).get("cache-targets") is False,
-        "Rust target archives must remain disabled")
-sccache = next((step for step in rust_tests.get("steps", []) if step.get("name") == "Set up sccache"), {})
-require(sccache.get("uses", "").startswith("mozilla-actions/sccache-action@")
-        and sccache.get("with", {}).get("version") == "v0.17.0",
-        "rust-tests must retain the pinned sccache setup")
-stats = next((step for step in rust_tests.get("steps", []) if step.get("name") == "Report sccache statistics"), {})
-require(stats.get("if") == "always()" and "sccache --show-stats" in stats.get("run", ""),
-        "cross-registration sccache reuse must be measured even after a test failure")
-require("SCCACHE_BASEDIRS" not in env,
-        "do not claim cross-checkout Rust remapping without pinned-source support")
-PY
+    setup = step("jobs.rust-tests", "name", "Set up Rust")
+    need(setup >= 0 && index(values["jobs.rust-tests.steps." setup ".uses"], "actions-rust-lang/setup-rust-toolchain@") == 1, "rust-tests must use setup-rust-toolchain")
+    need(values["jobs.rust-tests.steps." setup ".with.cache-key"] == "rust-tests", "Rust cache key must stay stable")
+    need(values["jobs.rust-tests.steps." setup ".with.cache-targets"] == "false", "Rust target archives must remain disabled")
+    sccache = step("jobs.rust-tests", "name", "Set up sccache")
+    need(sccache >= 0 && index(values["jobs.rust-tests.steps." sccache ".uses"], "mozilla-actions/sccache-action@") == 1 && values["jobs.rust-tests.steps." sccache ".with.version"] == "v0.17.0", "rust-tests must retain the pinned sccache setup")
+    stats = step("jobs.rust-tests", "name", "Report sccache statistics")
+    # Keep this assertion unconditional on the #1917 base: rust_tests_changed
+    # is introduced by #1918 and can be integrated when that branch rebases.
+    need(stats >= 0 && values["jobs.rust-tests.steps." stats ".if"] == "always()" && index(values["jobs.rust-tests.steps." stats ".run"], "sccache --show-stats") != 0, "cross-registration sccache reuse must be measured even after a test failure")
+    for (path in nodes) if (path ~ /^jobs\.rust-tests\.env\./ && path ~ /SCCACHE_BASEDIRS$/) fail("do not claim cross-checkout Rust remapping without pinned-source support")
+}
+' "$WORKFLOW"
 
 selector=$REPO_ROOT/scripts/dev/select-rust-tests-runner.sh
 tmp=${TMPDIR:-/tmp}/tcl-lsp-runner-policy.$$

--- a/scripts/dev/test-rust-tests-runner.sh
+++ b/scripts/dev/test-rust-tests-runner.sh
@@ -14,6 +14,17 @@ SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 REPO_ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/../.." && pwd)
 WORKFLOW=$REPO_ROOT/.github/workflows/ci.yml
 
+rust_tests_job=$(awk '
+    /^  rust-tests:/ { in_job = 1 }
+    in_job && /^  [A-Za-z0-9_-]+:/ && $1 != "rust-tests:" { exit }
+    in_job { print }
+' "$WORKFLOW")
+
+if [ -z "$rust_tests_job" ]; then
+    echo "ci.yml must define the rust-tests job" >&2
+    exit 1
+fi
+
 # Parse the workflow without PyYAML or another unprovisioned dependency.  This
 # is a strict parser for the YAML subset used by the contract: mappings,
 # sequences, scalar values, and literal block scalars.  It records paths only
@@ -179,7 +190,7 @@ END {
     paths_step = step("jobs.channel", "id", "paths")
     need(paths_step >= 0, "channel must define the paths step")
     paths_run = "jobs.channel.steps." paths_step ".run"
-    path_list = ".github/workflows/ci.yml | .github/dependabot.yml | scripts/dev/select-rust-tests-runner.sh | scripts/dev/test-rust-tests-runner.sh)"
+    path_list = ".github/workflows/ci.yml | .github/dependabot.yml | scripts/dev/changed-paths.sh | scripts/dev/rust-tests-path.sh | scripts/dev/rust-tests-input-paths.txt | scripts/dev/rust-tests-package-paths.txt | scripts/dev/select-rust-tests-runner.sh | scripts/dev/test-rust-tests-paths.sh | scripts/dev/test-rust-tests-runner.sh)"
     contains(paths_run, path_list, "runner and dependency-policy changes must classify themselves for hosted proof")
 
     runner_step = step("jobs.channel", "id", "rust-runner")
@@ -210,19 +221,50 @@ END {
     need(values["jobs.rust-tests.env.CARGO_HOME"] == "/home/runner/.cargo", "rust-tests must use the canonical Cargo home")
     need(values["jobs.rust-tests.env.RUSTUP_HOME"] == "/home/runner/.rustup", "rust-tests must use the canonical rustup home")
     need(!nodes["jobs.rust-tests.env.CARGO_TARGET_DIR"], "rust-tests must not share CARGO_TARGET_DIR")
-    need(values["jobs.rust-tests.env.RUSTC_WRAPPER"] == "sccache", "rust-tests must retain sccache")
+    need(!nodes["jobs.rust-tests.env.RUSTC_WRAPPER"], "sccache must not be correctness-critical at job scope")
     need(values["jobs.rust-tests.env.SCCACHE_GHA_ENABLED"] == "true", "rust-tests must enable GHA sccache")
+
+    changed = "needs.channel.outputs.rust_tests_changed == '\''true'\''"
+    preflight = step("jobs.rust-tests", "name", "Verify canonical Rust homes")
+    need(preflight >= 0 && values["jobs.rust-tests.steps." preflight ".if"] == changed,
+         "canonical-home preflight must skip with the unaffected root Rust archive")
+    contains("jobs.rust-tests.steps." preflight ".run", "test ! -L \"$root\"",
+             "canonical-home preflight must reject a symlinked root")
+    contains("jobs.rust-tests.steps." preflight ".run", "readlink -f \"$root\"",
+             "canonical-home preflight must resolve to the literal trusted root")
 
     setup = step("jobs.rust-tests", "name", "Set up Rust")
     need(setup >= 0 && index(values["jobs.rust-tests.steps." setup ".uses"], "actions-rust-lang/setup-rust-toolchain@") == 1, "rust-tests must use setup-rust-toolchain")
-    need(values["jobs.rust-tests.steps." setup ".with.cache-key"] == "rust-tests", "Rust cache key must stay stable")
+    need(values["jobs.rust-tests.steps." setup ".if"] == changed,
+         "Rust setup must skip with the unaffected root Rust archive")
+    need(values["jobs.rust-tests.steps." setup ".with.cache-key"] == "rust-tests-v2", "Rust cache key must reject old target-heavy archives")
     need(values["jobs.rust-tests.steps." setup ".with.cache-targets"] == "false", "Rust target archives must remain disabled")
     sccache = step("jobs.rust-tests", "name", "Set up sccache")
     need(sccache >= 0 && index(values["jobs.rust-tests.steps." sccache ".uses"], "mozilla-actions/sccache-action@") == 1 && values["jobs.rust-tests.steps." sccache ".with.version"] == "v0.17.0", "rust-tests must retain the pinned sccache setup")
+    need(values["jobs.rust-tests.steps." sccache ".with.disable_annotations"] == "true",
+         "the resilient statistics step must own cache-degradation warnings")
+    need(values["jobs.rust-tests.steps." sccache ".id"] == "sccache" &&
+         values["jobs.rust-tests.steps." sccache ".if"] == changed &&
+         values["jobs.rust-tests.steps." sccache ".continue-on-error"] == "true",
+         "sccache setup must be observable, gated, and non-fatal")
+    enable = step("jobs.rust-tests", "name", "Enable sccache when available")
+    need(enable > sccache && values["jobs.rust-tests.steps." enable ".if"] == changed,
+         "the compiler wrapper must only be enabled after optional sccache setup")
+    need(values["jobs.rust-tests.steps." enable ".env.SCCACHE_SETUP_OUTCOME"] == "${{ steps.sccache.outcome }}",
+         "wrapper enablement must inspect the sccache setup outcome")
+    contains("jobs.rust-tests.steps." enable ".run", "RUSTC_WRAPPER=sccache",
+             "successful optional setup must enable the compiler cache")
+    contains("jobs.rust-tests.steps." enable ".run", "continuing with uncached compilation",
+             "failed optional setup must report the uncached fallback")
     stats = step("jobs.rust-tests", "name", "Report sccache statistics")
-    # Keep this assertion unconditional on the #1917 base: rust_tests_changed
-    # is introduced by #1918 and can be integrated when that branch rebases.
-    need(stats >= 0 && values["jobs.rust-tests.steps." stats ".if"] == "always()" && index(values["jobs.rust-tests.steps." stats ".run"], "sccache --show-stats") != 0, "cross-registration sccache reuse must be measured even after a test failure")
+    need(stats > enable && values["jobs.rust-tests.steps." stats ".if"] == "always() && " changed,
+         "sccache reuse must be measured after every affected test attempt")
+    contains("jobs.rust-tests.steps." stats ".run", "sccache --show-stats",
+             "cross-registration sccache reuse must be observable")
+    contains("jobs.rust-tests.steps." stats ".run", "cache write errors",
+             "degraded cache writes must emit a workflow warning")
+    contains("jobs.rust-tests.steps." stats ".run", "exit 0",
+             "cache-statistics failures must not change test correctness")
     for (path in nodes) if (path ~ /^jobs\.rust-tests\.env\./ && path ~ /SCCACHE_BASEDIRS$/) fail("do not claim cross-checkout Rust remapping without pinned-source support")
 }
 ' "$WORKFLOW"
@@ -301,7 +343,7 @@ esac
 # toolchains, caches, interpreters, or test binaries when its archive is not
 # in the changed-path closure. These are step-level gates deliberately: a
 # job-level skip would leave the required status absent.
-require_path_gate_count "        if: needs.channel.outputs.rust_tests_changed == 'true'" 3
+require_path_gate_count "        if: needs.channel.outputs.rust_tests_changed == 'true'" 5
 require_path_gate_count "        if: needs.channel.outputs.rust_tests_changed == 'true' && needs.channel.outputs.docs_only != 'true' && needs.channel.outputs.already_green != 'true'" 2
 require_path_gate_count "        if: needs.channel.outputs.rust_tests_changed == 'true' && needs.channel.outputs.docs_only != 'true' && !(startsWith(github.ref, 'refs/tags/') && needs.channel.outputs.already_green == 'true')" 1
 case "$(cat "$WORKFLOW")" in


### PR DESCRIPTION
## Summary

- normalise the root Rust lane onto canonical Cargo and rustup homes across Tank registrations, with ownership, writability, and symlink preflight checks
- stop storing bulky Cargo target archives, bump the cache generation to reject old archives, and retain sccache as the per-object compiler cache
- make sccache setup and reporting performance-only: unavailable caching falls back to direct rustc, while setup/statistics/write degradation emits warnings
- force every runner selector, trusted classifier, closure manifest, and associated contract-test change onto hosted capacity
- replace the runner contract's undeclared PyYAML dependency with a structural AWK parser

## Local proof

- `make NPROC=1 rust-check` passed from an empty isolated target and again after rebasing onto the merged #1918 proof
- `make NPROC=1 prep-pr` passed: 30 smoke tests passed and 21,801 were skipped by the committed smoke filter
- `scripts/dev/test-rust-tests-runner.sh` passed
- `scripts/dev/test-rust-tests-paths.sh` passed with all 49 root-workspace packages in the audited closure
- `.github/workflows/ci.yml` parsed successfully as YAML
- independent review found and fixed a hosted-routing gap for trusted classifier and manifest changes

## Measurements

- cold top-level workspace check: 5m01s
- cold smoke ownership fixture compile inside `rust-check`: 3m28s
- cold `prep-pr` smoke-profile build: 11m44s for 343 binaries; its 30 selected tests then ran in 1.0s

The PR path deliberately runs on hosted capacity. Before merge I will run two sequential manual Tank jobs from this exact ref and record runner registration, dependency-cache restore, sccache hits/misses/write errors, cache bytes/upload time, and wall time against the issue baseline.

#1917 remains open until those repeated live experiments are green and the selected setup is merged.
