### PR TITLE
Fix the JetBrains plugin: highlighting, explorer, settings, and native editor panes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2341,6 +2341,27 @@ jobs:
             editors/jetbrains/*.gradle*
             editors/jetbrains/gradle/wrapper/gradle-wrapper.properties
 
+      # The plugin bundles the spec studio and the compiler explorer webview,
+      # both of which are built from the TypeScript sources. Without a pinned
+      # Node this job used whatever the runner image happened to ship, and the
+      # compiler explorer extraction silently no-opped.
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "24"
+
+      - name: Enable Corepack (pin npm via packageManager)
+        env:
+          COREPACK_ENABLE_DOWNLOAD_PROMPT: "0"
+        run: corepack enable npm
+
+      # The plugin's Kotlin suite runs nowhere else — it needs the IntelliJ
+      # SDK this job already downloads to build against.
+      - name: Test JetBrains plugin
+        env:
+          GRADLE_OPTS: -Dorg.gradle.daemon=false
+        run: make test-jetbrains
+
       - name: Build JetBrains plugin (universal — every platform except riscv64)
         env:
           GRADLE_OPTS: -Dorg.gradle.daemon=false

--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ editors/jetbrains/build/
 editors/jetbrains/.gradle/
 editors/jetbrains/server/
 editors/jetbrains/src/main/resources/compilerExplorer.html
+editors/jetbrains/src/main/resources/spec-studio/
 editors/jetbrains/src/main/resources/tcl-lsp-server.pyz
 
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,9 @@ make prep-pr        # format + codegen + lint/typecheck + smoke tier
   for the browser host `make lsp-server-wasm` then `npm run test:web` in
   `editors/vscode`. Emacs runs nowhere in CI — touch `editors/emacs` only
   with `make test-emacs`; its eglot semantic-token repaint failure is an
-  upstream xfail (#333), never chase it.
+  upstream xfail (#333), never chase it. The JetBrains plugin's Kotlin suite
+  runs only in the tag-only `build-jetbrains` job (it needs the multi-GB
+  IntelliJ SDK), so touch `editors/jetbrains` only with `make test-jetbrains`.
 - **Fuzzing is always manual.** Campaigns and fuzz-shaped tests
   (generator-driven or seeded-random bodies) are `#[ignore]`d into
   `make test-exhaustive` regardless of speed; deterministic fixed-input tests

--- a/INSTALL-editors.md
+++ b/INSTALL-editors.md
@@ -320,7 +320,7 @@ snippets. Use the base LSP commands and Sublime's built-in Tcl resources.
 
 ## JetBrains
 
-Requires IDEA Ultimate 2024.1+ (free editions from 2025.3).
+Requires IDEA Ultimate 2024.3+ (free editions from 2025.3).
 **Settings > Plugins > gear icon > Install Plugin from Disk…**,
 select the zip, restart. Configure under **Settings > Tools > Tcl
 Language Server**.

--- a/INSTALL-editors.md
+++ b/INSTALL-editors.md
@@ -320,7 +320,7 @@ snippets. Use the base LSP commands and Sublime's built-in Tcl resources.
 
 ## JetBrains
 
-Requires IDEA Ultimate 2024.3+ (free editions from 2025.3).
+Requires IDEA Ultimate 2025.3+ (or another paid JetBrains IDE).
 **Settings > Plugins > gear icon > Install Plugin from Disk…**,
 select the zip, restart. Configure under **Settings > Tools > Tcl
 Language Server**.

--- a/Makefile
+++ b/Makefile
@@ -310,7 +310,16 @@ $(VSIX_FILE): spec-studio-wasm $(if $(VSCE_TARGET),,$(LSP_SERVER_WASI_MODULE)) $
 		--exclude='.vscode-test-web/' \
 		$(EXT_DIR)/ $(STAGE_DIR)/
 	mkdir -p $(STAGE_DIR)/spec-studio
-	cp -R $(ROOT)rust/tcl-spec-studio-wasm/dist/. $(STAGE_DIR)/spec-studio/
+	@# The IDE-hosted studio never loads Monaco or the browser LSP worker:
+	@# `studio.ts::mountEditorHost` picks `nativeEditorHost.js` whenever the
+	@# host injects `__tclSpecStudioHost`, and every code surface then goes to
+	@# a native editor tab. Shipping them anyway cost ~3 MB (Monaco) + ~21 MB
+	@# (the wasm worker) per artefact for files nothing opens. The standalone
+	@# consumers — GitHub Pages and `tcl explore --serve` — still take the
+	@# whole dist, and `build-wasm.sh` still fails without Monaco, so the
+	@# exclusion is a packaging decision, not a build one.
+	rsync -a --exclude='assets/monaco-host.*' --exclude='lsp/' \
+		$(ROOT)rust/tcl-spec-studio-wasm/dist/ $(STAGE_DIR)/spec-studio/
 	@# The browser language server (package.json `browser`), for vscode.dev /
 	@# github.dev and every other web extension host.  Staged from
 	@# `make lsp-server-wasm`'s dist rather than trusting the extension
@@ -399,6 +408,17 @@ verify-vsix: $(VSIX_FILE) ## Fail if dev/cache artifacts leaked into the .vsix
 		if [[ -n "$$BAD_ENTRIES" ]]; then \
 			echo "VSIX contains dev/cache content that should be excluded:"; \
 			echo "$$BAD_ENTRIES"; \
+			exit 1; \
+		fi
+	@# The IDE-hosted spec studio delegates every code surface to a native
+	@# editor tab (studio.ts picks `nativeEditorHost.js` when the host injects
+	@# its bridge), so Monaco and the browser LSP worker are never loaded from
+	@# the VSIX. Shipping them is ~24 MB of files nothing opens.
+	@set -euo pipefail; \
+		STRAYS="$$(unzip -Z1 $(VSIX_FILE) | grep -E '^extension/spec-studio/(assets/monaco-host\.|lsp/)' || true)"; \
+		if [[ -n "$$STRAYS" ]]; then \
+			echo "VSIX ships the standalone studio's Monaco/worker, which it never loads:"; \
+			echo "$$STRAYS"; \
 			exit 1; \
 		fi
 	@# The extension ships native binaries only — the Python server and its
@@ -1968,7 +1988,16 @@ $(JB_PLUGIN): jb-plugin-force spec-studio-wasm $(OUT_DIR)/extension.js
 	"
 	rm -rf $(JB_DIR)/src/main/resources/spec-studio
 	mkdir -p $(JB_DIR)/src/main/resources/spec-studio
-	cp -R $(ROOT)rust/tcl-spec-studio-wasm/dist/. $(JB_DIR)/src/main/resources/spec-studio/
+	@# The IDE-hosted studio never loads Monaco or the browser LSP worker:
+	@# `studio.ts::mountEditorHost` picks `nativeEditorHost.js` whenever the
+	@# host injects `__tclSpecStudioHost`, and every code surface then goes to
+	@# a native editor tab. Shipping them anyway cost ~3 MB (Monaco) + ~21 MB
+	@# (the wasm worker) per artefact for files nothing opens. The standalone
+	@# consumers — GitHub Pages and `tcl explore --serve` — still take the
+	@# whole dist, and `build-wasm.sh` still fails without Monaco, so the
+	@# exclusion is a packaging decision, not a build one.
+	rsync -a --exclude='assets/monaco-host.*' --exclude='lsp/' \
+		$(ROOT)rust/tcl-spec-studio-wasm/dist/ $(JB_DIR)/src/main/resources/spec-studio/
 	@# Build plugin — pass version via env so build.gradle.kts picks it up
 	cd $(JB_DIR) && RELEASE_VERSION="$(SEMVER_VERSION)" ./gradlew buildPlugin
 	mkdir -p $(BUILD_DIR)
@@ -2037,7 +2066,19 @@ verify-jetbrains-resources: $(JB_PLUGIN) ## Fail if the JetBrains plugin is miss
 			echo "Built from a tree where 'make compile' or 'make spec-studio-wasm' had not run?"; \
 			exit 1; \
 		fi; \
-		echo "==> JetBrains plugin bundles the compiler explorer, spec studio, and TextMate grammar"
+		strays=""; \
+		for res in spec-studio/assets/monaco-host.js spec-studio/assets/monaco-host.css; do \
+			for jar in "$$tmp"/*/lib/*.jar; do \
+				[ -f "$$jar" ] || continue; \
+				if unzip -Z1 "$$jar" | grep -qxF "$$res"; then strays="$$strays $$res"; break; fi; \
+			done; \
+		done; \
+		if [ -n "$$strays" ]; then \
+			echo "JetBrains plugin ships Monaco, which the IDE-hosted studio never loads:$$strays"; \
+			echo "The staging copy should exclude it — see the rsync in the \$$(JB_PLUGIN) recipe."; \
+			exit 1; \
+		fi; \
+		echo "==> JetBrains plugin bundles the compiler explorer, spec studio, and TextMate grammar, and no Monaco"
 
 verify-editor-jetbrains: ## Run the IntelliJ Plugin Verifier over the JetBrains plugin (binary-compat gate)
 	@echo "==> Verifying JetBrains plugin against the configured IDE targets"

--- a/Makefile
+++ b/Makefile
@@ -2067,15 +2067,14 @@ verify-jetbrains-resources: $(JB_PLUGIN) ## Fail if the JetBrains plugin is miss
 			exit 1; \
 		fi; \
 		strays=""; \
-		for res in spec-studio/assets/monaco-host.js spec-studio/assets/monaco-host.css; do \
-			for jar in "$$tmp"/*/lib/*.jar; do \
-				[ -f "$$jar" ] || continue; \
-				if unzip -Z1 "$$jar" | grep -qxF "$$res"; then strays="$$strays $$res"; break; fi; \
-			done; \
+		for jar in "$$tmp"/*/lib/*.jar; do \
+			[ -f "$$jar" ] || continue; \
+			hit="$$(unzip -Z1 "$$jar" | grep -E '^spec-studio/(assets/monaco-host\.|lsp/)' || true)"; \
+			[ -z "$$hit" ] || strays="$$strays $$hit"; \
 		done; \
 		if [ -n "$$strays" ]; then \
-			echo "JetBrains plugin ships Monaco, which the IDE-hosted studio never loads:$$strays"; \
-			echo "The staging copy should exclude it — see the rsync in the \$$(JB_PLUGIN) recipe."; \
+			echo "JetBrains plugin ships the standalone studio's Monaco/worker, which it never loads:$$strays"; \
+			echo "The staging copy should exclude them — see the rsync in the \$$(JB_PLUGIN) recipe."; \
 			exit 1; \
 		fi; \
 		echo "==> JetBrains plugin bundles the compiler explorer, spec studio, and TextMate grammar, and no Monaco"

--- a/Makefile
+++ b/Makefile
@@ -208,7 +208,7 @@ TS_SRCS  := $(shell find $(EXT_DIR)/src -name '*.ts' 2>/dev/null)
 # Top-level gates
 .PHONY: rust-check check-all prep-pr _prep-pr-checks _prep-pr-tests _prep-pr-smoke _prep-pr-smoke-tier
 # Tests
-.PHONY: test test-ext test-emacs test-rust rust-server rust-tcl rust-f5 rust-mcp rust-clis ensure-server-cross-deps server-cross-build server-cross-build-all mcp-cross-build-all cli-cross-build-all server-cross-test server-cross-test-build print-server-targets-all print-server-targets-jetbrains
+.PHONY: test test-ext test-emacs test-jetbrains test-rust rust-server rust-tcl rust-f5 rust-mcp rust-clis ensure-server-cross-deps server-cross-build server-cross-build-all mcp-cross-build-all cli-cross-build-all server-cross-test server-cross-test-build print-server-targets-all print-server-targets-jetbrains
 .PHONY: xtask-check xtask-editor-extensions xtask-kcs-index-links xtask-diag-tables xtask-diag-emission-check xtask-gen-editor-catalogs xtask-gen-bundled-environments xtask-gen-editor-dialects xtask-gen-irule-test-data xtask-gen-zed-queries xtask-gen-editor-settings xtask-gen-vscode-package xtask-gen-jetbrains-catalog xtask-gen-ai-diagnostics xtask-owner-resolution xtask-command-backing xtask-audit-option-dialects xtask-registry-oracle xtask-sslictcl-data xtask-runtime-stdlib tcltest-sweep tcltest-sweep-check xtask-f5query-builtins-doc xtask-bigip-data-schema xtask-c-api-ownership check-c-api-ownership
 .PHONY: xtask-workflow-sync xtask-resolution-drift xtask-retired-api-gate xtask-pack-goldens xtask-number-drift xtask-gen-tmlanguage-keywords xtask-option-registry-drift xtask-callback-inventory check-tcl-reference-toolchains check-spectcl-compat-paths check-runtime-rust-paths check-rust-tests-runner check-already-green check-monitoring-triggers check-smoke-targets check-wasm-cc-env check-homebrew-ci check-sign-and-upload xtask-dialect-drift xtask-segmentation-drift
 # Lint / format / typecheck
@@ -227,7 +227,7 @@ TS_SRCS  := $(shell find $(EXT_DIR)/src -name '*.ts' 2>/dev/null)
 # Packaging + publish + release
 .PHONY: build-editors build-editor-vsix verify-vsix install package-vsix publish-vsix publish-openvsx
 .PHONY: build-editor-vsix-targets package-vsix-targets publish-vsix-targets publish-openvsx-targets
-.PHONY: build-editor-jetbrains verify-jetbrains-server verify-editor-jetbrains publish-jetbrains build-editor-sublime verify-standalone-eda build-editor-zed publish-zed publish-all publish-verify publish-flow
+.PHONY: build-editor-jetbrains verify-jetbrains-server verify-jetbrains-resources verify-editor-jetbrains publish-jetbrains build-editor-sublime verify-standalone-eda build-editor-zed publish-zed publish-all publish-verify publish-flow
 .PHONY: release release-tag release-zed-version release-sums
 .PHONY: release-perf release-notes-perf release-verify release-prepare release-rust-tag
 # Rust runtime port
@@ -1906,7 +1906,7 @@ package-vsix: compile $(VSIX_FILE) verify-vsix ## Package VSIX (skip lint/test, 
 JB_DIR     := $(ROOT)editors/jetbrains
 JB_PLUGIN  := $(BUILD_DIR)/tcl-lsp-jetbrains-$(VERSION).zip
 
-build-editor-jetbrains: $(JB_PLUGIN) verify-jetbrains-server ## Build JetBrains plugin (.zip), universal across all platforms except riscv64
+build-editor-jetbrains: $(JB_PLUGIN) verify-jetbrains-server verify-jetbrains-resources ## Build JetBrains plugin (.zip), universal across all platforms except riscv64
 
 # $(JB_PLUGIN)'s own prerequisites are staged binaries checked at recipe
 # time (below), not tracked by Make as file dependencies — so without a
@@ -1918,7 +1918,7 @@ build-editor-jetbrains: $(JB_PLUGIN) verify-jetbrains-server ## Build JetBrains 
 .PHONY: jb-plugin-force
 jb-plugin-force:
 
-$(JB_PLUGIN): jb-plugin-force spec-studio-wasm
+$(JB_PLUGIN): jb-plugin-force spec-studio-wasm $(OUT_DIR)/extension.js
 	@echo "==> Building JetBrains plugin"
 	@# build.gradle.kts reads RELEASE_VERSION from the environment first, so
 	@# the gradle.properties source file is never mutated by the build.
@@ -1954,11 +1954,18 @@ $(JB_PLUGIN): jb-plugin-force spec-studio-wasm
 			echo "             or:  make server-cross-build-all  (all 7 — needs cross deps)"; \
 			exit 1; \
 		fi
-	@# Extract compiler explorer HTML from VS Code extension
+	@# The Compiler Explorer tool window renders the VS Code webview, adapted
+	@# for JCEF at load time by CompilerExplorerHtml.kt. It is generated from
+	@# the compiled extension, hence the `$(OUT_DIR)/extension.js` prerequisite
+	@# above. This step used to swallow its own failure (`2>/dev/null || echo
+	@# skipped`) and the JetBrains CI job never compiled the TypeScript, so
+	@# every published plugin shipped without the resource and the tool window
+	@# showed only its "resource was not found in the plugin bundle"
+	@# placeholder. Let it fail the build instead.
 	cd $(EXT_DIR) && node -e " \
 		const {getWebviewHtml} = require('./out/compilerExplorerHtml'); \
 		require('fs').writeFileSync('$(JB_DIR)/src/main/resources/compilerExplorer.html', getWebviewHtml()); \
-	" 2>/dev/null || echo "(compiler explorer HTML extraction skipped — compile TS first)"
+	"
 	rm -rf $(JB_DIR)/src/main/resources/spec-studio
 	mkdir -p $(JB_DIR)/src/main/resources/spec-studio
 	cp -R $(ROOT)rust/tcl-spec-studio-wasm/dist/. $(JB_DIR)/src/main/resources/spec-studio/
@@ -1995,6 +2002,42 @@ verify-jetbrains-server: $(JB_PLUGIN) ## Fail if the JetBrains plugin is missing
 			exit 1; \
 		fi; \
 		echo "==> JetBrains plugin bundles $$have/$$want native server binaries, each with the shipped spec packs"
+
+test-jetbrains: ## Run the JetBrains plugin's Kotlin unit tests (downloads the IntelliJ SDK on first run)
+	@echo "==> Running JetBrains plugin tests"
+	@# Not part of `make test`: the suite needs the multi-GB IntelliJ SDK the
+	@# plugin compiles against. The tag-only `build-jetbrains` CI job already
+	@# downloads it, so that is where these run.
+	cd $(JB_DIR) && ./gradlew test
+
+verify-jetbrains-resources: $(JB_PLUGIN) ## Fail if the JetBrains plugin is missing a bundled webview or grammar resource
+	@echo "==> Verifying JetBrains plugin bundled resources"
+	@# The bundled surfaces a user notices the absence of, each of which the
+	@# build once produced best-effort: the compiler explorer webview (which
+	@# shipped missing from every release until the extraction became a hard
+	@# failure), the spec studio it sits beside, and the TextMate bundle
+	@# (manifest + grammar) without which every Tcl file opens as plain
+	@# black text.
+	@set -eu; \
+		tmp="$$(mktemp -d)"; \
+		trap 'rm -rf "$$tmp"' EXIT INT TERM; \
+		unzip -q -o "$(JB_PLUGIN)" -d "$$tmp" '*/lib/*.jar'; \
+		missing=""; \
+		for res in compilerExplorer.html spec-studio/index.html \
+		           textmate/package.json syntaxes/tcl.tmLanguage.json; do \
+			found=""; \
+			for jar in "$$tmp"/*/lib/*.jar; do \
+				[ -f "$$jar" ] || continue; \
+				if unzip -Z1 "$$jar" | grep -qxF "$$res"; then found=1; break; fi; \
+			done; \
+			[ -n "$$found" ] || missing="$$missing $$res"; \
+		done; \
+		if [ -n "$$missing" ]; then \
+			echo "JetBrains plugin jar is missing bundled resources:$$missing"; \
+			echo "Built from a tree where 'make compile' or 'make spec-studio-wasm' had not run?"; \
+			exit 1; \
+		fi; \
+		echo "==> JetBrains plugin bundles the compiler explorer, spec studio, and TextMate grammar"
 
 verify-editor-jetbrains: ## Run the IntelliJ Plugin Verifier over the JetBrains plugin (binary-compat gate)
 	@echo "==> Verifying JetBrains plugin against the configured IDE targets"

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ curl -fsSL https://raw.githubusercontent.com/bitwisecook/tcl-lsp/rust/scripts/in
 | [Emacs](editors/emacs/) | Config snippet (Elisp) | Add to `init.el` for eglot or lsp-mode | Works with built-in eglot (Emacs 29+) |
 | [Helix](editors/helix/) | Config snippet (TOML) | Add to `~/.config/helix/languages.toml` | Minimal pure-TOML setup |
 | [Sublime Text](editors/sublime-text/) | LSP helper package (.sublime-package) | Install LSP and LSP-Tcl from Package Control | Uses Sublime's built-in Tcl syntax and snippets; downloads the matching native server |
-| [JetBrains](editors/jetbrains/) | Full plugin (.zip) | Settings > Plugins > Install from Disk | Compiler explorer tool window, settings UI panel, dynamic file-type registration for pack-claimed extensions, IntelliJ IDEA 2024.1+ |
+| [JetBrains](editors/jetbrains/) | Full plugin (.zip) | Settings > Plugins > Install from Disk | Compiler explorer tool window, settings UI panel, dynamic file-type registration for pack-claimed extensions, IntelliJ IDEA 2024.3+ |
 
 All editors connect to the native Rust binary `tcl-lsp-server` over stdio
 (build it with `make rust-server`, or `cargo build -p tcl-lsp-server`).

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ curl -fsSL https://raw.githubusercontent.com/bitwisecook/tcl-lsp/rust/scripts/in
 | [Emacs](editors/emacs/) | Config snippet (Elisp) | Add to `init.el` for eglot or lsp-mode | Works with built-in eglot (Emacs 29+) |
 | [Helix](editors/helix/) | Config snippet (TOML) | Add to `~/.config/helix/languages.toml` | Minimal pure-TOML setup |
 | [Sublime Text](editors/sublime-text/) | LSP helper package (.sublime-package) | Install LSP and LSP-Tcl from Package Control | Uses Sublime's built-in Tcl syntax and snippets; downloads the matching native server |
-| [JetBrains](editors/jetbrains/) | Full plugin (.zip) | Settings > Plugins > Install from Disk | Compiler explorer tool window, settings UI panel, dynamic file-type registration for pack-claimed extensions, IntelliJ IDEA 2024.3+ |
+| [JetBrains](editors/jetbrains/) | Full plugin (.zip) | Settings > Plugins > Install from Disk | Compiler explorer tool window, settings UI panel, dynamic file-type registration for pack-claimed extensions, IntelliJ IDEA 2025.3+ |
 
 All editors connect to the native Rust binary `tcl-lsp-server` over stdio
 (build it with `make rust-server`, or `cargo build -p tcl-lsp-server`).

--- a/docs/design/contracts/command-spec-studio.md
+++ b/docs/design/contracts/command-spec-studio.md
@@ -63,10 +63,12 @@ privacy notice names the GitHub panel as the sole exception, and the boot check
 
 ## The editors are clients of the real language server
 
-The Pack DSL pane and the Test pane are Monaco editors whose language features
-all come from `rust/tcl-lsp-server-wasm` — the same `LspService<Backend>` the
-native binary runs, with a `postMessage` transport in place of stdio. Nothing in
-the front-end decides what a word means.
+On the standalone page the Pack DSL pane and the Test pane are Monaco editors
+whose language features all come from `rust/tcl-lsp-server-wasm` — the same
+`LspService<Backend>` the native binary runs, with a `postMessage` transport in
+place of stdio. Inside an IDE the same surfaces are native editor tabs served by
+the real language server. Either way, nothing in the front-end decides what a
+word means.
 
 | Concern | Where it lives |
 |---|---|
@@ -87,22 +89,43 @@ round-trip that can disagree with it.
 token type the server gains later paints as plain text rather than shifting
 every colour by one.
 
-### The fallback ladder
+### Two hosts, one contract
 
-Three rungs, each announced in the page's `#lspStatus` line rather than
+`web/src/editorHost.ts` is the interface; there are two implementations of it,
+chosen at runtime by `studio.ts::mountEditorHost`:
+
+- **`nativeEditorHost.ts`** — used whenever a host has injected
+  `window.__tclSpecStudioHost`, which both IDE hosts do
+  (`specStudio.ts::injectNativeBridge`, `SpecStudioHtml.kt`). It renders no
+  text at all: each code surface is opened as an ordinary editor tab in the
+  IDE, so the `.tclspec` and the Tcl sample get the real language server, the
+  user's colour scheme, find, folding and diff. The file is asserted
+  Monaco-free by `tests/web_contract.rs`.
+- **`monacoHost.ts`** — the standalone page (`GitHub Pages` `/spec-studio/`,
+  and the compiler explorer's shared editor via `mountTclEditor`), where there
+  is no host editor to delegate to.
+
+**The IDE artefacts therefore do not ship Monaco.** `mountEditorHost` can never
+choose it there, so the ~3 MB editor chunk and the ~21 MB browser LSP worker
+would be files nothing opens. The Makefile's two staging copies exclude
+`assets/monaco-host.*` and `lsp/`, `make verify-vsix` and
+`make verify-jetbrains-resources` fail if either reappears, and
+`tests/web_contract.rs` pins the exclusion. `build-wasm.sh` still hard-fails
+when Monaco is missing from `dist/`, because the standalone consumers take the
+whole directory.
+
+### The standalone fallback ladder
+
+On the standalone page, two rungs, each announced in `#lspStatus` rather than
 swallowed:
 
 1. **Monaco + the language server** — the full experience.
 2. **Monaco alone** — the worker did not start (wasm disabled, a partial
    deploy). The editor still edits; the status line says there is no analysis.
-3. **The textarea and the `dsl_highlight` overlay** — the editor chunk itself
-   never loaded (a `file://` page, an old browser). This is the surface the
-   studio had before Monaco, kept in the bundle for exactly this reason:
-   `web/src/dslEditor.ts` is ~170 lines and stays.
 
-The textarea is the state of record on every rung. Monaco writes through to it
-on each change, and `studio.ts` writes to both, so the two never disagree and
-rung 3 needs no separate state.
+The hidden textarea beside each mount point is the state of record on both
+rungs and under the native host. Monaco writes through to it on each change,
+and `studio.ts` writes to both, so the two never disagree.
 
 ### Bundle discipline
 

--- a/docs/design/contracts/explorer-compiler-coverage.md
+++ b/docs/design/contracts/explorer-compiler-coverage.md
@@ -34,3 +34,21 @@ data-shaped views, so a new descriptor cannot silently have no web pane.
 | World-state SSA | World SSA |
 | WASM | WASM |
 | Backend selection plans/proofs | WASM `codegenPlan` (when the canonical WASM pipeline runs) |
+
+## Native editor panes are additive
+
+An editor host may also render a tree view into one of its own editor panes,
+through the `tcl-lsp.compilerExplorerView` command: it returns
+`{text, lines}` from `tcl_explorer::render::render_view_mapped` — the same
+renderer `tcl explore --text` and the TUI use — where `lines[n]` is the source
+span the pane's line `n` points at, so a caret in the pane navigates back into
+the user's file.
+
+This never *replaces* a web pane. The rule above stands: every in-scope
+artefact keeps its renderer in both web shells. Three panes could not be a flat
+buffer anyway — the CFG's lane-routed edge overlay, the WASM branch-lane
+gutter, and the optimiser diff's bracket connectors are drawn, not written.
+
+`render_view_mapped` is the only producer of the line map, and it appends to
+the text and the map in the same place, so the two cannot drift; the alignment
+is asserted per view in `render.rs`'s tests.

--- a/editors/jetbrains/README.md
+++ b/editors/jetbrains/README.md
@@ -4,14 +4,13 @@ IntelliJ Platform plugin providing Tcl language support via the [tcl-lsp](../../
 
 ## Requirements
 
-- IntelliJ IDEA Ultimate 2024.1+ (or other paid JetBrains IDE)
+- IntelliJ IDEA Ultimate 2024.3+ (or other paid JetBrains IDE)
 
 Nothing else — the `.zip` plugin bundles the self-contained native
 `tcl-lsp-server` binary for every supported platform and launches the one
 matching your machine. No Python, runtime, or interpreter is needed.
 
-See the [Installation Guide](../../INSTALL-editors.md) for
-full details on Python setup across platforms.
+See the [Installation Guide](../../INSTALL-editors.md) for full details.
 
 > Starting with IntelliJ IDEA 2025.3, the LSP API will be available to all users,
 > including those without a paid subscription.
@@ -20,7 +19,11 @@ full details on Python setup across platforms.
 
 All features from the tcl-lsp server are supported:
 
-- **Syntax highlighting** via TextMate grammar
+- **Syntax highlighting** via the bundled TextMate grammar, which the
+  plugin registers with the IDE's TextMate service at startup
+- **Semantic highlighting** from the language server's own tokens, layered
+  over the grammar (needs IntelliJ 2024.3, where the LSP API grew
+  `lspSemanticTokensSupport`; toggle it under Features → Semantic tokens)
 - **Diagnostics** with 30+ configurable rules
 - **Auto-completion** for commands, subcommands, variables, and switches
 - **Hover** with command help and proc signatures
@@ -112,7 +115,8 @@ The plugin source lives in `editors/jetbrains/`. It uses:
 
 - **IntelliJ Platform Gradle Plugin 2.x** for building
 - **IntelliJ Platform LSP API** (`ProjectWideLspServerDescriptor`)
-- **TextMate** grammar (shared with VS Code)
+- **TextMate** grammar (shared with VS Code), contributed through
+  `com.intellij.textmate.bundleProvider`
 - **JCEF** browser for the Compiler Explorer webview
 
 ```bash

--- a/editors/jetbrains/README.md
+++ b/editors/jetbrains/README.md
@@ -19,7 +19,7 @@ See the [Installation Guide](../../INSTALL-editors.md) for full details.
 
 ## Features
 
-All features from the tcl-lsp server are supported:
+Everything the IDE's LSP client asks for is supported:
 
 - **Syntax highlighting** via the bundled TextMate grammar, which the
   plugin registers with the IDE's TextMate service at startup
@@ -28,12 +28,12 @@ All features from the tcl-lsp server are supported:
 - **Diagnostics** with 30+ configurable rules
 - **Auto-completion** for commands, subcommands, variables, and switches
 - **Hover** with command help and proc signatures
-- **Go-to-definition** and **find references**
-- **Rename symbol** (F2)
+- **Go-to-definition**, **go-to-type-definition**, and **find references**
 - **Document formatting** with 20+ style options
 - **Document symbols** and **workspace symbols**
-- **Call hierarchy** (incoming/outgoing)
+- **Call hierarchy** (incoming/outgoing) and **type hierarchy**
 - **Code folding**, **inlay hints**, **signature help**
+- **Rename symbol** (F2) — needs IntelliJ 2026.2 or newer
 - **Code actions** (quick fixes)
 - **Compiler Explorer** tool window (IR, CFG, SSA, optimiser, shimmer) — also
   available by right-clicking a Tcl/iRule file → **Open In Tcl Compiler Explorer**.
@@ -45,6 +45,29 @@ All features from the tcl-lsp server are supported:
 - **Dialect support**: Tcl 8.4–9.0, F5 iRules, F5 iApps, EDA Tools
 - **Pack-declared file extensions** registered as the packs that claim them
   load and unload (see below)
+
+### What your IDE version changes
+
+The LSP capability set is assembled by the platform's `lsp` module inside the
+IDE you are running, not by the SDK this plugin was built against, so a newer
+IDE asks the server for more without a plugin update. Relative to the 2025.3
+floor:
+
+| Feature | Needs |
+|---|---|
+| Code lens | 2026.1 |
+| Rename symbol, on-type formatting | 2026.2 |
+
+These the server implements and the VS Code extension uses, but no JetBrains
+IDE requests at any version from 2025.3 through 2026.3, so they do nothing
+here: **go-to-implementation**, **go-to-declaration**, **linked editing range**,
+and **auto-rewriting source paths on rename**. Their toggles stay in
+**Settings → Features**, marked with a dagger, because the same server settings
+are shared with editors that do support them.
+
+Both lists come from scanning every class in the published `lsp` platform module
+for `TextDocumentClientCapabilities.set*` and `WorkspaceClientCapabilities.set*`
+across builds 253, 261, 262 and 263.
 
 ## Pack-declared file extensions
 

--- a/editors/jetbrains/README.md
+++ b/editors/jetbrains/README.md
@@ -4,7 +4,7 @@ IntelliJ Platform plugin providing Tcl language support via the [tcl-lsp](../../
 
 ## Requirements
 
-- IntelliJ IDEA Ultimate 2024.3+ (or other paid JetBrains IDE)
+- IntelliJ IDEA Ultimate 2025.3+ (or another paid JetBrains IDE)
 
 Nothing else — the `.zip` plugin bundles the self-contained native
 `tcl-lsp-server` binary for every supported platform and launches the one
@@ -12,8 +12,10 @@ matching your machine. No Python, runtime, or interpreter is needed.
 
 See the [Installation Guide](../../INSTALL-editors.md) for full details.
 
-> Starting with IntelliJ IDEA 2025.3, the LSP API will be available to all users,
-> including those without a paid subscription.
+> The platform's LSP API reaches the free editions in 2025.3. The plugin still
+> declares `com.intellij.modules.ultimate`, so dropping that dependency — and
+> with it the paid-IDE requirement — is a separate change from raising the
+> build floor to 2025.3.
 
 ## Features
 
@@ -22,8 +24,7 @@ All features from the tcl-lsp server are supported:
 - **Syntax highlighting** via the bundled TextMate grammar, which the
   plugin registers with the IDE's TextMate service at startup
 - **Semantic highlighting** from the language server's own tokens, layered
-  over the grammar (needs IntelliJ 2024.3, where the LSP API grew
-  `lspSemanticTokensSupport`; toggle it under Features → Semantic tokens)
+  over the grammar (toggle it under Features → Semantic tokens)
 - **Diagnostics** with 30+ configurable rules
 - **Auto-completion** for commands, subcommands, variables, and switches
 - **Hover** with command help and proc signatures
@@ -35,7 +36,12 @@ All features from the tcl-lsp server are supported:
 - **Code folding**, **inlay hints**, **signature help**
 - **Code actions** (quick fixes)
 - **Compiler Explorer** tool window (IR, CFG, SSA, optimiser, shimmer) — also
-  available by right-clicking a Tcl/iRule file → **Open In Tcl Compiler Explorer**
+  available by right-clicking a Tcl/iRule file → **Open In Tcl Compiler Explorer**.
+  **Open in editor** puts the current view in an ordinary read-only editor tab,
+  where find, folding and the colour scheme all work, and moving the caret in it
+  reveals the matching source. The CFG, WASM and optimiser-diff panes stay in
+  the tool window, since their edges and connectors are drawn rather than
+  written.
 - **Dialect support**: Tcl 8.4–9.0, F5 iRules, F5 iApps, EDA Tools
 - **Pack-declared file extensions** registered as the packs that claim them
   load and unload (see below)

--- a/editors/jetbrains/build.gradle.kts
+++ b/editors/jetbrains/build.gradle.kts
@@ -26,12 +26,23 @@ kotlin {
 
 dependencies {
     testImplementation(kotlin("test"))
+    // The platform test runner loads through IntelliJ's own PathClassLoader
+    // and touches JUnit 4's `TestRule` while starting, even for a JUnit 5
+    // suite; from the 2024.3 SDK it is no longer on the platform classpath.
+    testRuntimeOnly("junit:junit:4.13.2")
     intellijPlatform {
-        // Compile at the 2024.1 support floor. JCEF is part of the platform at
-        // this version, so the 2025.3.1+ `intellij.platform.ui.jcef` bundled
-        // plugin cannot be added to this compile classpath. plugin.xml carries
-        // the optional compatibility dependency used by newer IDEs instead.
-        intellijIdeaUltimate("2024.1")
+        // Compile at the 2024.3 support floor. 2024.3 is where the LSP API
+        // grew `LspServerDescriptor.lspSemanticTokensSupport`: every published
+        // build of the `lsp` platform module below it — all seventeen 241.x
+        // releases — has no semantic-tokens member at all, so on an older IDE
+        // the host never advertises `textDocument/semanticTokens` and never
+        // asks the server for them, whatever the server offers.
+        //
+        // JCEF is part of the platform at this version, so the 2025.3.1+
+        // `intellij.platform.ui.jcef` bundled plugin cannot be added to this
+        // compile classpath. plugin.xml carries the optional compatibility
+        // dependency used by newer IDEs instead.
+        intellijIdeaUltimate("2024.3")
         bundledPlugin("org.jetbrains.plugins.textmate")
 
         pluginVerifier()
@@ -66,7 +77,7 @@ intellijPlatform {
         """.trimIndent()
 
         ideaVersion {
-            sinceBuild = "241"
+            sinceBuild = "243"
             untilBuild = provider { null }
         }
 
@@ -95,7 +106,7 @@ intellijPlatform {
             // class of binary incompatibility (see the jetbrains-plugin-compat
             // skill). Keep the newest verified stable major here as JetBrains
             // ships it.
-            create(org.jetbrains.intellij.platform.gradle.IntelliJPlatformType.IntellijIdeaUltimate, "2024.1")
+            create(org.jetbrains.intellij.platform.gradle.IntelliJPlatformType.IntellijIdeaUltimate, "2024.3")
             create(org.jetbrains.intellij.platform.gradle.IntelliJPlatformType.IntellijIdeaUltimate, "2025.1.7.2")
             create(org.jetbrains.intellij.platform.gradle.IntelliJPlatformType.IntellijIdeaUltimate, "2025.2.6.3")
             // First release whose core plugin advertises the JCEF dependency

--- a/editors/jetbrains/build.gradle.kts
+++ b/editors/jetbrains/build.gradle.kts
@@ -31,18 +31,30 @@ dependencies {
     // suite; from the 2024.3 SDK it is no longer on the platform classpath.
     testRuntimeOnly("junit:junit:4.13.2")
     intellijPlatform {
-        // Compile at the 2024.3 support floor. 2024.3 is where the LSP API
-        // grew `LspServerDescriptor.lspSemanticTokensSupport`: every published
-        // build of the `lsp` platform module below it — all seventeen 241.x
-        // releases — has no semantic-tokens member at all, so on an older IDE
-        // the host never advertises `textDocument/semanticTokens` and never
-        // asks the server for them, whatever the server offers.
+        // Compile at the 2025.3 support floor.
+        //
+        // `sinceBuild` bounds the oldest IDE whose API this plugin may
+        // *reference*, not the feature set a user gets: the LSP client
+        // capabilities are built by `LspServerDescriptor.getClientCapabilities`
+        // in the running IDE, which the plugin does not override, so folding,
+        // document symbols, inlay hints and the rest arrive with the user's
+        // IDE whatever we compile against.
+        //
+        // What does need a floor is anything the plugin *overrides*, because
+        // the symbol has to resolve when the class loads. Semantic tokens is
+        // the only such capability — `getClientCapabilities` has exactly one
+        // branch, `if (getLspSemanticTokensSupport() == null) skip` — and its
+        // member first exists at 2024.3. 2025.3 is chosen over that floor so
+        // the plugin can move to the `LspCustomization` shape that superseded
+        // the flat descriptor getters at 2025.2, and reach the per-feature
+        // customisers (`LspDocumentSymbolSupport` and friends) that let it
+        // honour its own feature toggles host-side.
         //
         // JCEF is part of the platform at this version, so the 2025.3.1+
         // `intellij.platform.ui.jcef` bundled plugin cannot be added to this
         // compile classpath. plugin.xml carries the optional compatibility
         // dependency used by newer IDEs instead.
-        intellijIdeaUltimate("2024.3")
+        intellijIdeaUltimate("2025.3")
         bundledPlugin("org.jetbrains.plugins.textmate")
 
         pluginVerifier()
@@ -77,7 +89,7 @@ intellijPlatform {
         """.trimIndent()
 
         ideaVersion {
-            sinceBuild = "243"
+            sinceBuild = "253"
             untilBuild = provider { null }
         }
 
@@ -106,11 +118,9 @@ intellijPlatform {
             // class of binary incompatibility (see the jetbrains-plugin-compat
             // skill). Keep the newest verified stable major here as JetBrains
             // ships it.
-            create(org.jetbrains.intellij.platform.gradle.IntelliJPlatformType.IntellijIdeaUltimate, "2024.3")
-            create(org.jetbrains.intellij.platform.gradle.IntelliJPlatformType.IntellijIdeaUltimate, "2025.1.7.2")
-            create(org.jetbrains.intellij.platform.gradle.IntelliJPlatformType.IntellijIdeaUltimate, "2025.2.6.3")
-            // First release whose core plugin advertises the JCEF dependency
-            // alias used to bridge the pre- and post-extraction layouts.
+            // The floor. Also the first release whose core plugin advertises
+            // the JCEF dependency alias bridging the pre- and post-extraction
+            // layouts, so the floor and that bridge now coincide.
             create(org.jetbrains.intellij.platform.gradle.IntelliJPlatformType.IntellijIdeaUltimate, "2025.3.6.1")
             create(org.jetbrains.intellij.platform.gradle.IntelliJPlatformType.IntellijIdeaUltimate, "2026.2.2")
             // #1780 was reported against this exact product/version, where

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/CompilerExplorerHtml.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/CompilerExplorerHtml.kt
@@ -97,7 +97,15 @@ internal fun adaptHtmlForJcef(html: String): String {
                     if (msg.type === 'compile' && typeof msg.source === 'string') {
                         window.__tcllspBridge('compile:' + msg.source + '\u0000' + (msg.dialect || ''));
                     } else if (msg.type === 'highlightSource') {
-                        window.__tcllspBridge('highlightSource:' + msg.start + ',' + msg.end);
+                        // Six fields: the UTF-16 line/column pair a caret is
+                        // actually placed with, then the byte offsets as a
+                        // fallback for a payload that predates them. An absent
+                        // field rides as an empty string.
+                        var n = function(v) { return v === undefined ? '' : v; };
+                        window.__tcllspBridge('highlightSource:' +
+                            n(msg.startLine) + ',' + n(msg.startCol) + ',' +
+                            n(msg.endLine) + ',' + n(msg.endCol) + ',' +
+                            n(msg.start) + ',' + n(msg.end));
                     } else if (msg.type === 'clearHighlight') {
                         window.__tcllspBridge('clearHighlight');
                     }

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/CompilerExplorerHtml.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/CompilerExplorerHtml.kt
@@ -80,7 +80,7 @@ fun getCompilerExplorerHtml(): String {
  * of "webview API unavailable", and ensures the `compile` request reaches
  * Kotlin so the IR pane stops showing "Waiting for source from editor...".
  */
-private fun adaptHtmlForJcef(html: String): String {
+internal fun adaptHtmlForJcef(html: String): String {
     var result = html
 
     val shim = """

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/CompilerExplorerHtml.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/CompilerExplorerHtml.kt
@@ -108,6 +108,10 @@ internal fun adaptHtmlForJcef(html: String): String {
                             n(msg.start) + ',' + n(msg.end));
                     } else if (msg.type === 'clearHighlight') {
                         window.__tcllspBridge('clearHighlight');
+                    } else if (msg.type === 'openProjection') {
+                        window.__tcllspBridge('openProjection:' + msg.view + '\u0000' +
+                            (msg.label || msg.view) + '\u0000' + (msg.dialect || '') +
+                            '\u0000' + (msg.source || ''));
                     }
                     // Other types (ready, dialectChange, scriptError, ...)
                     // have no host action in JCEF and are intentionally dropped.

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/CompilerExplorerToolWindowFactory.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/CompilerExplorerToolWindowFactory.kt
@@ -246,6 +246,20 @@ internal class CompilerExplorerPanel(private val project: Project) : Disposable 
                 message == "clearHighlight" -> {
                     clearSourceHighlight()
                 }
+                message.startsWith("openProjection:") -> {
+                    // `view\u0000label\u0000dialect\u0000source` — the source
+                    // rides last because it is the only field that can contain
+                    // anything, including the separator's neighbours.
+                    val parts = message.removePrefix("openProjection:").split('\u0000', limit = 4)
+                    if (parts.size == 4) {
+                        openProjection(
+                            view = parts[0],
+                            label = parts[1],
+                            dialect = parts[2].ifEmpty { TclLspSettings.getInstance().dialect },
+                            source = parts[3],
+                        )
+                    }
+                }
             }
         } catch (e: Exception) {
             LOG.warn("Error handling JS message: $message", e)
@@ -317,7 +331,7 @@ internal class CompilerExplorerPanel(private val project: Project) : Disposable 
                 // Pass the timeout explicitly. Omitting it makes Kotlin emit a
                 // call to the synthetic `LspServer.sendRequestSync$default`
                 // bridge, which is bound to the exact class that declared the
-                // method when we compiled (2024.3). In 2026.1+ `sendRequestSync`
+                // method when we compiled (2025.3). In 2026.1+ `sendRequestSync`
                 // moved up to the `LspClient` super-interface, so that bridge no
                 // longer resolves as `LspServer.sendRequestSync$default` and the
                 // plugin fails verification / throws NoSuchMethodError at runtime.
@@ -345,6 +359,46 @@ internal class CompilerExplorerPanel(private val project: Project) : Disposable 
             } catch (e: Exception) {
                 LOG.warn("Compile failed", e)
                 sendErrorToWebview(e.message ?: "Unknown error")
+            }
+        }
+    }
+
+    /**
+     * Render one explorer view through the server and show it in an ordinary
+     * IntelliJ editor tab.
+     *
+     * The tool window keeps the interactive panes — the CFG's routed edges and
+     * the WASM branch lanes do not survive as flat text — but everything that
+     * *is* linear reads better in a real editor, where find, folding and the
+     * colour scheme all work. The pane is read-only and carries a line map, so
+     * moving the caret in it navigates back into the source file.
+     */
+    private fun openProjection(view: String, label: String, dialect: String, source: String) {
+        ApplicationManager.getApplication().executeOnPooledThread {
+            val server = awaitRunningServer()
+            if (server == null) {
+                sendErrorToWebview("Tcl LSP server did not become ready — cannot render $label.")
+                return@executeOnPooledThread
+            }
+            // The explicit timeout is load-bearing; see the note in runCompile
+            // about `sendRequestSync$default`.
+            val result = server.sendRequestSync(LspServer.DEFAULT_REQUEST_TIMEOUT_MS) { lsp4j ->
+                lsp4j.workspaceService.executeCommand(
+                    org.eclipse.lsp4j.ExecuteCommandParams(
+                        "tcl-lsp.compilerExplorerView",
+                        listOf(source, dialect, view),
+                    )
+                )
+            } ?: return@executeOnPooledThread
+
+            val rendered = ExplorerProjection.parse(result)
+            if (rendered == null) {
+                sendErrorToWebview("Could not render the $label view.")
+                return@executeOnPooledThread
+            }
+            val origin = sourceFile
+            ApplicationManager.getApplication().invokeLater {
+                ExplorerProjections.getInstance(project).open(label, view, rendered, origin)
             }
         }
     }

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/CompilerExplorerToolWindowFactory.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/CompilerExplorerToolWindowFactory.kt
@@ -22,6 +22,7 @@ import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.editor.LogicalPosition
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.fileEditor.FileEditorManagerEvent
@@ -70,11 +71,18 @@ internal class CompilerExplorerPanel(private val project: Project) : Disposable 
     val browser: JBCefBrowser = JBCefBrowser()
     private val jsQuery: JBCefJSQuery = JBCefJSQuery.create(browser as JBCefBrowserBase)
 
-    // All three fields are touched only on the EDT (every mutator hops through
+    // All four fields are touched only on the EDT (every mutator hops through
     // invokeLater), so no extra synchronisation is needed.
     private var lastSource: String = ""
     private var pageReady = false
     private var pendingSource: String? = null
+
+    /**
+     * The file whose source the explorer last compiled — what a hover in the
+     * webview refers to. Not the selected tab: the explorer keeps showing one
+     * file while the user moves around the IDE.
+     */
+    private var sourceFile: VirtualFile? = null
 
     init {
         // Tie the native browser, the JS bridge query, and the editor-listener
@@ -169,6 +177,7 @@ internal class CompilerExplorerPanel(private val project: Project) : Disposable 
             val editor = manager.selectedTextEditor ?: return@invokeLater
             val file = manager.selectedFiles.firstOrNull() ?: return@invokeLater
             if (!TclFileType.isSupported(file)) return@invokeLater
+            sourceFile = file
             dispatchSource(editor.document.text, force)
         }
     }
@@ -178,6 +187,7 @@ internal class CompilerExplorerPanel(private val project: Project) : Disposable 
         ApplicationManager.getApplication().invokeLater {
             if (!TclFileType.isSupported(file)) return@invokeLater
             val document = FileDocumentManager.getInstance().getDocument(file) ?: return@invokeLater
+            sourceFile = file
             dispatchSource(document.text, force)
         }
     }
@@ -218,13 +228,19 @@ internal class CompilerExplorerPanel(private val project: Project) : Disposable 
                     runCompile(source, dialect)
                 }
                 message.startsWith("highlightSource:") -> {
-                    // Source highlighting in main editor
-                    val payload = message.removePrefix("highlightSource:")
-                    val parts = payload.split(",")
-                    if (parts.size == 2) {
-                        val start = parts[0].toIntOrNull() ?: return
-                        val end = parts[1].toIntOrNull() ?: return
-                        highlightSourceRange(start, end)
+                    // `startLine,startCol,endLine,endCol,startOffset,endOffset`
+                    // — see the shim in CompilerExplorerHtml.kt. The first four
+                    // are UTF-16 and may be empty on an older payload.
+                    val parts = message.removePrefix("highlightSource:").split(",")
+                    if (parts.size == 6) {
+                        highlightSourceRange(
+                            startLine = parts[0].toIntOrNull(),
+                            startCol = parts[1].toIntOrNull(),
+                            endLine = parts[2].toIntOrNull(),
+                            endCol = parts[3].toIntOrNull(),
+                            startOffset = parts[4].toIntOrNull(),
+                            endOffset = parts[5].toIntOrNull(),
+                        )
                     }
                 }
                 message == "clearHighlight" -> {
@@ -348,23 +364,73 @@ internal class CompilerExplorerPanel(private val project: Project) : Disposable 
         )
     }
 
-    private fun highlightSourceRange(startOffset: Int, endOffset: Int) {
-        // Highlight in the main editor — run on EDT
+    /**
+     * Select the source span the webview is hovering, in the file the
+     * explorer actually compiled.
+     *
+     * Two things this gets right that the offset-only version could not.
+     *
+     * The span arrives as a UTF-16 line/column pair, because that is what an
+     * IntelliJ caret is. The explorer's `startOffset`/`endOffset` count
+     * *bytes* — the payload's columns come from `LineIndex::position_at`,
+     * which returns a byte column — so feeding them to `offsetToLogicalPosition`
+     * is right only for ASCII and drifts by one per non-ASCII byte after that.
+     * The offsets remain the fallback for a payload without the UTF-16 pair.
+     *
+     * And it targets [sourceFile] rather than whatever tab happens to be
+     * selected. The explorer compiles one file and keeps showing it while the
+     * user moves around the IDE, so `selectedTextEditor` is simply a different
+     * document as soon as anything else is focused — including any pane the
+     * explorer itself opens.
+     */
+    private fun highlightSourceRange(
+        startLine: Int?,
+        startCol: Int?,
+        endLine: Int?,
+        endCol: Int?,
+        startOffset: Int?,
+        endOffset: Int?,
+    ) {
         ApplicationManager.getApplication().invokeLater {
-            val editor = FileEditorManager.getInstance(project).selectedTextEditor ?: return@invokeLater
+            val editor = editorForCompiledSource() ?: return@invokeLater
             val document = editor.document
-            if (startOffset < 0 || endOffset > document.textLength) return@invokeLater
+            val start = if (startLine != null && startCol != null) {
+                editor.logicalPositionToOffset(LogicalPosition(startLine, startCol))
+            } else {
+                startOffset ?: return@invokeLater
+            }
+            val end = if (endLine != null && endCol != null) {
+                editor.logicalPositionToOffset(LogicalPosition(endLine, endCol))
+            } else {
+                endOffset ?: return@invokeLater
+            }
+            if (start < 0 || end > document.textLength || start > end) return@invokeLater
 
-            val startPos = editor.offsetToLogicalPosition(startOffset)
-            editor.selectionModel.setSelection(startOffset, endOffset)
-            editor.scrollingModel.scrollTo(startPos, com.intellij.openapi.editor.ScrollType.CENTER_UP)
+            editor.selectionModel.setSelection(start, end)
+            editor.scrollingModel.scrollTo(
+                editor.offsetToLogicalPosition(start),
+                com.intellij.openapi.editor.ScrollType.CENTER_UP,
+            )
         }
+    }
+
+    /**
+     * The open editor for the file the explorer last compiled, or null when
+     * it has been closed. Falls back to the selected editor only when the
+     * explorer has not recorded a file yet.
+     */
+    private fun editorForCompiledSource(): com.intellij.openapi.editor.Editor? {
+        val manager = FileEditorManager.getInstance(project)
+        val file = sourceFile ?: return manager.selectedTextEditor
+        val document = FileDocumentManager.getInstance().getDocument(file) ?: return null
+        return com.intellij.openapi.editor.EditorFactory.getInstance()
+            .getEditors(document, project)
+            .firstOrNull()
     }
 
     private fun clearSourceHighlight() {
         ApplicationManager.getApplication().invokeLater {
-            val editor = FileEditorManager.getInstance(project).selectedTextEditor ?: return@invokeLater
-            editor.selectionModel.removeSelection()
+            editorForCompiledSource()?.selectionModel?.removeSelection()
         }
     }
 

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/CompilerExplorerToolWindowFactory.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/CompilerExplorerToolWindowFactory.kt
@@ -374,6 +374,12 @@ internal class CompilerExplorerPanel(private val project: Project) : Disposable 
      * moving the caret in it navigates back into the source file.
      */
     private fun openProjection(view: String, label: String, dialect: String, source: String) {
+        // Read on the caller's thread, before the request goes out. `sourceFile`
+        // tracks the selected editor, so a user who switches files while the
+        // render is in flight would otherwise have this view's line map paired
+        // with a file it was not rendered from, and every caret move would
+        // reveal an unrelated span there.
+        val origin = sourceFile
         ApplicationManager.getApplication().executeOnPooledThread {
             val server = awaitRunningServer()
             if (server == null) {
@@ -396,7 +402,6 @@ internal class CompilerExplorerPanel(private val project: Project) : Disposable 
                 sendErrorToWebview("Could not render the $label view.")
                 return@executeOnPooledThread
             }
-            val origin = sourceFile
             ApplicationManager.getApplication().invokeLater {
                 ExplorerProjections.getInstance(project).open(label, view, rendered, origin)
             }

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/CompilerExplorerToolWindowFactory.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/CompilerExplorerToolWindowFactory.kt
@@ -301,7 +301,7 @@ internal class CompilerExplorerPanel(private val project: Project) : Disposable 
                 // Pass the timeout explicitly. Omitting it makes Kotlin emit a
                 // call to the synthetic `LspServer.sendRequestSync$default`
                 // bridge, which is bound to the exact class that declared the
-                // method when we compiled (2024.1). In 2026.1+ `sendRequestSync`
+                // method when we compiled (2024.3). In 2026.1+ `sendRequestSync`
                 // moved up to the `LspClient` super-interface, so that bridge no
                 // longer resolves as `LspServer.sendRequestSync$default` and the
                 // plugin fails verification / throws NoSuchMethodError at runtime.

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/ExplorerProjections.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/ExplorerProjections.kt
@@ -21,10 +21,12 @@ package com.tcllsp.jetbrains
 import com.google.gson.Gson
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
+import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.editor.event.CaretEvent
 import com.intellij.openapi.editor.event.CaretListener
+import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.EditorFactory
 import com.intellij.openapi.editor.ScrollType
 import com.intellij.openapi.fileEditor.FileDocumentManager
@@ -106,7 +108,10 @@ internal class ExplorerProjections(private val project: Project) {
         val file: LightVirtualFile,
         var projection: ExplorerProjection,
         var origin: VirtualFile?,
-    )
+    ) {
+        /** The caret hook currently attached, so re-opening replaces it rather than stacking. */
+        var caretHook: Pair<Editor, CaretListener>? = null
+    }
 
     /**
      * Open (or refresh) the pane for [view], and focus it.
@@ -129,21 +134,50 @@ internal class ExplorerProjections(private val project: Project) {
         }
         pane.projection = projection
         pane.origin = origin
-        if (pane.file.content.toString() != projection.text) {
-            pane.file.setContent(this, projection.text, false)
-        }
+        refreshText(pane, projection.text)
 
         val editor = FileEditorManager.getInstance(project)
             .openTextEditor(OpenFileDescriptor(project, pane.file), true)
             ?: return
-        // One listener per pane. `EditorFactory` hands out a fresh editor each
-        // time the tab is re-opened, so attaching here — after the open —
-        // covers a pane the user closed and re-opened.
-        editor.caretModel.addCaretListener(object : CaretListener {
+        // One listener per pane. The platform hands out a fresh editor when a
+        // closed tab is re-opened, but returns the existing one when the tab is
+        // already live — so drop the previous hook before attaching, or a
+        // re-render would navigate once per call.
+        pane.caretHook?.let { (previous, hook) ->
+            if (!previous.isDisposed) previous.caretModel.removeCaretListener(hook)
+        }
+        val hook = object : CaretListener {
             override fun caretPositionChanged(event: CaretEvent) {
                 navigate(view, event.newPosition.line)
             }
-        })
+        }
+        editor.caretModel.addCaretListener(hook)
+        pane.caretHook = editor to hook
+    }
+
+    /**
+     * Put [text] into the pane's buffer.
+     *
+     * This goes through the [com.intellij.openapi.editor.Document] rather than
+     * `LightVirtualFile.setContent`: a light file's content change does not
+     * reach an editor that is already open, so a re-render would leave the
+     * visible text stale while the line map moved under it. The pane is
+     * read-only to the user's keystrokes, not to us — lift that for the write
+     * and put it straight back.
+     */
+    private fun refreshText(pane: Pane, text: String) {
+        val document = FileDocumentManager.getInstance().getDocument(pane.file)
+        if (document == null) {
+            pane.file.setContent(this, text, false)
+            return
+        }
+        if (document.text == text) return
+        document.setReadOnly(false)
+        try {
+            WriteCommandAction.runWriteCommandAction(project) { document.setText(text) }
+        } finally {
+            document.setReadOnly(true)
+        }
     }
 
     /** Reveal the source span the pane's [line] points at. */

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/ExplorerProjections.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/ExplorerProjections.kt
@@ -1,0 +1,176 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package com.tcllsp.jetbrains
+
+import com.google.gson.Gson
+import com.google.gson.JsonObject
+import com.google.gson.JsonParser
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
+import com.intellij.openapi.editor.event.CaretEvent
+import com.intellij.openapi.editor.event.CaretListener
+import com.intellij.openapi.editor.EditorFactory
+import com.intellij.openapi.editor.ScrollType
+import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.fileEditor.OpenFileDescriptor
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.testFramework.LightVirtualFile
+
+/**
+ * A source span as the explorer's `range_dict` emits it.
+ *
+ * Both coordinate systems ride along: the byte offsets index the source text
+ * the pipeline was handed, and the UTF-16 line/column pair is what an IntelliJ
+ * caret is actually placed with.
+ */
+internal data class ExplorerRange(
+    val startLine: Int,
+    val startColUtf16: Int,
+    val endLine: Int,
+    val endColUtf16: Int,
+)
+
+/**
+ * One rendered explorer view: the text a pane shows, and the source span each
+ * of its lines points at.
+ *
+ * `lines` is index-aligned with the text's lines — the server produces the two
+ * together in `render_view_mapped`, precisely so a map built by re-parsing the
+ * rendered text cannot drift from it.
+ */
+internal data class ExplorerProjection(
+    val text: String,
+    val lines: List<ExplorerRange?>,
+) {
+    companion object {
+        /** Read the `tcl-lsp.compilerExplorerView` reply, or null if it failed. */
+        fun parse(result: Any?): ExplorerProjection? {
+            val json = runCatching {
+                JsonParser.parseString(Gson().toJson(result)).asJsonObject
+            }.getOrNull() ?: return null
+            if (json.has("error") && !json.get("error").isJsonNull) return null
+            val text = json.get("text")?.takeIf { it.isJsonPrimitive }?.asString ?: return null
+            val lines = json.getAsJsonArray("lines")?.map { element ->
+                if (!element.isJsonObject) return@map null
+                val o = element.asJsonObject
+                runCatching {
+                    ExplorerRange(
+                        startLine = o.int("startLine"),
+                        startColUtf16 = o.int("startColUtf16"),
+                        endLine = o.int("endLine"),
+                        endColUtf16 = o.int("endColUtf16"),
+                    )
+                }.getOrNull()
+            } ?: emptyList()
+            return ExplorerProjection(text, lines)
+        }
+
+        private fun JsonObject.int(key: String): Int = get(key).asInt
+    }
+}
+
+/**
+ * Shows explorer views in ordinary editor tabs, and navigates from them.
+ *
+ * The tool window keeps the panes that are genuinely graphical — the CFG's
+ * routed edges, the WASM branch lanes — but everything linear reads better in
+ * a real editor, where find, folding, and the colour scheme all work. A pane
+ * is a read-only [LightVirtualFile]; moving the caret in one reveals the
+ * matching span in the file the view was rendered from.
+ */
+@Service(Service.Level.PROJECT)
+internal class ExplorerProjections(private val project: Project) {
+
+    /** Live panes, keyed by view id, so re-opening replaces rather than stacks. */
+    private val open = mutableMapOf<String, Pane>()
+
+    private class Pane(
+        val file: LightVirtualFile,
+        var projection: ExplorerProjection,
+        var origin: VirtualFile?,
+    )
+
+    /**
+     * Open (or refresh) the pane for [view], and focus it.
+     *
+     * Called on the EDT.
+     */
+    fun open(
+        label: String,
+        view: String,
+        projection: ExplorerProjection,
+        origin: VirtualFile?,
+    ) {
+        val pane = open.getOrPut(view) {
+            // `.txt` rather than a Tcl extension: a projection is a rendered
+            // tree, not Tcl, and typing it as Tcl would attach the language
+            // server to a buffer that is not a program.
+            val file = LightVirtualFile("$label.txt", projection.text)
+            file.isWritable = false
+            Pane(file, projection, origin)
+        }
+        pane.projection = projection
+        pane.origin = origin
+        if (pane.file.content.toString() != projection.text) {
+            pane.file.setContent(this, projection.text, false)
+        }
+
+        val editor = FileEditorManager.getInstance(project)
+            .openTextEditor(OpenFileDescriptor(project, pane.file), true)
+            ?: return
+        // One listener per pane. `EditorFactory` hands out a fresh editor each
+        // time the tab is re-opened, so attaching here — after the open —
+        // covers a pane the user closed and re-opened.
+        editor.caretModel.addCaretListener(object : CaretListener {
+            override fun caretPositionChanged(event: CaretEvent) {
+                navigate(view, event.newPosition.line)
+            }
+        })
+    }
+
+    /** Reveal the source span the pane's [line] points at. */
+    private fun navigate(view: String, line: Int) {
+        val pane = open[view] ?: return
+        val range = pane.projection.lines.getOrNull(line) ?: return
+        val origin = pane.origin ?: return
+        val document = FileDocumentManager.getInstance().getDocument(origin) ?: return
+        val editors = EditorFactory.getInstance().getEditors(document, project)
+        // Reveal without stealing focus: arrowing down a projection should walk
+        // the source alongside it, not tear the caret away on every keypress.
+        val target = editors.firstOrNull()
+            ?: FileEditorManager.getInstance(project)
+                .openTextEditor(OpenFileDescriptor(project, origin), false)
+            ?: return
+        val start = target.logicalPositionToOffset(
+            com.intellij.openapi.editor.LogicalPosition(range.startLine, range.startColUtf16),
+        )
+        val end = target.logicalPositionToOffset(
+            com.intellij.openapi.editor.LogicalPosition(range.endLine, range.endColUtf16),
+        )
+        if (start < 0 || end > target.document.textLength || start > end) return
+        target.selectionModel.setSelection(start, end)
+        target.scrollingModel.scrollTo(target.offsetToLogicalPosition(start), ScrollType.CENTER_UP)
+    }
+
+    companion object {
+        fun getInstance(project: Project): ExplorerProjections = project.service()
+    }
+}

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/TclLspDiagnostics.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/TclLspDiagnostics.kt
@@ -1,0 +1,114 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package com.tcllsp.jetbrains
+
+import com.google.gson.JsonObject
+import com.google.gson.JsonPrimitive
+import com.intellij.openapi.util.text.StringUtil
+import com.intellij.platform.lsp.api.customization.LspDiagnosticsSupport
+import com.tcllsp.jetbrains.settings.generated.DiagnosticCatalog
+import org.eclipse.lsp4j.Diagnostic
+
+/**
+ * How a diagnostic reads in this IDE.
+ *
+ * The server sends the code in the LSP `code` field, which is where it
+ * belongs — VS Code renders it in its own column, so putting it in the message
+ * text would show it twice there. IntelliJ's problems view shows the message
+ * and nothing else, so a bare "Forward literal load of 'a' from its single
+ * reaching definition" arrives with no code, no indication it is an optimiser
+ * rewrite rather than a defect, and no hint whether accepting it would change
+ * the file. This puts that back, on the client that drops it, without touching
+ * what goes over the wire.
+ */
+class TclLspDiagnostics : LspDiagnosticsSupport() {
+
+    override fun getMessage(diagnostic: Diagnostic): String {
+        val code = codeOf(diagnostic) ?: return diagnostic.message
+        return "[$code] ${diagnostic.message}"
+    }
+
+    override fun getTooltip(diagnostic: Diagnostic): String {
+        val code = codeOf(diagnostic)
+        val rows = buildList {
+            add(StringUtil.escapeXmlEntities(diagnostic.message))
+            code?.let { add("<b>${StringUtil.escapeXmlEntities(it)}</b> — ${kindOf(it)}") }
+            code?.let { c -> describe(c)?.let { add(StringUtil.escapeXmlEntities(it)) } }
+            add(fixSummary(diagnostic))
+        }
+        return rows.joinToString("<br/>")
+    }
+
+    private companion object {
+        /**
+         * Codes the catalogue lists as optimiser rewrites.
+         *
+         * Read from the generated catalogue rather than matched on an `O`
+         * prefix, so a family renamed in the Rust `DiagCode` source cannot
+         * leave this labelling silently wrong.
+         */
+        val OPTIMISATIONS: Set<String> =
+            DiagnosticCatalog.optimisations.mapTo(mutableSetOf()) { it.code }
+
+        /** Code → the documentation section it belongs to. */
+        val SECTIONS: Map<String, String> =
+            DiagnosticCatalog.diagnostics.associate { it.code to it.section }
+
+        /** Code → its catalogue description, with the leading `CODE: ` removed. */
+        val DESCRIPTIONS: Map<String, String> =
+            (DiagnosticCatalog.diagnostics.map { it.code to it.label } +
+                DiagnosticCatalog.optimisations.map { it.code to it.label })
+                .associate { (code, label) -> code to label.removePrefix("$code: ") }
+
+        fun codeOf(diagnostic: Diagnostic): String? {
+            val code = diagnostic.code ?: return null
+            return when {
+                code.isLeft -> code.left
+                code.isRight -> code.right?.toString()
+                else -> null
+            }?.takeIf { it.isNotBlank() }
+        }
+
+        fun kindOf(code: String): String = when {
+            code in OPTIMISATIONS -> "optimiser rewrite"
+            else -> SECTIONS[code]?.let { "$it diagnostic" } ?: "diagnostic"
+        }
+
+        fun describe(code: String): String? = DESCRIPTIONS[code]?.takeIf { it.isNotBlank() }
+
+        /**
+         * What accepting this diagnostic would do.
+         *
+         * The server attaches a `replacement` only when the rewrite has a
+         * precise sub-span to target; a hint-only optimisation deliberately
+         * carries no payload, because its span covers the whole consuming
+         * statement and splicing the fragment in would corrupt it. Saying
+         * which of the two this is means a suggestion that cannot be applied
+         * no longer looks like one that simply has not been tried.
+         */
+        fun fixSummary(diagnostic: Diagnostic): String {
+            val data = diagnostic.data as? JsonObject ?: return "No automatic fix."
+            val replacement = (data.get("replacement") as? JsonPrimitive)?.asString
+                ?: return "No automatic fix."
+            if (replacement.isEmpty()) return "Quick fix: deletes the highlighted code."
+            return "Quick fix: replaces the highlighted code with " +
+                "<code>${StringUtil.escapeXmlEntities(replacement)}</code>."
+        }
+    }
+}

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/TclLspServerDescriptor.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/TclLspServerDescriptor.kt
@@ -29,6 +29,7 @@ import com.intellij.platform.lsp.api.Lsp4jClient
 import com.intellij.platform.lsp.api.LspServerListener
 import com.intellij.platform.lsp.api.LspServerNotificationsHandler
 import com.intellij.platform.lsp.api.ProjectWideLspServerDescriptor
+import com.intellij.platform.lsp.api.customization.LspSemanticTokensSupport
 import com.intellij.util.system.CpuArch
 import com.tcllsp.jetbrains.packs.TclLsp4jClient
 import com.tcllsp.jetbrains.packs.TclLspPackAssociations
@@ -46,6 +47,12 @@ class TclLspServerDescriptor(project: Project) :
 
     override fun isSupportedFile(file: VirtualFile): Boolean =
         TclFileType.isSupported(file)
+
+    // Supplying this is what makes the IDE advertise
+    // `textDocument/semanticTokens` and ask the server for tokens at all; the
+    // platform's default is `null`, and before the 2024.3 support floor the
+    // descriptor had no such member to override.
+    override val lspSemanticTokensSupport: LspSemanticTokensSupport = TclSemanticTokens()
 
     // Pack-declared file extensions (issue #1650). The push is the main path:
     // the server sends `tcl-lsp/specPacksReloaded` after every reload, this

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/TclLspServerDescriptor.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/TclLspServerDescriptor.kt
@@ -29,7 +29,7 @@ import com.intellij.platform.lsp.api.Lsp4jClient
 import com.intellij.platform.lsp.api.LspServerListener
 import com.intellij.platform.lsp.api.LspServerNotificationsHandler
 import com.intellij.platform.lsp.api.ProjectWideLspServerDescriptor
-import com.intellij.platform.lsp.api.customization.LspSemanticTokensSupport
+import com.intellij.platform.lsp.api.customization.LspCustomization
 import com.intellij.util.system.CpuArch
 import com.tcllsp.jetbrains.packs.TclLsp4jClient
 import com.tcllsp.jetbrains.packs.TclLspPackAssociations
@@ -48,11 +48,13 @@ class TclLspServerDescriptor(project: Project) :
     override fun isSupportedFile(file: VirtualFile): Boolean =
         TclFileType.isSupported(file)
 
-    // Supplying this is what makes the IDE advertise
-    // `textDocument/semanticTokens` and ask the server for tokens at all; the
-    // platform's default is `null`, and before the 2024.3 support floor the
-    // descriptor had no such member to override.
-    override val lspSemanticTokensSupport: LspSemanticTokensSupport = TclSemanticTokens()
+    // Supplying a semantic-tokens customiser is what makes the IDE advertise
+    // `textDocument/semanticTokens` and ask the server for tokens at all.
+    // `getClientCapabilities` sets every other capability unconditionally and
+    // guards this one alone on the customiser being present — so without this
+    // the host never asks, whatever the server offers. That member first
+    // exists at 2024.3, which is the floor below which the plugin cannot go.
+    override val lspCustomization: LspCustomization = TclLspCustomization()
 
     // Pack-declared file extensions (issue #1650). The push is the main path:
     // the server sends `tcl-lsp/specPacksReloaded` after every reload, this

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/TclSemanticTokens.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/TclSemanticTokens.kt
@@ -1,0 +1,160 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package com.tcllsp.jetbrains
+
+import com.intellij.openapi.editor.DefaultLanguageHighlighterColors as Colors
+import com.intellij.openapi.editor.colors.TextAttributesKey
+import com.intellij.platform.lsp.api.customization.LspSemanticTokensSupport
+import com.intellij.psi.PsiFile
+import com.tcllsp.jetbrains.settings.TclLspSettings
+
+/**
+ * Colour for every semantic-token type the server advertises in its
+ * `initialize` legend (`tcl_lsp_core::semantic_tokens::legend_token_types`).
+ *
+ * `cargo xtask gen-jetbrains-catalog --check` fails when this map and that
+ * legend disagree: a type the server emits but this map omits is a token the
+ * IDE paints in the default foreground, which is indistinguishable from
+ * having no semantic highlighting at all.
+ *
+ * The keys the platform offers are a general-purpose set, so several Tcl
+ * types share one — the regexp operators are all `OPERATION_SIGN`, the
+ * `format`/`clock`/`binary` specifiers all read as escapes inside a string.
+ * That is the same collapsing the VS Code extension does with its
+ * `semanticTokenScopes` mapping.
+ */
+// @generated-check:semantic-token-colors — keys are verified against the
+// server legend by `cargo xtask gen-jetbrains-catalog`.
+internal val SEMANTIC_TOKEN_COLORS: Map<String, TextAttributesKey> = mapOf(
+    // Core Tcl.
+    "keyword" to Colors.KEYWORD,
+    "function" to Colors.FUNCTION_CALL,
+    "variable" to Colors.LOCAL_VARIABLE,
+    "string" to Colors.STRING,
+    "number" to Colors.NUMBER,
+    "comment" to Colors.LINE_COMMENT,
+    "namespace" to Colors.CLASS_REFERENCE,
+    "operator" to Colors.OPERATION_SIGN,
+    "escape" to Colors.VALID_STRING_ESCAPE,
+    "parameter" to Colors.PARAMETER,
+    "method" to Colors.INSTANCE_METHOD,
+    "class" to Colors.CLASS_NAME,
+    "object" to Colors.CLASS_REFERENCE,
+    "decorator" to Colors.METADATA,
+    "enumMember" to Colors.CONSTANT,
+    "property" to Colors.INSTANCE_FIELD,
+    // iRule events (`when HTTP_REQUEST`) — a tag-like name, not a call.
+    "event" to Colors.MARKUP_TAG,
+
+    // Regular-expression interiors.
+    "regexp" to Colors.STRING,
+    "regexpGroup" to Colors.OPERATION_SIGN,
+    "regexpCharClass" to Colors.CONSTANT,
+    "regexpQuantifier" to Colors.OPERATION_SIGN,
+    "regexpAnchor" to Colors.OPERATION_SIGN,
+    "regexpEscape" to Colors.VALID_STRING_ESCAPE,
+    "regexpBackref" to Colors.CONSTANT,
+    "regexpAlternation" to Colors.OPERATION_SIGN,
+
+    // `format` / `clock` / `binary` specifiers, all inside a string literal.
+    "formatPercent" to Colors.VALID_STRING_ESCAPE,
+    "formatSpec" to Colors.VALID_STRING_ESCAPE,
+    "formatFlag" to Colors.OPERATION_SIGN,
+    "formatWidth" to Colors.NUMBER,
+    "clockPercent" to Colors.VALID_STRING_ESCAPE,
+    "clockSpec" to Colors.VALID_STRING_ESCAPE,
+    "clockModifier" to Colors.OPERATION_SIGN,
+    "binarySpec" to Colors.VALID_STRING_ESCAPE,
+    "binaryCount" to Colors.NUMBER,
+    "binaryFlag" to Colors.OPERATION_SIGN,
+
+    // APL — the iApp presentation sublanguage.
+    "aplSection" to Colors.KEYWORD,
+    "aplSectionName" to Colors.CLASS_NAME,
+    "aplFieldType" to Colors.CLASS_REFERENCE,
+    "aplFieldName" to Colors.INSTANCE_FIELD,
+    "aplAttribute" to Colors.MARKUP_ATTRIBUTE,
+    "aplDefine" to Colors.KEYWORD,
+    "aplDefineName" to Colors.CONSTANT,
+    "aplDirective" to Colors.METADATA,
+    "aplOptional" to Colors.OPERATION_SIGN,
+    "aplValidator" to Colors.STATIC_METHOD,
+
+    // BIG-IP configuration objects and the values that name them.
+    "partition" to Colors.CLASS_NAME,
+    "pool" to Colors.CLASS_REFERENCE,
+    "monitor" to Colors.CLASS_REFERENCE,
+    "profile" to Colors.CLASS_REFERENCE,
+    "vlan" to Colors.CLASS_REFERENCE,
+    "bigipInterface" to Colors.CLASS_REFERENCE,
+    "ipAddress" to Colors.CONSTANT,
+    "port" to Colors.NUMBER,
+    "routeDomain" to Colors.NUMBER,
+    "fqdn" to Colors.CONSTANT,
+    "username" to Colors.IDENTIFIER,
+    "encrypted" to Colors.STRING,
+)
+
+/**
+ * Semantic-token overrides for the modifiers the server sets alongside a
+ * type (`legend_token_modifiers`). Only the pairs that carry real meaning in
+ * an IntelliJ colour scheme are listed; anything else falls through to the
+ * type's own colour.
+ */
+private val SEMANTIC_TOKEN_MODIFIER_COLORS: Map<Pair<String, String>, TextAttributesKey> = mapOf(
+    // A command head resolving to a registry built-in, versus a user proc.
+    ("function" to "defaultLibrary") to Colors.PREDEFINED_SYMBOL,
+    ("method" to "defaultLibrary") to Colors.PREDEFINED_SYMBOL,
+    // The name token of a `proc`/`method` definition, versus a call site.
+    ("function" to "definition") to Colors.FUNCTION_DECLARATION,
+    ("method" to "definition") to Colors.FUNCTION_DECLARATION,
+    // A variable the theme should not present as mutable.
+    ("variable" to "readonly") to Colors.CONSTANT,
+)
+
+/**
+ * Paints the semantic tokens the Tcl language server publishes.
+ *
+ * The IDE only advertises `textDocument/semanticTokens` in its client
+ * capabilities when a descriptor supplies one of these, so without it the
+ * server's tokens are never requested and all colour comes from the TextMate
+ * grammar.
+ */
+class TclSemanticTokens : LspSemanticTokensSupport() {
+
+    /**
+     * Honours the "Semantic tokens" feature toggle. The setting already
+     * reaches the server through `workspace/configuration`, but a server that
+     * has been told to stay quiet still answers the request, so the IDE has to
+     * stop asking too.
+     */
+    override fun shouldAskServerForSemanticTokens(psiFile: PsiFile): Boolean =
+        TclLspSettings.getInstance().featureSemanticTokens
+
+    override fun getTextAttributesKey(
+        tokenType: String,
+        modifiers: List<String>,
+    ): TextAttributesKey? {
+        for (modifier in modifiers) {
+            SEMANTIC_TOKEN_MODIFIER_COLORS[tokenType to modifier]?.let { return it }
+        }
+        return SEMANTIC_TOKEN_COLORS[tokenType]
+            ?: super.getTextAttributesKey(tokenType, modifiers)
+    }
+}

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/TclSemanticTokens.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/TclSemanticTokens.kt
@@ -21,6 +21,7 @@ package com.tcllsp.jetbrains
 import com.intellij.openapi.editor.DefaultLanguageHighlighterColors as Colors
 import com.intellij.openapi.editor.colors.TextAttributesKey
 import com.intellij.platform.lsp.api.customization.LspCustomization
+import com.intellij.platform.lsp.api.customization.LspDiagnosticsCustomizer
 import com.intellij.platform.lsp.api.customization.LspSemanticTokensCustomizer
 import com.intellij.platform.lsp.api.customization.LspSemanticTokensSupport
 import com.intellij.psi.PsiFile
@@ -141,6 +142,7 @@ private val SEMANTIC_TOKEN_MODIFIER_COLORS: Map<Pair<String, String>, TextAttrib
  */
 class TclLspCustomization : LspCustomization() {
     override val semanticTokensCustomizer: LspSemanticTokensCustomizer = TclSemanticTokens()
+    override val diagnosticsCustomizer: LspDiagnosticsCustomizer = TclLspDiagnostics()
 }
 
 /**

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/TclSemanticTokens.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/TclSemanticTokens.kt
@@ -20,6 +20,8 @@ package com.tcllsp.jetbrains
 
 import com.intellij.openapi.editor.DefaultLanguageHighlighterColors as Colors
 import com.intellij.openapi.editor.colors.TextAttributesKey
+import com.intellij.platform.lsp.api.customization.LspCustomization
+import com.intellij.platform.lsp.api.customization.LspSemanticTokensCustomizer
 import com.intellij.platform.lsp.api.customization.LspSemanticTokensSupport
 import com.intellij.psi.PsiFile
 import com.tcllsp.jetbrains.settings.TclLspSettings
@@ -127,6 +129,19 @@ private val SEMANTIC_TOKEN_MODIFIER_COLORS: Map<Pair<String, String>, TextAttrib
     // A variable the theme should not present as mutable.
     ("variable" to "readonly") to Colors.CONSTANT,
 )
+
+/**
+ * The plugin's LSP customisation.
+ *
+ * Only semantic tokens is customised; every other feature keeps the
+ * platform's default. This is the shape that superseded the flat
+ * `LspServerDescriptor.lsp*Support` properties in 2025.2 — the old ones still
+ * work through `DeprecatedLspCustomization`, but only while the descriptor
+ * does not supply a customisation of its own, so the two cannot be mixed.
+ */
+class TclLspCustomization : LspCustomization() {
+    override val semanticTokensCustomizer: LspSemanticTokensCustomizer = TclSemanticTokens()
+}
 
 /**
  * Paints the semantic tokens the Tcl language server publishes.

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/TclTextMateBundleProvider.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/TclTextMateBundleProvider.kt
@@ -1,0 +1,121 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package com.tcllsp.jetbrains
+
+import com.intellij.openapi.application.PathManager
+import com.intellij.openapi.diagnostic.Logger
+import org.jetbrains.plugins.textmate.api.TextMateBundleProvider
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+
+private val LOG = Logger.getInstance("com.tcllsp.jetbrains.TclTextMateBundleProvider")
+
+/** The bundle's name in Settings | Editor | TextMate Bundles. */
+private const val BUNDLE_NAME = "Tcl"
+
+/**
+ * The bundle's files, as classpath resource → path within the bundle
+ * directory. `package.json` is what makes `BundleType.detectBundleType` call
+ * this a VS Code-style bundle, and its `contributes.grammars[].path` is what
+ * ties the manifest to the grammar.
+ */
+private val BUNDLE_FILES = mapOf(
+    "textmate/package.json" to "package.json",
+    "syntaxes/tcl.tmLanguage.json" to "syntaxes/tcl.tmLanguage.json",
+)
+
+/**
+ * Hands the bundled `source.tcl` TextMate grammar to the TextMate plugin.
+ *
+ * Without this nothing ever registers the grammar, so
+ * `TextMateService.getLanguageDescriptorByFileName` finds no descriptor for a
+ * `.tcl` file, `TextMateSyntaxHighlighterFactory` falls back to the plain
+ * highlighter, and every Tcl file opens as undifferentiated black text — the
+ * plugin's `editorHighlighterProvider` registrations on their own only decide
+ * *how* a grammar is lexed, never *which* grammar applies.
+ *
+ * The TextMate service reads bundles from the filesystem, so the two resources
+ * are unpacked out of the plugin jar into the IDE's system directory. Contents
+ * are compared before writing, so an unchanged bundle costs two reads and the
+ * directory survives plugin upgrades without a cache-invalidation dance.
+ */
+class TclTextMateBundleProvider : TextMateBundleProvider {
+    override fun getBundles(): List<TextMateBundleProvider.PluginBundle> {
+        val directory = unpackBundle(defaultBundleDirectory()) ?: return emptyList()
+        return listOf(TextMateBundleProvider.PluginBundle(BUNDLE_NAME, directory))
+    }
+}
+
+/** Where the unpacked bundle lives: `<system>/tcl-lsp/textmate/`. */
+internal fun defaultBundleDirectory(): Path =
+    Path.of(PathManager.getSystemPath(), "tcl-lsp", "textmate")
+
+/**
+ * Unpack [BUNDLE_FILES] into [directory], returning it, or `null` when a
+ * resource is missing or the directory cannot be written.
+ *
+ * [readResource] is injectable so a test can drive the same unpack the
+ * provider performs.
+ */
+internal fun unpackBundle(
+    directory: Path,
+    readResource: (String) -> ByteArray? = ::bundleResource,
+): Path? =
+    try {
+        for ((resource, relative) in BUNDLE_FILES) {
+            val bytes = readResource(resource)
+            if (bytes == null) {
+                // A mis-packaged plugin. `make verify-jetbrains-resources`
+                // fails the build on exactly this, so reaching it means the
+                // jar was assembled some other way; warn rather than
+                // `LOG.error`, which would abort TextMate service startup
+                // for every other bundle too.
+                LOG.warn(
+                    "Tcl TextMate bundle resource '$resource' is missing from the plugin " +
+                        "jar — Tcl files will open without syntax highlighting."
+                )
+                return null
+            }
+            val file = directory.resolve(relative)
+            Files.createDirectories(file.parent)
+            if (!Files.exists(file) || !Files.readAllBytes(file).contentEquals(bytes)) {
+                // Two IDEs sharing this system directory can unpack at once
+                // after an upgrade. Write beside the target and move it into
+                // place, so a concurrent reader never sees a truncated
+                // grammar (which parses as no grammar at all).
+                val staged = Files.createTempFile(file.parent, ".${file.fileName}", ".tmp")
+                try {
+                    Files.write(staged, bytes)
+                    Files.move(staged, file, StandardCopyOption.REPLACE_EXISTING)
+                } finally {
+                    Files.deleteIfExists(staged)
+                }
+            }
+        }
+        directory
+    } catch (e: Exception) {
+        LOG.warn("Failed to unpack the Tcl TextMate bundle into $directory", e)
+        null
+    }
+
+private fun bundleResource(path: String): ByteArray? =
+    TclTextMateBundleProvider::class.java.classLoader
+        .getResourceAsStream(path)
+        ?.use { it.readBytes() }

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/actions/TclLspActionBase.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/actions/TclLspActionBase.kt
@@ -112,7 +112,7 @@ abstract class TclLspActionBase : AnAction() {
 
             // Pass the timeout explicitly. Omitting it makes Kotlin emit a call
             // to the synthetic `LspServer.sendRequestSync$default` bridge, bound
-            // to the class that declared the method when we compiled (2024.1).
+            // to the class that declared the method when we compiled (2024.3).
             // In 2026.1+ `sendRequestSync` moved up to the `LspClient`
             // super-interface, so that bridge no longer resolves as
             // `LspServer.sendRequestSync$default` and the plugin fails

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/actions/TclLspActionBase.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/actions/TclLspActionBase.kt
@@ -112,7 +112,7 @@ abstract class TclLspActionBase : AnAction() {
 
             // Pass the timeout explicitly. Omitting it makes Kotlin emit a call
             // to the synthetic `LspServer.sendRequestSync$default` bridge, bound
-            // to the class that declared the method when we compiled (2024.3).
+            // to the class that declared the method when we compiled (2025.3).
             // In 2026.1+ `sendRequestSync` moved up to the `LspClient`
             // super-interface, so that bridge no longer resolves as
             // `LspServer.sendRequestSync$default` and the plugin fails

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/settings/ReflowingGrid.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/settings/ReflowingGrid.kt
@@ -1,0 +1,144 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package com.tcllsp.jetbrains.settings
+
+import com.intellij.util.ui.JBUI
+import java.awt.Component
+import java.awt.Container
+import java.awt.Dimension
+import java.awt.LayoutManager
+import javax.swing.JComponent
+import javax.swing.JPanel
+
+/** Gap between cells, before HiDPI scaling. */
+private const val HGAP = 8
+private const val VGAP = 2
+
+/** Columns assumed before the grid has ever been given a width. */
+private const val UNMEASURED_COLUMNS = 2
+
+/**
+ * Equal-width cells in as many columns as the available width allows.
+ *
+ * The settings page laid its checkbox groups out with `GridLayout(0, n)`,
+ * which sizes every cell to the widest label and multiplies by `n`: the
+ * optimiser's four columns of sixty-character labels came to roughly 2000px,
+ * and the diagnostics groups to about half that. An IntelliJ settings pane
+ * never scrolls horizontally — the platform wraps a configurable's component
+ * in a vertical-only scroll pane — so every column past the pane's own width
+ * was simply unreachable, and the page ran off the right-hand edge.
+ *
+ * Width is read from the enclosing form rather than from this grid's own
+ * bounds, so a resize settles in a single pass: a container is sized before
+ * its children are laid out, so by the time the form's `GridBagLayout` asks
+ * this grid for a preferred size, the width the grid is about to be given is
+ * already known. Reading `width` here instead would answer with the previous
+ * pass's column count and leave the last row clipped after every resize.
+ */
+internal class ReflowingGrid(children: List<JComponent>) : JPanel() {
+
+    init {
+        layout = Reflow()
+        isOpaque = false
+        children.forEach { add(it) }
+    }
+
+    private inner class Reflow : LayoutManager {
+        override fun addLayoutComponent(name: String?, component: Component?) = Unit
+
+        override fun removeLayoutComponent(component: Component?) = Unit
+
+        override fun preferredLayoutSize(parent: Container): Dimension =
+            synchronized(parent.treeLock) { gridSize(columns(availableWidth())) }
+
+        /**
+         * One column. A settings pane that cannot show the grid's preferred
+         * width must squeeze it rather than clip it, and one column of one
+         * checkbox is as narrow as this can honestly get.
+         */
+        override fun minimumLayoutSize(parent: Container): Dimension =
+            synchronized(parent.treeLock) { gridSize(1) }
+
+        override fun layoutContainer(parent: Container) {
+            synchronized(parent.treeLock) {
+                val insets = insets
+                val cell = cellSize()
+                val content = width - insets.left - insets.right
+                val columns = columns(if (width > 0) content else availableWidth())
+                components.forEachIndexed { index, component ->
+                    val column = index % columns
+                    val row = index / columns
+                    component.setBounds(
+                        insets.left + column * (cell.width + JBUI.scale(HGAP)),
+                        insets.top + row * (cell.height + JBUI.scale(VGAP)),
+                        cell.width,
+                        cell.height,
+                    )
+                }
+            }
+        }
+    }
+
+    /** The widest and tallest child, which every cell is sized to. */
+    private fun cellSize(): Dimension {
+        var width = 1
+        var height = 1
+        for (component in components) {
+            val preferred = component.preferredSize
+            width = maxOf(width, preferred.width)
+            height = maxOf(height, preferred.height)
+        }
+        return Dimension(width, height)
+    }
+
+    private fun gridSize(columns: Int): Dimension {
+        val cell = cellSize()
+        val rows = (componentCount + columns - 1) / columns
+        val insets = insets
+        return Dimension(
+            insets.left + insets.right + columns * cell.width + (columns - 1) * JBUI.scale(HGAP),
+            insets.top + insets.bottom + rows * cell.height + (rows - 1).coerceAtLeast(0) * JBUI.scale(VGAP),
+        )
+    }
+
+    /** Columns that fit in [content] px of content width (insets excluded). */
+    private fun columns(content: Int): Int {
+        if (componentCount == 0) return 1
+        if (content <= 0) return UNMEASURED_COLUMNS.coerceAtMost(componentCount)
+        val cell = cellSize().width + JBUI.scale(HGAP)
+        return ((content + JBUI.scale(HGAP)) / cell).coerceIn(1, componentCount)
+    }
+
+    /**
+     * The width this grid is about to be laid out at: the nearest ancestor
+     * that has been sized, less every inset between it and here. Falls back
+     * to this grid's own width when it has no sized ancestor at all.
+     */
+    private fun availableWidth(): Int {
+        var lost = insets.left + insets.right
+        var ancestor: Container? = parent
+        while (ancestor != null) {
+            val ancestorInsets = ancestor.insets
+            lost += ancestorInsets.left + ancestorInsets.right
+            if (ancestor.width > 0) return ancestor.width - lost
+            ancestor = ancestor.parent
+        }
+        return width
+    }
+}

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/settings/TclLspSettings.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/settings/TclLspSettings.kt
@@ -285,37 +285,38 @@ class TclLspSettings : PersistentStateComponent<TclLspSettings> {
 
     // @generated:optimiser-vars:begin
     var optimiserEnabled: Boolean = true
-    var optimiserO100: Boolean = true
-    var optimiserO101: Boolean = true
-    var optimiserO102: Boolean = true
-    var optimiserO103: Boolean = true
-    var optimiserO104: Boolean = true
-    var optimiserO105: Boolean = true
-    var optimiserO106: Boolean = true
-    var optimiserO107: Boolean = true
-    var optimiserO108: Boolean = true
-    var optimiserO109: Boolean = true
-    var optimiserO110: Boolean = true
-    var optimiserO111: Boolean = true
-    var optimiserO112: Boolean = true
-    var optimiserO113: Boolean = true
-    var optimiserO114: Boolean = true
-    var optimiserO115: Boolean = true
-    var optimiserO116: Boolean = true
-    var optimiserO117: Boolean = true
-    var optimiserO118: Boolean = true
-    var optimiserO119: Boolean = true
-    var optimiserO120: Boolean = true
-    var optimiserO121: Boolean = true
-    var optimiserO122: Boolean = true
-    var optimiserO123: Boolean = true
-    var optimiserO124: Boolean = true
-    var optimiserO125: Boolean = true
-    var optimiserO126: Boolean = true
-    var optimiserO127: Boolean = true
-    var optimiserO128: Boolean = true
-    var optimiserO129: Boolean = true
-    var optimiserO130: Boolean = true
+    var optimiserProfile: String = "readability"
+    var optimiserO100: Boolean? = null
+    var optimiserO101: Boolean? = null
+    var optimiserO102: Boolean? = null
+    var optimiserO103: Boolean? = null
+    var optimiserO104: Boolean? = null
+    var optimiserO105: Boolean? = null
+    var optimiserO106: Boolean? = null
+    var optimiserO107: Boolean? = null
+    var optimiserO108: Boolean? = null
+    var optimiserO109: Boolean? = null
+    var optimiserO110: Boolean? = null
+    var optimiserO111: Boolean? = null
+    var optimiserO112: Boolean? = null
+    var optimiserO113: Boolean? = null
+    var optimiserO114: Boolean? = null
+    var optimiserO115: Boolean? = null
+    var optimiserO116: Boolean? = null
+    var optimiserO117: Boolean? = null
+    var optimiserO118: Boolean? = null
+    var optimiserO119: Boolean? = null
+    var optimiserO120: Boolean? = null
+    var optimiserO121: Boolean? = null
+    var optimiserO122: Boolean? = null
+    var optimiserO123: Boolean? = null
+    var optimiserO124: Boolean? = null
+    var optimiserO125: Boolean? = null
+    var optimiserO126: Boolean? = null
+    var optimiserO127: Boolean? = null
+    var optimiserO128: Boolean? = null
+    var optimiserO129: Boolean? = null
+    var optimiserO130: Boolean? = null
     // @generated:optimiser-vars:end
 
     // Shimmer
@@ -607,6 +608,7 @@ class TclLspSettings : PersistentStateComponent<TclLspSettings> {
             "optimiser" to mapOf(
                 // @generated:optimiser-map:begin
                 "enabled" to optimiserEnabled,
+                "profile" to optimiserProfile,
                 "O100" to optimiserO100,
                 "O101" to optimiserO101,
                 "O102" to optimiserO102,

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/settings/TclLspSettingsPanel.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/settings/TclLspSettingsPanel.kt
@@ -23,6 +23,7 @@ import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.util.text.StringUtil
 import com.intellij.platform.lsp.api.LspServerManager
 import com.intellij.ui.TitledSeparator
+import com.intellij.ui.components.ActionLink
 import com.intellij.ui.components.JBCheckBox
 import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBTextField
@@ -33,6 +34,7 @@ import com.intellij.util.ui.UIUtil
 import com.tcllsp.jetbrains.TclLspServerSupportProvider
 import java.awt.BorderLayout
 import java.awt.Dimension
+import java.awt.FlowLayout
 import java.awt.Rectangle
 import javax.swing.*
 
@@ -436,6 +438,14 @@ class TclLspSettingsPanel {
     private val optO128 = ThreeStateCheckBox("O128: Rewrite [expr {[llength \$L] - N}] / [expr {[string l...", ThreeStateCheckBox.State.DONT_CARE)
     private val optO129 = ThreeStateCheckBox("O129: Fold a pure builtin command substitution with consta...", ThreeStateCheckBox.State.DONT_CARE)
     private val optO130 = ThreeStateCheckBox("O130: Fold static lappend list build chains into a single ...", ThreeStateCheckBox.State.DONT_CARE)
+    private val optCodeBoxes: List<ThreeStateCheckBox> = listOf(
+        optO100, optO101, optO102, optO103, optO104, optO105,
+        optO106, optO107, optO108, optO109, optO110, optO111,
+        optO112, optO113, optO114, optO115, optO116, optO117,
+        optO118, optO119, optO120, optO121, optO122, optO123,
+        optO124, optO125, optO126, optO127, optO128, optO129,
+        optO130,
+    )
     // @generated:opt-checkboxes:end
 
     // Shimmer
@@ -656,23 +666,13 @@ class TclLspSettingsPanel {
         // @generated:opt-ui:begin
         builder.addComponent(TitledSeparator("Optimiser"))
         builder.addComponent(optEnabled)
-        builder.addLabeledComponent(JBLabel("Profile:"), optProfile)
-        builder.addComponent(
-            ReflowingGrid(
-                listOf(
-                    optO100, optO101, optO102, optO103, optO104, optO105,
-                    optO106, optO107, optO108, optO109, optO110, optO111,
-                    optO112, optO113, optO114, optO115, optO116, optO117,
-                    optO118, optO119, optO120, optO121, optO122, optO123,
-                    optO124, optO125, optO126, optO127, optO128, optO129,
-                    optO130,
-                ),
-            ),
-        )
+        builder.addLabeledComponent(JBLabel("Profile:"), profileRow())
+        builder.addComponent(ReflowingGrid(optCodeBoxes))
         builder.addWrappedComment(
             "The profile chooses which optimisation families run. A per-code box left " +
                 "in its mixed state inherits from the profile; tick or untick one to " +
-                "force that code on or off regardless of the profile.",
+                "force that code on or off regardless of the profile. Reset to profile " +
+                "clears every override and hands the choice back to the profile.",
         )
         // @generated:opt-ui:end
 
@@ -1301,6 +1301,36 @@ class TclLspSettingsPanel {
      * don't need a restart.
      */
     @Suppress("UnstableApiUsage")
+    /**
+     * The profile selector, with the link that clears every per-code override
+     * beside it.
+     *
+     * A function rather than a property: it reads `optProfile` and
+     * `optCodeBoxes`, both generated declarations, and building it while the
+     * form is assembled keeps it independent of the order those initialise in.
+     */
+    private fun profileRow(): JPanel =
+        JPanel(FlowLayout(FlowLayout.LEFT, JBUI.scale(8), 0)).apply {
+            add(optProfile)
+            add(ActionLink("Reset codes to profile") { resetCodesToProfile() })
+        }
+
+    /**
+     * Hand every per-code choice back to the profile.
+     *
+     * The third state is the one that defers, so this resets to "no opinion"
+     * rather than to a set of ticks: without it, a user who explicitly set a
+     * handful of codes has no way to find which, or to undo them short of
+     * clicking each back to mixed.
+     *
+     * Only the controls change — `isModified` then reports the panel dirty and
+     * the usual Apply writes it through, so this is as undoable as any other
+     * edit on the page.
+     */
+    private fun resetCodesToProfile() {
+        optCodeBoxes.forEach { it.state = ThreeStateCheckBox.State.DONT_CARE }
+    }
+
     private fun restartLspServers() {
         for (project in ProjectManager.getInstance().openProjects) {
             if (project.isDisposed) continue

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/settings/TclLspSettingsPanel.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/settings/TclLspSettingsPanel.kt
@@ -28,6 +28,7 @@ import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBTextField
 import com.intellij.util.ui.FormBuilder
 import com.intellij.util.ui.JBUI
+import com.intellij.util.ui.ThreeStateCheckBox
 import com.intellij.util.ui.UIUtil
 import com.tcllsp.jetbrains.TclLspServerSupportProvider
 import java.awt.BorderLayout
@@ -57,6 +58,28 @@ private const val SCROLL_UNIT = 16
  * so on a single line it alone asked the settings pane for about 1200px and
  * ran off the right-hand edge.
  */
+/**
+ * The stored value a tri-state optimiser box currently represents.
+ *
+ * `null` is the third state, and it is the important one: it means "inherit
+ * from the profile". The server treats a per-code override as beating the
+ * profile in both directions — `true` lifts a code out of the profile's
+ * disabled set, `false` forces it in — so only a real user choice may travel,
+ * and `DONT_CARE` must serialise to no opinion at all rather than to `false`.
+ */
+private fun triState(box: ThreeStateCheckBox): Boolean? = when (box.state) {
+    ThreeStateCheckBox.State.SELECTED -> true
+    ThreeStateCheckBox.State.NOT_SELECTED -> false
+    else -> null
+}
+
+/** The inverse of [triState], for loading a stored value back into the box. */
+private fun threeState(value: Boolean?): ThreeStateCheckBox.State = when (value) {
+    true -> ThreeStateCheckBox.State.SELECTED
+    false -> ThreeStateCheckBox.State.NOT_SELECTED
+    null -> ThreeStateCheckBox.State.DONT_CARE
+}
+
 private fun FormBuilder.addWrappedComment(text: String): FormBuilder =
     addComponentToRightColumn(
         JBLabel(
@@ -381,37 +404,38 @@ class TclLspSettingsPanel {
 
     // @generated:opt-checkboxes:begin
     private val optEnabled = JBCheckBox("Enable optimiser suggestions")
-    private val optO100 = JBCheckBox("O100: Propagate constant variables into expressions and co...")
-    private val optO101 = JBCheckBox("O101: Fold constant integer expressions")
-    private val optO102 = JBCheckBox("O102: Forward a variable's single reaching literal load to...")
-    private val optO103 = JBCheckBox("O103: Fold static procedure calls using interprocedural su...")
-    private val optO104 = JBCheckBox("O104: Fold static string build chains into a single assign...")
-    private val optO105 = JBCheckBox("O105: Propagate constants into variable references and det...")
-    private val optO106 = JBCheckBox("O106: Hoist loop-invariant computations")
-    private val optO107 = JBCheckBox("O107: Eliminate unreachable dead code")
-    private val optO108 = JBCheckBox("O108: Eliminate transitively dead code")
-    private val optO109 = JBCheckBox("O109: Eliminate dead stores")
-    private val optO110 = JBCheckBox("O110: Canonicalise expressions (InstCombine)")
-    private val optO111 = JBCheckBox("O111: Brace expression performance hints (paired with W100)")
-    private val optO112 = JBCheckBox("O112: Eliminate constant-condition compound statements")
-    private val optO113 = JBCheckBox("O113: Strength-reduce expressions (x**2 → x*x, x%8 → x&7)")
-    private val optO114 = JBCheckBox("O114: Recognise incr idiom (set x [expr {\$x + N}] → incr x N)")
-    private val optO115 = JBCheckBox("O115: Remove redundant nested [expr {...}] in expression c...")
-    private val optO116 = JBCheckBox("O116: Fold constant [list a b c] to literal value")
-    private val optO117 = JBCheckBox("O117: Simplify [string length \$s] == 0 → \$s eq \"\"")
-    private val optO118 = JBCheckBox("O118: Fold constant [lindex {a b c} 1] to element")
-    private val optO119 = JBCheckBox("O119: Pack consecutive set literals into lassign/foreach")
-    private val optO120 = JBCheckBox("O120: Prefer eq/ne over ==/!= for string comparisons")
-    private val optO121 = JBCheckBox("O121: Rewrite self-recursive tail calls to tailcall")
-    private val optO122 = JBCheckBox("O122: Convert fully tail-recursive proc to iterative while...")
-    private val optO123 = JBCheckBox("O123: Detect non-tail recursion eligible for accumulator i...")
-    private val optO124 = JBCheckBox("O124: Comment out unused procs in iRules (not called from ...")
-    private val optO125 = JBCheckBox("O125: Sink side-effect-free assignments into the deepest d...")
-    private val optO126 = JBCheckBox("O126: Remove unused variable assignments")
-    private val optO127 = JBCheckBox("O127: Inline single-use variable assignment")
-    private val optO128 = JBCheckBox("O128: Rewrite [expr {[llength \$L] - N}] / [expr {[string l...")
-    private val optO129 = JBCheckBox("O129: Fold a pure builtin command substitution with consta...")
-    private val optO130 = JBCheckBox("O130: Fold static lappend list build chains into a single ...")
+    private val optProfile = JComboBox(arrayOf("off", "readability", "standard", "full", "aggressive"))
+    private val optO100 = ThreeStateCheckBox("O100: Propagate constant variables into expressions and co...", ThreeStateCheckBox.State.DONT_CARE)
+    private val optO101 = ThreeStateCheckBox("O101: Fold constant integer expressions", ThreeStateCheckBox.State.DONT_CARE)
+    private val optO102 = ThreeStateCheckBox("O102: Forward a variable's single reaching literal load to...", ThreeStateCheckBox.State.DONT_CARE)
+    private val optO103 = ThreeStateCheckBox("O103: Fold static procedure calls using interprocedural su...", ThreeStateCheckBox.State.DONT_CARE)
+    private val optO104 = ThreeStateCheckBox("O104: Fold static string build chains into a single assign...", ThreeStateCheckBox.State.DONT_CARE)
+    private val optO105 = ThreeStateCheckBox("O105: Propagate constants into variable references and det...", ThreeStateCheckBox.State.DONT_CARE)
+    private val optO106 = ThreeStateCheckBox("O106: Hoist loop-invariant computations", ThreeStateCheckBox.State.DONT_CARE)
+    private val optO107 = ThreeStateCheckBox("O107: Eliminate unreachable dead code", ThreeStateCheckBox.State.DONT_CARE)
+    private val optO108 = ThreeStateCheckBox("O108: Eliminate transitively dead code", ThreeStateCheckBox.State.DONT_CARE)
+    private val optO109 = ThreeStateCheckBox("O109: Eliminate dead stores", ThreeStateCheckBox.State.DONT_CARE)
+    private val optO110 = ThreeStateCheckBox("O110: Canonicalise expressions (InstCombine)", ThreeStateCheckBox.State.DONT_CARE)
+    private val optO111 = ThreeStateCheckBox("O111: Brace expression performance hints (paired with W100)", ThreeStateCheckBox.State.DONT_CARE)
+    private val optO112 = ThreeStateCheckBox("O112: Eliminate constant-condition compound statements", ThreeStateCheckBox.State.DONT_CARE)
+    private val optO113 = ThreeStateCheckBox("O113: Strength-reduce expressions (x**2 → x*x, x%8 → x&7)", ThreeStateCheckBox.State.DONT_CARE)
+    private val optO114 = ThreeStateCheckBox("O114: Recognise incr idiom (set x [expr {\$x + N}] → incr x N)", ThreeStateCheckBox.State.DONT_CARE)
+    private val optO115 = ThreeStateCheckBox("O115: Remove redundant nested [expr {...}] in expression c...", ThreeStateCheckBox.State.DONT_CARE)
+    private val optO116 = ThreeStateCheckBox("O116: Fold constant [list a b c] to literal value", ThreeStateCheckBox.State.DONT_CARE)
+    private val optO117 = ThreeStateCheckBox("O117: Simplify [string length \$s] == 0 → \$s eq \"\"", ThreeStateCheckBox.State.DONT_CARE)
+    private val optO118 = ThreeStateCheckBox("O118: Fold constant [lindex {a b c} 1] to element", ThreeStateCheckBox.State.DONT_CARE)
+    private val optO119 = ThreeStateCheckBox("O119: Pack consecutive set literals into lassign/foreach", ThreeStateCheckBox.State.DONT_CARE)
+    private val optO120 = ThreeStateCheckBox("O120: Prefer eq/ne over ==/!= for string comparisons", ThreeStateCheckBox.State.DONT_CARE)
+    private val optO121 = ThreeStateCheckBox("O121: Rewrite self-recursive tail calls to tailcall", ThreeStateCheckBox.State.DONT_CARE)
+    private val optO122 = ThreeStateCheckBox("O122: Convert fully tail-recursive proc to iterative while...", ThreeStateCheckBox.State.DONT_CARE)
+    private val optO123 = ThreeStateCheckBox("O123: Detect non-tail recursion eligible for accumulator i...", ThreeStateCheckBox.State.DONT_CARE)
+    private val optO124 = ThreeStateCheckBox("O124: Comment out unused procs in iRules (not called from ...", ThreeStateCheckBox.State.DONT_CARE)
+    private val optO125 = ThreeStateCheckBox("O125: Sink side-effect-free assignments into the deepest d...", ThreeStateCheckBox.State.DONT_CARE)
+    private val optO126 = ThreeStateCheckBox("O126: Remove unused variable assignments", ThreeStateCheckBox.State.DONT_CARE)
+    private val optO127 = ThreeStateCheckBox("O127: Inline single-use variable assignment", ThreeStateCheckBox.State.DONT_CARE)
+    private val optO128 = ThreeStateCheckBox("O128: Rewrite [expr {[llength \$L] - N}] / [expr {[string l...", ThreeStateCheckBox.State.DONT_CARE)
+    private val optO129 = ThreeStateCheckBox("O129: Fold a pure builtin command substitution with consta...", ThreeStateCheckBox.State.DONT_CARE)
+    private val optO130 = ThreeStateCheckBox("O130: Fold static lappend list build chains into a single ...", ThreeStateCheckBox.State.DONT_CARE)
     // @generated:opt-checkboxes:end
 
     // Shimmer
@@ -632,6 +656,7 @@ class TclLspSettingsPanel {
         // @generated:opt-ui:begin
         builder.addComponent(TitledSeparator("Optimiser"))
         builder.addComponent(optEnabled)
+        builder.addLabeledComponent(JBLabel("Profile:"), optProfile)
         builder.addComponent(
             ReflowingGrid(
                 listOf(
@@ -643,6 +668,11 @@ class TclLspSettingsPanel {
                     optO130,
                 ),
             ),
+        )
+        builder.addWrappedComment(
+            "The profile chooses which optimisation families run. A per-code box left " +
+                "in its mixed state inherits from the profile; tick or untick one to " +
+                "force that code on or off regardless of the profile.",
         )
         // @generated:opt-ui:end
 
@@ -921,37 +951,38 @@ class TclLspSettingsPanel {
             (styleLineLength.value as Int) != s.styleLineLength ||
             // @generated:opt-dirty:begin
             optEnabled.isSelected != s.optimiserEnabled ||
-            optO100.isSelected != s.optimiserO100 ||
-            optO101.isSelected != s.optimiserO101 ||
-            optO102.isSelected != s.optimiserO102 ||
-            optO103.isSelected != s.optimiserO103 ||
-            optO104.isSelected != s.optimiserO104 ||
-            optO105.isSelected != s.optimiserO105 ||
-            optO106.isSelected != s.optimiserO106 ||
-            optO107.isSelected != s.optimiserO107 ||
-            optO108.isSelected != s.optimiserO108 ||
-            optO109.isSelected != s.optimiserO109 ||
-            optO110.isSelected != s.optimiserO110 ||
-            optO111.isSelected != s.optimiserO111 ||
-            optO112.isSelected != s.optimiserO112 ||
-            optO113.isSelected != s.optimiserO113 ||
-            optO114.isSelected != s.optimiserO114 ||
-            optO115.isSelected != s.optimiserO115 ||
-            optO116.isSelected != s.optimiserO116 ||
-            optO117.isSelected != s.optimiserO117 ||
-            optO118.isSelected != s.optimiserO118 ||
-            optO119.isSelected != s.optimiserO119 ||
-            optO120.isSelected != s.optimiserO120 ||
-            optO121.isSelected != s.optimiserO121 ||
-            optO122.isSelected != s.optimiserO122 ||
-            optO123.isSelected != s.optimiserO123 ||
-            optO124.isSelected != s.optimiserO124 ||
-            optO125.isSelected != s.optimiserO125 ||
-            optO126.isSelected != s.optimiserO126 ||
-            optO127.isSelected != s.optimiserO127 ||
-            optO128.isSelected != s.optimiserO128 ||
-            optO129.isSelected != s.optimiserO129 ||
-            optO130.isSelected != s.optimiserO130 ||
+            optProfile.selectedItem != s.optimiserProfile ||
+            triState(optO100) != s.optimiserO100 ||
+            triState(optO101) != s.optimiserO101 ||
+            triState(optO102) != s.optimiserO102 ||
+            triState(optO103) != s.optimiserO103 ||
+            triState(optO104) != s.optimiserO104 ||
+            triState(optO105) != s.optimiserO105 ||
+            triState(optO106) != s.optimiserO106 ||
+            triState(optO107) != s.optimiserO107 ||
+            triState(optO108) != s.optimiserO108 ||
+            triState(optO109) != s.optimiserO109 ||
+            triState(optO110) != s.optimiserO110 ||
+            triState(optO111) != s.optimiserO111 ||
+            triState(optO112) != s.optimiserO112 ||
+            triState(optO113) != s.optimiserO113 ||
+            triState(optO114) != s.optimiserO114 ||
+            triState(optO115) != s.optimiserO115 ||
+            triState(optO116) != s.optimiserO116 ||
+            triState(optO117) != s.optimiserO117 ||
+            triState(optO118) != s.optimiserO118 ||
+            triState(optO119) != s.optimiserO119 ||
+            triState(optO120) != s.optimiserO120 ||
+            triState(optO121) != s.optimiserO121 ||
+            triState(optO122) != s.optimiserO122 ||
+            triState(optO123) != s.optimiserO123 ||
+            triState(optO124) != s.optimiserO124 ||
+            triState(optO125) != s.optimiserO125 ||
+            triState(optO126) != s.optimiserO126 ||
+            triState(optO127) != s.optimiserO127 ||
+            triState(optO128) != s.optimiserO128 ||
+            triState(optO129) != s.optimiserO129 ||
+            triState(optO130) != s.optimiserO130 ||
             // @generated:opt-dirty:end
             // Shimmer
             shimmerEnabled.isSelected != s.shimmerEnabled ||
@@ -1212,37 +1243,38 @@ class TclLspSettingsPanel {
 
         // @generated:opt-apply:begin
         s.optimiserEnabled = optEnabled.isSelected
-        s.optimiserO100 = optO100.isSelected
-        s.optimiserO101 = optO101.isSelected
-        s.optimiserO102 = optO102.isSelected
-        s.optimiserO103 = optO103.isSelected
-        s.optimiserO104 = optO104.isSelected
-        s.optimiserO105 = optO105.isSelected
-        s.optimiserO106 = optO106.isSelected
-        s.optimiserO107 = optO107.isSelected
-        s.optimiserO108 = optO108.isSelected
-        s.optimiserO109 = optO109.isSelected
-        s.optimiserO110 = optO110.isSelected
-        s.optimiserO111 = optO111.isSelected
-        s.optimiserO112 = optO112.isSelected
-        s.optimiserO113 = optO113.isSelected
-        s.optimiserO114 = optO114.isSelected
-        s.optimiserO115 = optO115.isSelected
-        s.optimiserO116 = optO116.isSelected
-        s.optimiserO117 = optO117.isSelected
-        s.optimiserO118 = optO118.isSelected
-        s.optimiserO119 = optO119.isSelected
-        s.optimiserO120 = optO120.isSelected
-        s.optimiserO121 = optO121.isSelected
-        s.optimiserO122 = optO122.isSelected
-        s.optimiserO123 = optO123.isSelected
-        s.optimiserO124 = optO124.isSelected
-        s.optimiserO125 = optO125.isSelected
-        s.optimiserO126 = optO126.isSelected
-        s.optimiserO127 = optO127.isSelected
-        s.optimiserO128 = optO128.isSelected
-        s.optimiserO129 = optO129.isSelected
-        s.optimiserO130 = optO130.isSelected
+        s.optimiserProfile = optProfile.selectedItem as? String ?: s.optimiserProfile
+        s.optimiserO100 = triState(optO100)
+        s.optimiserO101 = triState(optO101)
+        s.optimiserO102 = triState(optO102)
+        s.optimiserO103 = triState(optO103)
+        s.optimiserO104 = triState(optO104)
+        s.optimiserO105 = triState(optO105)
+        s.optimiserO106 = triState(optO106)
+        s.optimiserO107 = triState(optO107)
+        s.optimiserO108 = triState(optO108)
+        s.optimiserO109 = triState(optO109)
+        s.optimiserO110 = triState(optO110)
+        s.optimiserO111 = triState(optO111)
+        s.optimiserO112 = triState(optO112)
+        s.optimiserO113 = triState(optO113)
+        s.optimiserO114 = triState(optO114)
+        s.optimiserO115 = triState(optO115)
+        s.optimiserO116 = triState(optO116)
+        s.optimiserO117 = triState(optO117)
+        s.optimiserO118 = triState(optO118)
+        s.optimiserO119 = triState(optO119)
+        s.optimiserO120 = triState(optO120)
+        s.optimiserO121 = triState(optO121)
+        s.optimiserO122 = triState(optO122)
+        s.optimiserO123 = triState(optO123)
+        s.optimiserO124 = triState(optO124)
+        s.optimiserO125 = triState(optO125)
+        s.optimiserO126 = triState(optO126)
+        s.optimiserO127 = triState(optO127)
+        s.optimiserO128 = triState(optO128)
+        s.optimiserO129 = triState(optO129)
+        s.optimiserO130 = triState(optO130)
         // @generated:opt-apply:end
 
         s.shimmerEnabled = shimmerEnabled.isSelected
@@ -1519,37 +1551,38 @@ class TclLspSettingsPanel {
 
         // @generated:opt-reset:begin
         optEnabled.isSelected = s.optimiserEnabled
-        optO100.isSelected = s.optimiserO100
-        optO101.isSelected = s.optimiserO101
-        optO102.isSelected = s.optimiserO102
-        optO103.isSelected = s.optimiserO103
-        optO104.isSelected = s.optimiserO104
-        optO105.isSelected = s.optimiserO105
-        optO106.isSelected = s.optimiserO106
-        optO107.isSelected = s.optimiserO107
-        optO108.isSelected = s.optimiserO108
-        optO109.isSelected = s.optimiserO109
-        optO110.isSelected = s.optimiserO110
-        optO111.isSelected = s.optimiserO111
-        optO112.isSelected = s.optimiserO112
-        optO113.isSelected = s.optimiserO113
-        optO114.isSelected = s.optimiserO114
-        optO115.isSelected = s.optimiserO115
-        optO116.isSelected = s.optimiserO116
-        optO117.isSelected = s.optimiserO117
-        optO118.isSelected = s.optimiserO118
-        optO119.isSelected = s.optimiserO119
-        optO120.isSelected = s.optimiserO120
-        optO121.isSelected = s.optimiserO121
-        optO122.isSelected = s.optimiserO122
-        optO123.isSelected = s.optimiserO123
-        optO124.isSelected = s.optimiserO124
-        optO125.isSelected = s.optimiserO125
-        optO126.isSelected = s.optimiserO126
-        optO127.isSelected = s.optimiserO127
-        optO128.isSelected = s.optimiserO128
-        optO129.isSelected = s.optimiserO129
-        optO130.isSelected = s.optimiserO130
+        optProfile.selectedItem = s.optimiserProfile
+        optO100.state = threeState(s.optimiserO100)
+        optO101.state = threeState(s.optimiserO101)
+        optO102.state = threeState(s.optimiserO102)
+        optO103.state = threeState(s.optimiserO103)
+        optO104.state = threeState(s.optimiserO104)
+        optO105.state = threeState(s.optimiserO105)
+        optO106.state = threeState(s.optimiserO106)
+        optO107.state = threeState(s.optimiserO107)
+        optO108.state = threeState(s.optimiserO108)
+        optO109.state = threeState(s.optimiserO109)
+        optO110.state = threeState(s.optimiserO110)
+        optO111.state = threeState(s.optimiserO111)
+        optO112.state = threeState(s.optimiserO112)
+        optO113.state = threeState(s.optimiserO113)
+        optO114.state = threeState(s.optimiserO114)
+        optO115.state = threeState(s.optimiserO115)
+        optO116.state = threeState(s.optimiserO116)
+        optO117.state = threeState(s.optimiserO117)
+        optO118.state = threeState(s.optimiserO118)
+        optO119.state = threeState(s.optimiserO119)
+        optO120.state = threeState(s.optimiserO120)
+        optO121.state = threeState(s.optimiserO121)
+        optO122.state = threeState(s.optimiserO122)
+        optO123.state = threeState(s.optimiserO123)
+        optO124.state = threeState(s.optimiserO124)
+        optO125.state = threeState(s.optimiserO125)
+        optO126.state = threeState(s.optimiserO126)
+        optO127.state = threeState(s.optimiserO127)
+        optO128.state = threeState(s.optimiserO128)
+        optO129.state = threeState(s.optimiserO129)
+        optO130.state = threeState(s.optimiserO130)
         // @generated:opt-reset:end
 
         shimmerEnabled.isSelected = s.shimmerEnabled

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/settings/TclLspSettingsPanel.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/settings/TclLspSettingsPanel.kt
@@ -119,6 +119,17 @@ class TclLspSettingsPanel {
     private val signatureHelpInheritDisabledCommands = JBCheckBox("Inherit from config.ini")
 
     // Feature toggles
+    // Two annotations here, both derived from the published `lsp` platform
+    // module rather than guessed. A dagger marks a server feature no IntelliJ
+    // advertises at all: scanning every class in the module for
+    // `TextDocumentClientCapabilities.set*` / `WorkspaceClientCapabilities.set*`
+    // across 253, 261, 262 and 263 turns up no implementation, declaration,
+    // linkedEditingRange or workspace fileOperations at any of them. A trailing
+    // version marks one the IDE does ask for, but only from that build on —
+    // codeLens lands in 261 and rename in 262, both above our 253 floor.
+    // Note the capability set is assembled by the LSP module in the *user's*
+    // IDE at runtime, so these track the IDE the user is running, not the SDK
+    // this plugin compiles against.
     private val featureHover = JBCheckBox("Hover")
     private val featureCompletion = JBCheckBox("Completion")
     private val featureDiagnostics = JBCheckBox("Diagnostics")
@@ -128,7 +139,7 @@ class TclLspSettingsPanel {
     private val featureReferences = JBCheckBox("Find references")
     private val featureDocumentSymbols = JBCheckBox("Document symbols")
     private val featureFolding = JBCheckBox("Code folding")
-    private val featureRename = JBCheckBox("Rename symbol")
+    private val featureRename = JBCheckBox("Rename symbol (2026.2+)")
     private val featureSignatureHelp = JBCheckBox("Signature help")
     private val featureWorkspaceSymbols = JBCheckBox("Workspace symbols")
     private val featureInlayTypeHints = JBCheckBox("Inlay type hints")
@@ -137,12 +148,12 @@ class TclLspSettingsPanel {
     private val featureDocumentLinks = JBCheckBox("Document links")
     private val featureSelectionRange = JBCheckBox("Selection range")
     private val featureDocumentHighlight = JBCheckBox("Document highlight")
-    private val featureCodeLens = JBCheckBox("Code lens")
-    private val featureWorkspaceFileOps = JBCheckBox("Auto-rewrite source paths on rename")
-    private val featureImplementation = JBCheckBox("Go to implementation")
+    private val featureCodeLens = JBCheckBox("Code lens (2026.1+)")
+    private val featureWorkspaceFileOps = JBCheckBox("Auto-rewrite source paths on rename \u2020")
+    private val featureImplementation = JBCheckBox("Go to implementation \u2020")
     private val featureTypeDefinition = JBCheckBox("Go to type definition")
-    private val featureDeclaration = JBCheckBox("Go to declaration")
-    private val featureLinkedEditingRange = JBCheckBox("Linked editing range")
+    private val featureDeclaration = JBCheckBox("Go to declaration \u2020")
+    private val featureLinkedEditingRange = JBCheckBox("Linked editing range \u2020")
 
     // Formatting
     private val fmtIndentSize = JSpinner(SpinnerNumberModel(4, 1, 16, 1))
@@ -463,6 +474,11 @@ class TclLspSettingsPanel {
                     featureLinkedEditingRange,
                 ),
             ),
+        )
+        builder.addWrappedComment(
+            "\u2020 Sent to the server, but never requested by any JetBrains IDE: IntelliJ's " +
+                "LSP client does not implement these, so the toggle has no effect here. " +
+                "A version in brackets is the IDE release that starts asking for that feature.",
         )
 
         // Formatting section

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/settings/TclLspSettingsPanel.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/settings/TclLspSettingsPanel.kt
@@ -20,6 +20,7 @@ package com.tcllsp.jetbrains.settings
 
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.ProjectManager
+import com.intellij.openapi.util.text.StringUtil
 import com.intellij.platform.lsp.api.LspServerManager
 import com.intellij.ui.TitledSeparator
 import com.intellij.ui.components.JBCheckBox
@@ -27,10 +28,83 @@ import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBTextField
 import com.intellij.util.ui.FormBuilder
 import com.intellij.util.ui.JBUI
+import com.intellij.util.ui.UIUtil
 import com.tcllsp.jetbrains.TclLspServerSupportProvider
+import java.awt.BorderLayout
+import java.awt.Dimension
+import java.awt.Rectangle
 import javax.swing.*
 
 private val LOG = Logger.getInstance("com.tcllsp.jetbrains.settings.TclLspSettingsPanel")
+
+/**
+ * Width a settings hint wraps at, before HiDPI scaling.
+ *
+ * A hint sits in the form's right-hand column, so this plus the widest label
+ * is most of what the page can never be narrower than. Keep it near a normal
+ * reading measure: wider makes the whole settings pane refuse to shrink.
+ */
+private const val COMMENT_WIDTH = 440
+
+/** Mouse-wheel step for the settings scroll pane, before HiDPI scaling. */
+private const val SCROLL_UNIT = 16
+
+/**
+ * A wrapping hint under a setting.
+ *
+ * `FormBuilder.addTooltip` builds a plain `JBLabel` straight from the string,
+ * and a `JLabel` never wraps: the longest hint on this page is 180 characters,
+ * so on a single line it alone asked the settings pane for about 1200px and
+ * ran off the right-hand edge.
+ */
+private fun FormBuilder.addWrappedComment(text: String): FormBuilder =
+    addComponentToRightColumn(
+        JBLabel(
+            "<html><body style='width:${JBUI.scale(COMMENT_WIDTH)}px'>" +
+                StringUtil.escapeXmlEntities(text) + "</body></html>",
+            UIUtil.ComponentStyle.SMALL,
+            UIUtil.FontColor.BRIGHTER,
+        ).apply { border = JBUI.Borders.emptyLeft(10) },
+        1,
+    )
+
+/**
+ * The component the settings dialog is handed, holding the form at the width
+ * of the scroll pane the platform puts around it.
+ *
+ * `ConfigurableCardPanel` wraps whatever `createComponent` returns in its own
+ * `JScrollPane` — unconditionally, unless the configurable implements
+ * `Configurable.NoScroll` — so returning a scroll pane of our own nested one
+ * inside the other. The inner pane was always exactly as large as its content,
+ * so it never scrolled, and it swallowed the wheel events that would otherwise
+ * have reached the outer one: the page could not be scrolled at all.
+ *
+ * Implementing [Scrollable] instead makes the platform's viewport size the
+ * form to its own width, so the content reflows rather than overflowing to the
+ * right, and leaves horizontal scrolling as the fallback for a pane narrower
+ * than the form can honestly be squeezed to.
+ */
+internal class ScrollableForm(form: JComponent) : JPanel(BorderLayout()), Scrollable {
+    init {
+        add(form, BorderLayout.CENTER)
+        isOpaque = false
+    }
+
+    override fun getPreferredScrollableViewportSize(): Dimension = preferredSize
+
+    override fun getScrollableUnitIncrement(visible: Rectangle, orientation: Int, direction: Int): Int =
+        JBUI.scale(SCROLL_UNIT)
+
+    override fun getScrollableBlockIncrement(visible: Rectangle, orientation: Int, direction: Int): Int =
+        if (orientation == SwingConstants.VERTICAL) visible.height else visible.width
+
+    override fun getScrollableTracksViewportWidth(): Boolean {
+        val viewport = parent as? JViewport ?: return false
+        return viewport.width >= minimumSize.width
+    }
+
+    override fun getScrollableTracksViewportHeight(): Boolean = false
+}
 
 class TclLspSettingsPanel {
 
@@ -354,17 +428,17 @@ class TclLspSettingsPanel {
         // General section
         builder.addComponent(TitledSeparator("General"))
         builder.addLabeledComponent(JBLabel("Server path:"), serverPathField)
-        builder.addTooltip("Path to a tcl-lsp checkout root (probes target/{release,debug}/tcl-lsp-server) or directly to a built native binary (dev mode). Leave empty to use the bundled server.")
+        builder.addWrappedComment("Path to a tcl-lsp checkout root (probes target/{release,debug}/tcl-lsp-server) or directly to a built native binary (dev mode). Leave empty to use the bundled server.")
         builder.addLabeledComponent(JBLabel("Dialect:"), dialectCombo)
         builder.addLabeledComponent(JBLabel("Extra commands:"), extraCommandsField)
-        builder.addTooltip("Comma-separated list of additional command names to treat as known.")
+        builder.addWrappedComment("Comma-separated list of additional command names to treat as known.")
         builder.addLabeledComponent(JBLabel("Library paths:"), libraryPathsField)
-        builder.addTooltip("Comma-separated directories to scan for Tcl packages.")
+        builder.addWrappedComment("Comma-separated directories to scan for Tcl packages.")
         builder.addLabeledComponent(
             JBLabel("Signature help disabled commands:"),
             signatureHelpDisabledCommandsField,
         )
-        builder.addTooltip("Comma-separated built-in command names to silence, such as set,incr. Leave Inherit unchecked and this list empty to show every signature. User-defined proc signatures remain enabled.")
+        builder.addWrappedComment("Comma-separated built-in command names to silence, such as set,incr. Leave Inherit unchecked and this list empty to show every signature. User-defined proc signatures remain enabled.")
         builder.addComponent(signatureHelpInheritDisabledCommands)
         signatureHelpInheritDisabledCommands.toolTipText =
             "Use the disabled-command list from config.ini instead of overriding it in the IDE."
@@ -375,25 +449,21 @@ class TclLspSettingsPanel {
 
         // Features section
         builder.addComponent(TitledSeparator("Features"))
-        val featurePanel = JPanel().apply {
-            layout = BoxLayout(this, BoxLayout.Y_AXIS)
-            val features = listOf(
-                featureHover, featureCompletion, featureDiagnostics,
-                featureSemanticTokens, featureCodeActions, featureDefinition, featureReferences,
-                featureDocumentSymbols, featureFolding, featureRename, featureSignatureHelp,
-                featureWorkspaceSymbols, featureInlayTypeHints, featureInlayParameterHints,
-                featureCallHierarchy,
-                featureDocumentLinks, featureSelectionRange,
-                featureDocumentHighlight, featureCodeLens, featureWorkspaceFileOps,
-                featureImplementation, featureTypeDefinition, featureDeclaration,
-                featureLinkedEditingRange,
-            )
-            // Lay out in a 3-column grid
-            val grid = JPanel(java.awt.GridLayout(0, 3, 8, 2))
-            features.forEach { grid.add(it) }
-            add(grid)
-        }
-        builder.addComponent(featurePanel)
+        builder.addComponent(
+            ReflowingGrid(
+                listOf(
+                    featureHover, featureCompletion, featureDiagnostics,
+                    featureSemanticTokens, featureCodeActions, featureDefinition, featureReferences,
+                    featureDocumentSymbols, featureFolding, featureRename, featureSignatureHelp,
+                    featureWorkspaceSymbols, featureInlayTypeHints, featureInlayParameterHints,
+                    featureCallHierarchy,
+                    featureDocumentLinks, featureSelectionRange,
+                    featureDocumentHighlight, featureCodeLens, featureWorkspaceFileOps,
+                    featureImplementation, featureTypeDefinition, featureDeclaration,
+                    featureLinkedEditingRange,
+                ),
+            ),
+        )
 
         // Formatting section
         builder.addComponent(TitledSeparator("Formatting"))
@@ -427,96 +497,116 @@ class TclLspSettingsPanel {
 
         // @generated:diag-ui:begin
         builder.addComponent(TitledSeparator("Diagnostics — Errors"))
-        val diagErrorPanel = JPanel(java.awt.GridLayout(0, 2, 8, 2))
-        listOf(
-            diagE001, diagE002, diagE003, diagE005, diagE006, diagE200,
-        ).forEach { diagErrorPanel.add(it) }
-        builder.addComponent(diagErrorPanel)
+        builder.addComponent(
+            ReflowingGrid(
+                listOf(
+                    diagE001, diagE002, diagE003, diagE005, diagE006, diagE200,
+                ),
+            ),
+        )
 
         builder.addComponent(TitledSeparator("Diagnostics — Style & Best Practice"))
-        val diagWarnPanel = JPanel(java.awt.GridLayout(0, 2, 8, 2))
-        listOf(
-            diagW001, diagW002, diagW003, diagW004, diagW100, diagW104,
-            diagW105, diagW106, diagW107, diagW108, diagW109, diagW110,
-            diagW111, diagW112, diagW113, diagW114, diagW115, diagW116,
-            diagW117, diagW118, diagW120, diagW121, diagW124, diagW125,
-            diagW126, diagW127, diagW128, diagW129, diagW135, diagW136,
-            diagW137, diagW138, diagW139, diagW140, diagW141, diagW142,
-            diagW143, diagW144, diagW145, diagW146, diagW147, diagW148,
-            diagW149, diagW150, diagW151, diagW152, diagW200, diagW201,
-            diagW230, diagW231, diagW232, diagW233, diagW240, diagW241,
-            diagW250, diagW308, diagW314, diagW315,
-        ).forEach { diagWarnPanel.add(it) }
-        builder.addComponent(diagWarnPanel)
+        builder.addComponent(
+            ReflowingGrid(
+                listOf(
+                    diagW001, diagW002, diagW003, diagW004, diagW100, diagW104,
+                    diagW105, diagW106, diagW107, diagW108, diagW109, diagW110,
+                    diagW111, diagW112, diagW113, diagW114, diagW115, diagW116,
+                    diagW117, diagW118, diagW120, diagW121, diagW124, diagW125,
+                    diagW126, diagW127, diagW128, diagW129, diagW135, diagW136,
+                    diagW137, diagW138, diagW139, diagW140, diagW141, diagW142,
+                    diagW143, diagW144, diagW145, diagW146, diagW147, diagW148,
+                    diagW149, diagW150, diagW151, diagW152, diagW200, diagW201,
+                    diagW230, diagW231, diagW232, diagW233, diagW240, diagW241,
+                    diagW250, diagW308, diagW314, diagW315,
+                ),
+            ),
+        )
 
         builder.addComponent(TitledSeparator("Diagnostics — Variables"))
-        val diagVarPanel = JPanel(java.awt.GridLayout(0, 2, 8, 2))
-        listOf(
-            diagW210, diagW211, diagW212, diagW213, diagW214, diagW215,
-            diagW216, diagW217, diagW218, diagW220,
-        ).forEach { diagVarPanel.add(it) }
-        builder.addComponent(diagVarPanel)
+        builder.addComponent(
+            ReflowingGrid(
+                listOf(
+                    diagW210, diagW211, diagW212, diagW213, diagW214, diagW215,
+                    diagW216, diagW217, diagW218, diagW220,
+                ),
+            ),
+        )
 
         builder.addComponent(TitledSeparator("Diagnostics — Security"))
-        val diagSecPanel = JPanel(java.awt.GridLayout(0, 2, 8, 2))
-        listOf(
-            diagW101, diagW102, diagW103, diagW300, diagW301, diagW302,
-            diagW303, diagW304, diagW305, diagW306, diagW307, diagW309,
-            diagW313,
-        ).forEach { diagSecPanel.add(it) }
-        builder.addComponent(diagSecPanel)
+        builder.addComponent(
+            ReflowingGrid(
+                listOf(
+                    diagW101, diagW102, diagW103, diagW300, diagW301, diagW302,
+                    diagW303, diagW304, diagW305, diagW306, diagW307, diagW309,
+                    diagW313,
+                ),
+            ),
+        )
 
         builder.addComponent(TitledSeparator("Diagnostics — Hints"))
-        val diagHintPanel = JPanel(java.awt.GridLayout(0, 2, 8, 2))
-        listOf(
-            diagH300, diagH301, diagI230, diagI231, diagW123, diagW242,
-        ).forEach { diagHintPanel.add(it) }
-        builder.addComponent(diagHintPanel)
+        builder.addComponent(
+            ReflowingGrid(
+                listOf(
+                    diagH300, diagH301, diagI230, diagI231, diagW123, diagW242,
+                ),
+            ),
+        )
 
         builder.addComponent(TitledSeparator("Diagnostics — Shimmer"))
-        val diagShimmerPanel = JPanel(java.awt.GridLayout(0, 2, 8, 2))
-        listOf(
-            diagS100, diagS101, diagS102, diagS103, diagS110,
-        ).forEach { diagShimmerPanel.add(it) }
-        builder.addComponent(diagShimmerPanel)
+        builder.addComponent(
+            ReflowingGrid(
+                listOf(
+                    diagS100, diagS101, diagS102, diagS103, diagS110,
+                ),
+            ),
+        )
 
         builder.addComponent(TitledSeparator("Diagnostics — Taint"))
-        val diagTaintPanel = JPanel(java.awt.GridLayout(0, 2, 8, 2))
-        listOf(
-            diagT100, diagT101, diagT102, diagT104, diagT105,
-        ).forEach { diagTaintPanel.add(it) }
-        builder.addComponent(diagTaintPanel)
+        builder.addComponent(
+            ReflowingGrid(
+                listOf(
+                    diagT100, diagT101, diagT102, diagT104, diagT105,
+                ),
+            ),
+        )
 
         builder.addComponent(TitledSeparator("Diagnostics — iRules"))
-        val diagIRulePanel = JPanel(java.awt.GridLayout(0, 2, 8, 2))
-        listOf(
-            diagIRULE1001, diagIRULE1002, diagIRULE1003, diagIRULE1004, diagIRULE1005, diagIRULE1006,
-            diagIRULE1007, diagIRULE1008, diagIRULE1201, diagIRULE1202, diagIRULE2001, diagIRULE2002,
-            diagIRULE2003, diagIRULE2004, diagIRULE2101, diagIRULE5001, diagIRULE5002, diagIRULE5004,
-            diagIRULE5005, diagIRULE5006, diagIRULE5007, diagIRULE3001, diagIRULE3002, diagIRULE3003,
-            diagIRULE3004, diagIRULE3101, diagIRULE3102, diagIRULE4001, diagIRULE4002, diagIRULE4003,
-            diagIRULE4004, diagIRULE4005,
-        ).forEach { diagIRulePanel.add(it) }
-        builder.addComponent(diagIRulePanel)
+        builder.addComponent(
+            ReflowingGrid(
+                listOf(
+                    diagIRULE1001, diagIRULE1002, diagIRULE1003, diagIRULE1004, diagIRULE1005, diagIRULE1006,
+                    diagIRULE1007, diagIRULE1008, diagIRULE1201, diagIRULE1202, diagIRULE2001, diagIRULE2002,
+                    diagIRULE2003, diagIRULE2004, diagIRULE2101, diagIRULE5001, diagIRULE5002, diagIRULE5004,
+                    diagIRULE5005, diagIRULE5006, diagIRULE5007, diagIRULE3001, diagIRULE3002, diagIRULE3003,
+                    diagIRULE3004, diagIRULE3101, diagIRULE3102, diagIRULE4001, diagIRULE4002, diagIRULE4003,
+                    diagIRULE4004, diagIRULE4005,
+                ),
+            ),
+        )
 
         builder.addComponent(TitledSeparator("Diagnostics — BIG-IP Configuration"))
-        val diagBigIpPanel = JPanel(java.awt.GridLayout(0, 2, 8, 2))
-        listOf(
-            diagBIGIP6001, diagBIGIP6002, diagBIGIP6003, diagBIGIP6004, diagBIGIP6005, diagBIGIP6006,
-            diagBIGIP6007, diagBIGIP6008, diagBIGIP6009, diagBIGIP6010, diagBIGIP6011, diagBIGIP6012,
-            diagBIGIP6013, diagBIGIP6014, diagBIGIP6038, diagBIGIP6039, diagIAPP7001, diagIAPP7002,
-            diagIAPP7003,
-        ).forEach { diagBigIpPanel.add(it) }
-        builder.addComponent(diagBigIpPanel)
+        builder.addComponent(
+            ReflowingGrid(
+                listOf(
+                    diagBIGIP6001, diagBIGIP6002, diagBIGIP6003, diagBIGIP6004, diagBIGIP6005, diagBIGIP6006,
+                    diagBIGIP6007, diagBIGIP6008, diagBIGIP6009, diagBIGIP6010, diagBIGIP6011, diagBIGIP6012,
+                    diagBIGIP6013, diagBIGIP6014, diagBIGIP6038, diagBIGIP6039, diagIAPP7001, diagIAPP7002,
+                    diagIAPP7003,
+                ),
+            ),
+        )
 
         builder.addComponent(TitledSeparator("Diagnostics — SslicTcl"))
-        val diagSslicTclPanel = JPanel(java.awt.GridLayout(0, 2, 8, 2))
-        listOf(
-            diagSSLIC1001, diagSSLIC1002, diagSSLIC1003, diagSSLIC1004, diagSSLIC1005, diagSSLIC1006,
-            diagSSLIC1007, diagSSLIC1008, diagSSLIC1009, diagSSLIC1010, diagSSLIC1011, diagSSLIC1012,
-            diagSSLIC1101, diagSSLIC1102, diagSSLIC1103,
-        ).forEach { diagSslicTclPanel.add(it) }
-        builder.addComponent(diagSslicTclPanel)
+        builder.addComponent(
+            ReflowingGrid(
+                listOf(
+                    diagSSLIC1001, diagSSLIC1002, diagSSLIC1003, diagSSLIC1004, diagSSLIC1005, diagSSLIC1006,
+                    diagSSLIC1007, diagSSLIC1008, diagSSLIC1009, diagSSLIC1010, diagSSLIC1011, diagSSLIC1012,
+                    diagSSLIC1101, diagSSLIC1102, diagSSLIC1103,
+                ),
+            ),
+        )
         // @generated:diag-ui:end
 
         // Style section
@@ -526,16 +616,18 @@ class TclLspSettingsPanel {
         // @generated:opt-ui:begin
         builder.addComponent(TitledSeparator("Optimiser"))
         builder.addComponent(optEnabled)
-        val optPanel = JPanel(java.awt.GridLayout(0, 4, 8, 2))
-        listOf(
-            optO100, optO101, optO102, optO103, optO104, optO105,
-            optO106, optO107, optO108, optO109, optO110, optO111,
-            optO112, optO113, optO114, optO115, optO116, optO117,
-            optO118, optO119, optO120, optO121, optO122, optO123,
-            optO124, optO125, optO126, optO127, optO128, optO129,
-            optO130,
-        ).forEach { optPanel.add(it) }
-        builder.addComponent(optPanel)
+        builder.addComponent(
+            ReflowingGrid(
+                listOf(
+                    optO100, optO101, optO102, optO103, optO104, optO105,
+                    optO106, optO107, optO108, optO109, optO110, optO111,
+                    optO112, optO113, optO114, optO115, optO116, optO117,
+                    optO118, optO119, optO120, optO121, optO122, optO123,
+                    optO124, optO125, optO126, optO127, optO128, optO129,
+                    optO130,
+                ),
+            ),
+        )
         // @generated:opt-ui:end
 
         // Shimmer section
@@ -550,29 +642,27 @@ class TclLspSettingsPanel {
         builder.addComponent(TitledSeparator("Runtime Validation"))
         builder.addComponent(runtimeValidation)
         builder.addLabeledComponent(JBLabel("Adapter mode:"), rtAdapter)
-        builder.addTooltip("auto: detect from dialect.  tclsh: use tclsh.  expect: use Expect.")
+        builder.addWrappedComment("auto: detect from dialect.  tclsh: use tclsh.  expect: use Expect.")
         builder.addLabeledComponent(JBLabel("tclsh path:"), rtTclshPath)
-        builder.addTooltip("Path to tclsh interpreter. Leave empty for auto-discovery.")
+        builder.addWrappedComment("Path to tclsh interpreter. Leave empty for auto-discovery.")
         builder.addLabeledComponent(JBLabel("Timeout (ms):"), rtTimeoutMs)
 
         // AI
         builder.addComponent(TitledSeparator("AI"))
         builder.addComponent(aiEnabled)
         builder.addLabeledComponent(JBLabel("Extra prompts (JSON):"), aiExtraPrompts)
-        builder.addTooltip("JSON array of prompt objects for AI-assisted features.")
+        builder.addWrappedComment("JSON array of prompt objects for AI-assisted features.")
 
         // Diagnostic patterns
         builder.addComponent(TitledSeparator("Diagnostic Patterns"))
         builder.addLabeledComponent(JBLabel("Generic variable patterns:"), genericPatternsField)
-        builder.addTooltip("Newline-separated regex patterns for IRULE4002 generic variable detection.")
+        builder.addWrappedComment("Newline-separated regex patterns for IRULE4002 generic variable detection.")
         builder.addLabeledComponent(JBLabel("Exclude files from diagnostics:"), diagnosticsExcludeField)
-        builder.addTooltip("Newline-separated glob patterns (e.g. generated/** or *.gen.tcl); matching files publish no diagnostics. Longer lists are easier to keep in the [diagnostics] exclude key of .tcl-lsp.ini.")
+        builder.addWrappedComment("Newline-separated glob patterns (e.g. generated/** or *.gen.tcl); matching files publish no diagnostics. Longer lists are easier to keep in the [diagnostics] exclude key of .tcl-lsp.ini.")
 
         builder.addComponentFillVertically(JPanel(), 0)
 
-        root = JScrollPane(builder.panel).apply {
-            border = JBUI.Borders.empty()
-        }
+        root = ScrollableForm(builder.panel)
 
         reset()
     }

--- a/editors/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/editors/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -21,7 +21,7 @@
     <depends>com.intellij.modules.ultimate</depends>
     <!-- JCEF moved behind its own plugin classloader in 2026.2.  The alias
          only exists from 2025.3.1 onward, so this must remain optional while
-         the plugin supports the 2024.1 floor (where JCEF is platform-owned).
+         the plugin supports the 2024.3 floor (where JCEF is platform-owned).
          The supplemental descriptor is intentionally empty: the dependency
          edge itself is what makes JCEF classes visible on newer IDEs. -->
     <depends optional="true"
@@ -43,7 +43,26 @@
             fieldName="INSTANCE"
             extensions="irul;irule;irules"/>
 
-        <!-- TextMate grammar for syntax highlighting -->
+        <!-- TextMate grammar for syntax highlighting.
+
+             Three registrations, all load-bearing:
+
+             * `textmate.bundleProvider` hands the TextMate service the
+               bundled `source.tcl` grammar. Nothing else registers it, and
+               without a registered grammar the two providers below resolve
+               nothing and Tcl opens as plain black text.
+             * `lang.syntaxHighlighterFactory` decides *which* highlighter the
+               Tcl language gets. The platform's default for a
+               `LanguageFileType` with no factory is `PlainSyntaxHighlighter`,
+               which is what `TextMateEditorHighlighterProvider` would then be
+               handed — so the provider alone is not enough.
+             * `editorHighlighterProvider` supplies TextMate's own
+               `TextMateLexerDataStorage`, which the incremental highlighter
+               needs to hold TextMate's dynamically-created element types. -->
+        <textmate.bundleProvider
+            implementation="com.tcllsp.jetbrains.TclTextMateBundleProvider"/>
+        <lang.syntaxHighlighterFactory language="Tcl"
+            implementationClass="org.jetbrains.plugins.textmate.language.syntax.highlighting.TextMateSyntaxHighlighterFactory"/>
         <editorHighlighterProvider filetype="Tcl"
             implementationClass="org.jetbrains.plugins.textmate.language.syntax.highlighting.TextMateEditorHighlighterProvider"/>
         <editorHighlighterProvider filetype="iRule"

--- a/editors/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/editors/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -8,7 +8,7 @@
             <li>Semantic highlighting, diagnostics, and code actions</li>
             <li>Auto-completion for commands, subcommands, variables, and switches</li>
             <li>Hover information with command help and proc signatures</li>
-            <li>Go-to-definition, find references, and rename symbol</li>
+            <li>Go-to-definition, go-to-type-definition, and find references</li>
             <li>Document formatting with configurable style</li>
             <li>Document symbols, workspace symbols, and call hierarchy</li>
             <li>Code folding, inlay hints, and signature help</li>

--- a/editors/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/editors/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -21,7 +21,7 @@
     <depends>com.intellij.modules.ultimate</depends>
     <!-- JCEF moved behind its own plugin classloader in 2026.2.  The alias
          only exists from 2025.3.1 onward, so this must remain optional while
-         the plugin supports the 2024.3 floor (where JCEF is platform-owned).
+         the plugin supports the 2025.3 floor (where JCEF is platform-owned).
          The supplemental descriptor is intentionally empty: the dependency
          edge itself is what makes JCEF classes visible on newer IDEs. -->
     <depends optional="true"

--- a/editors/jetbrains/src/main/resources/textmate/package.json
+++ b/editors/jetbrains/src/main/resources/textmate/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "tcl-lsp",
+  "displayName": "Tcl",
+  "description": "TextMate grammar bundle shipped inside the Tcl Language Support plugin.",
+  "version": "1.0.0",
+  "engines": {
+    "vscode": "*"
+  },
+  "contributes": {
+    "languages": [
+      {
+        "id": "tcl",
+        "aliases": [
+          "Tcl",
+          "tcl"
+        ],
+        "extensions": [
+          ".tcl",
+          ".tk",
+          ".itcl",
+          ".tm",
+          ".test",
+          ".globals",
+          ".exp",
+          ".expect",
+          ".scf",
+          ".iapp",
+          ".iappimpl",
+          ".impl",
+          ".irul",
+          ".irule",
+          ".irules",
+          ".tmsh",
+          ".qsf",
+          ".qpf",
+          ".qip",
+          ".do",
+          ".tclspec",
+          ".sslictcl",
+          ".sdc",
+          ".upf",
+          ".xdc",
+          ".apl"
+        ]
+      }
+    ],
+    "grammars": [
+      {
+        "language": "tcl",
+        "scopeName": "source.tcl",
+        "path": "./syntaxes/tcl.tmLanguage.json"
+      }
+    ]
+  }
+}

--- a/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/CompilerExplorerHtmlTest.kt
+++ b/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/CompilerExplorerHtmlTest.kt
@@ -1,0 +1,71 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package com.tcllsp.jetbrains
+
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The JCEF adapter never ran against a real page: the compiler explorer HTML
+ * was missing from every published plugin, so the tool window always fell back
+ * to its placeholder. These pin the two rewrites it performs against the shape
+ * the VS Code build actually emits — a bare `<head>` and a
+ * `Content-Security-Policy` meta whose attributes span two lines.
+ */
+class CompilerExplorerHtmlTest {
+
+    private val shippedShape = """
+        <!DOCTYPE html>
+        <html lang="en">
+        <head>
+        <meta charset="utf-8">
+        <meta http-equiv="Content-Security-Policy"
+          content="default-src 'none'; style-src 'unsafe-inline'; script-src 'nonce-123' data:;">
+        <title>Tcl Compiler Explorer</title>
+        </head>
+        <body>
+        <script>var __vscodeApi = acquireVsCodeApi();</script>
+        </body>
+        </html>
+    """.trimIndent()
+
+    @Test
+    fun theBridgeShimIsInjectedBeforeAnyScriptThatCapturesIt() {
+        val adapted = adaptHtmlForJcef(shippedShape)
+
+        val shim = adapted.indexOf("window.acquireVsCodeApi = function()")
+        val capture = adapted.indexOf("var __vscodeApi = acquireVsCodeApi()")
+        assertTrue(shim > 0, "the shim must be injected")
+        assertTrue(
+            shim < capture,
+            "the shim must run before the page captures the host bridge",
+        )
+        assertContains(adapted, "window.__tcllspFlushQueue")
+    }
+
+    @Test
+    fun theContentSecurityPolicyThatWouldBlockTheShimIsStripped() {
+        val adapted = adaptHtmlForJcef(shippedShape)
+
+        assertFalse(adapted.contains("Content-Security-Policy", ignoreCase = true))
+        assertContains(adapted, "<!-- CSP removed for JCEF -->")
+    }
+
+    @Test
+    fun aHeadTagCarryingAttributesIsStillFound() {
+        val adapted = adaptHtmlForJcef("<html><HEAD data-x='1'><title>t</title></head><body></body></html>")
+
+        assertContains(adapted, "window.acquireVsCodeApi = function()")
+    }
+
+    /**
+     * A template with no `<head>` is a broken upstream build, and the adapter
+     * reports it through `LOG.error` — which the platform test logger turns
+     * into a throw. That the failure is loud rather than a silent no-op is the
+     * behaviour worth having; asserting on it here would pin the test logger,
+     * not the adapter.
+     */
+}

--- a/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/TclLspDiagnosticsTest.kt
+++ b/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/TclLspDiagnosticsTest.kt
@@ -1,0 +1,81 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package com.tcllsp.jetbrains
+
+import com.google.gson.JsonObject
+import org.eclipse.lsp4j.Diagnostic
+import org.eclipse.lsp4j.jsonrpc.messages.Either
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * IntelliJ's problems view renders only a diagnostic's message, so anything the
+ * server puts in the `code` field or the quick-fix payload is invisible there
+ * unless this customizer puts it back.
+ */
+class TclLspDiagnosticsTest {
+
+    private val support = TclLspDiagnostics()
+
+    private fun diagnostic(code: String?, message: String, data: Any? = null): Diagnostic {
+        val d = Diagnostic()
+        d.message = message
+        code?.let { d.setCode(Either.forLeft<String, Int>(it)) }
+        d.data = data
+        return d
+    }
+
+    @Test
+    fun `the message carries the code the problems view would otherwise drop`() {
+        val d = diagnostic("O102", "Forward literal load of 'a'")
+        assertEquals("[O102] Forward literal load of 'a'", support.getMessage(d))
+    }
+
+    @Test
+    fun `a diagnostic with no code is left exactly as the server sent it`() {
+        val d = diagnostic(null, "something happened")
+        assertEquals("something happened", support.getMessage(d))
+    }
+
+    @Test
+    fun `an optimiser code is named as a rewrite rather than a defect`() {
+        val tip = support.getTooltip(diagnostic("O102", "Forward literal load of 'a'"))
+        assertTrue(tip.contains("optimiser rewrite"), tip)
+    }
+
+    @Test
+    fun `an analyser code is named by its catalogue section`() {
+        val tip = support.getTooltip(diagnostic("E001", "Missing dispatch word"))
+        assertTrue(tip.contains("diagnostic"), tip)
+        assertTrue(tip.contains("E001"), tip)
+    }
+
+    @Test
+    fun `a hint-only optimisation says plainly that nothing can be applied`() {
+        // The server withholds `data` when the rewrite has no precise sub-span,
+        // which is exactly when a user most needs telling that the suggestion
+        // is informational — otherwise it reads as a fix that failed to appear.
+        val tip = support.getTooltip(diagnostic("O102", "Forward literal load of 'a'"))
+        assertTrue(tip.contains("No automatic fix."), tip)
+    }
+
+    @Test
+    fun `an applicable rewrite previews what accepting it would write`() {
+        val data = JsonObject().apply { addProperty("replacement", "7") }
+        val tip = support.getTooltip(diagnostic("O102", "Forward literal load of 'n'", data))
+        assertTrue(tip.contains("replaces the highlighted code with"), tip)
+        assertTrue(tip.contains("7"), tip)
+    }
+
+    @Test
+    fun `a replacement is escaped rather than injected into the tooltip markup`() {
+        val data = JsonObject().apply { addProperty("replacement", "<b>&x</b>") }
+        val tip = support.getTooltip(diagnostic("O102", "m", data))
+        assertTrue(tip.contains("&lt;b&gt;"), tip)
+        assertTrue(!tip.contains("<b>&x"), tip)
+    }
+}

--- a/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/TclSemanticTokensTest.kt
+++ b/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/TclSemanticTokensTest.kt
@@ -1,0 +1,60 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package com.tcllsp.jetbrains
+
+import com.intellij.openapi.editor.DefaultLanguageHighlighterColors as Colors
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+/**
+ * The colour map is only reachable through [TclSemanticTokens], and the
+ * modifier half of it decides whether a built-in reads differently from a
+ * user proc — the distinction the server goes to the trouble of publishing.
+ */
+class TclSemanticTokensTest {
+
+    private val tokens = TclSemanticTokens()
+
+    @Test
+    fun aTokenTypeGetsItsMappedColour() {
+        assertEquals(Colors.KEYWORD, tokens.getTextAttributesKey("keyword", emptyList()))
+        assertEquals(Colors.MARKUP_TAG, tokens.getTextAttributesKey("event", emptyList()))
+        assertEquals(Colors.NUMBER, tokens.getTextAttributesKey("port", emptyList()))
+    }
+
+    @Test
+    fun aModifierTheServerSetsOverridesTheTypeColour() {
+        val call = tokens.getTextAttributesKey("function", emptyList())
+        val builtin = tokens.getTextAttributesKey("function", listOf("defaultLibrary"))
+        val definition = tokens.getTextAttributesKey("function", listOf("definition"))
+
+        assertEquals(Colors.FUNCTION_CALL, call)
+        assertEquals(Colors.PREDEFINED_SYMBOL, builtin)
+        assertEquals(Colors.FUNCTION_DECLARATION, definition)
+        assertNotEquals(call, builtin)
+        assertNotEquals(call, definition)
+    }
+
+    @Test
+    fun aModifierWithNoRuleOfItsOwnKeepsTheTypeColour() {
+        assertEquals(
+            Colors.LOCAL_VARIABLE,
+            tokens.getTextAttributesKey("variable", listOf("declaration")),
+        )
+    }
+
+    @Test
+    fun everyMappedColourIsDistinctEnoughToBeWorthPublishing() {
+        // Not every type needs its own key — the platform's palette is
+        // smaller than the legend — but a map that collapsed to one key would
+        // paint the whole file in a single colour and still pass the coverage
+        // gate in xtask.
+        assertEquals(
+            true,
+            SEMANTIC_TOKEN_COLORS.values.distinct().size >= 10,
+            "the legend must map onto a range of colours, not a single key",
+        )
+    }
+}

--- a/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/TclTextMateBundleTest.kt
+++ b/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/TclTextMateBundleTest.kt
@@ -6,7 +6,11 @@ package com.tcllsp.jetbrains
 import com.google.gson.JsonParser
 import org.jetbrains.plugins.textmate.bundles.BundleType
 import org.jetbrains.plugins.textmate.bundles.TextMateFileNameMatcher
+import org.jetbrains.plugins.textmate.bundles.TextMateNioResourceReader
 import org.jetbrains.plugins.textmate.bundles.readVSCBundle
+import org.jetbrains.plugins.textmate.plist.JsonPlistReader
+import org.jetbrains.plugins.textmate.plist.XmlPlistReader
+import org.jetbrains.plugins.textmate.plist.JsonOrXmlPlistReader
 import java.io.ByteArrayInputStream
 import java.nio.file.Files
 import java.nio.file.Path
@@ -30,11 +34,10 @@ class TclTextMateBundleTest {
     fun theUnpackedBundleIsOneTheTextMateServiceCanRead() {
         val dir = unpackIntoTempDirectory()
 
-        assertEquals(BundleType.VSCODE, BundleType.detectBundleType(dir))
+        val resources = TextMateNioResourceReader(dir)
+        assertEquals(BundleType.VSCODE, BundleType.detectBundleType(resources, "Tcl"))
 
-        val reader = assertNotNull(
-            readVSCBundle { relative -> Files.newInputStream(dir.resolve(relative)) },
-        )
+        val reader = assertNotNull(readVSCBundle(JsonOrXmlPlistReader(JsonPlistReader(), XmlPlistReader()), resources))
         val grammars = reader.readGrammars().toList()
         assertEquals(1, grammars.size, "the bundle contributes exactly one grammar")
 

--- a/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/TclTextMateBundleTest.kt
+++ b/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/TclTextMateBundleTest.kt
@@ -1,0 +1,110 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package com.tcllsp.jetbrains
+
+import com.google.gson.JsonParser
+import org.jetbrains.plugins.textmate.bundles.BundleType
+import org.jetbrains.plugins.textmate.bundles.TextMateFileNameMatcher
+import org.jetbrains.plugins.textmate.bundles.readVSCBundle
+import java.io.ByteArrayInputStream
+import java.nio.file.Files
+import java.nio.file.Path
+import javax.xml.parsers.DocumentBuilderFactory
+import kotlin.io.path.createTempDirectory
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * The grammar only highlights anything if the TextMate service can read it as
+ * a bundle, so these drive the real platform bundle reader over exactly what
+ * [TclTextMateBundleProvider] unpacks — a manifest that parses but does not
+ * resolve a grammar for `.tcl` is the failure that shipped.
+ */
+class TclTextMateBundleTest {
+
+    @Test
+    fun theUnpackedBundleIsOneTheTextMateServiceCanRead() {
+        val dir = unpackIntoTempDirectory()
+
+        assertEquals(BundleType.VSCODE, BundleType.detectBundleType(dir))
+
+        val reader = assertNotNull(
+            readVSCBundle { relative -> Files.newInputStream(dir.resolve(relative)) },
+        )
+        val grammars = reader.readGrammars().toList()
+        assertEquals(1, grammars.size, "the bundle contributes exactly one grammar")
+
+        val grammar = grammars.single()
+        assertEquals("source.tcl", grammar.plist.value.getPlistValue("scopeName")?.string)
+
+        val extensions = grammar.fileNameMatchers
+            .filterIsInstance<TextMateFileNameMatcher.Extension>()
+            .map { it.extension }
+            .toSet()
+        for (expected in listOf("tcl", "tm", "irule", "iapp", "tclspec")) {
+            assertContains(extensions, expected)
+        }
+    }
+
+    /**
+     * The manifest and the plugin's own file types must claim the same
+     * extensions: an extension the manifest omits opens as a Tcl file with no
+     * grammar, and one only the manifest claims registers a TextMate mapping
+     * for a file type the plugin never handles.
+     */
+    @Test
+    fun theManifestClaimsExactlyTheFileTypeExtensions() {
+        val manifest = JsonParser.parseString(String(resource("textmate/package.json")))
+            .asJsonObject["contributes"].asJsonObject["languages"].asJsonArray
+            .flatMap { it.asJsonObject["extensions"].asJsonArray }
+            .map { it.asString.removePrefix(".") }
+            .toSortedSet()
+
+        assertEquals(fileTypeExtensions(), manifest)
+    }
+
+    @Test
+    fun unpackingIsIdempotentAndRepairsATamperedBundle() {
+        val dir = unpackIntoTempDirectory()
+        val grammar = dir.resolve("syntaxes/tcl.tmLanguage.json")
+        val original = Files.readAllBytes(grammar)
+
+        assertNotNull(unpackBundle(dir, ::resourceOrNull))
+        assertTrue(Files.readAllBytes(grammar).contentEquals(original))
+
+        Files.write(grammar, "{}".toByteArray())
+        assertNotNull(unpackBundle(dir, ::resourceOrNull))
+        assertTrue(Files.readAllBytes(grammar).contentEquals(original))
+    }
+
+    @Test
+    fun aMissingResourceIsReportedRatherThanHandedOverAsAnEmptyBundle() {
+        val dir = createTempDirectory("tcl-textmate-missing")
+        assertEquals(null, unpackBundle(dir) { null })
+    }
+
+    private fun unpackIntoTempDirectory(): Path =
+        assertNotNull(unpackBundle(createTempDirectory("tcl-textmate"), ::resourceOrNull))
+
+    /** The `extensions="a;b;c"` attributes of the plugin's two file types. */
+    private fun fileTypeExtensions(): Set<String> {
+        val document = DocumentBuilderFactory.newInstance().newDocumentBuilder()
+            .parse(ByteArrayInputStream(resource("META-INF/plugin.xml")))
+        val fileTypes = document.getElementsByTagName("fileType")
+        return (0 until fileTypes.length)
+            .map { fileTypes.item(it) }
+            .flatMap {
+                assertNotNull(it.attributes.getNamedItem("extensions")).nodeValue.split(";")
+            }
+            .toSortedSet()
+    }
+
+    private fun resourceOrNull(path: String): ByteArray? =
+        javaClass.classLoader.getResourceAsStream(path)?.use { it.readBytes() }
+
+    private fun resource(path: String): ByteArray = assertNotNull(resourceOrNull(path))
+}

--- a/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/settings/ReflowingGridTest.kt
+++ b/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/settings/ReflowingGridTest.kt
@@ -1,0 +1,79 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package com.tcllsp.jetbrains.settings
+
+import com.intellij.ui.components.JBCheckBox
+import java.awt.Rectangle
+import javax.swing.JComponent
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The settings page's checkbox groups used `GridLayout(0, n)`, whose width is
+ * the widest label times `n` regardless of the space available — about 2000px
+ * for the optimiser's four columns. An IntelliJ settings pane never scrolls
+ * horizontally, so those columns ran off the right-hand edge unreachably.
+ */
+class ReflowingGridTest {
+
+    private fun grid(count: Int = 12): ReflowingGrid =
+        ReflowingGrid((1..count).map { JBCheckBox("IRULE400$it: a label of realistic length") })
+
+    /** Width of one cell, which is what the grid may never go below. */
+    private fun cellWidth(grid: ReflowingGrid): Int =
+        grid.components.maxOf { it.preferredSize.width }
+
+    @Test
+    fun theGridNeverAsksForMoreThanOneColumnOfWidth() {
+        val grid = grid()
+        val cell = cellWidth(grid)
+
+        assertTrue(
+            grid.minimumSize.width <= cell + grid.insets.left + grid.insets.right,
+            "minimum width ${grid.minimumSize.width} exceeds one ${cell}px cell — " +
+                "the page cannot be squeezed into a narrow settings pane",
+        )
+    }
+
+    @Test
+    fun aWiderPaneGetsMoreColumnsAndFewerRows() {
+        val grid = grid()
+        val cell = cellWidth(grid)
+
+        val narrow = layoutAt(grid, cell + 4)
+        val wide = layoutAt(grid, cell * 3 + 40)
+
+        assertEquals(1, columnsIn(narrow), "one cell of width must yield one column")
+        assertEquals(3, columnsIn(wide), "three cells of width must yield three columns")
+        assertTrue(rowsIn(wide) < rowsIn(narrow))
+    }
+
+    @Test
+    fun everyCheckboxStaysInsideTheWidthTheGridWasGiven() {
+        val grid = grid(31)
+        val cell = cellWidth(grid)
+
+        for (width in listOf(cell, cell * 2 + 8, cell * 4 + 40, cell * 7)) {
+            val bounds = layoutAt(grid, width)
+            val overflow = bounds.filter { it.x + it.width > width }
+            assertTrue(
+                overflow.isEmpty(),
+                "${overflow.size} of ${bounds.size} cells overflow a ${width}px grid",
+            )
+            assertTrue(grid.preferredSize.width <= width || columnsIn(bounds) == 1)
+        }
+    }
+
+    /** Lay the grid out at [width] and report where each child landed. */
+    private fun layoutAt(grid: ReflowingGrid, width: Int): List<Rectangle> {
+        grid.setSize(width, Int.MAX_VALUE / 2)
+        grid.doLayout()
+        return grid.components.map { (it as JComponent).bounds }
+    }
+
+    private fun columnsIn(bounds: List<Rectangle>): Int = bounds.map { it.x }.distinct().size
+
+    private fun rowsIn(bounds: List<Rectangle>): Int = bounds.map { it.y }.distinct().size
+}

--- a/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/settings/ScrollableFormTest.kt
+++ b/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/settings/ScrollableFormTest.kt
@@ -1,0 +1,47 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package com.tcllsp.jetbrains.settings
+
+import com.intellij.ui.components.JBCheckBox
+import javax.swing.JPanel
+import javax.swing.JViewport
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * `ConfigurableCardPanel` already wraps a configurable's component in a scroll
+ * pane, so the settings page must hand it a plain [Scrollable] form. Returning
+ * a `JScrollPane` nested one pane inside another: the inner one was always its
+ * own preferred size, so it never scrolled, and it swallowed the wheel events
+ * meant for the outer one.
+ */
+class ScrollableFormTest {
+
+    private fun form(): ScrollableForm =
+        ScrollableForm(JPanel().apply { add(JBCheckBox("a setting with a label")) })
+
+    @Test
+    fun theFormTakesTheViewportWidthUntilItCannotBeSqueezedFurther() {
+        val form = form()
+        val viewport = JViewport().apply { view = form }
+
+        viewport.setSize(form.minimumSize.width + 200, 400)
+        assertTrue(
+            form.scrollableTracksViewportWidth,
+            "a pane wider than the form's minimum must reflow the form, not scroll it sideways",
+        )
+
+        viewport.setSize(form.minimumSize.width - 1, 400)
+        assertFalse(
+            form.scrollableTracksViewportWidth,
+            "a pane narrower than the form's minimum must scroll rather than clip",
+        )
+    }
+
+    @Test
+    fun theFormScrollsVerticallyRatherThanBeingSquashedIntoThePane() {
+        assertFalse(form().scrollableTracksViewportHeight)
+    }
+}

--- a/editors/vscode/src/compilerExplorer.ts
+++ b/editors/vscode/src/compilerExplorer.ts
@@ -177,6 +177,11 @@ async function openProjection(
     );
     return;
   }
+  // Captured before the await: `explorerEditor` follows the active editor, so
+  // switching files while the render is in flight would otherwise pair this
+  // view's line map with a document it was not rendered from, and every caret
+  // move in the projection would reveal an unrelated span there.
+  const origin = explorerEditor?.document.uri;
   const result = (await client.sendRequest("workspace/executeCommand", {
     command: "tcl-lsp.compilerExplorerView",
     arguments: [source, dialect, view],
@@ -198,7 +203,7 @@ async function openProjection(
   projections.set(uri.toString(), {
     text: result.text,
     lines: result.lines ?? [],
-    source: explorerEditor?.document.uri,
+    source: origin,
   });
   projectionProvider.refresh(uri);
 

--- a/editors/vscode/src/compilerExplorer.ts
+++ b/editors/vscode/src/compilerExplorer.ts
@@ -63,6 +63,152 @@ export function waitForCompileComplete(timeoutMs = 10_000): Promise<boolean> {
   });
 }
 
+/** URI scheme for the read-only projection panes the explorer opens. */
+const PROJECTION_SCHEME = "tcl-explorer";
+
+/**
+ * A rendered projection, keyed by the URI its pane is showing.
+ *
+ * `lines[n]` is the source span the pane's line `n` points at, so moving the
+ * caret in a projection navigates back into the user's file. The entry is
+ * replaced whenever the view is re-opened, which is what makes a re-open pick
+ * up an edited source.
+ */
+interface Projection {
+  text: string;
+  lines: (ExplorerRange | null)[];
+  /** The file the projection was rendered from. */
+  source: vscode.Uri | undefined;
+}
+
+/** A span in the two coordinate systems `range_dict` emits. */
+interface ExplorerRange {
+  startLine: number;
+  startColUtf16: number;
+  endLine: number;
+  endColUtf16: number;
+  startOffset: number;
+  endOffset: number;
+}
+
+const projections = new Map<string, Projection>();
+
+/**
+ * Serves the projection panes.
+ *
+ * A virtual document rather than an untitled one — which is what the rest of
+ * the extension uses for command output — because a projection is derived,
+ * read-only, and re-rendered in place: an untitled document would prompt to
+ * save and would accumulate a tab per compile.
+ */
+class ProjectionProvider implements vscode.TextDocumentContentProvider {
+  private readonly changed = new vscode.EventEmitter<vscode.Uri>();
+  readonly onDidChange = this.changed.event;
+
+  provideTextDocumentContent(uri: vscode.Uri): string {
+    return projections.get(uri.toString())?.text ?? "";
+  }
+
+  refresh(uri: vscode.Uri): void {
+    this.changed.fire(uri);
+  }
+}
+
+const projectionProvider = new ProjectionProvider();
+
+/**
+ * Register the projection machinery. Called once from `activate`.
+ *
+ * The caret listener is what makes a pane navigable: it maps the caret's line
+ * through the projection's line map and reveals the matching span in the file
+ * the projection came from.
+ */
+export function registerCompilerExplorerProjections(context: vscode.ExtensionContext): void {
+  context.subscriptions.push(
+    vscode.workspace.registerTextDocumentContentProvider(PROJECTION_SCHEME, projectionProvider),
+    vscode.window.onDidChangeTextEditorSelection((event) => {
+      if (event.textEditor.document.uri.scheme !== PROJECTION_SCHEME) {
+        return;
+      }
+      void revealFromProjection(
+        event.textEditor.document.uri,
+        event.selections[0]?.active.line ?? 0,
+      );
+    }),
+  );
+}
+
+/** Reveal the source span the projection's line `line` points at. */
+async function revealFromProjection(uri: vscode.Uri, line: number): Promise<void> {
+  const projection = projections.get(uri.toString());
+  const range = projection?.lines[line];
+  if (!projection?.source || !range) {
+    return;
+  }
+  const document = await vscode.workspace.openTextDocument(projection.source);
+  const target = new vscode.Range(
+    new vscode.Position(range.startLine, range.startColUtf16),
+    new vscode.Position(range.endLine, range.endColUtf16),
+  );
+  // `preserveFocus` so the caret stays in the projection the user is reading:
+  // arrowing down a projection should walk the source alongside it, not tear
+  // focus away on every keypress.
+  const editor = await vscode.window.showTextDocument(document, {
+    viewColumn: vscode.ViewColumn.One,
+    preserveFocus: true,
+  });
+  editor.setDecorations(highlightDecoration, [target]);
+  editor.revealRange(target, vscode.TextEditorRevealType.InCenterIfOutsideViewport);
+}
+
+/**
+ * Render `view` through the server and show it in a read-only editor pane.
+ */
+async function openProjection(
+  view: string,
+  label: string,
+  source: string,
+  dialect: string,
+): Promise<void> {
+  const client = getClient();
+  if (!client) {
+    void vscode.window.showWarningMessage(
+      "Tcl LSP: the language server is not running, so the view cannot be rendered.",
+    );
+    return;
+  }
+  const result = (await client.sendRequest("workspace/executeCommand", {
+    command: "tcl-lsp.compilerExplorerView",
+    arguments: [source, dialect, view],
+  })) as { text?: string; lines?: (ExplorerRange | null)[]; error?: string };
+
+  if (!result || result.error || typeof result.text !== "string") {
+    void vscode.window.showWarningMessage(
+      `Tcl LSP: could not render the ${label} view${result?.error ? `: ${result.error}` : ""}.`,
+    );
+    return;
+  }
+
+  // One stable URI per view, so re-opening replaces the pane's contents
+  // instead of stacking tabs. The label rides in the path because that is what
+  // the tab shows.
+  const uri = vscode.Uri.parse(
+    `${PROJECTION_SCHEME}:${view}.tcl-explorer?${encodeURIComponent(label)}`,
+  );
+  projections.set(uri.toString(), {
+    text: result.text,
+    lines: result.lines ?? [],
+    source: explorerEditor?.document.uri,
+  });
+  projectionProvider.refresh(uri);
+
+  const document = await vscode.workspace.openTextDocument(uri);
+  await vscode.window.showTextDocument(document, {
+    viewColumn: vscode.ViewColumn.Beside,
+    preview: false,
+  });
+}
+
 const highlightDecoration = vscode.window.createTextEditorDecorationType({
   backgroundColor: new vscode.ThemeColor("editor.selectionBackground"),
   isWholeLine: false,
@@ -96,6 +242,8 @@ export function openCompilerExplorer(): void {
       startCol?: number;
       endLine?: number;
       endCol?: number;
+      view?: string;
+      label?: string;
       message?: string;
       stack?: string;
       filename?: string;
@@ -125,6 +273,17 @@ export function openCompilerExplorer(): void {
         msg.end !== undefined
       ) {
         highlightSourceRange(msg);
+      } else if (
+        msg.type === "openProjection" &&
+        typeof msg.view === "string" &&
+        typeof msg.source === "string"
+      ) {
+        await openProjection(
+          msg.view,
+          typeof msg.label === "string" ? msg.label : msg.view,
+          msg.source,
+          typeof msg.dialect === "string" ? msg.dialect : getActiveDialect(),
+        );
       } else if (msg.type === "clearHighlight") {
         clearSourceHighlight();
       } else if (msg.type === "coreError") {

--- a/editors/vscode/src/compilerExplorer.ts
+++ b/editors/vscode/src/compilerExplorer.ts
@@ -92,6 +92,10 @@ export function openCompilerExplorer(): void {
       dialect?: string;
       start?: number;
       end?: number;
+      startLine?: number;
+      startCol?: number;
+      endLine?: number;
+      endCol?: number;
       message?: string;
       stack?: string;
       filename?: string;
@@ -120,7 +124,7 @@ export function openCompilerExplorer(): void {
         msg.start !== undefined &&
         msg.end !== undefined
       ) {
-        highlightSourceRange(msg.start, msg.end);
+        highlightSourceRange(msg);
       } else if (msg.type === "clearHighlight") {
         clearSourceHighlight();
       } else if (msg.type === "coreError") {
@@ -322,15 +326,39 @@ function postSourceUpdate(update: { source: string; dialect: string }): void {
     });
 }
 
-function highlightSourceRange(startOffset: number, endOffset: number): void {
+/**
+ * Highlight the source span the webview is hovering.
+ *
+ * The explorer's `startOffset`/`endOffset` count **bytes** (the payload's
+ * columns come from `LineIndex::position_at`, which returns a byte column),
+ * while `Position` and `positionAt` are UTF-16. Feeding one to the other is
+ * correct only for ASCII and drifts by one position per non-ASCII byte
+ * thereafter, so prefer the UTF-16 line/column pair the payload now carries
+ * and keep the offsets as the fallback for an older payload.
+ */
+function highlightSourceRange(msg: {
+  start?: number;
+  end?: number;
+  startLine?: number;
+  startCol?: number;
+  endLine?: number;
+  endCol?: number;
+}): void {
   const editor = explorerEditor;
   if (!editor) {
     return;
   }
   const doc = editor.document;
-  const start = doc.positionAt(startOffset);
-  const end = doc.positionAt(endOffset);
-  const range = new vscode.Range(start, end);
+  const range =
+    msg.startLine !== undefined &&
+    msg.startCol !== undefined &&
+    msg.endLine !== undefined &&
+    msg.endCol !== undefined
+      ? new vscode.Range(
+          new vscode.Position(msg.startLine, msg.startCol),
+          new vscode.Position(msg.endLine, msg.endCol),
+        )
+      : new vscode.Range(doc.positionAt(msg.start ?? 0), doc.positionAt(msg.end ?? 0));
   editor.setDecorations(highlightDecoration, [range]);
   editor.revealRange(range, vscode.TextEditorRevealType.InCenterIfOutsideViewport);
 }

--- a/editors/vscode/src/compilerExplorerHtml.ts
+++ b/editors/vscode/src/compilerExplorerHtml.ts
@@ -37,9 +37,10 @@ function explorerAssetDirs(): string[] {
   return [
     // When built via Makefile, assets are copied next to the bundle.
     __dirname,
-    // Fallback: the source tree (dev / tsc-watch mode).
-    // __dirname is  editors/vscode/out  →  walk up to repo root.
-    join(__dirname, "..", "..", "..", "tooling", "explorer", "static"),
+    // Fallback: the source tree (dev / tsc-watch mode). __dirname is
+    // editors/vscode/out, so walk up to the repo root and into the
+    // explorer's own static directory (EXPLORER_STATIC in the Makefile).
+    join(__dirname, "..", "..", "..", "rust", "tcl-cli", "gui"),
   ];
 }
 
@@ -51,8 +52,8 @@ function findCoreJs(): string {
     }
   }
   throw new Error(
-    "explorer-core.js not found next to the bundle or in tooling/explorer/static. " +
-      "Run 'make compile' or copy tooling/explorer/static/explorer-core.js to editors/vscode/out/.",
+    "explorer-core.js not found next to the bundle or in rust/tcl-cli/gui. " +
+      "Run 'make compile' or copy rust/tcl-cli/gui/explorer-core.js to editors/vscode/out/.",
   );
 }
 
@@ -837,7 +838,7 @@ body {
 }
 .disasm-diff-unchanged-note { padding: 4px 8px; color: var(--text-dim); font-size: 11px; font-style: italic; }
 /* Generic expand-on-click / Space items (shared explorer-core renderers).
-   Must mirror tooling/explorer/static/index.html so the shared xpand() /
+   Must mirror rust/tcl-cli/gui/index.html so the shared xpand() /
    optimiser-lens markup renders the same in the VS Code webview. */
 .xpand { cursor: pointer; outline: none; border-radius: 4px; }
 .xpand:focus-visible { box-shadow: inset 2px 0 0 var(--accent); background: var(--highlight); }

--- a/editors/vscode/src/compilerExplorerHtml.ts
+++ b/editors/vscode/src/compilerExplorerHtml.ts
@@ -1345,7 +1345,15 @@ function setupHoverHighlighting(container) {
     if (!el) return;
     const start = parseInt(el.dataset.start);
     const end = parseInt(el.dataset.end);
-    vscode.postMessage({ type: 'highlightSource', start, end });
+    // Byte offsets for hosts that still slice bytes; UTF-16 line/column for
+    // placing a caret, which is what an editor position actually is.
+    vscode.postMessage({
+      type: 'highlightSource', start, end,
+      startLine: el.dataset.sl === undefined ? undefined : parseInt(el.dataset.sl),
+      startCol: el.dataset.sc === undefined ? undefined : parseInt(el.dataset.sc),
+      endLine: el.dataset.el === undefined ? undefined : parseInt(el.dataset.el),
+      endCol: el.dataset.ec === undefined ? undefined : parseInt(el.dataset.ec),
+    });
     if (currentHighlighted && currentHighlighted !== el) {
       currentHighlighted.classList.remove('highlighted');
     }

--- a/editors/vscode/src/compilerExplorerHtml.ts
+++ b/editors/vscode/src/compilerExplorerHtml.ts
@@ -255,6 +255,22 @@ body {
   flex-shrink: 0;
   min-width: 0;
 }
+/* Pushed to the far end of the tab bar; hidden for a tab with no tree view. */
+.open-in-editor {
+  margin-left: auto;
+  align-self: center;
+  background: transparent;
+  color: var(--fg-dim);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  font: inherit;
+  font-size: 11px;
+  padding: 2px 8px;
+  margin-right: 6px;
+  cursor: pointer;
+}
+.open-in-editor:hover { color: var(--fg); border-color: var(--fg-dim); }
+.open-in-editor[hidden] { display: none; }
 .tab {
   padding: 6px 10px;
   font-size: 12px;
@@ -951,20 +967,27 @@ body {
   <div class="main" id="main">
     <div class="output-panel" id="outputPanel" style="position:relative">
       <div class="tab-bar" id="tabBar">
-        <div class="tab active" data-tab="ir">IR</div>
-        <div class="tab" data-tab="cfg-pre">CFG</div>
-        <div class="tab" data-tab="cfg-post">SSA+Analysis</div>
-        <div class="tab" data-tab="interproc">Interproc</div>
-        <div class="tab" data-tab="types">Types</div>
-        <div class="tab" data-tab="opt">Optimiser</div>
-        <div class="tab" data-tab="gvn">GVN</div>
-        <div class="tab" data-tab="shimmer">Shimmer</div>
-        <div class="tab" data-tab="taint">Taint</div>
-        <div class="tab" data-tab="irules-flow">iRules Flow</div>
-        <div class="tab" data-tab="callouts">Callouts</div>
+        <!-- \`data-view\` is the canonical explorer view id (views.rs
+             VIEW_META), which differs from the pane's own \`data-tab\` for the
+             two CFG tabs. A tab without one has no tree view to render into an
+             editor pane, so the "Open in editor" button hides for it. -->
+        <div class="tab active" data-tab="ir" data-view="ir">IR</div>
+        <div class="tab" data-tab="cfg-pre" data-view="cfg">CFG</div>
+        <div class="tab" data-tab="cfg-post" data-view="ssa">SSA+Analysis</div>
+        <div class="tab" data-tab="interproc" data-view="interproc">Interproc</div>
+        <div class="tab" data-tab="types" data-view="types">Types</div>
+        <div class="tab" data-tab="opt" data-view="opt">Optimiser</div>
+        <div class="tab" data-tab="gvn" data-view="gvn">GVN</div>
+        <div class="tab" data-tab="shimmer" data-view="shimmer">Shimmer</div>
+        <div class="tab" data-tab="taint" data-view="taint">Taint</div>
+        <div class="tab" data-tab="irules-flow" data-view="irules">iRules Flow</div>
+        <div class="tab" data-tab="callouts" data-view="callouts">Callouts</div>
         <div class="tab" data-tab="asm">Tcl ASM</div>
         <div class="tab" data-tab="wasm">WASM</div>
         <div class="tab" data-tab="trait-reference">Trait reference</div>
+        <button class="open-in-editor" id="openInEditor" type="button"
+                hidden
+                title="Open this view in an editor tab, where it can be searched, folded and navigated">Open in editor</button>
       </div>
       <div class="output-content" id="outputContent">
         <div class="tab-pane active" id="pane-ir">
@@ -1179,6 +1202,7 @@ window.addEventListener('message', function(event) {
       if (msg.dialect) {
         $('#dialect').value = msg.dialect;
       }
+      syncOpenInEditor();
       compile();
       break;
     case 'result':
@@ -1244,6 +1268,31 @@ $('#tabBar').addEventListener('click', e => {
   if (data && (tab.dataset.tab === 'cfg-pre' || tab.dataset.tab === 'cfg-post' || tab.dataset.tab === 'opt')) {
     requestAnimationFrame(() => scheduleEdgeRedraw());
   }
+  syncOpenInEditor();
+});
+
+// "Open in editor": ask the host to render the active view into one of its own
+// editor panes, where it can be searched, folded and navigated back to source.
+// Only tabs carrying a canonical view id have one to render.
+function activeViewId() {
+  const tab = $('.tab.active');
+  return tab && tab.dataset.view ? tab.dataset.view : null;
+}
+function syncOpenInEditor() {
+  const button = $('#openInEditor');
+  if (!button) return;
+  button.hidden = activeViewId() === null || !currentSource.trim();
+}
+$('#openInEditor').addEventListener('click', () => {
+  const view = activeViewId();
+  if (!view) return;
+  vscode.postMessage({
+    type: 'openProjection',
+    view,
+    label: ($('.tab.active') || {}).textContent || view,
+    source: currentSource,
+    dialect: $('#dialect').value,
+  });
 });
 
 // Compile

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -79,6 +79,7 @@ import {
   explorerDocChanged,
   explorerEditorChanged,
   openCompilerExplorer,
+  registerCompilerExplorerProjections,
 } from "./compilerExplorer";
 import { openTkPreview, tkPreviewDocChanged, tkPreviewEditorChanged } from "./tkPreviewPanel";
 import { openSpecStudio, prepareSpecStudioStorage } from "./specStudio";
@@ -315,6 +316,10 @@ export async function activate(context: ExtensionContext) {
       tkPreviewEditorChanged();
     }),
   );
+
+  // The explorer's read-only projection panes: a virtual-document provider
+  // plus the caret listener that navigates from a pane back into the source.
+  registerCompilerExplorerProjections(context);
   onActiveEditorChanged(window.activeTextEditor);
 
   // Warn once when semantic highlighting can't reach a Tcl buffer (wrong

--- a/rust/tcl-cli/gui/explorer-core.js
+++ b/rust/tcl-cli/gui/explorer-core.js
@@ -236,9 +236,19 @@ function updateGenericExplorerBadges(views) {
 }
 
 // Hover highlighting helpers
+//
+// `startOffset`/`endOffset` count bytes, which is what this page wants: it
+// slices the source string it was handed. An editor host cannot use them —
+// VS Code positions and IntelliJ document offsets are both UTF-16 — so the
+// UTF-16 line/column pair rides along for hosts to place a caret with.
 function sourceRangeAttrs(range) {
   if (!range) return '';
-  return ' data-start="' + range.startOffset + '" data-end="' + range.endOffset + '"';
+  var attrs = ' data-start="' + range.startOffset + '" data-end="' + range.endOffset + '"';
+  if (range.startColUtf16 !== undefined) {
+    attrs += ' data-sl="' + range.startLine + '" data-sc="' + range.startColUtf16 + '"' +
+      ' data-el="' + range.endLine + '" data-ec="' + range.endColUtf16 + '"';
+  }
+  return attrs;
 }
 function spanLabel(range) {
   if (!range) return '';

--- a/rust/tcl-compiler/src/optimiser/profiles.rs
+++ b/rust/tcl-compiler/src/optimiser/profiles.rs
@@ -66,7 +66,7 @@ impl OptimisationProfile {
     /// Every profile, in increasing order of aggressiveness.
     ///
     /// This is the list every surface that offers a profile choice is built
-    /// from — the VS Code `enum`, the JetBrains dropdown, the docs table — so
+    /// from — the VS Code `enum`, the `JetBrains` dropdown, the docs table — so
     /// adding a tier here is the only edit needed to reach all of them, and a
     /// generator's `--check` mode fails until each has been regenerated.
     pub const ALL: [Self; 5] = [

--- a/rust/tcl-compiler/src/optimiser/profiles.rs
+++ b/rust/tcl-compiler/src/optimiser/profiles.rs
@@ -63,6 +63,36 @@ fn opt_code_categories() -> impl Iterator<Item = (&'static str, OptCategory)> {
 }
 
 impl OptimisationProfile {
+    /// Every profile, in increasing order of aggressiveness.
+    ///
+    /// This is the list every surface that offers a profile choice is built
+    /// from — the VS Code `enum`, the JetBrains dropdown, the docs table — so
+    /// adding a tier here is the only edit needed to reach all of them, and a
+    /// generator's `--check` mode fails until each has been regenerated.
+    pub const ALL: [Self; 5] = [
+        Self::Off,
+        Self::Readability,
+        Self::Standard,
+        Self::Full,
+        Self::Aggressive,
+    ];
+
+    /// One sentence describing what the tier does, for the editor setting's
+    /// help text. Kept here rather than in each generator so the wording
+    /// cannot differ between editors.
+    #[must_use]
+    pub fn description(self) -> &'static str {
+        match self {
+            Self::Off => "All optimisations disabled.",
+            Self::Readability => {
+                "Readability improvements only — idiomatic rewrites, no code removal."
+            }
+            Self::Standard => "Readability + constant folding and pattern recognition.",
+            Self::Full => "All optimisations enabled (single pass).",
+            Self::Aggressive => "All optimisations with multi-pass to fixpoint.",
+        }
+    }
+
     /// Parse a profile name (`"off"` / `"readability"` / `"standard"` /
     /// `"full"` / `"aggressive"`); unknown names fall back to
     /// [`DEFAULT_EDITOR_PROFILE`].
@@ -133,6 +163,30 @@ pub fn profile_to_disabled(profile: OptimisationProfile) -> HashSet<&'static str
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn all_lists_every_profile_and_round_trips_through_parse() {
+        // `ALL` is what every editor's profile picker is generated from, so a
+        // variant missing here silently disappears from all of them at once.
+        for profile in OptimisationProfile::ALL {
+            assert_eq!(
+                OptimisationProfile::parse(profile.name()),
+                profile,
+                "{} must round-trip through parse",
+                profile.name(),
+            );
+            assert!(
+                !profile.description().is_empty(),
+                "{} needs a description for the editor setting",
+                profile.name(),
+            );
+        }
+        // Exhaustive: adding a variant without adding it to ALL fails here.
+        let mut seen = OptimisationProfile::ALL.to_vec();
+        seen.dedup();
+        assert_eq!(seen.len(), OptimisationProfile::ALL.len());
+        assert!(OptimisationProfile::ALL.contains(&DEFAULT_EDITOR_PROFILE));
+    }
 
     #[test]
     fn readability_disables_constant_folding_and_dce() {

--- a/rust/tcl-explorer/src/formatters.rs
+++ b/rust/tcl-explorer/src/formatters.rs
@@ -91,6 +91,20 @@ pub fn range_dict(span: Span, line_index: &LineIndex, source: &str) -> Value {
     let end = line_index.position_at(inclusive_end);
     let start_utf16 = line_index.position_at_utf16(span.start(), source);
     let end_utf16 = line_index.position_at_utf16(inclusive_end, source);
+    // `inclusive_end` is the last *byte* of the final character, so
+    // `position_at_utf16` snaps back to that character's start. Advancing by
+    // one code unit would land inside a surrogate pair for anything outside
+    // the BMP — an emoji is two units — and hand both editor hosts a range
+    // ending mid-character. Advance by the character's own width instead.
+    // Deriving this from the exclusive byte end directly is not equivalent:
+    // that offset can be the first column of the *next* line, which is why
+    // the inclusive end is what the line number comes from.
+    let exclusive_end = tcl_lexer::word_span_at(source, span).end() as usize;
+    let end_units = source
+        .get(..exclusive_end)
+        .and_then(|s| s.chars().next_back())
+        .and_then(|c| u32::try_from(c.len_utf16()).ok())
+        .unwrap_or(1);
     json!({
         "startLine": start.line,
         "startCol": start.character.get(),
@@ -99,7 +113,7 @@ pub fn range_dict(span: Span, line_index: &LineIndex, source: &str) -> Value {
         "endCol": end.character.get() + 1,
         "endOffset": end.offset + 1,
         "startColUtf16": start_utf16.character.get(),
-        "endColUtf16": end_utf16.character.get() + 1,
+        "endColUtf16": end_utf16.character.get() + end_units,
     })
 }
 
@@ -438,5 +452,23 @@ mod tests {
         assert_eq!(d["endCol"], 8);
         assert_eq!(d["endColUtf16"], 7);
         assert_eq!(d["startLine"], 0, "line numbers are encoding-independent");
+    }
+
+    #[test]
+    fn range_dict_spans_the_whole_of_a_surrogate_pair() {
+        // An emoji is four UTF-8 bytes and *two* UTF-16 code units. The
+        // inclusive end lands on its last byte, which maps back to the
+        // character's start, so an end column derived by adding a single unit
+        // would stop between the two halves of the pair and leave both editor
+        // hosts selecting half a character.
+        let source = "set v 😀";
+        let li = LineIndex::new(source);
+        let start = u32::try_from(source.find('😀').unwrap()).unwrap();
+        let d = range_dict(Span::new(start, start + 4), &li, source);
+        assert_eq!(d["startColUtf16"], 6, "the emoji starts after `set v `");
+        assert_eq!(
+            d["endColUtf16"], 8,
+            "the end must clear both code units of the pair",
+        );
     }
 }

--- a/rust/tcl-explorer/src/formatters.rs
+++ b/rust/tcl-explorer/src/formatters.rs
@@ -75,11 +75,22 @@ fn widened_inclusive_end(span: Span, source: &str) -> u32 {
 /// `endCol` / `endOffset` are the inclusive end plus one (the front-end
 /// slices with an exclusive end), computed from the *inclusive* end
 /// position so a closer on the next line does not roll the column over.
+///
+/// `startCol` / `endCol` / `startOffset` / `endOffset` count **bytes** —
+/// [`LineIndex::position_at`] returns a [`tcl_lexer::ByteCol`], which agrees
+/// with an editor column only for ASCII. The web front-end slices the source
+/// string it was handed, so bytes are what it wants; an editor host placing a
+/// caret does not, because both `VS Code` positions and `IntelliJ` document
+/// offsets are UTF-16. `startColUtf16` / `endColUtf16` carry the same two
+/// positions in UTF-16 code units so a host never has to re-derive them (the
+/// line numbers are encoding-independent and are shared).
 #[must_use]
 pub fn range_dict(span: Span, line_index: &LineIndex, source: &str) -> Value {
     let start = line_index.position_at(span.start());
     let inclusive_end = widened_inclusive_end(span, source);
     let end = line_index.position_at(inclusive_end);
+    let start_utf16 = line_index.position_at_utf16(span.start(), source);
+    let end_utf16 = line_index.position_at_utf16(inclusive_end, source);
     json!({
         "startLine": start.line,
         "startCol": start.character.get(),
@@ -87,6 +98,8 @@ pub fn range_dict(span: Span, line_index: &LineIndex, source: &str) -> Value {
         "endLine": end.line,
         "endCol": end.character.get() + 1,
         "endOffset": end.offset + 1,
+        "startColUtf16": start_utf16.character.get(),
+        "endColUtf16": end_utf16.character.get() + 1,
     })
 }
 
@@ -400,5 +413,30 @@ mod tests {
         assert_eq!(d["startOffset"], 0);
         assert_eq!(d["endOffset"], 5);
         assert_eq!(d["endCol"], 5);
+    }
+
+    /// The byte columns are what the web front-end slices with; the UTF-16
+    /// pair is what an editor host places a caret with. They agree on ASCII
+    /// and must not on anything else, or a host would be placing carets in
+    /// the wrong column for every non-ASCII line.
+    #[test]
+    fn range_dict_carries_utf16_columns_beside_the_byte_ones() {
+        let ascii = "set a 1";
+        let li = LineIndex::new(ascii);
+        let d = range_dict(Span::new(4, 5), &li, ascii);
+        assert_eq!(d["startCol"], d["startColUtf16"]);
+        assert_eq!(d["endCol"], d["endColUtf16"]);
+
+        // `é` is two UTF-8 bytes and one UTF-16 code unit, so every column
+        // after it disagrees by one.
+        let source = "set é 1";
+        let li = LineIndex::new(source);
+        let value = u32::try_from(source.find('1').unwrap()).unwrap();
+        let d = range_dict(Span::new(value, value + 1), &li, source);
+        assert_eq!(d["startCol"], 7, "byte column counts é as two");
+        assert_eq!(d["startColUtf16"], 6, "UTF-16 column counts é as one");
+        assert_eq!(d["endCol"], 8);
+        assert_eq!(d["endColUtf16"], 7);
+        assert_eq!(d["startLine"], 0, "line numbers are encoding-independent");
     }
 }

--- a/rust/tcl-explorer/src/render.rs
+++ b/rust/tcl-explorer/src/render.rs
@@ -31,7 +31,7 @@
 
 use serde_json::Value;
 
-use crate::view_tree::{ViewNode, build_view};
+use crate::view_tree::{ViewNode, ViewRange, build_view};
 use crate::views::tree_view_ids;
 
 const RESET: &str = "\x1b[0m";
@@ -117,32 +117,73 @@ fn push_section(out: &mut String, view: &str, body: &str, use_colour: bool) {
 /// Render a single tree view's [`ViewNode`] forest as a box-drawing tree.
 #[must_use]
 pub fn render_view(view: &str, data: &Value, use_colour: bool) -> String {
+    render_view_mapped(view, data, use_colour).text
+}
+
+/// A rendered view, plus the source span each of its lines points at.
+///
+/// `lines[i]` is the span for the `i`th line of `text`, or `None` for a line
+/// that points nowhere (a header, a note, a row whose node has no span). An
+/// editor host showing `text` in a pane uses this to turn a caret position
+/// into a jump back into the user's file, so the two must be produced
+/// together — a map built by re-parsing the rendered text would drift the
+/// moment the renderer changed.
+#[derive(Debug, Clone, Default)]
+pub struct RenderedView {
+    /// The rendered tree.
+    pub text: String,
+    /// One entry per line of [`Self::text`].
+    pub lines: Vec<Option<ViewRange>>,
+}
+
+/// Render a view and its line → source-span map.
+#[must_use]
+pub fn render_view_mapped(view: &str, data: &Value, use_colour: bool) -> RenderedView {
     let roots = build_view(view, data);
+    let mut rendered = RenderedView::default();
     if roots.is_empty() {
-        return "  (no data)\n".to_owned();
+        rendered.push_rows("  (no data)\n", None);
+        return rendered;
     }
-    let mut out = String::new();
     let last = roots.len() - 1;
     for (i, node) in roots.iter().enumerate() {
-        render_node(node, "", i == last, use_colour, &mut out);
+        render_node(node, "", i == last, use_colour, &mut rendered);
     }
-    out
+    rendered
+}
+
+impl RenderedView {
+    /// Append `chunk` (which must end in a newline) as rows all pointing at
+    /// `range`.
+    ///
+    /// Counting the newlines rather than assuming one per push is what keeps
+    /// the map aligned: a detail *value* can itself span lines — the
+    /// structural index's inert spans do — so a row is not always a line.
+    fn push_rows(&mut self, chunk: &str, range: Option<ViewRange>) {
+        self.text.push_str(chunk);
+        self.lines
+            .extend(std::iter::repeat_n(range, chunk.matches('\n').count()));
+    }
 }
 
 /// Recursively render `node` under `prefix`, with its detail rows inlined.
-fn render_node(node: &ViewNode, prefix: &str, is_last: bool, use_colour: bool, out: &mut String) {
+fn render_node(
+    node: &ViewNode,
+    prefix: &str,
+    is_last: bool,
+    use_colour: bool,
+    out: &mut RenderedView,
+) {
     let connector = if is_last { TREE_LAST } else { TREE_BRANCH };
-    out.push_str(prefix);
-    out.push_str(connector);
-    out.push_str(&paint(&node.label, node.style.as_deref(), use_colour));
-    out.push('\n');
+    let label = paint(&node.label, node.style.as_deref(), use_colour);
+    out.push_rows(&format!("{prefix}{connector}{label}\n"), node.range);
 
     let child_prefix = format!("{prefix}{}", if is_last { TREE_GAP } else { TREE_VBAR });
     for (key, value) in &node.detail {
-        let row = format!("· {key}: {value}");
-        out.push_str(&child_prefix);
-        out.push_str(&paint(&row, Some("dim"), use_colour));
-        out.push('\n');
+        let row = paint(&format!("· {key}: {value}"), Some("dim"), use_colour);
+        // A detail row belongs to its node, so it navigates to the same span:
+        // a caret anywhere in a node's block should reach the source.
+        out.push_rows(&format!("{child_prefix}{row}\n"), node.range);
     }
     let last = node.children.len().saturating_sub(1);
     for (i, child) in node.children.iter().enumerate() {
@@ -253,5 +294,51 @@ mod tests {
         let wat = render_wasm(&d);
         assert!(wat.contains("(module"), "{wat}");
         assert!(wat.contains("$::top"), "{wat}");
+    }
+
+    /// The map has exactly one entry per rendered line.
+    ///
+    /// This is the property an editor pane depends on: it turns a caret line
+    /// into an index into `lines`, so a map that drifted by one would send
+    /// every click to the wrong statement.
+    #[test]
+    fn the_line_map_is_aligned_with_the_rendered_text() {
+        let d = data("proc greet {who} {\n    puts \"hi $who\"\n}\ngreet world\n");
+        for view in crate::views::tree_view_ids() {
+            let rendered = render_view_mapped(view, &d, false);
+            assert_eq!(
+                rendered.text.lines().count(),
+                rendered.lines.len(),
+                "{view}: one map entry per rendered line"
+            );
+            assert_eq!(
+                rendered.text,
+                render_view(view, &d, false),
+                "{view}: the mapped render is the same text"
+            );
+        }
+    }
+
+    /// A mapped line points at the span its row displays.
+    #[test]
+    fn a_mapped_line_points_at_the_span_its_row_shows() {
+        let source = "set x 1\n";
+        let d = data(source);
+        let rendered = render_view_mapped("ir", &d, false);
+        let (index, range) = rendered
+            .lines
+            .iter()
+            .enumerate()
+            .find_map(|(i, r)| r.map(|r| (i, r)))
+            .expect("the IR view maps at least one line");
+        let line = rendered.text.lines().nth(index).unwrap();
+        assert!(
+            line.contains("set") || line.contains("assign") || line.contains("range"),
+            "line {index} ({line:?}) should be a statement row"
+        );
+        assert!(
+            usize::try_from(range.end_offset).unwrap() <= source.len(),
+            "the span must index the source it came from"
+        );
     }
 }

--- a/rust/tcl-explorer/src/view_tree.rs
+++ b/rust/tcl-explorer/src/view_tree.rs
@@ -30,6 +30,49 @@
 
 use serde_json::Value;
 
+/// The source span a view row points at, in the two coordinate systems its
+/// consumers need.
+///
+/// Byte offsets are what the web front-end slices the source string with;
+/// UTF-16 line/column is what an editor host places a caret with. Both come
+/// straight from [`crate::formatters::range_dict`], so neither is re-derived.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ViewRange {
+    /// 0-based start line.
+    pub start_line: u32,
+    /// 0-based start column, in UTF-16 code units.
+    pub start_col_utf16: u32,
+    /// 0-based end line.
+    pub end_line: u32,
+    /// Exclusive end column, in UTF-16 code units.
+    pub end_col_utf16: u32,
+    /// Start byte offset.
+    pub start_offset: u32,
+    /// Exclusive end byte offset.
+    pub end_offset: u32,
+}
+
+impl ViewRange {
+    /// Read a range dict, or `None` when the value is absent or not a range
+    /// (`range_or_null` emits `null` for a statement with no span).
+    #[must_use]
+    pub fn from_value(v: &Value) -> Option<Self> {
+        if !v.is_object() {
+            return None;
+        }
+        let field = |k: &str| v[k].as_u64().map(|n| u32::try_from(n).unwrap_or(u32::MAX));
+        Some(Self {
+            start_line: field("startLine")?,
+            start_col_utf16: field("startColUtf16")?,
+            end_line: field("endLine")?,
+            end_col_utf16: field("endColUtf16")?,
+            start_offset: field("startOffset")?,
+            end_offset: field("endOffset")?,
+        })
+    }
+}
+
 /// One expandable row: a summary `label`, a `detail` table, and children.
 ///
 /// `Serialize` is for the differential test harness (compared against
@@ -44,15 +87,30 @@ pub struct ViewNode {
     pub children: Vec<ViewNode>,
     /// Optional style hint (a colour name).
     pub style: Option<String>,
+    /// Where this row points in the source, when it points anywhere.
+    ///
+    /// The `detail` table already carries a human-readable `range` row, but
+    /// that is a formatted string — a consumer that wants to *navigate* had to
+    /// parse `line:col  (start…end)` back out of it. This keeps the structured
+    /// value beside it so navigation reads a field instead.
+    pub range: Option<ViewRange>,
 }
 
 impl ViewNode {
+    /// Attach the source span this row points at, from its range dict.
+    #[must_use]
+    fn with_range(mut self, range: &Value) -> Self {
+        self.range = ViewRange::from_value(range);
+        self
+    }
+
     fn leaf(label: impl Into<String>, detail: Vec<(String, String)>, style: Option<&str>) -> Self {
         Self {
             label: label.into(),
             detail,
             children: Vec::new(),
             style: style.map(str::to_owned),
+            range: None,
         }
     }
 
@@ -67,6 +125,7 @@ impl ViewNode {
             detail,
             children,
             style: style.map(str::to_owned),
+            range: None,
         }
     }
 
@@ -227,7 +286,7 @@ fn ir_nodes(nodes: &[Value]) -> Vec<ViewNode> {
                     )
                 })
                 .collect();
-            ViewNode::branch(s(n, "summary"), detail, children, None)
+            ViewNode::branch(s(n, "summary"), detail, children, None).with_range(&n["range"])
         })
         .collect()
 }
@@ -247,12 +306,15 @@ fn build_ir(d: &Value) -> Vec<ViewNode> {
             let proc = &procs[name];
             let params = arr_to_strings(&proc["params"]).join(" ");
             let header = format!("{name} {{{params}}}");
-            nodes.push(ViewNode::branch(
-                header,
-                vec![det("range", rng(&proc["range"]))],
-                ir_nodes(arr(proc, "body")),
-                Some("cyan"),
-            ));
+            nodes.push(
+                ViewNode::branch(
+                    header,
+                    vec![det("range", rng(&proc["range"]))],
+                    ir_nodes(arr(proc, "body")),
+                    Some("cyan"),
+                )
+                .with_range(&proc["range"]),
+            );
         }
     }
     nodes
@@ -326,14 +388,17 @@ fn build_cfg(funcs: &[Value], post: bool) -> Vec<ViewNode> {
                     detail.push(det("uses", fmt_usedef(&st["uses"])));
                     detail.push(det("defs", fmt_usedef(&st["defs"])));
                 }
-                items.push(ViewNode::leaf(s(st, "summary"), detail, None));
+                items.push(ViewNode::leaf(s(st, "summary"), detail, None).with_range(&st["range"]));
             }
             let term = &b["terminator"];
-            items.push(ViewNode::leaf(
-                term_label(term),
-                vec![det("range", rng(&term["range"]))],
-                Some("blue"),
-            ));
+            items.push(
+                ViewNode::leaf(
+                    term_label(term),
+                    vec![det("range", rng(&term["range"]))],
+                    Some("blue"),
+                )
+                .with_range(&term["range"]),
+            );
             let mut tags = String::new();
             if b["isEntry"].as_bool().unwrap_or(false) {
                 tags.push_str(" [entry]");
@@ -986,6 +1051,7 @@ fn build_opt(d: &Value) -> Vec<ViewNode> {
                 ],
                 Some("green"),
             )
+            .with_range(&o["range"])
         })
         .collect();
     if out.is_empty() {
@@ -1126,6 +1192,7 @@ fn build_optimiser_passes(d: &Value) -> Vec<ViewNode> {
                         ],
                         Some("green"),
                     )
+                    .with_range(&o["range"])
                 })
                 .collect();
             let count = s(p, "count");
@@ -1163,6 +1230,7 @@ fn build_gvn(d: &Value) -> Vec<ViewNode> {
                 ],
                 Some("green"),
             )
+            .with_range(&w["range"])
         })
         .collect();
     if out.is_empty() {
@@ -1193,6 +1261,7 @@ fn build_shimmer(d: &Value) -> Vec<ViewNode> {
                 ],
                 Some("yellow"),
             )
+            .with_range(&w["range"])
         })
         .collect();
     if out.is_empty() {
@@ -1226,11 +1295,14 @@ fn build_taint(d: &Value) -> Vec<ViewNode> {
             detail.push(det("sink command", sink));
         }
         detail.push(det("range", rng(&w["range"])));
-        out.push(ViewNode::leaf(
-            format!("{} {}", s(w, "code"), s(w, "message")),
-            detail,
-            Some("red"),
-        ));
+        out.push(
+            ViewNode::leaf(
+                format!("{} {}", s(w, "code"), s(w, "message")),
+                detail,
+                Some("red"),
+            )
+            .with_range(&w["range"]),
+        );
     }
     if out.is_empty() {
         vec![ViewNode::note("(no tainted data flows)", "dim")]
@@ -1310,32 +1382,38 @@ fn build_irules(d: &Value) -> Vec<ViewNode> {
     for e in arr(d, "eventOrder") {
         let eff =
             e["base_priority"].as_i64().unwrap_or(0) + e["priority_offset"].as_i64().unwrap_or(0);
-        out.push(ViewNode::leaf(
-            format!("{} eff={eff}", s(e, "event")),
-            vec![
-                det("event", s(e, "event")),
-                det("effective priority", eff.to_string()),
-                det("base", s(e, "base_priority")),
-                det("offset", s(e, "priority_offset")),
-                det("multiplicity", {
-                    let m = s(e, "multiplicity");
-                    if m.is_empty() { "once".to_owned() } else { m }
-                }),
-                det("range", rng(&e["range"])),
-            ],
-            Some("blue"),
-        ));
+        out.push(
+            ViewNode::leaf(
+                format!("{} eff={eff}", s(e, "event")),
+                vec![
+                    det("event", s(e, "event")),
+                    det("effective priority", eff.to_string()),
+                    det("base", s(e, "base_priority")),
+                    det("offset", s(e, "priority_offset")),
+                    det("multiplicity", {
+                        let m = s(e, "multiplicity");
+                        if m.is_empty() { "once".to_owned() } else { m }
+                    }),
+                    det("range", rng(&e["range"])),
+                ],
+                Some("blue"),
+            )
+            .with_range(&e["range"]),
+        );
     }
     for w in arr(d, "irulesFlow") {
-        out.push(ViewNode::leaf(
-            format!("{} {}", s(w, "code"), s(w, "message")),
-            vec![
-                det("code", s(w, "code")),
-                det("message", s(w, "message")),
-                det("range", rng(&w["range"])),
-            ],
-            Some("yellow"),
-        ));
+        out.push(
+            ViewNode::leaf(
+                format!("{} {}", s(w, "code"), s(w, "message")),
+                vec![
+                    det("code", s(w, "code")),
+                    det("message", s(w, "message")),
+                    det("range", rng(&w["range"])),
+                ],
+                Some("yellow"),
+            )
+            .with_range(&w["range"]),
+        );
     }
     if out.is_empty() {
         vec![ViewNode::note("(no iRules events)", "dim")]
@@ -1379,6 +1457,7 @@ fn build_event_order(d: &Value) -> Vec<ViewNode> {
                 ],
                 Some("blue"),
             )
+            .with_range(&e["range"])
         })
         .collect();
     if out.is_empty() {
@@ -1402,6 +1481,7 @@ fn build_callouts(d: &Value) -> Vec<ViewNode> {
                 ],
                 None,
             )
+            .with_range(&a["range"])
         })
         .collect();
     if out.is_empty() {
@@ -1647,6 +1727,63 @@ mod tests {
 
     fn data(src: &str) -> Value {
         serialise_result(&run_pipeline(src, "tcl8.6"))
+    }
+
+    /// A row that shows a range must also *carry* it.
+    ///
+    /// The detail table's `range` row is a formatted string; an editor host
+    /// navigating to it would otherwise have to parse `line:col  (start…end)`
+    /// back out. These are the views a host navigates from.
+    #[test]
+    fn rows_that_display_a_range_also_carry_the_structured_one() {
+        let d = data("proc greet {who} {\n    puts \"hi $who\"\n}\ngreet world\n");
+        for view in ["ir", "cfg", "ssa"] {
+            let nodes = build_view(view, &d);
+            assert!(!nodes.is_empty(), "{view} produced no rows");
+            // `rng` renders a missing span as "?" — a terminator-less block
+            // shows a range row with nothing behind it, and carrying `None`
+            // there is correct.
+            let displayed = |n: &ViewNode| {
+                n.detail
+                    .iter()
+                    .any(|(k, v)| k == "range" && v.as_str() != "?")
+            };
+            let mut checked = 0usize;
+            let mut stack: Vec<&ViewNode> = nodes.iter().collect();
+            while let Some(node) = stack.pop() {
+                if displayed(node) {
+                    assert!(
+                        node.range.is_some(),
+                        "{view} row {:?} shows a range but carries none",
+                        node.label
+                    );
+                    checked += 1;
+                }
+                stack.extend(node.children.iter());
+            }
+            assert!(checked > 0, "{view} showed no range rows at all");
+        }
+    }
+
+    /// The structured range agrees with the payload it came from, in both
+    /// coordinate systems.
+    #[test]
+    fn the_structured_range_matches_the_payload() {
+        let d = data("set x 1\n");
+        let expected = ViewRange::from_value(&d["ir"]["topLevel"][0]["range"])
+            .expect("the payload's top-level statement has a range");
+
+        // The IR view nests its statements under a `top-level` branch, so walk.
+        let mut found = Vec::new();
+        let mut stack: Vec<ViewNode> = build_view("ir", &d);
+        while let Some(node) = stack.pop() {
+            found.extend(node.range);
+            stack.extend(node.children);
+        }
+        assert!(
+            found.contains(&expected),
+            "the statement's range must survive into the view model; got {found:?}"
+        );
     }
 
     #[test]

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -2048,7 +2048,7 @@ const SEMANTIC_TOKENS_REFRESH_DEBOUNCE: std::time::Duration = std::time::Duratio
 /// bound: browsing a large tree retained a full `Vec<Diagnostic>` for every file
 /// the editor ever opened, for the process's life.  Every entry is re-derivable
 /// from disk, so evicting the oldest costs nothing but a recompute on reopen.
-/// Sized well above a realistic "recently visited" working set (VS Code's own
+/// Sized well above a realistic "recently visited" working set (`VS Code`'s own
 /// Problems view is the consumer) yet far below the thousands of files a
 /// workspace walk touches.
 const CLOSED_DIAG_BADGE_CAP: usize = 512;
@@ -2564,7 +2564,7 @@ fn next_pull_diag_result_id() -> String {
 /// How long a `workspace/didChangeConfiguration` leader waits before running
 /// the reload, so the rest of a burst folds into the same generation.
 ///
-/// Long enough to swallow a settings-editor keystroke burst (VS Code emits one
+/// Long enough to swallow a settings-editor keystroke burst (`VS Code` emits one
 /// notification per changed key) and short enough that a single deliberate
 /// toggle still feels immediate.
 const CONFIG_RELOAD_DEBOUNCE: std::time::Duration = std::time::Duration::from_millis(150);
@@ -6820,7 +6820,7 @@ pub struct Backend {
     /// `textDocument/semanticTokens/full/delta` answer with a minimal
     /// token-aligned [`core_semantic_tokens::diff`] edit instead of resending
     /// the whole stream, the incremental behaviour rust-analyzer / clangd use.
-    /// Every editor that speaks `full/delta` (VS Code, Zed, Neovim, eglot, …)
+    /// Every editor that speaks `full/delta` (`VS Code`, Zed, Neovim, eglot, …)
     /// benefits: a keystroke transmits a few changed tokens rather than the
     /// entire document, which keeps the client's token round-trip — and, for
     /// eglot, its stale-repaint window (issue #333) — small on large files.
@@ -6863,7 +6863,7 @@ pub struct Backend {
     /// second one. Without this, many cold large tabs finishing their
     /// enriched computation around the same time (e.g. on startup) would
     /// each fire their own workspace-wide refresh, and a client that does
-    /// not coalesce them itself (VS Code does; eglot may not) would re-pull
+    /// not coalesce them itself (`VS Code` does; eglot may not) would re-pull
     /// every open document once per refresh.
     semantic_tokens_refresh_pending: Arc<std::sync::atomic::AtomicBool>,
     /// URIs with a detached semantic-token convergence continuation in flight
@@ -7560,7 +7560,7 @@ enum FolderGenericPatterns {
 /// value.  In a multi-root workspace each root can
 /// carry its own diagnostics, optimiser, formatting, dialect, and feature
 /// settings.  The other source of a per-folder dialect —
-/// The analyser inputs VS Code declares `"scope": "resource"` — settings whose
+/// The analyser inputs `VS Code` declares `"scope": "resource"` — settings whose
 /// value belongs to the document rather than the session.
 ///
 /// Bundled rather than passed as three more positional arguments because each
@@ -12160,7 +12160,7 @@ impl Backend {
     /// file is not a Tcl document and must not become one: routing it to this
     /// server would put JavaScript through the Tcl analyser, the workspace
     /// index and the diagnostics pipeline, none of which have anything true to
-    /// say about it. The VS Code client instead registers a *second*
+    /// say about it. The `VS Code` client instead registers a *second*
     /// `ReferenceProvider` for `javascript` that calls this and contributes its
     /// answers alongside the JavaScript language service's own — so the editor
     /// shows the Tcl call sites without either provider displacing the other.
@@ -16421,7 +16421,7 @@ impl Backend {
     /// Handle `tcl-lsp.setDialect`: switch the session default dialect and
     /// re-resolve every open document under it (so buffers that fell back to
     /// the default re-analyse immediately).  Returns `{success, dialect}`, or
-    /// `{success: false, error}` for an unknown dialect.  Drives the VS Code
+    /// `{success: false, error}` for an unknown dialect.  Drives the `VS Code`
     /// `tclLsp.selectDialect` command.
     async fn set_dialect_command(
         &self,
@@ -16488,7 +16488,7 @@ impl Backend {
     /// editor language id (`null` where the dialect has none) and the file
     /// extensions it owns, each with its human-facing name.
     ///
-    /// The VS Code extension gets this list projected into its manifest at
+    /// The `VS Code` extension gets this list projected into its manifest at
     /// build time (`cargo xtask gen-editor-dialects`); every other editor asks
     /// for it here, so a dialect picker or status bar never has to hardcode one.
     fn list_dialects_command() -> serde_json::Value {
@@ -17327,7 +17327,7 @@ impl Backend {
     /// `getEffectiveConfig` *reports* for a document cannot drift from what the
     /// providers *do* for it.  It used to: the command reported the global map
     /// while every gate below consulted the folder chain first, which made
-    /// `waitForFeatureToggle` (the VS Code suite's barrier before asserting a
+    /// `waitForFeatureToggle` (the `VS Code` suite's barrier before asserting a
     /// toggle took effect) observe a different fact from the one the provider
     /// would use — issue #1295.
     ///
@@ -17968,7 +17968,7 @@ impl Backend {
     /// server-side — `dialect_from_extension` consults pack routing before the
     /// static catalogue — but an editor learns its associations from a static
     /// manifest written long before the pack existed, so the file never
-    /// associates, the client never attaches, and in VS Code the extension may
+    /// associates, the client never attaches, and in `VS Code` the extension may
     /// not even activate. Advertising the pairs here lets a client that *can*
     /// register at runtime do so.
     ///
@@ -18825,7 +18825,7 @@ impl Backend {
     /// analysis, so O-codes the user had just disabled came back on that
     /// publish and only cleared on the reschedule a moment later.
     ///
-    /// Issue #1651 is that window, seen from the VS Code suite: the
+    /// Issue #1651 is that window, seen from the `VS Code` suite: the
     /// `optimiser.enabled` test failed exactly when its post-toggle edit landed
     /// before the reschedule, which is why a slower local runner reproduced it
     /// and CI (with a shorter pack walk) did not.  Widening the reschedule's
@@ -19382,6 +19382,30 @@ impl Backend {
         // scan here would be the same walk twice.
         if extensions_changed && trigger != ReloadTrigger::Startup {
             self.scan_workspace_folders().await;
+        }
+
+        // Everything a client caches per document and only re-requests on an
+        // edit is now stale, because the registry is what classifies it. A
+        // pack decides whether a command head is a `function` at all, whether
+        // it carries `defaultLibrary`, and — through `arg_role` — whether a
+        // braced word is tokenised as code or as one opaque string. Diagnostics
+        // and hover already recover: the callers re-analyse open documents, and
+        // hover is pulled per request. Semantic tokens, code lenses and folding
+        // ranges do not; without a push they stay on screen exactly as they
+        // were until the user types in the buffer, which is what made a Spec
+        // Studio pack edit leave the sample's colours frozen.
+        //
+        // Here rather than at the `didChangeWatchedFiles` call site because
+        // this is the one place every trigger passes through, and `run_config_reload`
+        // already does the code-lens/folding half for its own path only.
+        // Best-effort: a client without refresh support rejects the request.
+        if changed {
+            self.request_semantic_tokens_retry();
+            let _ = self
+                .client
+                .send_request::<FoldingRangeRefreshRequest>(())
+                .await;
+            let _ = self.client.code_lens_refresh().await;
         }
 
         // Tell the client the reload is finished. A client that reacts to the
@@ -27513,7 +27537,7 @@ fn whole_line_range(
 ///
 /// The canonicalisation starts with `ls_types`' own `from_file_path`, then
 /// [`uri_norm::repair_file_uri_from_path`] gives a leading `//` the authority
-/// shape VS Code's `URI.file` uses on every host and removes Windows-only
+/// shape `VS Code`'s `URI.file` uses on every host and removes Windows-only
 /// extended-length markers. Finally, [`uri_norm::canonical_uri_string`] pins
 /// Windows drive-letter and percent-escape case to the spelling `vscode-uri`
 /// uses on every platform.
@@ -28466,7 +28490,7 @@ fn tcl_source_glob() -> String {
 /// The same extension set as [`tcl_source_glob`], written so it matches **any
 /// casing** — `**/*.{[tT][cC][lL],…}`.
 ///
-/// `workspace/didChangeWatchedFiles` has no `ignoreCase` option, and VS Code
+/// `workspace/didChangeWatchedFiles` has no `ignoreCase` option, and `VS Code`
 /// matches watcher globs against the platform file system: case-insensitively
 /// on Windows and macOS, case-**sensitively** on Linux.  A single-cased glob
 /// therefore missed every external create/change/delete of an `UPPER.TCL` on
@@ -28475,7 +28499,7 @@ fn tcl_source_glob() -> String {
 /// full scan or an explicit open (issue #1215).
 ///
 /// The set is the same one [`is_tcl_source`] case-folds, and the pattern is
-/// built by the registry so the VS Code activation glob
+/// built by the registry so the `VS Code` activation glob
 /// (`cargo xtask gen-vscode-package`) is the same string by construction
 /// (issue #1242).
 fn tcl_source_watch_glob() -> String {
@@ -28607,7 +28631,7 @@ fn client_supports_pull_diagnostics(params: &InitializeParams) -> bool {
 /// config change flips `features.folding` (the client otherwise keeps its
 /// cached ranges until the next document edit) and once from `initialized`,
 /// so a tab restored before the provider went live recomputes its folding —
-/// and, in VS Code, its sticky-scroll model with it (issue #1122).
+/// and, in `VS Code`, its sticky-scroll model with it (issue #1122).
 enum FoldingRangeRefreshRequest {}
 
 impl tower_lsp_server::ls_types::request::Request for FoldingRangeRefreshRequest {
@@ -31258,7 +31282,7 @@ mod tests {
     /// The shipped `tclLsp.xcDiagnostics.enabled` setting is a dedicated
     /// config *section*, not a `features.*` key — `parse_folder_config` must
     /// still map it onto the `xcDiagnostics` feature toggle so the advertised
-    /// VS Code opt-in actually reaches `xc_diagnostics_enabled`.
+    /// `VS Code` opt-in actually reaches `xc_diagnostics_enabled`.
     #[test]
     fn folder_config_maps_xc_diagnostics_section_to_toggle() {
         let cfg = serde_json::json!({ "xcDiagnostics": { "enabled": true } });
@@ -33539,7 +33563,7 @@ mod tests {
         );
     }
 
-    /// The VS Code extension contributes *undotted* version-pinned language
+    /// The `VS Code` extension contributes *undotted* version-pinned language
     /// ids (`tcl84` … `tcl91`) because a dotted id cannot carry a
     /// `configurationDefaults` override (issue #1122). Every other editor
     /// integration still sends the dotted form, so both spellings must resolve
@@ -39622,7 +39646,7 @@ proc p {} {
     }
 
     /// Issue #1215: `workspace/didChangeWatchedFiles` carries no `ignoreCase`
-    /// option and VS Code matches watcher globs case-**sensitively** on Linux,
+    /// option and `VS Code` matches watcher globs case-**sensitively** on Linux,
     /// so the registration folds case per character instead.
     #[test]
     fn watch_glob_matches_every_casing_of_every_indexed_extension() {

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -16560,6 +16560,65 @@ impl Backend {
         }
     }
 
+    /// Handle `tcl-lsp.compilerExplorerView`: render one explorer view as text
+    /// plus the source span each of its lines points at.
+    ///
+    /// `args` is `(source, dialect, viewId)`. The reply is
+    /// `{text, lines: [null | {startLine, startColUtf16, endLine, endColUtf16,
+    /// startOffset, endOffset}]}`, one `lines` entry per line of `text`.
+    ///
+    /// This exists so an editor host can show a projection in one of its own
+    /// editor panes and still navigate from it: the pane holds `text`, and a
+    /// caret on line *n* resolves through `lines[n]` back into the user's
+    /// file. Rendering it here rather than in each host keeps one renderer —
+    /// the same [`tcl_explorer::render`] the `tcl explore --text` CLI and the
+    /// TUI use — and keeps the line map produced by the code that produced the
+    /// lines, so the two cannot drift.
+    async fn compiler_explorer_view_command(
+        &self,
+        args: &[serde_json::Value],
+    ) -> jsonrpc::Result<Option<serde_json::Value>> {
+        let source = args
+            .first()
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_default()
+            .to_owned();
+        if source.trim().is_empty() {
+            return Ok(Some(serde_json::json!({ "error": "no source to compile" })));
+        }
+        let dialect = match args.get(1).and_then(serde_json::Value::as_str) {
+            Some(d) => d.to_owned(),
+            None => self.session_dialect().await,
+        };
+        let view = args
+            .get(2)
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("ir")
+            .to_owned();
+        // Same containment as `compiler_explorer_command`: heavy pure-CPU work
+        // off the event loop, and a parser panic surfaced as `{error}` rather
+        // than tearing down the worker.
+        let value = crate::rt::spawn_blocking(move || {
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                let result = tcl_explorer::run_pipeline(&source, &dialect);
+                let data = tcl_explorer::serialise_result(&result);
+                let rendered = tcl_explorer::render::render_view_mapped(&view, &data, false);
+                serde_json::json!({
+                    "view": view,
+                    "text": rendered.text,
+                    "lines": rendered.lines,
+                })
+            }))
+        })
+        .await;
+        match value {
+            Ok(Ok(v)) => Ok(Some(v)),
+            _ => Ok(Some(serde_json::json!({
+                "error": "compiler explorer failed to render the view",
+            }))),
+        }
+    }
+
     /// Pull the `tclLsp` configuration section from the client and apply it.
     ///
     /// The editor (and the e2e harness) answer `workspace/configuration` with
@@ -23938,6 +23997,9 @@ impl LanguageServer for Backend {
                     .await
             }
             "tcl-lsp.compilerExplorer" => self.compiler_explorer_command(&params.arguments).await,
+            "tcl-lsp.compilerExplorerView" => {
+                self.compiler_explorer_view_command(&params.arguments).await
+            }
             "tcl-lsp.tkPreview" => self.tk_preview_command(&params.arguments).await,
             "tcl-lsp.ilxReferences" => Ok(self.ilx_references_command(&params.arguments).await),
             _ => Ok(None),
@@ -28747,6 +28809,7 @@ fn build_server_capabilities(
                 "tcl-lsp.setDialect".to_owned(),
                 "tcl-lsp.setSessionDialectOverride".to_owned(),
                 "tcl-lsp.compilerExplorer".to_owned(),
+                "tcl-lsp.compilerExplorerView".to_owned(),
                 "tcl-lsp.tkPreview".to_owned(),
                 "tcl-lsp.ilxReferences".to_owned(),
             ],

--- a/rust/tcl-lsp-server/tests/e2e/rename_safety.rs
+++ b/rust/tcl-lsp-server/tests/e2e/rename_safety.rs
@@ -968,7 +968,7 @@ fn fn_guard_a_fully_tracked_member_renames_from_every_trigger_position() {
 
 // -- the collision gate must not fire when there is nothing to collide with --
 
-/// Reported from CLion against exactly this buffer: renaming `a` to `b` was
+/// Reported from `CLion` against exactly this buffer: renaming `a` to `b` was
 /// refused with "`::b` is already declared in this workspace", in a workspace
 /// whose only Tcl file is the three lines below and which contains no `b` at
 /// all.
@@ -997,7 +997,7 @@ fn a_global_variable_renames_when_the_target_cell_is_free() {
 
 /// The same rename, after the buffer has already held `b` once.
 ///
-/// This is the shape the CLion report is most likely to be: rename `a` to `b`,
+/// This is the shape the `CLion` report is most likely to be: rename `a` to `b`,
 /// undo it, rename again. If the workspace index still carries the `::b` it
 /// saw between the two edits, the collision gate refuses a rename whose target
 /// cell is not live in any current document.

--- a/rust/tcl-lsp-server/tests/e2e/rename_safety.rs
+++ b/rust/tcl-lsp-server/tests/e2e/rename_safety.rs
@@ -965,3 +965,56 @@ fn fn_guard_a_fully_tracked_member_renames_from_every_trigger_position() {
         );
     }
 }
+
+// -- the collision gate must not fire when there is nothing to collide with --
+
+/// Reported from CLion against exactly this buffer: renaming `a` to `b` was
+/// refused with "`::b` is already declared in this workspace", in a workspace
+/// whose only Tcl file is the three lines below and which contains no `b` at
+/// all.
+///
+/// The gate is right to refuse a rename that would merge two live namespace
+/// cells. It is wrong whenever the target cell does not exist, and a global
+/// `set` is the most ordinary shape there is, so this is the case that has to
+/// hold before any of the subtler ones mean anything.
+#[test]
+fn a_global_variable_renames_when_the_target_cell_is_free() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(&uri, "set a 1\nincr a\nputs \"$a\"\n");
+    let result = lsp.rename(&uri, 0, 4, "b");
+    assert!(
+        !result.is_null(),
+        "renaming `a` to `b` should produce edits, got null",
+    );
+    let texts = all_texts(&result);
+    assert_eq!(
+        texts,
+        vec!["b".to_owned(), "b".to_owned(), "$b".to_owned()],
+        "the two commands and the substitution should all be rewritten",
+    );
+}
+
+/// The same rename, after the buffer has already held `b` once.
+///
+/// This is the shape the CLion report is most likely to be: rename `a` to `b`,
+/// undo it, rename again. If the workspace index still carries the `::b` it
+/// saw between the two edits, the collision gate refuses a rename whose target
+/// cell is not live in any current document.
+#[test]
+fn a_variable_renames_again_after_the_first_rename_was_undone() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(&uri, "set a 1\nincr a\nputs \"$a\"\n");
+    // The editor applies the rename...
+    lsp.replace_document(&uri, 2, "set b 1\nincr b\nputs \"$b\"\n");
+    lsp.await_diagnostics(&uri);
+    // ...and the user undoes it.
+    lsp.replace_document(&uri, 3, "set a 1\nincr a\nputs \"$a\"\n");
+    lsp.await_diagnostics(&uri);
+    let result = lsp.rename(&uri, 0, 4, "b");
+    assert!(
+        !result.is_null(),
+        "`::b` is not declared in any live document, so the rename must proceed",
+    );
+}

--- a/rust/tcl-lsp-server/tests/e2e/spec_packs.rs
+++ b/rust/tcl-lsp-server/tests/e2e/spec_packs.rs
@@ -290,6 +290,53 @@ fn a_pack_added_after_startup_reloads_and_re_analyses_open_documents() {
     let _ = std::fs::remove_dir_all(&root);
 }
 
+/// A reload asks the client to re-pull the semantic tokens it is already
+/// showing.
+///
+/// The registry is what classifies a token: a pack decides whether a head is
+/// a `function` at all, whether it carries `defaultLibrary`, and — through
+/// `arg 1 -role Body` — whether a braced word is tokenised as code or as one
+/// opaque string. The server recomputes correctly because the salsa inputs are
+/// keyed on the pack key, but a client only re-requests tokens when the
+/// document changes. Without the push the editor keeps painting the old stream
+/// over new meaning until the user happens to type in that buffer — which is
+/// what left a Spec Studio pack edit with the sample's colours frozen while its
+/// squiggles and hovers updated.
+#[test]
+fn a_pack_reload_asks_the_client_to_re_pull_semantic_tokens() {
+    let root = workspace("token-refresh");
+    let source = "mylib::with_var counter {\n    set counter 1\n}\n";
+    let doc = root.join("app.tcl");
+    write(&doc, source);
+
+    let mut lsp =
+        Lsp::with_config_at_root(json!({ "features": { "linkedEditingRange": true } }), &root);
+    let uri = file_uri(&doc);
+    lsp.open_ready(&uri, source);
+    // Take the tokens first, so the server is genuinely serving a stream the
+    // reload is about to invalidate rather than one nobody has asked for.
+    let _ = lsp.semantic_tokens_settled(&uri);
+
+    let cursor = lsp.server_request_cursor();
+    let pack = root.join(".tcl-lsp/mylib.tclspec");
+    write(&pack, MYLIB_PACK);
+    notify_pack_changed(&mut lsp, &pack, CREATED);
+    await_pack_named(&mut lsp, "mylib");
+
+    assert!(
+        lsp.try_await_server_request(
+            "workspace/semanticTokens/refresh",
+            std::time::Duration::from_secs(20),
+            cursor,
+        )
+        .is_some(),
+        "a pack reload that changed the command surface must push \
+         workspace/semanticTokens/refresh"
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
 /// Load notices land as diagnostics **on the pack file**, at the line the
 /// author wrote — and clear when the author fixes them.
 #[test]

--- a/rust/tcl-lsp-server/tests/e2e/vscode_parity.rs
+++ b/rust/tcl-lsp-server/tests/e2e/vscode_parity.rs
@@ -289,6 +289,72 @@ fn test_compiler_explorer_valid_source() {
     assert!(r.get("ir").is_some());
 }
 
+/// The view command renders one projection as text with a line → source map,
+/// which is what lets an editor host put a projection in a native pane and
+/// still navigate out of it.
+#[test]
+fn test_compiler_explorer_view_maps_every_line() {
+    let mut lsp = Lsp::tcl();
+    let source = "set x 10\nputs $x\n";
+    let r = lsp.execute_command(
+        "tcl-lsp.compilerExplorerView",
+        json!([source, "tcl8.6", "ir"]),
+    );
+    assert!(r.get("error").is_none_or(Value::is_null), "{r:#?}");
+
+    let text = r
+        .get("text")
+        .and_then(Value::as_str)
+        .expect("rendered text");
+    let lines = r.get("lines").and_then(Value::as_array).expect("line map");
+    assert!(!text.is_empty(), "the ir view rendered nothing");
+    assert_eq!(
+        text.lines().count(),
+        lines.len(),
+        "one map entry per rendered line, or a caret resolves to the wrong row"
+    );
+
+    let mapped = lines.iter().find(|l| !l.is_null()).expect("a mapped line");
+    for key in [
+        "startLine",
+        "startColUtf16",
+        "endLine",
+        "endColUtf16",
+        "startOffset",
+        "endOffset",
+    ] {
+        assert!(mapped.get(key).is_some(), "{key} missing from {mapped:#?}");
+    }
+    let end = usize::try_from(mapped["endOffset"].as_u64().unwrap()).unwrap();
+    assert!(
+        end <= source.len(),
+        "the span must index the source it came from"
+    );
+}
+
+/// An unknown view id renders the same "(no data)" placeholder the CLI shows,
+/// rather than erroring — a host asking for a view this build does not have
+/// should get an empty pane, not a failure dialog.
+#[test]
+fn test_compiler_explorer_view_unknown_view_is_empty_not_an_error() {
+    let mut lsp = Lsp::tcl();
+    let r = lsp.execute_command(
+        "tcl-lsp.compilerExplorerView",
+        json!(["set x 1\n", "tcl8.6", "no-such-view"]),
+    );
+    assert!(r.get("error").is_none_or(Value::is_null), "{r:#?}");
+    let text = r.get("text").and_then(Value::as_str).unwrap_or_default();
+    assert!(text.contains("no data"), "{text:?}");
+}
+
+#[test]
+fn test_compiler_explorer_view_empty_source_is_error() {
+    let mut lsp = Lsp::tcl();
+    let r = lsp.execute_command("tcl-lsp.compilerExplorerView", json!(["", "tcl8.6", "ir"]));
+    let err = r.get("error");
+    assert!(err.is_some() && !err.unwrap().is_null());
+}
+
 #[test]
 fn test_compiler_explorer_empty_source_is_error() {
     let mut lsp = Lsp::tcl();

--- a/rust/tcl-spec-studio/tests/web_contract.rs
+++ b/rust/tcl-spec-studio/tests/web_contract.rs
@@ -54,6 +54,53 @@ fn standalone_uses_only_monaco_and_ides_delegate_to_native_file_tabs() {
     assert!(!STUDIO_TS.contains("addEventListener(\"input\", scheduleTest)"));
 }
 
+/// The IDE artefacts must not carry the standalone page's editor.
+///
+/// Both hosts inject `__tclSpecStudioHost`, so `mountEditorHost` always picks
+/// the native controller and Monaco is dead weight there — about 3 MB, plus
+/// ~21 MB for the browser LSP worker the native path never starts. The
+/// standalone consumers (`GitHub Pages`, `tcl explore --serve`) still take the
+/// whole dist, which is why this is a packaging rule rather than a build one,
+/// and why `build-wasm.sh` must keep failing when Monaco is absent.
+#[test]
+fn the_ide_artefacts_exclude_the_standalone_editor() {
+    let makefile = std::fs::read_to_string(
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../Makefile"),
+    )
+    .expect("read the Makefile");
+
+    // A recipe line can be continued with a trailing backslash, so join those
+    // before matching or the excludes and the paths land on different lines.
+    let joined = makefile.replace("\\\n", " ");
+    let hosted: Vec<&str> = joined
+        .lines()
+        .filter(|line| line.contains("tcl-spec-studio-wasm/dist"))
+        .filter(|line| line.contains("STAGE_DIR") || line.contains("JB_DIR"))
+        .collect();
+    assert_eq!(
+        hosted.len(),
+        2,
+        "one staging copy each for the VSIX and the plugin: {hosted:#?}"
+    );
+    for line in hosted {
+        assert!(
+            line.contains("--exclude='assets/monaco-host.*'") && line.contains("--exclude='lsp/'"),
+            "the hosted staging copy must exclude Monaco and the worker: {line}"
+        );
+    }
+
+    // And the standalone build must keep requiring what it still loads.
+    let build = std::fs::read_to_string(
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../tcl-spec-studio-wasm/build-wasm.sh"),
+    )
+    .expect("read build-wasm.sh");
+    assert!(
+        build.contains("monaco-host.js"),
+        "build-wasm.sh must still assert the standalone editor is present"
+    );
+}
+
 #[test]
 fn compiler_explorer_monaco_preserves_shortcuts_and_lsp_failures() {
     assert!(MONACO_TS.contains("monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter"));

--- a/rust/tcl-spec-studio/web/src/nativeEditorHost.ts
+++ b/rust/tcl-spec-studio/web/src/nativeEditorHost.ts
@@ -89,7 +89,6 @@ export async function mountEditors(options: EditorHostOptions): Promise<EditorHo
   for (const surface of Object.keys(texts) as Surface[]) {
     bridge.postMessage({ type: "surfaceUpdate", surface, text: texts[surface] });
   }
-  bridge.postMessage({ type: "studioReady" });
   options.report("using the IDE's native file editor beside Spec Studio", "ok");
 
   return {

--- a/rust/xtask/src/editor_extensions.rs
+++ b/rust/xtask/src/editor_extensions.rs
@@ -34,7 +34,8 @@
 //!   `src/extension.ts` `LANGUAGE_ID_DIALECTS`, and
 //!   `src/languageIds.ts` `EXTENSION_LANGUAGE_IDS` (marked blocks).
 //! - `JetBrains` `plugin.xml`: the `Tcl` and `iRule` fileType
-//!   `extensions="…"` attributes.
+//!   `extensions="…"` attributes, `TclFileType.SUPPORTED_EXTENSIONS`, and the
+//!   `TextMate` bundle manifest that binds them all to the `source.tcl` grammar.
 //! - Sublime's minimal `LSP-Tcl` helper suffix bridge and Zed's
 //!   `languages/tcl/config.toml` `path_suffixes` (single-syntax editors get
 //!   the full union).
@@ -61,6 +62,7 @@ const VSCODE_LANGUAGE_IDS: &str = "editors/vscode/src/languageIds.ts";
 const JETBRAINS_PLUGIN: &str = "editors/jetbrains/src/main/resources/META-INF/plugin.xml";
 const JETBRAINS_FILETYPE: &str =
     "editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/TclFileType.kt";
+const JETBRAINS_TEXTMATE: &str = "editors/jetbrains/src/main/resources/textmate/package.json";
 const SUBLIME_PLUGIN: &str = "editors/sublime-text/plugin.py";
 const ZED_CONFIG: &str = "editors/zed/languages/tcl/config.toml";
 const HELIX_README: &str = "editors/helix/README.md";
@@ -617,6 +619,33 @@ fn render_jetbrains_kotlin(original: &str, langs: &[Language]) -> Result<String>
     )
 }
 
+/// The `JetBrains` plugin's `TextMate` bundle manifest claims the same union
+/// again, in the one place the *grammar* is bound to file extensions.
+///
+/// `TextMateService` resolves a grammar by file name, so an extension missing
+/// here opens as a Tcl file that no grammar matches — a plain-text editor with
+/// a language server attached, which is what shipped before the bundle was
+/// registered at all.
+fn render_jetbrains_textmate(original: &str, langs: &[Language]) -> Result<String> {
+    let mut root: Value =
+        serde_json::from_str(original).context("parsing the JetBrains TextMate package.json")?;
+    let extensions: Vec<Value> = all_extensions(langs)
+        .into_iter()
+        .map(|ext| Value::String(format!(".{ext}")))
+        .collect();
+    let languages = root["contributes"]["languages"]
+        .as_array_mut()
+        .context("contributes.languages must be an array")?;
+    let [language] = languages.as_mut_slice() else {
+        bail!(
+            "{JETBRAINS_TEXTMATE} must contribute exactly one language — the plugin \
+             binds every extension to the single `source.tcl` grammar"
+        );
+    };
+    language["extensions"] = Value::Array(extensions);
+    Ok(format!("{}\n", serde_json::to_string_pretty(&root)?))
+}
+
 /// Rewrite a Zed `config.toml`'s `path_suffixes = […]` array.
 fn set_zed_suffixes(original: &str, extensions: &[String]) -> Result<String> {
     let start = original
@@ -887,6 +916,7 @@ fn render_targets() -> Vec<(&'static str, Render)> {
         (VSCODE_RUNTIME, Box::new(render_vscode_runtime)),
         (JETBRAINS_PLUGIN, Box::new(render_jetbrains)),
         (JETBRAINS_FILETYPE, Box::new(render_jetbrains_kotlin)),
+        (JETBRAINS_TEXTMATE, Box::new(render_jetbrains_textmate)),
         (SUBLIME_PLUGIN, Box::new(render_sublime_plugin)),
         (ZED_CONFIG, Box::new(render_zed)),
         (HELIX_README, Box::new(render_helix_readme)),
@@ -1091,6 +1121,7 @@ mod tests {
             VSCODE_RUNTIME,
             JETBRAINS_PLUGIN,
             JETBRAINS_FILETYPE,
+            JETBRAINS_TEXTMATE,
             SUBLIME_PLUGIN,
             ZED_CONFIG,
             HELIX_README,

--- a/rust/xtask/src/gen_jetbrains.rs
+++ b/rust/xtask/src/gen_jetbrains.rs
@@ -413,10 +413,7 @@ fn panel(current: &str) -> String {
             opt_dirty,
             "            triState(opt{code}) != s.optimiser{code} ||"
         );
-        let _ = writeln!(
-            opt_apply,
-            "        s.optimiser{code} = triState(opt{code})"
-        );
+        let _ = writeln!(opt_apply, "        s.optimiser{code} = triState(opt{code})");
         let _ = writeln!(
             opt_reset,
             "        opt{code}.state = threeState(s.optimiser{code})"

--- a/rust/xtask/src/gen_jetbrains.rs
+++ b/rust/xtask/src/gen_jetbrains.rs
@@ -278,13 +278,88 @@ fn settings(current: &str) -> String {
 /// The note under the optimiser grid. A tri-state checkbox is unusual enough
 /// in a settings page that the third state needs saying out loud.
 const PROFILE_LEGEND: [&str; 6] = [
-    r#"        builder.addWrappedComment("#,
+    r"        builder.addWrappedComment(",
     r#"            "The profile chooses which optimisation families run. A per-code box left " +"#,
     r#"                "in its mixed state inherits from the profile; tick or untick one to " +"#,
     r#"                "force that code on or off regardless of the profile. Reset to profile " +"#,
     r#"                "clears every override and hands the choice back to the profile.","#,
-    r#"        )"#,
+    r"        )",
 ];
+
+/// Regenerate the optimiser half of `TclLspSettingsPanel.kt`: the profile
+/// picker, the tri-state per-code boxes, and their dirty/apply/reset arms.
+///
+/// Split out of [`panel`] to keep each side inside clippy's per-function line
+/// budget; the two halves share nothing but the file being rewritten.
+fn optimiser_blocks(current: String, opts: &[(&'static str, &'static str)]) -> String {
+    let opts = opts.to_vec();
+    let mut out = current;
+    // opt-checkboxes.
+    let mut opt_cb =
+        String::from("    private val optEnabled = JBCheckBox(\"Enable optimiser suggestions\")\n");
+    let profile_items = OptimisationProfile::ALL
+        .iter()
+        .map(|p| format!("\"{}\"", p.name()))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let _ = writeln!(
+        opt_cb,
+        "    private val optProfile = JComboBox(arrayOf({profile_items}))"
+    );
+    // Tri-state, so a code can say "inherit from the profile" — the state the
+    // VS Code setting expresses as `null` and its default.
+    for (code, description) in &opts {
+        let _ = writeln!(
+            opt_cb,
+            "    private val opt{code} = ThreeStateCheckBox(\"{}\", ThreeStateCheckBox.State.DONT_CARE)",
+            short_label(code, description)
+        );
+    }
+    // One named list, so the grid and the "reset to profile" link cannot
+    // disagree about which boxes are per-code overrides.
+    opt_cb.push_str("    private val optCodeBoxes: List<ThreeStateCheckBox> = listOf(\n");
+    let box_refs: Vec<String> = opts.iter().map(|(code, _)| format!("opt{code}")).collect();
+    opt_cb.push_str(&six_per_line_at(&box_refs, 8));
+    opt_cb.push_str("    )\n");
+    out = replace_block(&out, "opt-checkboxes", &opt_cb);
+
+    // opt-ui.
+    let mut opt_ui = String::from(
+        "        builder.addComponent(TitledSeparator(\"Optimiser\"))\n\
+         \x20       builder.addComponent(optEnabled)\n\
+         \x20       builder.addLabeledComponent(JBLabel(\"Profile:\"), profileRow())\n\
+         \x20       builder.addComponent(ReflowingGrid(optCodeBoxes))\n",
+    );
+    for line in PROFILE_LEGEND {
+        let _ = writeln!(opt_ui, "{line}");
+    }
+    out = replace_block(&out, "opt-ui", &opt_ui);
+
+    // opt dirty/apply/reset.
+    let mut opt_dirty =
+        String::from("            optEnabled.isSelected != s.optimiserEnabled ||\n");
+    opt_dirty.push_str("            optProfile.selectedItem != s.optimiserProfile ||\n");
+    let mut opt_apply = String::from("        s.optimiserEnabled = optEnabled.isSelected\n");
+    opt_apply.push_str(
+        "        s.optimiserProfile = optProfile.selectedItem as? String ?: s.optimiserProfile\n",
+    );
+    let mut opt_reset = String::from("        optEnabled.isSelected = s.optimiserEnabled\n");
+    opt_reset.push_str("        optProfile.selectedItem = s.optimiserProfile\n");
+    for (code, _) in &opts {
+        let _ = writeln!(
+            opt_dirty,
+            "            triState(opt{code}) != s.optimiser{code} ||"
+        );
+        let _ = writeln!(opt_apply, "        s.optimiser{code} = triState(opt{code})");
+        let _ = writeln!(
+            opt_reset,
+            "        opt{code}.state = threeState(s.optimiser{code})"
+        );
+    }
+    out = replace_block(&out, "opt-dirty", &opt_dirty);
+    out = replace_block(&out, "opt-apply", &opt_apply);
+    replace_block(&out, "opt-reset", &opt_reset)
+}
 
 /// Join checkbox field refs six-per-line at `indent` spaces.
 fn six_per_line_at(refs: &[String], indent: usize) -> String {
@@ -357,71 +432,7 @@ fn panel(current: &str) -> String {
     out = replace_block(&out, "diag-apply", &apply);
     out = replace_block(&out, "diag-reset", &reset);
 
-    // opt-checkboxes.
-    let mut opt_cb =
-        String::from("    private val optEnabled = JBCheckBox(\"Enable optimiser suggestions\")\n");
-    let profile_items = OptimisationProfile::ALL
-        .iter()
-        .map(|p| format!("\"{}\"", p.name()))
-        .collect::<Vec<_>>()
-        .join(", ");
-    let _ = writeln!(
-        opt_cb,
-        "    private val optProfile = JComboBox(arrayOf({profile_items}))"
-    );
-    // Tri-state, so a code can say "inherit from the profile" — the state the
-    // VS Code setting expresses as `null` and its default.
-    for (code, description) in &opts {
-        let _ = writeln!(
-            opt_cb,
-            "    private val opt{code} = ThreeStateCheckBox(\"{}\", ThreeStateCheckBox.State.DONT_CARE)",
-            short_label(code, description)
-        );
-    }
-    // One named list, so the grid and the "reset to profile" link cannot
-    // disagree about which boxes are per-code overrides.
-    opt_cb.push_str("    private val optCodeBoxes: List<ThreeStateCheckBox> = listOf(\n");
-    let box_refs: Vec<String> = opts.iter().map(|(code, _)| format!("opt{code}")).collect();
-    opt_cb.push_str(&six_per_line_at(&box_refs, 8));
-    opt_cb.push_str("    )\n");
-    out = replace_block(&out, "opt-checkboxes", &opt_cb);
-
-    // opt-ui.
-    let mut opt_ui = String::from(
-        "        builder.addComponent(TitledSeparator(\"Optimiser\"))\n\
-         \x20       builder.addComponent(optEnabled)\n\
-         \x20       builder.addLabeledComponent(JBLabel(\"Profile:\"), profileRow())\n\
-         \x20       builder.addComponent(ReflowingGrid(optCodeBoxes))\n",
-    );
-    for line in PROFILE_LEGEND {
-        let _ = writeln!(opt_ui, "{line}");
-    }
-    out = replace_block(&out, "opt-ui", &opt_ui);
-
-    // opt dirty/apply/reset.
-    let mut opt_dirty =
-        String::from("            optEnabled.isSelected != s.optimiserEnabled ||\n");
-    opt_dirty.push_str("            optProfile.selectedItem != s.optimiserProfile ||\n");
-    let mut opt_apply = String::from("        s.optimiserEnabled = optEnabled.isSelected\n");
-    opt_apply.push_str(
-        "        s.optimiserProfile = optProfile.selectedItem as? String ?: s.optimiserProfile\n",
-    );
-    let mut opt_reset = String::from("        optEnabled.isSelected = s.optimiserEnabled\n");
-    opt_reset.push_str("        optProfile.selectedItem = s.optimiserProfile\n");
-    for (code, _) in &opts {
-        let _ = writeln!(
-            opt_dirty,
-            "            triState(opt{code}) != s.optimiser{code} ||"
-        );
-        let _ = writeln!(opt_apply, "        s.optimiser{code} = triState(opt{code})");
-        let _ = writeln!(
-            opt_reset,
-            "        opt{code}.state = threeState(s.optimiser{code})"
-        );
-    }
-    out = replace_block(&out, "opt-dirty", &opt_dirty);
-    out = replace_block(&out, "opt-apply", &opt_apply);
-    replace_block(&out, "opt-reset", &opt_reset)
+    optimiser_blocks(out, &opts)
 }
 
 /// One generated `JetBrains` file: `(relative-path, regenerated-content)`.

--- a/rust/xtask/src/gen_jetbrains.rs
+++ b/rust/xtask/src/gen_jetbrains.rs
@@ -35,6 +35,8 @@ use std::process::ExitCode;
 use anyhow::{Context, Result};
 use tcl_core_types::{DiagCode, DocRow};
 
+use tcl_compiler::optimiser::profiles::{DEFAULT_EDITOR_PROFILE, OptimisationProfile};
+
 use crate::util::{repo_root, write_if_changed};
 
 const CATALOG_PATH: &str = "editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/settings/generated/DiagnosticCatalog.kt";
@@ -250,17 +252,38 @@ fn settings(current: &str) -> String {
     out = replace_block(&out, "diagnostic-map", &map);
 
     let mut opt_vars = String::from("    var optimiserEnabled: Boolean = true\n");
+    let _ = writeln!(
+        opt_vars,
+        "    var optimiserProfile: String = \"{}\"",
+        DEFAULT_EDITOR_PROFILE.name()
+    );
+    // Each per-code override is tri-state, exactly as the VS Code setting is
+    // (`["boolean", "null"]`, default `null`). A non-null value here *beats*
+    // the profile server-side — `true` lifts the code out of the profile's
+    // disabled set — so a hard default would silently switch on every
+    // optimisation the chosen profile deliberately leaves off.
     for (code, _) in &opts {
-        let _ = writeln!(opt_vars, "    var optimiser{code}: Boolean = true");
+        let _ = writeln!(opt_vars, "    var optimiser{code}: Boolean? = null");
     }
     out = replace_block(&out, "optimiser-vars", &opt_vars);
 
     let mut opt_map = String::from("                \"enabled\" to optimiserEnabled,\n");
+    opt_map.push_str("                \"profile\" to optimiserProfile,\n");
     for (code, _) in &opts {
         let _ = writeln!(opt_map, "                \"{code}\" to optimiser{code},");
     }
     replace_block(&out, "optimiser-map", &opt_map)
 }
+
+/// The note under the optimiser grid. A tri-state checkbox is unusual enough
+/// in a settings page that the third state needs saying out loud.
+const PROFILE_LEGEND: [&str; 5] = [
+    r#"        builder.addWrappedComment("#,
+    r#"            "The profile chooses which optimisation families run. A per-code box left " +"#,
+    r#"                "in its mixed state inherits from the profile; tick or untick one to " +"#,
+    r#"                "force that code on or off regardless of the profile.","#,
+    r#"        )"#,
+];
 
 /// Join checkbox field refs six-per-line at `indent` spaces.
 fn six_per_line_at(refs: &[String], indent: usize) -> String {
@@ -336,10 +359,21 @@ fn panel(current: &str) -> String {
     // opt-checkboxes.
     let mut opt_cb =
         String::from("    private val optEnabled = JBCheckBox(\"Enable optimiser suggestions\")\n");
+    let profile_items = OptimisationProfile::ALL
+        .iter()
+        .map(|p| format!("\"{}\"", p.name()))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let _ = writeln!(
+        opt_cb,
+        "    private val optProfile = JComboBox(arrayOf({profile_items}))"
+    );
+    // Tri-state, so a code can say "inherit from the profile" — the state the
+    // VS Code setting expresses as `null` and its default.
     for (code, description) in &opts {
         let _ = writeln!(
             opt_cb,
-            "    private val opt{code} = JBCheckBox(\"{}\")",
+            "    private val opt{code} = ThreeStateCheckBox(\"{}\", ThreeStateCheckBox.State.DONT_CARE)",
             short_label(code, description)
         );
     }
@@ -349,6 +383,7 @@ fn panel(current: &str) -> String {
     let mut opt_ui = String::from(
         "        builder.addComponent(TitledSeparator(\"Optimiser\"))\n\
          \x20       builder.addComponent(optEnabled)\n\
+         \x20       builder.addLabeledComponent(JBLabel(\"Profile:\"), optProfile)\n\
          \x20       builder.addComponent(\n\
          \x20           ReflowingGrid(\n\
          \x20               listOf(\n",
@@ -356,25 +391,33 @@ fn panel(current: &str) -> String {
     let opt_refs: Vec<String> = opts.iter().map(|(code, _)| format!("opt{code}")).collect();
     opt_ui.push_str(&six_per_line_at(&opt_refs, 20));
     opt_ui.push_str("                ),\n            ),\n        )\n");
+    for line in PROFILE_LEGEND {
+        let _ = writeln!(opt_ui, "{line}");
+    }
     out = replace_block(&out, "opt-ui", &opt_ui);
 
     // opt dirty/apply/reset.
     let mut opt_dirty =
         String::from("            optEnabled.isSelected != s.optimiserEnabled ||\n");
+    opt_dirty.push_str("            optProfile.selectedItem != s.optimiserProfile ||\n");
     let mut opt_apply = String::from("        s.optimiserEnabled = optEnabled.isSelected\n");
+    opt_apply.push_str(
+        "        s.optimiserProfile = optProfile.selectedItem as? String ?: s.optimiserProfile\n",
+    );
     let mut opt_reset = String::from("        optEnabled.isSelected = s.optimiserEnabled\n");
+    opt_reset.push_str("        optProfile.selectedItem = s.optimiserProfile\n");
     for (code, _) in &opts {
         let _ = writeln!(
             opt_dirty,
-            "            opt{code}.isSelected != s.optimiser{code} ||"
+            "            triState(opt{code}) != s.optimiser{code} ||"
         );
         let _ = writeln!(
             opt_apply,
-            "        s.optimiser{code} = opt{code}.isSelected"
+            "        s.optimiser{code} = triState(opt{code})"
         );
         let _ = writeln!(
             opt_reset,
-            "        opt{code}.isSelected = s.optimiser{code}"
+            "        opt{code}.state = threeState(s.optimiser{code})"
         );
     }
     out = replace_block(&out, "opt-dirty", &opt_dirty);

--- a/rust/xtask/src/gen_jetbrains.rs
+++ b/rust/xtask/src/gen_jetbrains.rs
@@ -277,11 +277,12 @@ fn settings(current: &str) -> String {
 
 /// The note under the optimiser grid. A tri-state checkbox is unusual enough
 /// in a settings page that the third state needs saying out loud.
-const PROFILE_LEGEND: [&str; 5] = [
+const PROFILE_LEGEND: [&str; 6] = [
     r#"        builder.addWrappedComment("#,
     r#"            "The profile chooses which optimisation families run. A per-code box left " +"#,
     r#"                "in its mixed state inherits from the profile; tick or untick one to " +"#,
-    r#"                "force that code on or off regardless of the profile.","#,
+    r#"                "force that code on or off regardless of the profile. Reset to profile " +"#,
+    r#"                "clears every override and hands the choice back to the profile.","#,
     r#"        )"#,
 ];
 
@@ -377,20 +378,21 @@ fn panel(current: &str) -> String {
             short_label(code, description)
         );
     }
+    // One named list, so the grid and the "reset to profile" link cannot
+    // disagree about which boxes are per-code overrides.
+    opt_cb.push_str("    private val optCodeBoxes: List<ThreeStateCheckBox> = listOf(\n");
+    let box_refs: Vec<String> = opts.iter().map(|(code, _)| format!("opt{code}")).collect();
+    opt_cb.push_str(&six_per_line_at(&box_refs, 8));
+    opt_cb.push_str("    )\n");
     out = replace_block(&out, "opt-checkboxes", &opt_cb);
 
     // opt-ui.
     let mut opt_ui = String::from(
         "        builder.addComponent(TitledSeparator(\"Optimiser\"))\n\
          \x20       builder.addComponent(optEnabled)\n\
-         \x20       builder.addLabeledComponent(JBLabel(\"Profile:\"), optProfile)\n\
-         \x20       builder.addComponent(\n\
-         \x20           ReflowingGrid(\n\
-         \x20               listOf(\n",
+         \x20       builder.addLabeledComponent(JBLabel(\"Profile:\"), profileRow())\n\
+         \x20       builder.addComponent(ReflowingGrid(optCodeBoxes))\n",
     );
-    let opt_refs: Vec<String> = opts.iter().map(|(code, _)| format!("opt{code}")).collect();
-    opt_ui.push_str(&six_per_line_at(&opt_refs, 20));
-    opt_ui.push_str("                ),\n            ),\n        )\n");
     for line in PROFILE_LEGEND {
         let _ = writeln!(opt_ui, "{line}");
     }

--- a/rust/xtask/src/gen_jetbrains.rs
+++ b/rust/xtask/src/gen_jetbrains.rs
@@ -23,6 +23,11 @@
 //! The file is a full-file projection of the user-configurable diagnostics +
 //! optimisations, each carrying a short checkbox `label`. `--check` verifies
 //! the committed file matches, exiting non-zero on drift.
+//!
+//! It also gates the plugin's hand-written semantic-token colour map against
+//! the legend the server advertises, in both modes: a token type the server
+//! emits that the map has no colour for is painted in the default foreground,
+//! which in an editor is indistinguishable from no semantic highlighting.
 
 use std::fmt::Write as _;
 use std::process::ExitCode;
@@ -33,6 +38,12 @@ use tcl_core_types::{DiagCode, DocRow};
 use crate::util::{repo_root, write_if_changed};
 
 const CATALOG_PATH: &str = "editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/settings/generated/DiagnosticCatalog.kt";
+
+/// The hand-written map this module verifies (rather than generates): the
+/// colour for a token type is an editor judgement, but its *key set* is the
+/// server's to decide.
+const SEMANTIC_TOKENS_PATH: &str =
+    "editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/TclSemanticTokens.kt";
 
 /// The section grouping `(key, title)` in table order (the three `irules*` keys
 /// share the iRules title, collapsing in `sectionTitles`/`sectionOrder`).
@@ -251,29 +262,12 @@ fn settings(current: &str) -> String {
     replace_block(&out, "optimiser-map", &opt_map)
 }
 
-/// The `JBPanel` variable name for a diagnostics section title.
-fn panel_var_for(title: &str) -> &'static str {
-    match title {
-        "Diagnostics — Errors" => "diagErrorPanel",
-        "Diagnostics — Style & Best Practice" => "diagWarnPanel",
-        "Diagnostics — Variables" => "diagVarPanel",
-        "Diagnostics — Security" => "diagSecPanel",
-        "Diagnostics — Hints" => "diagHintPanel",
-        "Diagnostics — Shimmer" => "diagShimmerPanel",
-        "Diagnostics — Taint" => "diagTaintPanel",
-        "Diagnostics — iRules" => "diagIRulePanel",
-        "Diagnostics — BIG-IP Configuration" => "diagBigIpPanel",
-        "Diagnostics — SslicTcl" => "diagSslicTclPanel",
-        "Diagnostics — Package Manager" => "diagPackagePanel",
-        _ => "diagPanel",
-    }
-}
-
-/// Join checkbox field refs six-per-line, each line `            a, b, …,\n`.
-fn six_per_line(refs: &[String]) -> String {
+/// Join checkbox field refs six-per-line at `indent` spaces.
+fn six_per_line_at(refs: &[String], indent: usize) -> String {
+    let pad = " ".repeat(indent);
     let mut out = String::new();
     for chunk in refs.chunks(6) {
-        let _ = writeln!(out, "            {},", chunk.join(", "));
+        let _ = writeln!(out, "{pad}{},", chunk.join(", "));
     }
     out
 }
@@ -305,23 +299,19 @@ fn panel(current: &str) -> String {
     // diag-ui: titled separator + grid panel + six-per-line refs.
     let mut ui = String::new();
     for (title, group) in &groups {
-        let pv = panel_var_for(title);
         let _ = writeln!(
             ui,
             "        builder.addComponent(TitledSeparator(\"{title}\"))"
         );
-        let _ = writeln!(
-            ui,
-            "        val {pv} = JPanel(java.awt.GridLayout(0, 2, 8, 2))"
+        ui.push_str(
+            "        builder.addComponent(\n            ReflowingGrid(\n                listOf(\n",
         );
-        ui.push_str("        listOf(\n");
         let refs: Vec<String> = group
             .iter()
             .map(|(code, _, _, _)| format!("diag{code}"))
             .collect();
-        ui.push_str(&six_per_line(&refs));
-        let _ = writeln!(ui, "        ).forEach {{ {pv}.add(it) }}");
-        let _ = writeln!(ui, "        builder.addComponent({pv})");
+        ui.push_str(&six_per_line_at(&refs, 20));
+        ui.push_str("                ),\n            ),\n        )\n");
         ui.push('\n');
     }
     let ui = ui.strip_suffix('\n').unwrap_or(&ui);
@@ -359,13 +349,13 @@ fn panel(current: &str) -> String {
     let mut opt_ui = String::from(
         "        builder.addComponent(TitledSeparator(\"Optimiser\"))\n\
          \x20       builder.addComponent(optEnabled)\n\
-         \x20       val optPanel = JPanel(java.awt.GridLayout(0, 4, 8, 2))\n\
-         \x20       listOf(\n",
+         \x20       builder.addComponent(\n\
+         \x20           ReflowingGrid(\n\
+         \x20               listOf(\n",
     );
     let opt_refs: Vec<String> = opts.iter().map(|(code, _)| format!("opt{code}")).collect();
-    opt_ui.push_str(&six_per_line(&opt_refs));
-    opt_ui.push_str("        ).forEach { optPanel.add(it) }\n");
-    opt_ui.push_str("        builder.addComponent(optPanel)\n");
+    opt_ui.push_str(&six_per_line_at(&opt_refs, 20));
+    opt_ui.push_str("                ),\n            ),\n        )\n");
     out = replace_block(&out, "opt-ui", &opt_ui);
 
     // opt dirty/apply/reset.
@@ -406,8 +396,68 @@ fn artifacts() -> Result<Vec<(&'static str, String)>> {
 }
 
 /// Write (or, with `check`, verify) the three generated `JetBrains` files.
+/// Every token type and modifier the plugin must have a colour rule for is
+/// one the server actually advertises, and vice versa.
+fn verify_semantic_token_colors(root: &std::path::Path) -> Result<()> {
+    let path = root.join(SEMANTIC_TOKENS_PATH);
+    let source =
+        std::fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
+
+    let mapped = quoted_keys(&source, "internal val SEMANTIC_TOKEN_COLORS", "\n)");
+    let legend: Vec<String> = tcl_lsp_core::semantic_tokens::legend_token_types()
+        .into_iter()
+        .map(str::to_owned)
+        .collect();
+    let missing: Vec<&String> = legend.iter().filter(|t| !mapped.contains(*t)).collect();
+    let unknown: Vec<&String> = mapped.iter().filter(|t| !legend.contains(t)).collect();
+    if !missing.is_empty() || !unknown.is_empty() {
+        anyhow::bail!(
+            "{SEMANTIC_TOKENS_PATH} SEMANTIC_TOKEN_COLORS disagrees with the server \
+             legend — uncoloured token types: {missing:?}; types the server never \
+             emits: {unknown:?}"
+        );
+    }
+
+    // The modifier half: a rule keyed on a modifier the server cannot set is
+    // dead, and reads as a colour the user will never see.
+    let modifiers = tcl_lsp_core::semantic_tokens::legend_token_modifiers();
+    for key in quoted_keys(&source, "SEMANTIC_TOKEN_MODIFIER_COLORS", "\n)") {
+        if !legend.contains(&key) && !modifiers.contains(&key.as_str()) {
+            anyhow::bail!(
+                "{SEMANTIC_TOKENS_PATH} SEMANTIC_TOKEN_MODIFIER_COLORS names {key:?}, \
+                 which is in neither the token-type nor the token-modifier legend"
+            );
+        }
+    }
+    Ok(())
+}
+
+/// Every double-quoted string between `start` and the next `end` after it.
+fn quoted_keys(source: &str, start: &str, end: &str) -> Vec<String> {
+    let Some(from) = source.find(start) else {
+        return Vec::new();
+    };
+    let rest = &source[from..];
+    let body = rest.find(end).map_or(rest, |n| &rest[..n]);
+    let mut out = Vec::new();
+    let mut chars = body.char_indices();
+    while let Some((i, c)) = chars.next() {
+        if c != '"' {
+            continue;
+        }
+        if let Some(len) = body[i + 1..].find('"') {
+            out.push(body[i + 1..i + 1 + len].to_owned());
+            for _ in 0..body[i + 1..=i + len + 1].chars().count() {
+                chars.next();
+            }
+        }
+    }
+    out
+}
+
 pub fn run(check: bool) -> Result<ExitCode> {
     let root = repo_root();
+    verify_semantic_token_colors(&root)?;
     let mut drift = Vec::new();
     for (rel, content) in artifacts()? {
         let path = root.join(rel);
@@ -460,16 +510,52 @@ mod tests {
     }
 
     #[test]
-    fn diagnostic_panel_variables_are_unique() {
+    fn the_semantic_token_colour_map_covers_the_server_legend() {
+        verify_semantic_token_colors(&repo_root())
+            .expect("every advertised semantic-token type needs a colour in the plugin");
+    }
+
+    #[test]
+    fn quoted_keys_reads_only_the_block_it_is_given() {
+        let source = "internal val A = mapOf(\n  \"x\" to 1,\n  \"y\" to 2,\n)\nval B = \"z\"\n";
+        assert_eq!(quoted_keys(source, "internal val A", "\n)"), ["x", "y"]);
+        assert!(quoted_keys(source, "no such marker", "\n)").is_empty());
+    }
+
+    #[test]
+    fn every_diagnostic_section_gets_its_own_titled_reflowing_grid() {
+        let panel = artifacts()
+            .expect("render JetBrains files")
+            .into_iter()
+            .find(|(rel, _)| rel.ends_with("TclLspSettingsPanel.kt"))
+            .expect("the settings panel is generated")
+            .1;
+
         let groups = diag_section_groups();
-        let names: std::collections::HashSet<_> = groups
-            .iter()
-            .map(|(title, _)| panel_var_for(title))
-            .collect();
+        for (title, _) in &groups {
+            assert_eq!(
+                panel
+                    .matches(&format!("TitledSeparator(\"{title}\")"))
+                    .count(),
+                1,
+                "diagnostics section {title:?} must be emitted exactly once"
+            );
+        }
+        let diag_ui = panel
+            .split_once("// @generated:diag-ui:begin")
+            .and_then(|(_, rest)| rest.split_once("// @generated:diag-ui:end"))
+            .expect("the diagnostics UI block")
+            .0;
         assert_eq!(
-            names.len(),
+            diag_ui.matches("ReflowingGrid(").count(),
             groups.len(),
-            "each generated diagnostics section needs a distinct Kotlin local variable"
+            "one reflowing grid per diagnostics section"
+        );
+        // A fixed column count is what made the page wider than any settings
+        // pane and pushed its right-hand columns out of reach.
+        assert!(
+            !panel.contains("GridLayout("),
+            "the settings page must not lay checkboxes out in a fixed number of columns"
         );
     }
 

--- a/rust/xtask/src/gen_vscode_package.rs
+++ b/rust/xtask/src/gen_vscode_package.rs
@@ -36,7 +36,11 @@ use std::process::ExitCode;
 
 use anyhow::{Context, Result};
 use serde_json::{Map, Value, json};
+use tcl_compiler::optimiser::profiles::{DEFAULT_EDITOR_PROFILE, OptimisationProfile};
 use tcl_core_types::{DiagCode, DocRow};
+
+/// The profile tiers every editor's picker is built from.
+const PROFILES: [OptimisationProfile; OptimisationProfile::ALL.len()] = OptimisationProfile::ALL;
 
 use crate::util::{repo_root, write_if_changed};
 
@@ -320,15 +324,15 @@ fn optimiser_section(order: usize) -> Value {
             "tclLsp.optimiser.profile",
             json!({
                 "type": "string",
-                "enum": ["off", "readability", "standard", "full", "aggressive"],
-                "default": "readability",
-                "enumDescriptions": [
-                    "All optimisations disabled.",
-                    "Readability improvements only — idiomatic rewrites, no code removal.",
-                    "Readability + constant folding and pattern recognition.",
-                    "All optimisations enabled (single pass).",
-                    "All optimisations with multi-pass to fixpoint.",
-                ],
+                // Both lists come from `OptimisationProfile::ALL`, the same
+                // constant the JetBrains picker is generated from, so a new
+                // tier reaches every editor or none.
+                "enum": PROFILES.iter().map(|p| p.name()).collect::<Vec<_>>(),
+                "default": DEFAULT_EDITOR_PROFILE.name(),
+                "enumDescriptions": PROFILES
+                    .iter()
+                    .map(|p| p.description())
+                    .collect::<Vec<_>>(),
                 "markdownDescription": "Optimisation profile controlling which passes run as diagnostics. Individual `O1xx` toggles below override the profile when explicitly set.",
                 "order": 1,
             })


### PR DESCRIPTION
## Summary

- Fixes the three defects reported against the JetBrains plugin: no syntax highlighting, the Compiler Explorer failing to open, and a settings page that could not scroll and ran off the right edge.
- Adds native editor panes for the Compiler Explorer's linear views, with a per-line map back into the source, so find, folding, the colour scheme and the caret all work in them. The genuinely graphical panes (CFG routed edges, WASM branch lanes, optimiser-diff connectors) stay in the tool window, which keeps `explorer-compiler-coverage.md`'s web-renderer requirement intact.
- Raises the JetBrains build floor to `253` and migrates the descriptor off the deprecated flat getters to `LspCustomization`. **This drops IntelliJ 2024.1–2025.2 users** — see *Compatibility* below.
- Drops Monaco and the ~21 MB wasm `lsp/` tree from the VSIX and the plugin. Neither host has loaded Monaco since `nativeEditorHost.ts`; both artefacts shipped it anyway.
- Makes the optimiser profile generate from one source for every editor, and gives JetBrains the profile selector it never had.
- Tells the truth about which LSP features a JetBrains IDE actually requests, in the settings panel, the README and the marketplace description.

### Root causes, briefly

**Highlighting** — the grammar shipped but nothing registered it. Three registrations are load-bearing together: a `textmate.bundleProvider`, a `lang.syntaxHighlighterFactory`, and the bundle unpacked to a real directory (the TextMate reader needs a filesystem path, not a jar entry).

**Compiler Explorer** — `compilerExplorer.html` was never in the plugin jar. The build extracted it best-effort and swallowed the failure, so every release shipped without it. Extraction is now a hard failure, with `verify-jetbrains-resources` as the gate.

**Semantic tokens** — `getClientCapabilities()` at 243 has exactly one branch in the whole method, an `ifnull` on `getLspSemanticTokensSupport()`. Every other capability is set unconditionally. The default is `null`, so without an override the IDE advertises nothing and never asks.

**O102 appearing in a stock CLion** — the plugin declared every per-code optimiser override as `Boolean = true` and pushed all 31 on each configuration change. Server-side a per-code `true` *removes* that code from the profile's disabled set, so the plugin force-enabled every optimisation the `readability` profile deliberately switches off. Overrides are now `Boolean?` behind a tri-state control, matching VS Code's `["boolean", "null"]`.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

```
make prep-pr                      # green on the merged tree (exit 0)
cd editors/jetbrains && ./gradlew test
cd editors/jetbrains && ./gradlew verifyPlugin
cd rust/tcl-spec-studio/web && npm test && npm run typecheck && npm run lint
cargo test -p tcl-lsp-server --test e2e
cargo test -p tcl-compiler --lib profiles::
cargo run -p xtask -- gen-vscode-package --check
cargo run -p xtask -- gen-jetbrains-catalog --check
```

Plugin verifier, run against the branch: **Compatible** with zero problems on IU-253.33813.55 (the new floor), IU-262.10315.125 and CL-262.10315.131. CLion is the target that matters most here — it is the product from #1780 where JCEF sits behind the bundled Web Browser plugin, which is the environment the explorer failed to load in.

`gen-vscode-package` output is byte-identical after the profile change: the generator now derives what it previously hardcoded.

New tests: explorer projection line-map coverage, a pack reload triggering `workspace/semanticTokens/refresh` (verified to fail without the fix), the rename collision gate's negative cases, the JetBrains diagnostics presentation, TextMate bundle unpacking, `ReflowingGrid`, and a profile round-trip that fails if a tier is added without reaching every editor.

## Compiler / diagnostics checklist

- [x] Did this change alter a compiler fact contract? Yes — `range_dict` now emits UTF-16 line/column alongside the existing byte fields.
- [x] If yes, I updated the owning design doc: `docs/design/contracts/explorer-compiler-coverage.md` and `docs/design/contracts/command-spec-studio.md`.
- [x] If I added or changed a diagnostic or optimisation code — no codes were added, changed or renumbered. O102's behaviour is unchanged; only how JetBrains *presents* diagnostics changed, and only client-side.
- [x] If I added a design doc, I linked it from `docs/design/README.md` — no new design docs.

### The offset fix

`range_dict`'s columns and offsets are **bytes** (`LineIndex::position_at` returns `ByteCol`, which agrees with LSP only for ASCII), and both hosts fed them straight into UTF-16 APIs. Harmless on ASCII, wrong on anything else, and native panes make it far more visible. `position_at_utf16` already existed and `tcl-explorer` never called it. Both hosts now consume the UTF-16 fields; the byte fields are unchanged for existing consumers.

## Compatibility

`sinceBuild` moves `241` → `253`, so **IntelliJ 2024.1, 2024.2, 2024.3, 2025.1 and 2025.2 stop receiving plugin updates.** Semantic tokens is the one capability that genuinely required it: it is the sole opt-in in `getClientCapabilities()`, and overriding it needs the symbol to resolve at class-load. 253 additionally lets the descriptor adopt `LspCustomization`, which is what makes the new diagnostics presentation possible.

Existing users' optimiser settings are unaffected: the platform only persists non-default values, and nothing was stored while the per-code default was `true`, so they move to inheriting from the profile.

## Related

Closes #1921, closes #1922, closes #1923.
Found along the way and filed separately, not fixed here: #1931 (Spec Studio has no per-document dialect seam), #1934 (O102 fires on `incr a`), #1935 (a rename refused against a variable in no document).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LpDBn11ye5zAxJsWi5CQmG

---
_Generated by [Claude Code](https://claude.ai/code/session_01LpDBn11ye5zAxJsWi5CQmG)_