### PR TITLE
Pin one document to a dialect without re-tagging the session (#1931)

### DIFF
--- a/docs/design/contracts/dialect-detection.md
+++ b/docs/design/contracts/dialect-detection.md
@@ -15,6 +15,7 @@ fails — it returns `default` when nothing fires.
 
 | Priority | Source | Example |
 |----------|--------|---------|
+| −1 | **Per-document override** | `tcl-lsp.setDocumentDialectOverride(uri, dialect)` — a host naming one exact URI, above everything including the language id |
 | 0 | **Editor language ID / explicit `--dialect`** | Applied by the *caller*, above `detect_dialect`, and overrides everything below |
 | 1 | **Comment directive** | `# tcl-dialect: tcl8.4` in the first 5 lines (`DIALECT_DIRECTIVE_SCAN_LINES`) |
 | 2 | **Shebang** | `#!/usr/bin/env tclsh8.5` or `#!/usr/bin/expect` (first line only) |
@@ -121,6 +122,26 @@ specific dialect and falls through to the next tier. So does a version this
 project does not model (`tclsh8.3`, `tclsh9.2`) — an unmodelled version is an
 abstention, not an error.
 
+## Per-document override (`tcl-lsp.setDocumentDialectOverride`)
+
+`workspace/executeCommand` with `["file:///…/test.tcl", "f5-irules"]` pins one
+document to a dialect; a `null` or absent second argument releases it. The
+override is held in `Backend::document_dialect_overrides`, keyed by URI string,
+and consulted at the very top of `Backend::dialect_for_open_sync` — ahead of
+the language id, the BIG-IP basename and the in-source directive. It survives a
+`didClose`, because the entry belongs to the host session that installed it
+rather than to any one open/close cycle.
+
+It is the strongest tier deliberately. The two older dialect commands
+(`tcl-lsp.setDialect`, `tcl-lsp.setSessionDialectOverride`) are session-global,
+so a host using either to re-tag a *single* buffer re-tags every other open
+buffer with it — the behaviour #1217 moved away from. The Spec Studio's dialect
+selector is the first caller: its sample surface is always materialised as
+`test.tcl`, so without a per-document seam the server resolves it as generic
+Tcl however the selector is set, and a pack whose commands only exist in
+another dialect shows nothing in the very buffer the studio exists to give
+feedback on (issue #1931).
+
 ## User setting (`tclLsp.dialect`)
 
 This setting acts as the default dialect for files that have no per-file
@@ -167,6 +188,7 @@ Dialect is re-evaluated when:
 - Any of the first 5 lines of the active document are edited (covers both
   shebang and comment directive changes).
 - The `tclLsp.dialect` setting changes.
+- A per-document override is installed or released (that one document only).
 
 ## Editor language ID mapping
 

--- a/docs/kcs/features/kcs-feature-dialect-selection.md
+++ b/docs/kcs/features/kcs-feature-dialect-selection.md
@@ -29,6 +29,16 @@ MCP, all-editors
 
 ## Operational context
 
+A host can also pin **one document** to a dialect, without disturbing any other
+buffer, by calling `tcl-lsp.setDocumentDialectOverride` with the document's URI
+and a dialect name (a `null` or absent second argument releases it). That
+override is the strongest tier — above the language id and the
+`# tcl-dialect:` comment — because a host that names one exact URI has already
+decided. The Spec Studio uses it so its sample buffer follows the studio's own
+dialect selector; the two older commands (`tcl-lsp.setDialect`,
+`tcl-lsp.setSessionDialectOverride`) are session-wide and would re-tag every
+open buffer instead.
+
 The dialect controls which commands are available in completions and hover, which diagnostic rules apply, and which event metadata is loaded. iRules dialects enable iRules-specific commands (HTTP::, IP::, etc.) and event handlers.
 
 ## Failure modes

--- a/docs/kcs/features/kcs-feature-spec-studio.md
+++ b/docs/kcs/features/kcs-feature-spec-studio.md
@@ -441,6 +441,16 @@ are exactly what you would get in VS Code, Neovim, or JetBrains. The
 **Test** tab's Tcl sample gets the same treatment, opened under whichever
 dialect the selector at the top of the page names.
 
+That holds in the editor panes too. When the studio runs inside VS Code or
+JetBrains its sample is materialised as a real `test.tcl` under
+`.tcl-lsp/.spec-studio/`, which the language server would otherwise resolve as
+generic Tcl however the selector is set — so a pack whose commands only exist
+in, say, `f5-irules` would show no highlighting, completion or hover in the one
+buffer you are testing it with. Changing the selector now pins that document to
+the chosen dialect through `tcl-lsp.setDocumentDialectOverride`, and closing the
+studio releases it. Only the sample is pinned: every other buffer you have open
+keeps the dialect it resolved on its own (issue #1931).
+
 The status line under the editor says what is running. If the language
 server cannot start — an old browser, WebAssembly turned off, the page
 opened from `file://` — the page says so and falls back to a plain text

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/SpecStudioToolWindowFactory.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/SpecStudioToolWindowFactory.kt
@@ -18,6 +18,7 @@ import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowFactory
+import com.intellij.platform.lsp.api.LspServer
 import com.intellij.platform.lsp.api.LspServerManager
 import com.intellij.platform.lsp.api.LspServerState
 import com.intellij.ui.content.ContentFactory
@@ -27,6 +28,7 @@ import com.intellij.ui.jcef.JBCefJSQuery
 import org.cef.browser.CefBrowser
 import org.cef.handler.CefLoadHandlerAdapter
 import org.eclipse.lsp4j.DidChangeWatchedFilesParams
+import org.eclipse.lsp4j.ExecuteCommandParams
 import org.eclipse.lsp4j.FileChangeType
 import org.eclipse.lsp4j.FileEvent
 import java.nio.file.Files
@@ -106,6 +108,7 @@ internal class SpecStudioPanel(private val project: Project) : Disposable {
                     materialise(surface!!, message["text"] as String)
                 }
                 "openSurface" -> if (surface in paths) openSurface(surface!!)
+                "dialectUpdate" -> applySampleDialect(message["dialect"] as? String)
             }
         } catch (error: Exception) {
             SPEC_LOG.warn("Could not handle Spec Studio message", error)
@@ -150,6 +153,41 @@ internal class SpecStudioPanel(private val project: Project) : Disposable {
         )
     }
 
+    /**
+     * Pin the sample surface to the studio's selected dialect, or release it
+     * when [dialect] is null.
+     *
+     * The sample is always materialised as `test.tcl`, so without this the
+     * server resolves it as generic Tcl however the studio's selector is set,
+     * and a pack whose commands only exist in another dialect shows no
+     * highlighting, completion or hover in the very buffer the studio exists
+     * to give feedback on.  The per-document override is the seam that leaves
+     * every other open buffer alone, unlike the two session-global dialect
+     * commands (issue #1931).
+     */
+    @Suppress("UnstableApiUsage")
+    private fun applySampleDialect(dialect: String?) {
+        val uri = paths.getValue("sample").toUri().toString()
+        // Releasing sends the URI alone rather than a null second argument:
+        // the server reads an absent dialect as a clear, and this keeps the
+        // argument list free of nulls across the Gson boundary.
+        val args: List<Any> = if (dialect == null) listOf(uri) else listOf(uri, dialect)
+        ApplicationManager.getApplication().executeOnPooledThread {
+            val server = LspServerManager.getInstance(project)
+                .getServersForProvider(TclLspServerSupportProvider::class.java)
+                .firstOrNull { it.state == LspServerState.Running } ?: return@executeOnPooledThread
+            try {
+                server.sendRequestSync(LspServer.DEFAULT_REQUEST_TIMEOUT_MS) { lsp4j ->
+                    lsp4j.workspaceService.executeCommand(
+                        ExecuteCommandParams("tcl-lsp.setDocumentDialectOverride", args)
+                    )
+                }
+            } catch (error: Exception) {
+                SPEC_LOG.warn("Could not set the Spec Studio sample dialect", error)
+            }
+        }
+    }
+
     @Suppress("UnstableApiUsage")
     private fun notifyPack(path: Path, type: FileChangeType) {
         ApplicationManager.getApplication().executeOnPooledThread {
@@ -167,6 +205,7 @@ internal class SpecStudioPanel(private val project: Project) : Disposable {
     override fun dispose() {
         if (disposed) return
         disposed = true
+        applySampleDialect(null)
         val pack = paths.getValue("dsl")
         val existed = Files.exists(pack)
         ApplicationManager.getApplication().executeOnPooledThread {

--- a/editors/vscode/src/specStudio.ts
+++ b/editors/vscode/src/specStudio.ts
@@ -126,6 +126,33 @@ class SpecStudioSession implements vscode.Disposable {
     }
     if (message.type === "surfaceUpdate" && message.surface && typeof message.text === "string") {
       await this.writeSurface(message.surface, message.text);
+      return;
+    }
+    if (message.type === "dialectUpdate") {
+      await this.applySampleDialect(message.dialect);
+    }
+  }
+
+  /**
+   * Pin the sample surface to the studio's selected dialect.
+   *
+   * The sample is always materialised as `test.tcl`, so without this the
+   * server resolves it as generic Tcl however the studio's selector is set,
+   * and a pack whose commands only exist in another dialect shows no
+   * highlighting, completion or hover in the very buffer the studio exists to
+   * give feedback on. The per-document override is the seam that does not
+   * disturb any other open buffer, unlike the two session-global dialect
+   * commands (issue #1931).
+   */
+  private async applySampleDialect(dialect: string | undefined): Promise<void> {
+    const uri = this.documents.get("sample")!;
+    try {
+      await this.client.sendRequest("workspace/executeCommand", {
+        command: "tcl-lsp.setDocumentDialectOverride",
+        arguments: [uri.toString(), dialect ?? null],
+      });
+    } catch (error) {
+      console.error("[spec-studio] could not set the sample document dialect", error);
     }
   }
 
@@ -198,6 +225,7 @@ class SpecStudioSession implements vscode.Disposable {
     this.disposed = true;
     for (const timer of this.saveTimers.values()) clearTimeout(timer);
     for (const subscription of this.subscriptions.splice(0)) subscription.dispose();
+    void this.applySampleDialect(undefined);
     const pack = this.documents.get("dsl")!;
     const packExisted = fs.existsSync(pack.fsPath);
     void vscode.workspace.fs.delete(this.sessionDir, { recursive: true, useTrash: false }).then(

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -6442,6 +6442,24 @@ pub struct Backend {
     /// setting one changes nothing about which documents it can reach; it only
     /// changes how long it lasts.
     session_dialect_override: Mutex<Option<String>>,
+    /// Deliberate per-document dialect overrides, keyed by document URI
+    /// string, installed by `tcl-lsp.setDocumentDialectOverride`.
+    ///
+    /// The strongest tier in the ladder: a host that names a URI and a dialect
+    /// outright has made a choice no inference should second-guess, so this is
+    /// consulted ahead of the language id, the BIG-IP basename, and the
+    /// in-source `# tcl-dialect:` directive.  Every other override is either
+    /// session-wide ([`Backend::session_dialect_override`]) or folder-wide
+    /// ([`Backend::folder_dialects`]); re-tagging one buffer through either of
+    /// those re-tags every other buffer with it, which is exactly what
+    /// #1217 moved away from (issue #1931).
+    ///
+    /// Keyed by URI *string* rather than [`Uri`], matching how
+    /// `folder_dialect_for` compares folder URIs.  Survives a document
+    /// retirement: the entry belongs to the host session that installed it
+    /// (the Spec Studio panel), not to any one `didOpen`/`didClose` cycle, and
+    /// is removed only by a `null` argument to the command that set it.
+    document_dialect_overrides: Mutex<HashMap<String, String>>,
     /// Coalescing state for `workspace/didChangeConfiguration` — see
     /// [`Backend::coalesced_config_reload`].
     config_reload: Mutex<ConfigReloadSlot>,
@@ -8077,6 +8095,7 @@ impl Backend {
             default_dialect: Mutex::new("tcl8.6".to_owned()),
             default_dialect_explicit: Mutex::new(false),
             session_dialect_override: Mutex::new(None),
+            document_dialect_overrides: Mutex::new(HashMap::new()),
             config_reload: Mutex::new(ConfigReloadSlot::default()),
             workspace_folders: Mutex::new(Vec::new()),
             folder_dialects: Mutex::new(Vec::new()),
@@ -9907,6 +9926,22 @@ impl Backend {
         }
     }
 
+    /// Re-resolve one open document's dialect after a change that can only
+    /// affect it (a per-document override). Marking just this document keeps a
+    /// pinned buffer from disturbing every other one, which is the whole point
+    /// of the per-document tier.
+    async fn reresolve_open_document_dialect(&self, uri: &Uri) {
+        {
+            let mut docs = self.documents.lock("reresolve_open_document_dialect").await;
+            let Some(doc) = docs.get_mut(uri) else {
+                return;
+            };
+            doc.mark_dialect_resolution_dirty();
+        }
+        self.resolve_dirty_open_document_dialect(uri, "reresolve_open_document_dialect")
+            .await;
+    }
+
     /// Re-resolve every open document's dialect after a session/folder-default
     /// change. Mark all documents first so a concurrent edit carries the work
     /// forward; each resolver then retries until it consumes the exact current
@@ -10343,6 +10378,11 @@ impl Backend {
     ///
     /// Resolution order:
     ///
+    /// 0. A deliberate per-document override installed by
+    ///    `tcl-lsp.setDocumentDialectOverride`
+    ///    ([`Backend::document_dialect_overrides`]) — a host naming this exact
+    ///    URI outranks every inference below, including the in-source
+    ///    directive (issue #1931).
     /// 1. The LSP ``languageId`` field — when it names a known
     ///    dialect (``"tcl-irule"`` / ``"f5-irules"`` / ``"tcl90"`` /
     ///    ``"tcl9.0"`` / etc.), use it directly.
@@ -10357,9 +10397,33 @@ impl Backend {
     ///    dialect.
     /// 4. The session-wide ``default_dialect`` fallback.
     async fn dialect_for_open(&self, uri: &Uri, language_id: &str, text: &str) -> String {
+        let document_override = self.document_dialect_override(uri).await;
         let folder_dialects = self.folder_dialect_overrides().await;
         let default_dialect = self.session_dialect().await;
-        Self::dialect_for_open_sync(uri, language_id, text, &folder_dialects, &default_dialect)
+        Self::dialect_for_open_sync(
+            uri,
+            language_id,
+            text,
+            document_override.as_deref(),
+            &folder_dialects,
+            &default_dialect,
+        )
+    }
+
+    /// The deliberate per-document dialect in force for `uri`, if a host
+    /// installed one with `tcl-lsp.setDocumentDialectOverride`.
+    async fn document_dialect_override(&self, uri: &Uri) -> Option<String> {
+        self.document_dialect_overrides
+            .lock()
+            .await
+            .get(uri.as_str())
+            .cloned()
+    }
+
+    /// One snapshot of every per-document override, for a caller resolving
+    /// many URIs off-lock (the watched-files batch reindex, #1161).
+    async fn document_dialect_override_snapshot(&self) -> Arc<HashMap<String, String>> {
+        Arc::new(self.document_dialect_overrides.lock().await.clone())
     }
 
     /// The session-wide fallback dialect: the deliberate
@@ -10423,6 +10487,11 @@ impl Backend {
     ///
     /// Resolution order:
     ///
+    /// 0. A deliberate per-document override installed by
+    ///    `tcl-lsp.setDocumentDialectOverride`
+    ///    ([`Backend::document_dialect_overrides`]) — a host naming this exact
+    ///    URI outranks every inference below, including the in-source
+    ///    directive (issue #1931).
     /// 1. The LSP ``languageId`` field — when it names a known
     ///    dialect (``"tcl-irule"`` / ``"f5-irules"`` / ``"tcl90"`` /
     ///    ``"tcl9.0"`` / etc.), use it directly.
@@ -10440,9 +10509,15 @@ impl Backend {
         uri: &Uri,
         language_id: &str,
         text: &str,
+        document_override: Option<&str>,
         folder_dialects: &[(Uri, String)],
         default_dialect: &str,
     ) -> String {
+        // A host that named this URI outright has already decided; nothing
+        // inferred from the id, the basename or the text may overrule it.
+        if let Some(dialect) = document_override {
+            return dialect.to_owned();
+        }
         // An explicit BIG-IP language id (`tcl-bigip`, advertised by the VS
         // Code extension, or the canonical `f5-bigip`) selects the BIG-IP
         // config dialect even when the basename is not a canonical
@@ -11424,6 +11499,7 @@ impl Backend {
     async fn scan_disk_file(
         store: &Arc<dyn vfs::SourceStore>,
         uri: Uri,
+        document_overrides: Arc<HashMap<String, String>>,
         folder_dialects: Arc<Vec<(Uri, String)>>,
         default_dialect: Arc<String>,
         resource: Arc<ResourceAnalyserInputs>,
@@ -11442,8 +11518,13 @@ impl Backend {
             // the index with nothing said about it.
             let (raw, _) = store.read_source(&path).ok()?;
             let text = tcl_lexer::normalise_lone_cr(&raw).into_owned();
-            let dialect =
-                Self::dialect_for_closed_sync(&uri, &text, &folder_dialects, &default_dialect);
+            let dialect = Self::dialect_for_closed_sync(
+                &uri,
+                &text,
+                document_overrides.get(uri.as_str()).map(String::as_str),
+                &folder_dialects,
+                &default_dialect,
+            );
             // The declared edges belong here as much as on the interactive
             // path: this analysis becomes the file's *index* entry, and
             // `workspace_index` harvests `package_requires` from it. Without
@@ -11485,6 +11566,7 @@ impl Backend {
         if uris.is_empty() {
             return;
         }
+        let document_overrides = self.document_dialect_override_snapshot().await;
         let folder_dialects = Arc::new(self.folder_dialect_overrides().await);
         let default_dialect = Arc::new(self.session_dialect().await);
         // No document in hand: this batch spans folders, so the global values
@@ -11496,6 +11578,7 @@ impl Backend {
             .iter()
             .cloned()
             .map(|uri| {
+                let document_overrides = Arc::clone(&document_overrides);
                 let folder_dialects = Arc::clone(&folder_dialects);
                 let default_dialect = Arc::clone(&default_dialect);
                 let store = Arc::clone(&self.store);
@@ -11504,6 +11587,7 @@ impl Backend {
                     let scanned = Self::scan_disk_file(
                         &store,
                         uri.clone(),
+                        document_overrides,
                         folder_dialects,
                         default_dialect,
                         resource,
@@ -11541,12 +11625,14 @@ impl Backend {
         // same on-disk population as the workspace index, so a proc defined in
         // a closed/never-opened file still suppresses W123 / drives the arity
         // error in its siblings.
+        let document_overrides = self.document_dialect_override_snapshot().await;
         let folder_dialects = Arc::new(self.folder_dialect_overrides().await);
         let default_dialect = Arc::new(self.session_dialect().await);
         let resource = Arc::new(self.resource_analyser_inputs(Some(uri)).await);
         let scanned = Self::scan_disk_file(
             &self.store,
             uri.clone(),
+            document_overrides,
             folder_dialects,
             default_dialect,
             resource,
@@ -11681,11 +11767,19 @@ impl Backend {
     fn dialect_for_closed_sync(
         uri: &Uri,
         text: &str,
+        document_override: Option<&str>,
         folder_dialects: &[(Uri, String)],
         default_dialect: &str,
     ) -> String {
         let language_id = tcl_registry::dialect_from_extension(uri.as_str()).unwrap_or("tcl");
-        Self::dialect_for_open_sync(uri, language_id, text, folder_dialects, default_dialect)
+        Self::dialect_for_open_sync(
+            uri,
+            language_id,
+            text,
+            document_override,
+            folder_dialects,
+            default_dialect,
+        )
     }
 
     /// Bump and return `uri`'s closed-file diagnostics generation (#865). Each
@@ -11783,6 +11877,9 @@ impl Backend {
             closed_diag_gen: _,
             closed_diag_order: _,
             semantic_tokens_convergence: _,
+            // Owned by the host session that installed it, not by any one
+            // document lifetime — cleared only by the command that set it.
+            document_dialect_overrides: _,
             // Owned by the SpecTcl reload path: watch registrations track the
             // configured pack roots, not any document's lifetime.
             external_pack_watch_globs: _,
@@ -16480,6 +16577,68 @@ impl Backend {
         Ok(Some(
             serde_json::json!({ "success": true, "dialect": requested }),
         ))
+    }
+
+    /// Handle `tcl-lsp.setDocumentDialectOverride`: pin one document to a
+    /// dialect, or (with a `null` / absent second argument) release it.
+    ///
+    /// The per-document counterpart of
+    /// [`Self::set_session_dialect_override_command`], and the seam a host
+    /// needs when *one* buffer must differ from the session. Both existing
+    /// dialect commands are session-global, so a host using either to re-tag a
+    /// single buffer re-tags every other open buffer with it — the behaviour
+    /// #1217 deliberately moved away from. The Spec Studio's dialect selector
+    /// is the first caller: its sample surface is always materialised as
+    /// `test.tcl`, so without this the server resolves it as generic Tcl and a
+    /// pack whose commands only exist in, say, `f5-irules` shows no
+    /// highlighting, completion or hover in the very buffer the studio exists
+    /// to give feedback on (issue #1931).
+    ///
+    /// Arguments are `[uri, dialect]`; `dialect` absent or `null` clears.
+    /// Returns `{success, uri, dialect}` (`dialect: null` when cleared), or
+    /// `{success: false, error}` for a missing URI or an unknown dialect.
+    async fn set_document_dialect_override_command(
+        &self,
+        args: &[serde_json::Value],
+    ) -> jsonrpc::Result<Option<serde_json::Value>> {
+        let Some(uri_arg) = args.first().and_then(serde_json::Value::as_str) else {
+            return Ok(Some(serde_json::json!({
+                "success": false,
+                "error": "tcl-lsp.setDocumentDialectOverride needs a document URI as its first argument",
+            })));
+        };
+        let Ok(uri) = Uri::from_str(uri_arg) else {
+            return Ok(Some(serde_json::json!({
+                "success": false,
+                "error": format!("not a valid document URI: {uri_arg}"),
+            })));
+        };
+        let requested = args.get(1).and_then(serde_json::Value::as_str);
+        if let Some(dialect) = requested
+            && !is_known_dialect_name(dialect)
+        {
+            return Ok(Some(serde_json::json!({
+                "success": false,
+                "error": unknown_dialect_error(dialect),
+            })));
+        }
+        {
+            let mut overrides = self.document_dialect_overrides.lock().await;
+            match requested {
+                Some(dialect) => {
+                    overrides.insert(uri.as_str().to_owned(), dialect.to_owned());
+                }
+                None => {
+                    overrides.remove(uri.as_str());
+                }
+            }
+        }
+        self.reresolve_open_document_dialect(&uri).await;
+        Ok(Some(serde_json::json!({
+            "success": true,
+            "uri": uri.as_str(),
+            "dialect": requested,
+        })))
     }
 
     /// Handle `tcl-lsp.listDialects`: the dialect catalog as presentation data
@@ -23996,6 +24155,10 @@ impl LanguageServer for Backend {
                 self.set_session_dialect_override_command(&params.arguments)
                     .await
             }
+            "tcl-lsp.setDocumentDialectOverride" => {
+                self.set_document_dialect_override_command(&params.arguments)
+                    .await
+            }
             "tcl-lsp.compilerExplorer" => self.compiler_explorer_command(&params.arguments).await,
             "tcl-lsp.compilerExplorerView" => {
                 self.compiler_explorer_view_command(&params.arguments).await
@@ -28808,6 +28971,7 @@ fn build_server_capabilities(
                 "tcl-lsp.listDialects".to_owned(),
                 "tcl-lsp.setDialect".to_owned(),
                 "tcl-lsp.setSessionDialectOverride".to_owned(),
+                "tcl-lsp.setDocumentDialectOverride".to_owned(),
                 "tcl-lsp.compilerExplorer".to_owned(),
                 "tcl-lsp.compilerExplorerView".to_owned(),
                 "tcl-lsp.tkPreview".to_owned(),
@@ -33994,6 +34158,7 @@ mod tests {
             default_dialect: Mutex::new("tcl8.6".to_owned()),
             default_dialect_explicit: Mutex::new(false),
             session_dialect_override: Mutex::new(None),
+            document_dialect_overrides: Mutex::new(HashMap::new()),
             config_reload: Mutex::new(ConfigReloadSlot::default()),
             workspace_folders: Mutex::new(Vec::new()),
             folder_dialects: Mutex::new(Vec::new()),
@@ -36194,6 +36359,100 @@ mod tests {
             "tcl9.0",
             "an explicit language id must still outrank the session tier",
         );
+    }
+
+    /// Issue #1931: a per-document override is the strongest tier — stronger
+    /// than an explicit language id and than the in-source directive — and it
+    /// reaches only the document it names.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_document_dialect_override_outranks_every_inference() {
+        let backend = test_backend();
+        let sample = Uri::from_str("file:///studio/test.tcl").unwrap();
+        let sibling = Uri::from_str("file:///studio/other.tcl").unwrap();
+        backend
+            .set_document_dialect_override_command(&[
+                serde_json::json!(sample.as_str()),
+                serde_json::json!("f5-irules"),
+            ])
+            .await
+            .expect("override command");
+
+        assert_eq!(
+            backend.dialect_for_open(&sample, "tcl", "set x 1\n").await,
+            "f5-irules",
+            "the named document takes the override",
+        );
+        assert_eq!(
+            backend
+                .dialect_for_open(&sample, "tcl90", "set x 1\n")
+                .await,
+            "f5-irules",
+            "an explicit language id does not outrank a named document",
+        );
+        assert_eq!(
+            backend
+                .dialect_for_open(&sample, "tcl", "# tcl-dialect: tcl8.4\n")
+                .await,
+            "f5-irules",
+            "an in-source directive does not outrank a named document",
+        );
+        assert_eq!(
+            backend.dialect_for_open(&sibling, "tcl", "set x 1\n").await,
+            "tcl8.6",
+            "no other buffer is re-tagged — the whole point of the tier",
+        );
+    }
+
+    /// Clearing releases the document back to ordinary resolution.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_document_dialect_override_is_released_by_a_null_argument() {
+        let backend = test_backend();
+        let sample = Uri::from_str("file:///studio/test.tcl").unwrap();
+        backend
+            .set_document_dialect_override_command(&[
+                serde_json::json!(sample.as_str()),
+                serde_json::json!("f5-irules"),
+            ])
+            .await
+            .expect("override command");
+        assert_eq!(
+            backend.dialect_for_open(&sample, "tcl", "set x 1\n").await,
+            "f5-irules",
+        );
+        backend
+            .set_document_dialect_override_command(&[serde_json::json!(sample.as_str())])
+            .await
+            .expect("clear command");
+        assert_eq!(
+            backend.dialect_for_open(&sample, "tcl", "set x 1\n").await,
+            "tcl8.6",
+            "a cleared document resolves normally again",
+        );
+        assert!(backend.document_dialect_overrides.lock().await.is_empty());
+    }
+
+    /// A missing URI and an unknown dialect are both reported rather than
+    /// installed.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_document_dialect_override_rejects_bad_arguments() {
+        let backend = test_backend();
+        let missing_uri = backend
+            .set_document_dialect_override_command(&[])
+            .await
+            .expect("command")
+            .expect("a reply");
+        assert_eq!(missing_uri["success"], serde_json::json!(false));
+
+        let unknown = backend
+            .set_document_dialect_override_command(&[
+                serde_json::json!("file:///studio/test.tcl"),
+                serde_json::json!("tcl99"),
+            ])
+            .await
+            .expect("command")
+            .expect("a reply");
+        assert_eq!(unknown["success"], serde_json::json!(false), "{unknown}");
+        assert!(backend.document_dialect_overrides.lock().await.is_empty());
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/rust/tcl-lsp-server/tests/e2e/config.rs
+++ b/rust/tcl-lsp-server/tests/e2e/config.rs
@@ -692,6 +692,66 @@ fn a_session_dialect_override_outlives_a_config_pull() {
     assert_eq!(cfg["session_dialect_override"], Value::Null, "{cfg}");
 }
 
+/// Issue #1931: a per-document override reaches only the document it names,
+/// and outranks every inference — including an explicit language id.
+///
+/// The Spec Studio's sample surface is always materialised as `test.tcl`, so
+/// without a per-document seam the server resolves it as generic Tcl however
+/// the studio's dialect selector is set. Both session-wide dialect commands
+/// would re-tag every other open buffer instead, which is what #1217 moved
+/// away from.
+#[test]
+fn a_document_dialect_override_reaches_only_the_document_it_names() {
+    let sample = unique_uri("studio-sample");
+    let sibling = unique_uri("studio-sibling");
+    let mut lsp = Lsp::tcl();
+    lsp.open_ready(&sample, "set x 1\n");
+    lsp.open_ready(&sibling, "set x 1\n");
+    lsp.apply_configuration_settle(json!({ "dialect": "tcl8.6" }), "", |cfg| {
+        cfg["dialect"] == json!("tcl8.6")
+    });
+
+    let set = lsp.execute_command(
+        "tcl-lsp.setDocumentDialectOverride",
+        json!([sample.clone(), "f5-irules"]),
+    );
+    assert_eq!(set["success"], json!(true), "{set}");
+
+    let pinned = lsp.effective_config(&sample);
+    assert_eq!(pinned["dialect"], json!("f5-irules"), "{pinned}");
+    let untouched = lsp.effective_config(&sibling);
+    assert_eq!(
+        untouched["dialect"],
+        json!("tcl8.6"),
+        "no other buffer may be re-tagged: {untouched}"
+    );
+    // The session tier is not what carried it.
+    assert_eq!(pinned["session_dialect_override"], Value::Null, "{pinned}");
+
+    let cleared = lsp.execute_command(
+        "tcl-lsp.setDocumentDialectOverride",
+        json!([sample.clone(), Value::Null]),
+    );
+    assert_eq!(cleared["success"], json!(true), "{cleared}");
+    let released = lsp.effective_config(&sample);
+    assert_eq!(released["dialect"], json!("tcl8.6"), "{released}");
+}
+
+/// An unknown dialect is reported rather than installed.
+#[test]
+fn a_document_dialect_override_rejects_an_unknown_dialect() {
+    let uri = unique_uri("studio-sample");
+    let mut lsp = Lsp::tcl();
+    lsp.open_ready(&uri, "set x 1\n");
+    let reply = lsp.execute_command(
+        "tcl-lsp.setDocumentDialectOverride",
+        json!([uri.clone(), "tcl99"]),
+    );
+    assert_eq!(reply["success"], json!(false), "{reply}");
+    let cfg = lsp.effective_config(&uri);
+    assert_eq!(cfg["dialect"], json!("tcl8.6"), "{cfg}");
+}
+
 /// Issue #1213: a burst of `didChangeConfiguration` notifications must produce
 /// **one** `workspace/configuration` pull, not one per notification.
 ///


### PR DESCRIPTION
## Summary

- Add `tcl-lsp.setDocumentDialectOverride(uri, dialect | null)`: the per-document dialect seam the Spec Studio's selector needs, and the first tier in the resolution ladder that reaches exactly one buffer.
- Wire both native editor hosts to the `dialectUpdate` message the studio has been posting all along, and release the override when the studio session is disposed.

Closes #1931.

### Why a new tier rather than the existing commands

`tcl-lsp.setDialect` and `tcl-lsp.setSessionDialectOverride` are both session-global. Using either to re-tag the studio's sample buffer re-tags every other open Tcl buffer with it — precisely the behaviour #1217 moved away from, and the reason `dialectUpdate` was left unhandled rather than wired to one of them.

The studio's sample surface is always materialised as `test.tcl`, so today the server resolves it as generic Tcl however the selector is set: a pack whose commands only exist in, say, `f5-irules` shows no highlighting, completion or hover in the very buffer the studio exists to give feedback on.

### Where it sits in the ladder

Above everything, including the in-source `# tcl-dialect:` directive and an explicit `languageId`. A host that names one exact URI and one dialect has already decided; nothing inferred from the id, the basename or the text should overrule it. That is a stronger position than the session override (which only ever reaches the fallback tier), and it is deliberate — it is also what makes the override useful beyond the studio, anywhere one buffer must differ from its session.

The map is keyed by URI string (matching how `folder_dialect_for` compares folder URIs) and survives a `didClose`: the entry belongs to the host session that installed it, not to any one open/close cycle, so it is removed only by the command that set it.

Threaded through `dialect_for_open_sync` / `dialect_for_closed_sync`, so the interactive path, the single-file disk reindex and the watched-files batch reindex (#1161) all agree; the batch takes one snapshot rather than a lock round trip per file.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

```
cargo test -p tcl-lsp-server --lib document_dialect                    # 3 passed
cargo test -p tcl-lsp-server --test e2e a_document_dialect_override    # 2 passed
make prep-pr                                                          # exit 0
cargo fmt --all --check && cargo clippy -p tcl-lsp-server --all-targets   # clean
```

Tests added:

- `a_document_dialect_override_outranks_every_inference` — the named document takes the override over a generic id, an explicit `tcl90` id and a `# tcl-dialect: tcl8.4` directive; a sibling buffer is untouched.
- `a_document_dialect_override_is_released_by_a_null_argument`
- `a_document_dialect_override_rejects_bad_arguments` — missing URI, unknown dialect; neither installs anything.
- e2e `a_document_dialect_override_reaches_only_the_document_it_names` — over the real `workspace/executeCommand` surface, asserting through `getEffectiveConfig` that the sibling keeps `tcl8.6` and that the *session* override slot stayed `null`.
- e2e `a_document_dialect_override_rejects_an_unknown_dialect`.

**Not run locally: the JetBrains Kotlin suite.** `./gradlew test` cannot resolve its dependencies in this environment — Maven Central returns `429 Too Many Requests` through the egress proxy. The plugin change follows the compat rule `TclLspActionBase` documents (pass `LspServer.DEFAULT_REQUEST_TIMEOUT_MS` explicitly so Kotlin does not emit the `sendRequestSync$default` bridge that breaks on 2026.1+), and sends the URI alone when releasing so the argument list carries no nulls across the Gson boundary. The tag-only `build-jetbrains` job is the gate for it.

## Compiler / diagnostics checklist

- [x] Did this change alter a compiler fact contract? No — this is dialect *resolution*, not a compiler fact. The owning contract doc (`docs/design/contracts/dialect-detection.md`) gains the new tier, its rationale and its re-resolution trigger.
- [x] If I added or changed a diagnostic or optimisation code: none added.
- [x] If I added a design doc, I linked it: no new doc. Updated `dialect-detection.md`, `kcs-feature-dialect-selection.md`, and `kcs-feature-spec-studio.md` (whose claim that the Test tab's sample follows the selector was true only in the hosted studio, not in the editor panes — now true in both).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F6pDxCsXjcTW4A9rTTpQS7

---
_Generated by [Claude Code](https://claude.ai/code/session_01F6pDxCsXjcTW4A9rTTpQS7)_