### PR TITLE
fix(tclvm): distinguish undefined cells during unset

### DIFF
--- a/rust/tcl-vm/src/exec.rs
+++ b/rust/tcl-vm/src/exec.rs
@@ -2099,17 +2099,14 @@ impl Vm {
         key: &str,
         complain: bool,
     ) -> Result<(), Completion<Value>> {
-        if complain && self.get_array_elem(name, key).is_none() {
-            let what = if self.var_is_array(name) {
-                "no such element in array"
-            } else if self.exists_var(name) {
-                "variable isn't array"
-            } else {
-                "no such variable"
-            };
-            return Err(err(format!("can't unset \"{name}({key})\": {what}")));
+        let miss_reason = complain.then(|| self.array_element_unset_miss_reason(name));
+        let existed = self.array_unset_elem(name, key);
+        if !existed && let Some(what) = miss_reason {
+            return Err(crate::command::err_with_code(
+                format!("can't unset \"{name}({key})\": {what}"),
+                "TCL UNSET VARNAME",
+            ));
         }
-        self.array_unset_elem(name, key);
         Ok(())
     }
 

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -9207,15 +9207,10 @@ impl Vm {
         let Some(id) = resolved.id else {
             return false;
         };
-        let existed = self.var_arena.get(id).is_some_and(|cell| {
-            matches!(
-                cell.state(),
-                Local::Undefined | Local::Scalar(_) | Local::Array(_)
-            )
-        });
-        if !existed {
+        let Some(state) = self.var_arena.get(id).map(crate::vars::VarCell::state) else {
             return false;
-        }
+        };
+        let existed = matches!(state, Local::Scalar(_) | Local::Array(_));
         self.drop_array_descendant_traces(id);
         if matches!(
             self.var_arena.get(id).map(crate::vars::VarCell::state),
@@ -9679,16 +9674,13 @@ impl Vm {
         complain: bool,
     ) -> Result<(), Completion<Value>> {
         if let Some((array, key)) = elem_ref(name) {
+            let miss_reason = complain.then(|| self.array_element_unset_miss_reason(array));
             let existed = self.array_unset_elem_spelled(array, key);
-            if !existed && complain {
-                let what = if self.var_is_array(array) {
-                    "no such element in array"
-                } else if self.exists_var(array) {
-                    "variable isn't array"
-                } else {
-                    "no such variable"
-                };
-                return Err(err(format!("can't unset \"{name}\": {what}")));
+            if !existed && let Some(what) = miss_reason {
+                return Err(err_with_code(
+                    format!("can't unset \"{name}\": {what}"),
+                    "TCL UNSET VARNAME",
+                ));
             }
             return Ok(());
         }
@@ -9702,7 +9694,10 @@ impl Vm {
             return Ok(());
         }
         if !self.unset_var(name) && complain {
-            return Err(err(format!("can't unset \"{name}\": no such variable")));
+            return Err(err_with_code(
+                format!("can't unset \"{name}\": no such variable"),
+                "TCL UNSET VARNAME",
+            ));
         }
         Ok(())
     }
@@ -9762,7 +9757,7 @@ impl Vm {
     fn unbind_storage_resolved(&mut self, resolved: &ResolvedVar) -> bool {
         let id = resolved.id;
         let existed = self.unbind_resolved(resolved);
-        if existed && let Some(id) = id {
+        if let Some(id) = id {
             self.drop_var_traces(id);
         }
         existed
@@ -9783,6 +9778,20 @@ impl Vm {
             .and_then(|resolved| resolved.id)
             .and_then(|id| self.var_arena.get(id))
             .is_some_and(|cell| matches!(cell.state(), Local::Array(_)))
+    }
+
+    /// Classify an array-element unset miss before teardown starts. An unset
+    /// trace may delete or retype the parent array, but Tcl reports the lookup
+    /// failure that selected the original cell rather than the callback's
+    /// replacement state.
+    pub(crate) fn array_element_unset_miss_reason(&self, name: &str) -> &'static str {
+        if self.var_is_array(name) {
+            "no such element in array"
+        } else if self.exists_var(name) {
+            "variable isn't array"
+        } else {
+            "no such variable"
+        }
     }
 
     /// C's three-way read-miss message (`tclVar.c`): a scalar read of an array
@@ -10206,15 +10215,10 @@ impl Vm {
     }
 
     fn unbind_array_element(&mut self, base_id: VarId, key: &str, raw: VarId, id: VarId) -> bool {
-        let existed = self.var_arena.get(id).is_some_and(|cell| {
-            matches!(
-                cell.state(),
-                Local::Undefined | Local::Scalar(_) | Local::Array(_)
-            )
-        });
-        if !existed {
+        let Some(state) = self.var_arena.get(id).map(crate::vars::VarCell::state) else {
             return false;
-        }
+        };
+        let existed = matches!(state, Local::Scalar(_) | Local::Array(_));
         self.drop_array_descendant_traces(id);
         let _ = self.var_arena.unset_state(id);
         if matches!(
@@ -10223,12 +10227,12 @@ impl Vm {
         ) || self.var_arena.has_link_refs(id)
             || self.var_arena.has_operation_refs(id)
         {
-            return true;
+            return existed;
         }
         let _ = self.var_arena.array_remove(base_id, key);
         self.const_vars.remove(&id);
         self.var_arena.unbind(raw);
-        true
+        existed
     }
 
     fn resolve_array_elem_from(&self, start: usize, name: &str, key: &str) -> Option<ResolvedVar> {
@@ -10813,9 +10817,7 @@ impl VarStore for Vm {
 
     fn unset_elem(&mut self, frame: FrameId, name: &str, key: &str) -> bool {
         if frame.0 == self.current_level() {
-            let existed = self.get_array_elem(name, key).is_some();
-            self.array_unset_elem(name, key);
-            return existed;
+            return self.array_unset_elem(name, key);
         }
         self.unset_array_elem_from(frame.0, name, key)
     }
@@ -11951,6 +11953,27 @@ mod family_b_tests {
         assert!(vm.var_traces.is_empty());
         assert_eq!(vm.var_arena.len(), baseline + 1, "the empty array remains");
         assert_eq!(vm.array_keys(GLOBAL_FRAME, "a"), Some(Vec::new()));
+        vm.pop_call_frame();
+    }
+
+    #[test]
+    fn noncurrent_varstore_unset_reports_trace_only_cells_missing() {
+        let mut vm = Vm::new();
+        let baseline = vm.var_arena.len();
+        vm.add_var_trace("x", vec!["unset".to_owned()], "callback".to_owned(), false);
+        assert!(vm.ensure_array("a").is_ok());
+        vm.add_var_trace(
+            "a(k)",
+            vec!["unset".to_owned()],
+            "callback".to_owned(),
+            false,
+        );
+        vm.push_call_frame(Some("p".to_owned()), vec![Value::string("p")]);
+
+        assert!(!vm.unset(GLOBAL_FRAME, "x"));
+        assert!(!vm.unset_elem(GLOBAL_FRAME, "a", "k"));
+        assert!(vm.var_traces.is_empty());
+        assert_eq!(vm.var_arena.len(), baseline + 1, "the empty array remains");
         vm.pop_call_frame();
     }
 

--- a/rust/tcl-vm/tests/opcode_c_parity.rs
+++ b/rust/tcl-vm/tests/opcode_c_parity.rs
@@ -1457,6 +1457,48 @@ fn unset_array_complain_flag_errors() {
     assert_eq!(err_str(&c), "can't unset \"nope(k)\": no such variable");
 }
 
+#[test]
+fn unset_array_trace_only_miss_kind_precedes_callback_mutation() {
+    // Directly exercise unsetArray: Tcl 9.0.4 retains the missing-element
+    // lookup result even when its callback deletes or retypes the parent.
+    let cases = [
+        "unset -nocomplain ::a",
+        "unset -nocomplain ::a; set ::a scalar",
+    ];
+    for action in cases {
+        let mut vm = Vm::new();
+        vm.set_compiler(Box::new(compiler::svc()));
+        let setup = format!(
+            "set fired 0\n\
+             proc U {{action args}} {{incr ::fired; uplevel #0 $action}}\n\
+             array set a {{}}\n\
+             trace add variable a(missing) unset [list U {{{action}}}]\n"
+        );
+        let completion = vm.eval_source(&setup).expect("setup compiles");
+        assert_eq!(completion.code, Code::Ok, "setup failed for {action}");
+
+        let mut asm = Asm::new();
+        let slot = asm.slot("a");
+        asm.push("missing").op(Op::UNSET_ARRAY, &[1, slot]);
+        let completion = run(&mut vm, asm);
+        assert_eq!(
+            err_str(&completion),
+            "can't unset \"a(missing)\": no such element in array",
+            "callback action: {action}"
+        );
+        assert_eq!(
+            err_code(&completion),
+            "TCL UNSET VARNAME",
+            "callback action: {action}"
+        );
+        assert_eq!(
+            vm.get_var("fired").map(|value| value.to_str().to_string()),
+            Some("1".to_owned()),
+            "callback action: {action}"
+        );
+    }
+}
+
 // -- strfind / strrfind ----------------------------------------------------
 
 /// An **empty needle is a miss**. Both C helpers open with

--- a/rust/tcl-vm/tests/variable_trace_semantics_e2e.rs
+++ b/rust/tcl-vm/tests/variable_trace_semantics_e2e.rs
@@ -962,6 +962,56 @@ puts $events
 }
 
 #[test]
+fn unsetting_a_trace_only_array_element_fires_then_reports_it_missing() {
+    // Exact Tcl 9.0.4 transcript. A trace materialises the element's variable
+    // cell, but does not give it a value: unset tears the cell down and runs
+    // its callback before reporting that no element existed.
+    let script = r"
+proc U args {incr ::fired}
+proc P {} {
+    array set a {}
+    trace add variable a(missing) unset U
+    set code [catch {unset a(missing)} message options]
+    list $code $message [dict get $options -errorcode]
+}
+set fired 0
+puts [list [P] $fired]
+";
+    assert_eq!(
+        vm_output(script),
+        r#"{1 {can't unset "a(missing)": no such element in array} {TCL UNSET VARNAME}} 1"#
+    );
+}
+
+#[test]
+fn unset_element_miss_kind_survives_parent_mutation_in_its_callback() {
+    // Exact Tcl 9.0.4 transcript. The undefined element is selected before its
+    // callback runs, so deleting or retyping the parent cannot rewrite the
+    // pending lookup failure.
+    let script = r"
+proc U {action args} {
+    incr ::fired
+    uplevel #0 $action
+}
+set fired 0
+set outcomes {}
+array set a {}
+trace add variable a(missing) unset [list U {unset -nocomplain ::a}]
+set code [catch {unset a(missing)} message options]
+lappend outcomes [list $code $message [dict get $options -errorcode]]
+array set b {}
+trace add variable b(missing) unset [list U {unset -nocomplain ::b; set ::b scalar}]
+set code [catch {unset b(missing)} message options]
+lappend outcomes [list $code $message [dict get $options -errorcode]]
+puts [list $outcomes $fired $b]
+";
+    assert_eq!(
+        vm_output(script),
+        r#"{{1 {can't unset "a(missing)": no such element in array} {TCL UNSET VARNAME}} {1 {can't unset "b(missing)": no such element in array} {TCL UNSET VARNAME}}} 2 scalar"#
+    );
+}
+
+#[test]
 fn every_advertised_array_member_validates_arity_before_tracing() {
     // Exact Tcl 9.0.4 transcript for all seven members implemented by the VM.
     // The registry arity check precedes LocateArray, so none reaches its trace.


### PR DESCRIPTION
## Summary

- distinguish an addressable Undefined VarId cell from an existing Tcl scalar or array value
- run unset teardown and retire trace pins before reporting whether a value existed
- snapshot the Tcl lookup category before callbacks can delete or retype the parent array
- route generic, specialised array-element opcode, and non-current VarStore consumers through the same result
- attach Tcl 9.0.4 TCL UNSET VARNAME completion metadata to missing unsets

Closes #1948.

The separate source-aware unset codegen issue remains #1946.

## Tcl 9.0.4 coverage

The regressions prove that unsetting a trace-only undefined array element fires its callback once, returns catch code 1, reports no such element in array, and carries TCL UNSET VARNAME. Generic and direct UNSET_ARRAY cases preserve that pre-unset diagnosis even when the callback deletes the parent array or replaces it with a scalar.

## Validation

- make rust-check
- make prep-pr NPROC=1 — 30/30 smoke tests
- make test-spectcl-compat — SpecTcl 1.x/2.0 paths all green
- cargo test -p tcl-vm unset
- variable_trace_semantics_e2e
- direct opcode and non-current VarStore regressions
- cargo clippy -p tcl-vm --tests -- -D warnings