### PR TITLE
Use sites: a variable name is not an operand, and a nested conversion still counts (#1934, #1851)

### DIFF
--- a/docs/design/compiler/ssa-construction.md
+++ b/docs/design/compiler/ssa-construction.md
@@ -166,6 +166,37 @@ Phi nodes participate in def-use chains in two roles:
 - **As uses**: Each incoming edge `(pred_block, incoming_ver)` is a
   `UseKind::PhiIncoming` use of the incoming version.
 
+#### Operand uses and name uses are different facts
+
+A statement can reach a variable two ways, and the chains record which:
+
+| `UseKind` | shape | who counts it |
+|---|---|---|
+| `Operand` | a substituted `$a` word — `puts $a`, `expr {$a + 1}` | liveness **and** rewriting passes |
+| `VariableName` | a variable-*name* argument — `incr a`, `append a x`, `info exists a`, `unset a` | liveness only |
+
+Both are genuine reads: `incr a` really does read `a`, and dropping the use
+would make the feeding store look dead. What separates them is that a name
+position has **no word to rewrite**. A pass that splices a value over one
+destroys the statement — forwarding `a`'s reaching literal `1` into `incr a`
+leaves `1` in command position, which tclsh answers with `invalid command
+name "1"` (issue #1934).
+
+The classification is produced during the SSA scan as
+`ssa::UseClass::Name` — the registry's `ArgRole::VarRead` positions, its
+`READS_BEFORE_WRITE` targets, `DESTROYS_VARIABLE` targets, and
+`Statement::Incr`'s own target — carried on `SsaStatement::name_only_uses`
+and stamped onto the use site by `build_def_use_chains`. A name reached
+*both* ways in one statement (`lappend a $a`) is `Operand`: the definite
+operand is the stronger fact, the same way `Substituted` already outranks
+`Quoted`.
+
+The rule for a consumer is mechanical: match `Operand | VariableName`
+wherever the question is "is this value consumed", and match `Operand` alone
+wherever the question is "may I rewrite this use". `UseKind` is matched
+exhaustively everywhere it is consumed, so a new variant cannot be added
+without every consumer deciding.
+
 ### Memory-SSA for aliases
 
 Variables aliased into another frame or namespace — through `upvar`,

--- a/docs/kcs/codes/kcs-optimisation-o100-constant-propagation.md
+++ b/docs/kcs/codes/kcs-optimisation-o100-constant-propagation.md
@@ -33,6 +33,35 @@ set n 10
 expr {10 + 1}
 ```
 
+## Also: a constant proved at one particular read
+
+Most of O100 substitutes by *name*: it asks "is this variable always this
+constant", which is the only question a source rewrite keyed on a name can
+ask. That answer is unavailable for any variable reassigned to a different
+constant — a counter, most obviously.
+
+Where the read is reached through the def-use chains, O100 can ask the
+stronger, per-value question instead: "what did SCCP prove *this* read
+sees". That covers a definition which computes its value rather than
+writing one out:
+
+```tcl
+set a 1
+incr a
+puts "$a"
+```
+
+`incr` is not a load of `a` — it names the cell it mutates — so there is no
+literal for [O102](kcs-optimisation-o102-load-forwarding.md) to forward.
+SCCP has nonetheless proved the read sees `2`, so O100 inlines it, giving
+`puts 2`; the now-dead `set` and `incr` go to `O108`/`O109` on the next
+pass, and the `aggressive` profile's fixpoint reduces the whole snippet to
+`puts 2`.
+
+The same guards apply as for the by-name form, plus every guard O102's
+def-use walk applies (single reaching definition, no trace, no alias, no
+intervening barrier).
+
 ## Safety conditions
 
 - Skipped when the variable is aliased (`global`, `variable`, `upvar`) or traced anywhere in its own procedure, or — for a top-level variable specifically — when *any* procedure in the file reassigns it via `global`. A top-level name already lives in the global frame, so a procedure elsewhere can rewrite it between the assignment and a later top-level use even though the top-level code itself never mentions `global`.
@@ -47,4 +76,4 @@ Toggle the optimiser profile in your editor settings. See the [optimiser feature
 - [KCS codes index](README.md)
 - [Optimiser feature](../features/kcs-feature-optimiser.md)
 - [Constant folding](../../GLOSSARY.md#constant-folding)
-- Related codes: `O101`, `O105`
+- Related codes: `O101`, `O102`, `O105`, `O108`, `O109`

--- a/docs/kcs/codes/kcs-optimisation-o102-load-forwarding.md
+++ b/docs/kcs/codes/kcs-optimisation-o102-load-forwarding.md
@@ -47,7 +47,11 @@ value-identical to the original read, in every one of these senses:
 
 - The variable has a **single reaching definition** on every path
   to the read, and that definition is a literal (not a computed
-  value).
+  value). A definition that *computes* its value is not O102's to
+  forward even when the result is knowable: `set a 1; incr a` leaves
+  `a` provably `2`, and inlining that constant is
+  [O100](kcs-optimisation-o100-constant-propagation.md)'s per-value
+  form.
 - The variable carries **no active variable trace**
   (`trace add variable`/`trace variable`, or the `remove`/`vdelete`
   spellings) anywhere in the module, and no dynamic
@@ -59,6 +63,12 @@ value-identical to the original read, in every one of these senses:
 - The variable is not **aliased** into another stack frame
   (`upvar`/`global`/`variable`) — a proc reached between the
   definition and the read could write it through the alias.
+- The read is an **operand**, not a variable *name* argument. `incr a`,
+  `append a x`, `info exists a` and `unset a` all read `a`, but they name
+  the cell rather than substituting it, so there is no word to rewrite —
+  splicing the literal over one destroys the statement. Those reads carry
+  their own `UseKind::VariableName` in the def-use chains precisely so no
+  forwarding pass can mistake them for operands.
 - No statement between the definition and the read (within the same
   block) is a **barrier** (`eval`/`uplevel`/`interp eval`/…) or a call
   the compiler cannot prove pure — including any call to a
@@ -78,6 +88,13 @@ related [O100](kcs-optimisation-o100-constant-propagation.md) path
 instead; a reference nested inside an arbitrary command substitution
 falls back to a **hint-only** suggestion covering the whole
 statement, with no automatic fix offered).
+
+A hint-only O102 carries **no replacement text**. Its span is the whole
+consuming statement, so the literal would not be a valid replacement for
+it, and recording one anyway is how a hint came to be read as a one-click
+rewrite: a surface that showed the payload without the flag presented
+`incr a → 1` as an offered fix. The compiler explorer now reports
+`hintOnly` alongside the range, as the language server always has.
 
 ## Related history
 

--- a/rust/tcl-compiler/src/dataflow_graph.rs
+++ b/rust/tcl-compiler/src/dataflow_graph.rs
@@ -527,6 +527,7 @@ mod tests {
             defs,
             may_defs: std::collections::HashSet::new(),
             quoted_uses: std::collections::HashSet::new(),
+            name_only_uses: std::collections::HashSet::new(),
         }
     }
 
@@ -663,6 +664,7 @@ mod tests {
             defs: ydefs,
             may_defs: std::collections::HashSet::new(),
             quoted_uses: std::collections::HashSet::new(),
+            name_only_uses: std::collections::HashSet::new(),
         });
         ssa.blocks.insert(entry_id, entry);
 

--- a/rust/tcl-compiler/src/def_use.rs
+++ b/rust/tcl-compiler/src/def_use.rs
@@ -52,6 +52,17 @@ pub enum DefKind {
 pub enum UseKind {
     /// Read as an operand of a statement.
     Operand,
+    /// Named by a statement rather than substituted into it: `incr a`,
+    /// `append a x`, `info exists a`, `unset a` — the cell is read (and often
+    /// written) through a variable-*name* argument, with no `$a` word.
+    ///
+    /// Split from [`Self::Operand`] because the two answer different questions
+    /// and a pass that conflates them is unsound. Liveness must count both: the
+    /// value really is consumed. A pass that *rewrites* the use must count only
+    /// `Operand`, because a name position has nothing to rewrite — forwarding
+    /// `a`'s single reaching literal into `incr a` yields `incr` over `1`,
+    /// which is neither an increment nor a command (issue #1934).
+    VariableName,
     /// Incoming edge of a phi node.
     PhiIncoming,
     /// Read by a branch condition (terminator).
@@ -260,8 +271,15 @@ pub fn build_def_use_chains(
                 let key = (ssa.var_name(*sym).to_owned(), *ver);
                 let class = if stmt.quoted_uses.contains(sym) {
                     UseClass::Quoted
+                } else if stmt.name_only_uses.contains(sym) {
+                    UseClass::Name
                 } else {
                     UseClass::Substituted
+                };
+                let kind = if class == UseClass::Name {
+                    UseKind::VariableName
+                } else {
+                    UseKind::Operand
                 };
                 add_use(
                     &mut chains,
@@ -269,7 +287,7 @@ pub fn build_def_use_chains(
                     key,
                     UseSite {
                         block: block.name.clone(),
-                        kind: UseKind::Operand,
+                        kind,
                         statement_index: i32::try_from(idx).unwrap_or(i32::MAX),
                         variable: String::new(),
                         phi_version: 0,
@@ -494,6 +512,7 @@ mod tests {
             defs,
             may_defs: std::collections::HashSet::new(),
             quoted_uses: std::collections::HashSet::new(),
+            name_only_uses: std::collections::HashSet::new(),
         }
     }
 
@@ -524,6 +543,7 @@ mod tests {
             defs: d,
             may_defs: std::collections::HashSet::new(),
             quoted_uses: std::collections::HashSet::new(),
+            name_only_uses: std::collections::HashSet::new(),
         }
     }
 

--- a/rust/tcl-compiler/src/gvn.rs
+++ b/rust/tcl-compiler/src/gvn.rs
@@ -2865,6 +2865,7 @@ mod tests {
             defs: HashMap::new(),
             may_defs: std::collections::HashSet::new(),
             quoted_uses: std::collections::HashSet::new(),
+            name_only_uses: std::collections::HashSet::new(),
         };
         let occurrences =
             statement_occurrences(&registry, &stmt_ssa, "entry", 0, None, &bare_ssa());
@@ -2886,6 +2887,7 @@ mod tests {
             defs: HashMap::new(),
             may_defs: std::collections::HashSet::new(),
             quoted_uses: std::collections::HashSet::new(),
+            name_only_uses: std::collections::HashSet::new(),
         };
         assert!(
             statement_occurrences(&registry, &stmt_ssa, "entry", 0, None, &bare_ssa()).is_empty()
@@ -2943,6 +2945,7 @@ mod tests {
             defs: Map::new(),
             may_defs: std::collections::HashSet::new(),
             quoted_uses: std::collections::HashSet::new(),
+            name_only_uses: std::collections::HashSet::new(),
         }
     }
 
@@ -3185,6 +3188,7 @@ mod tests {
             defs: HashMap::new(),
             may_defs: std::collections::HashSet::new(),
             quoted_uses: std::collections::HashSet::new(),
+            name_only_uses: std::collections::HashSet::new(),
         };
         let occ = statement_occurrences(&registry, &stmt_ssa, "entry", 0, None, &bare_ssa());
         assert_eq!(occ.len(), 1);
@@ -3207,6 +3211,7 @@ mod tests {
             defs: HashMap::new(),
             may_defs: std::collections::HashSet::new(),
             quoted_uses: std::collections::HashSet::new(),
+            name_only_uses: std::collections::HashSet::new(),
         };
         let occ = statement_occurrences(&registry, &stmt_ssa, "entry", 0, None, &bare_ssa());
         assert_eq!(occ.len(), 1);
@@ -3453,6 +3458,7 @@ mod tests {
             defs,
             may_defs: std::collections::HashSet::new(),
             quoted_uses: std::collections::HashSet::new(),
+            name_only_uses: std::collections::HashSet::new(),
         });
         // llength $i — uses map tracks `i`, not `x`.
         let mut uses_i = Map::new();
@@ -3463,6 +3469,7 @@ mod tests {
             defs: Map::new(),
             may_defs: std::collections::HashSet::new(),
             quoted_uses: std::collections::HashSet::new(),
+            name_only_uses: std::collections::HashSet::new(),
         });
         ssa.blocks.insert(header, h);
         ssa.blocks.insert(body, b);

--- a/rust/tcl-compiler/src/memory_ssa.rs
+++ b/rust/tcl-compiler/src/memory_ssa.rs
@@ -1104,6 +1104,7 @@ mod tests {
                 defs: HashMap::new(),
                 may_defs: std::collections::HashSet::new(),
                 quoted_uses: std::collections::HashSet::new(),
+                name_only_uses: std::collections::HashSet::new(),
             });
         }
         let entry = BlockId(0);
@@ -1271,6 +1272,7 @@ mod tests {
             defs: HashMap::new(),
             may_defs: std::collections::HashSet::new(),
             quoted_uses: std::collections::HashSet::new(),
+            name_only_uses: std::collections::HashSet::new(),
         });
         let mut defs = HashMap::new();
         defs.insert(shared, 1);
@@ -1280,6 +1282,7 @@ mod tests {
             defs,
             may_defs: std::collections::HashSet::new(),
             quoted_uses: std::collections::HashSet::new(),
+            name_only_uses: std::collections::HashSet::new(),
         });
         let mut uses = HashMap::new();
         uses.insert(shared, 1);
@@ -1289,6 +1292,7 @@ mod tests {
             defs: HashMap::new(),
             may_defs: std::collections::HashSet::new(),
             quoted_uses: std::collections::HashSet::new(),
+            name_only_uses: std::collections::HashSet::new(),
         });
 
         ssa.blocks.insert(
@@ -1345,6 +1349,7 @@ mod tests {
             defs: HashMap::new(),
             may_defs: std::collections::HashSet::new(),
             quoted_uses: std::collections::HashSet::new(),
+            name_only_uses: std::collections::HashSet::new(),
         });
         let mut defs1 = HashMap::new();
         defs1.insert(shared, 1);
@@ -1354,6 +1359,7 @@ mod tests {
             defs: defs1,
             may_defs: std::collections::HashSet::new(),
             quoted_uses: std::collections::HashSet::new(),
+            name_only_uses: std::collections::HashSet::new(),
         });
         let mut uses = HashMap::new();
         uses.insert(shared, 1);
@@ -1365,6 +1371,7 @@ mod tests {
             defs: defs2,
             may_defs: std::collections::HashSet::new(),
             quoted_uses: std::collections::HashSet::new(),
+            name_only_uses: std::collections::HashSet::new(),
         });
         ssa.blocks.insert(
             entry,

--- a/rust/tcl-compiler/src/optimiser/elimination.rs
+++ b/rust/tcl-compiler/src/optimiser/elimination.rs
@@ -763,7 +763,11 @@ fn build_adce_consumers(fu: &FunctionUnit) -> (ConsumerMap, HashSet<(String, u32
         let key = chain.key.clone();
         for use_site in &chain.uses {
             match use_site.kind {
-                UseKind::Operand => {
+                // A name position consumes the value exactly as an operand
+                // does — `incr a` reads `a` — so it keeps the feeding store
+                // alive at the statement that names it. Only *rewriting*
+                // passes have to tell the two apart (issue #1934).
+                UseKind::Operand | UseKind::VariableName => {
                     if let Ok(idx) = usize::try_from(use_site.statement_index) {
                         consumer_stmt_keys
                             .entry(key.clone())
@@ -1739,9 +1743,12 @@ mod tests {
             "proc f {} { set a(k) 1; set a(j) 2; puts $a(k) }",
             &registry(),
         );
+        // Scoped to the payload-bearing rewrites: a hint-only O102 spans the
+        // whole consuming statement and deliberately carries no replacement
+        // (issue #1934), so it cannot conflate anything.
         assert!(
             opts.iter()
-                .all(|o| o.code != DiagCode::O102 || o.replacement == "1"),
+                .all(|o| o.code != DiagCode::O102 || o.hint_only || o.replacement == "1"),
             "a forwarded a(k) load must carry a(k)'s value, got {opts:?}",
         );
         // A non-constant element value cannot be forwarded, so the store

--- a/rust/tcl-compiler/src/optimiser/propagation.rs
+++ b/rust/tcl-compiler/src/optimiser/propagation.rs
@@ -281,20 +281,40 @@ fn run_load_forwarding(
         let Some(def_stmt) = block.statements.get(idx) else {
             continue;
         };
-        let literal = match def_stmt {
-            Statement::AssignConst { value, .. } => value.clone(),
+        // Which code claims the rewrite follows from *why* the value is known,
+        // and the two contracts are different: O102 forwards a variable whose
+        // single reaching definition is written out as a literal, O100 inlines
+        // a constant SCCP proved. `set a 1; incr a` is the second — the
+        // defining statement computes its value — so it is folded, not
+        // forwarded (issue #1934).
+        let (code, literal) = match def_stmt {
+            Statement::AssignConst { value, .. } => (DiagCode::O102, value.clone()),
             Statement::AssignValue { value, .. }
                 if !value.contains(['$', '[', '\\', '"']) && !value.is_empty() =>
             {
-                value.clone()
+                (DiagCode::O102, value.clone())
             }
-            _ => continue,
+            // The name-keyed projection `sccp_constants_for` the other O100
+            // forms read cannot answer here: it drops any variable whose
+            // versions hold different constants, which is every variable that
+            // is ever reassigned — precisely this shape. A def-use consumer
+            // already knows which version it is inlining, so it can index the
+            // lattice by `(symbol, version)` and get an answer where the
+            // name-keyed map has none. Every guard above this point still
+            // applies.
+            _ => match sccp_value_literal(fu, var_name, chain.key.1) {
+                Some(text) => (DiagCode::O100, text),
+                None => continue,
+            },
         };
         if !is_value_safe_bare_word(&literal) {
             continue;
         }
-        let message =
-            format!("Forward literal load of '{var_name}' from its single reaching definition");
+        let message = if code == DiagCode::O102 {
+            format!("Forward literal load of '{var_name}' from its single reaching definition")
+        } else {
+            format!("Inline the constant value of '{var_name}' proved at this read")
+        };
         for use_site in &chain.uses {
             if use_site.kind != UseKind::Operand {
                 continue;
@@ -327,7 +347,7 @@ fn run_load_forwarding(
             if has_intervening_barrier(fu, &chain.definition.block, idx, &use_site.block, use_idx) {
                 continue;
             }
-            report_load_forward(ctx, fu, use_stmt, var_name, &message, &literal);
+            report_load_forward(ctx, fu, use_stmt, code, var_name, &message, &literal);
         }
     }
 }
@@ -409,6 +429,7 @@ fn report_load_forward(
     ctx: &mut PassContext<'_>,
     fu: &crate::compilation_unit::FunctionUnit,
     use_stmt: &Statement,
+    code: DiagCode,
     var_name: &str,
     message: &str,
     literal: &str,
@@ -434,7 +455,7 @@ fn report_load_forward(
                 continue;
             }
             ctx.report(Optimisation::new(
-                DiagCode::O102,
+                code,
                 message.to_owned(),
                 tcl_lexer::word_span_at(ctx.source, fu.abs_span(*argv_span)),
                 literal.to_owned(),
@@ -445,11 +466,19 @@ fn report_load_forward(
     if emitted_applicable {
         return;
     }
+    // No operand word was found to target, so the span is the whole consuming
+    // statement — and `literal` is not a valid replacement for it. Record the
+    // hint with no replacement rather than a payload that would corrupt the
+    // statement if anything ever applied it: `set a 1; incr a` once recorded
+    // `1` over the whole of `incr a`, which reads as a one-click rewrite to a
+    // bare `1` in command position wherever a surface shows the payload
+    // without the flag (issue #1934). The appliers already filter `hint_only`;
+    // this makes the data model agree with them.
     let mut opt = Optimisation::new(
-        DiagCode::O102,
+        code,
         message.to_owned(),
         fu.abs_span(use_stmt.span()),
-        literal.to_owned(),
+        String::new(),
     );
     opt.hint_only = true;
     ctx.report(opt);
@@ -2999,6 +3028,28 @@ fn render_propagation_word(value: &str) -> String {
     }
 }
 
+/// The SCCP-proved constant for one exact SSA value, rendered as source text.
+///
+/// The per-value counterpart of [`sccp_constants_for`]'s name-keyed map: that
+/// projection answers "is this *name* always this constant", which is the
+/// question a by-name source substitution has to ask, and it necessarily
+/// abstains for a name whose versions hold different constants. A def-use
+/// consumer already knows which version it is forwarding, so it can ask the
+/// stronger question and get an answer where the map has none.
+fn sccp_value_literal(
+    fu: &FunctionUnit,
+    var_name: &str,
+    version: crate::ssa::Version,
+) -> Option<String> {
+    use super::helpers::literals::format_constant;
+
+    let sym = fu.ssa.var_symbol(var_name)?;
+    match fu.sccp.values.get(&(sym, version))? {
+        LatticeValue::Const(cv) => format_constant(cv),
+        _ => None,
+    }
+}
+
 pub(super) fn sccp_constants_for(fu: &FunctionUnit) -> std::collections::HashMap<String, String> {
     sccp_constants_from(&fu.sccp, &fu.ssa)
 }
@@ -3714,6 +3765,96 @@ mod tests {
         assert!(
             opts.iter().any(|o| o.code == DiagCode::O102),
             "expected O102 load-forwarding, got {opts:?}",
+        );
+    }
+
+    /// Issue #1934 — a definition whose value SCCP proved still forwards.
+    ///
+    /// `set a 1; incr a` leaves `a` provably `2`, and that is what a use of it
+    /// should see. O102 only ever recognised a *syntactic* literal as a
+    /// reaching definition, so the chain stopped at the `incr` and the whole
+    /// snippet optimised to nothing. The name-keyed `sccp_constants_for`
+    /// projection cannot rescue it either: `a` holds `1` at one version and
+    /// `2` at another, so that map drops the variable entirely.
+    #[test]
+    fn a_computed_definition_forwards_the_constant_sccp_proved() {
+        for (source, want) in [
+            ("set a 1\nincr a\nputs \"$a\"\n", "2"),
+            ("set a 1\nincr a\nputs $a\n", "2"),
+            ("set a 1\nincr a 5\nputs $a\n", "6"),
+        ] {
+            let opts = run_pass(source);
+            assert!(
+                opts.iter()
+                    .any(|o| o.code == DiagCode::O100 && !o.hint_only && o.replacement == want),
+                "expected an applicable O100 inlining {want:?} for {source:?}, got {opts:?}",
+            );
+        }
+    }
+
+    /// A hint-only forward records no replacement.
+    ///
+    /// Its span is the whole consuming statement, so the literal is not a
+    /// valid replacement for it — recording one anyway is what let a hint on
+    /// `incr a` read as a one-click rewrite to a bare `1`.
+    #[test]
+    fn a_hint_only_forward_carries_no_replacement() {
+        let opts = run_pass("set n 7\nputs \"n=$n\"\n");
+        let hints: Vec<&Optimisation> = opts.iter().filter(|o| o.hint_only).collect();
+        assert!(!hints.is_empty(), "expected a hint-only O102, got {opts:?}");
+        assert!(
+            hints.iter().all(|o| o.replacement.is_empty()),
+            "a hint with no sub-span target must carry no payload, got {hints:?}",
+        );
+    }
+
+    /// Issue #1934 — a variable-*name* argument is not an operand, so no
+    /// propagation code may target it.
+    ///
+    /// `set a 1; incr a` has one reaching literal for `a`, and `incr a`'s only
+    /// mention of `a` names the cell it mutates. Forwarding the literal there
+    /// produced `O102 … → 1` over the whole of `incr a`: a rewrite that
+    /// destroys the increment and leaves `1` in command position, where tclsh
+    /// answers `invalid command name "1"`. It was unreachable behind the
+    /// `hint_only` guard, but it was a wrong payload sitting one guard away
+    /// from being applied, and wrong advice about the statement either way.
+    #[test]
+    fn no_o1xx_targets_a_variable_name_argument() {
+        // One row per registry role that names a variable rather than passing
+        // a value: `VarWrite` read-modify-write, `VarRead`, and the
+        // destroying form. Each is the *only* mention of the variable in its
+        // statement, so any O1xx on that line is targeting the name.
+        for source in [
+            "set a 1\nincr a\n",
+            "set a 1\nappend a x\n",
+            "set a 1\nlappend a x\n",
+            "set a 1\ndict incr a k\n",
+            "set a 1\ninfo exists a\n",
+            "set a 1\nunset a\n",
+            "set a 1\nbinary scan xy c a\n",
+            "set a 1\nregexp {(x)} xy -> a\n",
+        ] {
+            let opts = run_pass(source);
+            let forwarded: Vec<&Optimisation> = opts
+                .iter()
+                .filter(|o| o.code.as_str().starts_with("O1") && o.replacement == "1")
+                .collect();
+            assert!(
+                forwarded.is_empty(),
+                "no O1xx may forward the literal into a variable-name position \
+                 of {source:?}, got {forwarded:?}",
+            );
+        }
+    }
+
+    /// The guard is about the *position*, not the command: the same commands
+    /// still forward into a genuine operand word beside the name.
+    #[test]
+    fn a_value_operand_beside_a_name_argument_still_forwards() {
+        let opts = run_pass("set n 7\nset a {}\nlappend a $n\n");
+        assert!(
+            opts.iter().any(|o| o.code == DiagCode::O102),
+            "the `$n` operand is still an operand, got {opts:?}",
         );
     }
 

--- a/rust/tcl-compiler/src/sccp.rs
+++ b/rust/tcl-compiler/src/sccp.rs
@@ -2396,6 +2396,7 @@ mod tests {
             defs,
             may_defs: std::collections::HashSet::new(),
             quoted_uses: std::collections::HashSet::new(),
+            name_only_uses: std::collections::HashSet::new(),
         }
     }
 
@@ -2479,6 +2480,7 @@ mod tests {
             defs,
             may_defs: std::collections::HashSet::new(),
             quoted_uses: std::collections::HashSet::new(),
+            name_only_uses: std::collections::HashSet::new(),
         });
         let mut values: HashMap<ValueKey, LatticeValue> = HashMap::new();
         let escaping: HashSet<String> = HashSet::new();
@@ -2691,6 +2693,7 @@ mod tests {
             defs,
             may_defs: std::collections::HashSet::new(),
             quoted_uses: std::collections::HashSet::new(),
+            name_only_uses: std::collections::HashSet::new(),
         };
 
         let mut values = HashMap::new();
@@ -2748,6 +2751,7 @@ mod tests {
             defs,
             may_defs: std::collections::HashSet::new(),
             quoted_uses: std::collections::HashSet::new(),
+            name_only_uses: std::collections::HashSet::new(),
         };
         let mut values = HashMap::new();
         values.insert(
@@ -2796,6 +2800,7 @@ mod tests {
             defs,
             may_defs: std::collections::HashSet::new(),
             quoted_uses: std::collections::HashSet::new(),
+            name_only_uses: std::collections::HashSet::new(),
         }
     }
 
@@ -2936,6 +2941,7 @@ mod tests {
             defs,
             may_defs: std::collections::HashSet::new(),
             quoted_uses: std::collections::HashSet::new(),
+            name_only_uses: std::collections::HashSet::new(),
         }
     }
 
@@ -3156,6 +3162,7 @@ mod tests {
             defs,
             may_defs: std::collections::HashSet::new(),
             quoted_uses: std::collections::HashSet::new(),
+            name_only_uses: std::collections::HashSet::new(),
         }
     }
 

--- a/rust/tcl-compiler/src/shimmer/sharing.rs
+++ b/rust/tcl-compiler/src/shimmer/sharing.rs
@@ -375,7 +375,9 @@ fn partner_read_after(
                 u.block == block_name
                     || reachable(ctx, block_name, &u.block) && executable(ctx, &u.block)
             }
-            UseKind::Operand => {
+            // A name position (`llength $x` vs `lappend x y`) is as much a
+            // later read of the partner as an operand is.
+            UseKind::Operand | UseKind::VariableName => {
                 if u.block == block_name {
                     usize::try_from(u.statement_index).is_ok_and(|i| i > stmt_idx)
                 } else {
@@ -428,7 +430,7 @@ fn executable(ctx: &SharingCtx<'_>, block: &str) -> bool {
 fn use_span(ctx: &SharingCtx<'_>, u: &UseSite) -> Option<Span> {
     let id = ctx.cfg.block_id(&u.block)?;
     match u.kind {
-        UseKind::Operand => {
+        UseKind::Operand | UseKind::VariableName => {
             let idx = usize::try_from(u.statement_index).ok()?;
             ctx.ssa
                 .blocks

--- a/rust/tcl-compiler/src/shimmer/span.rs
+++ b/rust/tcl-compiler/src/shimmer/span.rs
@@ -118,6 +118,7 @@ mod tests {
             },
             may_defs: std::collections::HashSet::new(),
             quoted_uses: std::collections::HashSet::new(),
+            name_only_uses: std::collections::HashSet::new(),
         };
         let block = SsaBlock {
             name: "entry".to_owned(),

--- a/rust/tcl-compiler/src/shimmer/use_site.rs
+++ b/rust/tcl-compiler/src/shimmer/use_site.rs
@@ -205,34 +205,75 @@ impl LoopFacts {
     }
 
     /// Record the expected intrep of every `$var` argument at a shimmering
-    /// position of `stmt` (a direct call or a `[cmd …]` substitution
-    /// inside an assignment value).
+    /// position of `stmt` — its own words, and every `[cmd …]` nested in one.
+    ///
+    /// This reads a statement's arguments, and it must read them by the rules
+    /// the *emitting* passes use, or its answer disagrees with theirs about the
+    /// same code. Two rules were missing (issue #1851):
+    ///
+    /// - **Nested substitutions count.** `puts [list [llength $x]]` converts
+    ///   `x` to a list exactly as `llength $x` does — Tcl runs the inner
+    ///   command either way. Walking only the flat argument text saw the single
+    ///   word `[list [llength $x]]`, recorded nothing, and left `use_targets`
+    ///   short of the two distinct targets `effective_in_loop` needs, so a
+    ///   genuinely per-iteration conversion was downgraded to a one-time one.
+    ///   `use_site::check_lifted_calls` and `commit::push_lifted_reads` have
+    ///   consulted the same [`crate::word_subst::lifted_calls`] owner since
+    ///   #1826 / #1848; this was the last consumer on the flat path.
+    /// - **Braced words are inert.** A `Statement::Call`'s `args` are
+    ///   *de-braced*, so `lindex {$x} 0` looked like a live `$x` here even
+    ///   though Tcl substitutes nothing inside braces. #1850 gave the emitting
+    ///   passes that gate; this function was left alone because it does not
+    ///   emit, but a spurious target flips a loop-invariance judgement between
+    ///   S100 and S101 just the same.
+    ///
+    /// A lifted call needs no brace gate of its own: its argument words are
+    /// raw source with the braces still on, so the `$` test declines them —
+    /// the same reasoning [`inert_braced_args`] records for its own scope.
     fn record_use_targets(&mut self, stmt: &Statement, registry: &CommandRegistry) {
-        let mut record = |command: &str, args: &[String]| {
+        if let Statement::Call {
+            command,
+            args,
+            tokens,
+            ..
+        } = stmt
+        {
             let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
-            for (i, word) in args.iter().enumerate() {
-                if !word.trim_start().starts_with('$') {
-                    continue;
-                }
-                if let Some(expected) = arg_shimmer_type(registry, command, &arg_refs, i) {
-                    let var = element_var_name(word.trim()).to_owned();
-                    self.use_targets.entry(var).or_default().insert(expected);
-                }
+            let inert = inert_braced_args(registry, command, &arg_refs, tokens.as_ref());
+            self.record_invocation(command, args, &inert, registry);
+        }
+        let tokens = match stmt {
+            Statement::Call { tokens, .. } | Statement::AssignValue { tokens, .. } => {
+                tokens.as_ref()
             }
+            _ => return,
         };
-        match stmt {
-            Statement::Call { command, args, .. } => record(command, args),
-            Statement::AssignValue { value, .. } => {
-                if let Some((command, args)) =
-                    crate::value_shapes::parse_command_substitution_with_config(
-                        value.trim(),
-                        tcl_lexer::LexerConfig::for_profile(registry.profile()),
-                    )
-                {
-                    record(&command, &args);
-                }
+        for lifted in crate::word_subst::lifted_calls(
+            tokens,
+            tcl_lexer::LexerConfig::for_profile(registry.profile()),
+        ) {
+            self.record_invocation(&lifted.command, &lifted.args, &[], registry);
+        }
+    }
+
+    /// Record one invocation's shimmering `$var` arguments, skipping the
+    /// argument positions in `inert`.
+    fn record_invocation(
+        &mut self,
+        command: &str,
+        args: &[String],
+        inert: &[usize],
+        registry: &CommandRegistry,
+    ) {
+        let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+        for (i, word) in args.iter().enumerate() {
+            if inert.contains(&i) || !word.trim_start().starts_with('$') {
+                continue;
             }
-            _ => {}
+            if let Some(expected) = arg_shimmer_type(registry, command, &arg_refs, i) {
+                let var = element_var_name(word.trim()).to_owned();
+                self.use_targets.entry(var).or_default().insert(expected);
+            }
         }
     }
 
@@ -1370,6 +1411,66 @@ mod tests {
             w.unwrap().code,
             DiagCode::S100,
             "loop-invariant single-target use is one-time (S100): {warnings:?}"
+        );
+    }
+
+    /// Issue #1851 — a conversion performed by a *nested* `[cmd …]` is paid on
+    /// every iteration exactly as the direct spelling is, so it classifies the
+    /// same way.
+    ///
+    /// `record_use_targets` read only the flat argument text, so for
+    /// `puts [list [llength $x]]` the single word `[list [llength $x]]` did not
+    /// start with `$`, nothing was recorded, `use_targets` stayed below the two
+    /// distinct targets `effective_in_loop` needs, and a genuinely
+    /// per-iteration conversion was reported S100 instead of S101.
+    #[test]
+    fn a_nested_conversion_in_a_loop_classifies_as_s101_like_the_direct_one() {
+        for (first, second) in [
+            // Direct statements — the row that was already right.
+            ("llength $x", "dict size $x"),
+            // Nested inside a `Statement::Call`.
+            ("puts [list [llength $x]]", "puts [list [dict size $x]]"),
+            // Nested inside a `Statement::AssignValue`.
+            ("set a [list [llength $x]]", "set b [list [dict size $x]]"),
+        ] {
+            let src = format!(
+                "proc f {{l}} {{\n  set x [dict create a 1 b 2]\n  foreach i $l {{\n    \
+                 {first}\n    {second}\n  }}\n  return $x\n}}\n"
+            );
+            let cu = CompilationUnit::build_for(&src, &registry(), false);
+            let fu = cu.function("::f").unwrap();
+            let warnings = use_site_shimmers(fu, &registry());
+            let on_x: Vec<&ShimmerWarning> =
+                warnings.iter().filter(|w| w.variable == "x").collect();
+            assert!(
+                !on_x.is_empty(),
+                "expected shimmer warnings on x for {first:?} / {second:?}: {warnings:?}",
+            );
+            assert!(
+                on_x.iter().all(|w| w.code == DiagCode::S101),
+                "a per-iteration conversion is S101 however it is spelled; \
+                 {first:?} / {second:?} gave {on_x:?}",
+            );
+        }
+    }
+
+    /// The brace gate the emitting passes gained in #1850, applied here too: a
+    /// braced word substitutes nothing, so it contributes no use target and
+    /// cannot push a loop-invariant value over the two-target threshold.
+    #[test]
+    fn a_braced_argument_contributes_no_use_target() {
+        let src = "proc f {l} {\n  set x [dict create a 1 b 2]\n  foreach i $l {\n    \
+                   llength {$x}\n    dict size $x\n  }\n  return $x\n}\n";
+        let cu = CompilationUnit::build_for(src, &registry(), false);
+        let fu = cu.function("::f").unwrap();
+        let warnings = use_site_shimmers(fu, &registry());
+        assert!(
+            warnings
+                .iter()
+                .filter(|w| w.variable == "x")
+                .all(|w| w.code != DiagCode::S101),
+            "`llength {{$x}}` reads nothing, so only one target is live and the \
+             conversion is one-time: {warnings:?}",
         );
     }
 

--- a/rust/tcl-compiler/src/ssa.rs
+++ b/rust/tcl-compiler/src/ssa.rs
@@ -120,6 +120,12 @@ pub struct SsaStatement {
     /// use is real for liveness (the text may be evaluated later) but is not
     /// a read *here*, so read-before-set must ignore it. See [`UseClass`].
     pub quoted_uses: HashSet<Symbol>,
+    /// The subset of [`Self::uses`] that are [`UseClass::Name`] — reached by
+    /// naming the cell (`incr a`, `append a x`, `info exists a`, `unset a`)
+    /// rather than by substituting a `$a` word. As real a read as any other,
+    /// but with no operand for a value-forwarding pass to rewrite; carried
+    /// through to [`crate::def_use::UseKind::VariableName`] (issue #1934).
+    pub name_only_uses: HashSet<Symbol>,
 }
 
 /// How a statement consumes a variable reference.
@@ -156,6 +162,18 @@ pub enum UseClass {
     /// which of them land here. Kept as a use so liveness stays conservative;
     /// ignored by read-before-set.
     Quoted,
+    /// Named rather than substituted: the statement reaches the cell through a
+    /// variable-*name* argument — `incr a`, `append a x`, `info exists a`,
+    /// `unset a` — with no `$a` word anywhere in it.
+    ///
+    /// As definite a read as [`Self::Substituted`], and read-before-set must
+    /// treat it as one: `incr a` really does read `a`. What separates it is
+    /// that there is **no operand to rewrite**. A value-forwarding pass that
+    /// splices a literal over such a use destroys the statement — the reaching
+    /// literal of `a` is `1`, and `incr 1` is neither an increment nor a
+    /// command (issue #1934). [`UseKind::VariableName`] is how the def-use
+    /// chains carry that distinction to those passes.
+    Name,
 }
 
 /// A CFG basic block in SSA form.
@@ -1473,6 +1491,7 @@ pub fn uses_of(
 struct ClassifiedUses {
     substituted: BTreeSet<String>,
     quoted: BTreeSet<String>,
+    by_name: BTreeSet<String>,
 }
 
 impl ClassifiedUses {
@@ -1483,6 +1502,7 @@ impl ClassifiedUses {
     fn merge(&mut self, other: ClassifiedUses) {
         self.substituted.extend(other.substituted);
         self.quoted.extend(other.quoted);
+        self.by_name.extend(other.by_name);
     }
 
     /// Absorb a classified name list (as [`uses_of_classified`] returns it).
@@ -1491,6 +1511,7 @@ impl ClassifiedUses {
             match class {
                 UseClass::Substituted => self.substituted.insert(name),
                 UseClass::Quoted => self.quoted.insert(name),
+                UseClass::Name => self.by_name.insert(name),
             };
         }
     }
@@ -1499,6 +1520,7 @@ impl ClassifiedUses {
     fn remove_defs(&mut self, defs: &HashSet<String>) {
         self.substituted.retain(|v| !defs.contains(v));
         self.quoted.retain(|v| !defs.contains(v));
+        self.by_name.retain(|v| !defs.contains(v));
     }
 }
 
@@ -1528,6 +1550,7 @@ pub fn uses_of_classified(
                 scanner,
                 registry,
                 &mut found.substituted,
+                &mut found.by_name,
                 &mut reads_own_def,
             );
         }
@@ -1603,16 +1626,24 @@ pub fn uses_of_classified(
     let defs: HashSet<String> = defs_of_with_registry(stmt, Some(registry))
         .into_iter()
         .collect();
-    // A name reached both ways is a definite read — the quoted mention adds
-    // nothing the substituted one does not already assert.
+    // A name reached more than one way keeps its most definite class, and the
+    // three are ordered by what a consumer may do with them: a substituted
+    // word is a read *and* an operand something may rewrite; a name argument
+    // is a read with nothing to rewrite; a quoted mention is neither. So
+    // `lappend a $a` is Substituted (there is an operand), `lappend a {$a}` is
+    // Name (the braced mention adds nothing to the name argument), and the
+    // weaker classes drop the name the stronger one already asserts.
     let ClassifiedUses {
         substituted,
         mut quoted,
+        mut by_name,
     } = found;
-    quoted.retain(|v| !substituted.contains(v));
+    by_name.retain(|v| !substituted.contains(v));
+    quoted.retain(|v| !substituted.contains(v) && !by_name.contains(v));
     substituted
         .into_iter()
         .map(|v| (v, UseClass::Substituted))
+        .chain(by_name.into_iter().map(|v| (v, UseClass::Name)))
         .chain(quoted.into_iter().map(|v| (v, UseClass::Quoted)))
         .filter(|(v, _)| !v.is_empty() && (!defs.contains(v) || reads_own_def.contains(v)))
         .collect()
@@ -1799,14 +1830,18 @@ fn uses_in_call(
             vars_found.insert(v);
         }
     }
+    // `reads` are the registry's `ArgRole::VarRead` positions and
+    // `reads_own_defs` its `READS_BEFORE_WRITE` targets: both name the cell
+    // rather than substituting it, so they are `UseClass::Name` — a real read
+    // with no operand word behind it (issue #1934).
     for name in reads {
         if !name.is_empty() {
-            vars_found.insert(name.clone());
+            found.by_name.insert(name.clone());
         }
     }
     if *reads_own_defs {
         for name in defs {
-            vars_found.insert(name.clone());
+            found.by_name.insert(name.clone());
             reads_own_def.insert(name.clone());
         }
     }
@@ -1822,7 +1857,7 @@ fn uses_in_call(
         });
     if destroys {
         for name in defs {
-            vars_found.insert(name.clone());
+            found.by_name.insert(name.clone());
             reads_own_def.insert(name.clone());
         }
     }
@@ -1833,6 +1868,7 @@ fn uses_in_assignment(
     scanner: &mut VarReferenceScanner,
     registry: &CommandRegistry,
     vars_found: &mut BTreeSet<String>,
+    by_name: &mut BTreeSet<String>,
     reads_own_def: &mut BTreeSet<String>,
 ) {
     // A brace-quoted target's `$` is part of a literal name, not a
@@ -1900,9 +1936,10 @@ fn uses_in_assignment(
             if is_dynamic_write_target(name, *name_braced) {
                 vars_found.extend(scanner.scan_word(name, registry));
             } else {
+                // `incr a` names the cell it mutates; there is no `$a` word.
                 let norm = scanner.canonical_name_braced(name, *name_braced);
                 if !norm.is_empty() {
-                    vars_found.insert(norm.to_owned());
+                    by_name.insert(norm.to_owned());
                     reads_own_def.insert(norm.to_owned());
                 }
             }
@@ -2001,6 +2038,9 @@ fn scan_command_words(
             match class {
                 UseClass::Quoted => out.quoted.insert(name),
                 UseClass::Substituted => out.substituted.insert(name),
+                // `braced_word_class` classifies a *word*, and a word is
+                // never a name argument — those never reach the scanner.
+                UseClass::Name => out.by_name.insert(name),
             };
         }
     }
@@ -2205,6 +2245,7 @@ fn switch_reads(
     let mut reads = ClassifiedUses {
         substituted: scanner.scan_word(subject, registry),
         quoted: BTreeSet::new(),
+        by_name: BTreeSet::new(),
     };
     for arm in arms {
         // A pattern from the canonical single braced `{pat body …}` block is a
@@ -2850,6 +2891,7 @@ impl RenameWalk {
         let uses_list: Vec<String> = classified.iter().map(|(name, _)| name.clone()).collect();
         let mut uses_map: HashMap<Symbol, Version> = HashMap::new();
         let mut quoted_uses: HashSet<Symbol> = HashSet::new();
+        let mut name_only_uses: HashSet<Symbol> = HashSet::new();
         // A base read (`$a($i)`, `array get a`) reads every known
         // constant-keyed element — record their versions so the element chains
         // are live. A fanned element inherits its base's class: reached only
@@ -2866,8 +2908,14 @@ impl RenameWalk {
                 let base = &var[..var.find('(')?];
                 class_of.get(base).copied()
             });
-            if class == Some(UseClass::Quoted) {
-                quoted_uses.insert(sym);
+            match class {
+                Some(UseClass::Quoted) => {
+                    quoted_uses.insert(sym);
+                }
+                Some(UseClass::Name) => {
+                    name_only_uses.insert(sym);
+                }
+                Some(UseClass::Substituted) | None => {}
             }
         }
 
@@ -2904,6 +2952,7 @@ impl RenameWalk {
             defs: defs_map,
             may_defs,
             quoted_uses,
+            name_only_uses,
         }
     }
 
@@ -3234,6 +3283,7 @@ mod tests {
             defs: HashMap::from([(Symbol(0), 1)]),
             may_defs: std::collections::HashSet::new(),
             quoted_uses: std::collections::HashSet::new(),
+            name_only_uses: std::collections::HashSet::new(),
         };
         assert_eq!(stmt.defs[&Symbol(0)], 1);
         assert!(stmt.uses.is_empty());

--- a/rust/tcl-compiler/src/taint.rs
+++ b/rust/tcl-compiler/src/taint.rs
@@ -6200,7 +6200,7 @@ mod tests {
     #[test]
     fn propagate_taints_gets_is_source() {
         use crate::cfg::{Function, Terminator};
-        use crate::ssa::{SsaBlock, SsaFunction, SsaStatement};
+        use crate::ssa::{SsaBlock, SsaFunction};
         use tcl_lexer::Span;
 
         let registry = CommandRegistry::build_default();
@@ -6230,13 +6230,7 @@ mod tests {
 
         let mut ssa = SsaFunction::trivial("::top", entry, cfg.block_names().to_vec());
         let x = ssa.intern_var("x");
-        let ssa_stmt = SsaStatement {
-            statement: stmt,
-            uses: HashMap::new(),
-            defs: [(x, 1u32)].into_iter().collect(),
-            may_defs: std::collections::HashSet::new(),
-            quoted_uses: std::collections::HashSet::new(),
-        };
+        let ssa_stmt = ssa_stmt(stmt, HashMap::new(), [(x, 1u32)].into_iter().collect());
         ssa.blocks.insert(
             entry,
             SsaBlock {
@@ -6259,7 +6253,7 @@ mod tests {
     #[test]
     fn find_taint_warnings_eval_with_tainted_var() {
         use crate::cfg::{Function, Terminator};
-        use crate::ssa::{SsaBlock, SsaFunction, SsaStatement};
+        use crate::ssa::{SsaBlock, SsaFunction};
         use tcl_lexer::Span;
 
         let registry = CommandRegistry::build_default();
@@ -6307,20 +6301,8 @@ mod tests {
 
         let mut ssa = SsaFunction::trivial("::top", entry, cfg.block_names().to_vec());
         let x = ssa.intern_var("x");
-        let ssa_assign = SsaStatement {
-            statement: assign,
-            uses: HashMap::new(),
-            defs: [(x, 1u32)].into_iter().collect(),
-            may_defs: std::collections::HashSet::new(),
-            quoted_uses: std::collections::HashSet::new(),
-        };
-        let ssa_eval = SsaStatement {
-            statement: eval_call,
-            uses: [(x, 1u32)].into_iter().collect(),
-            defs: HashMap::new(),
-            may_defs: std::collections::HashSet::new(),
-            quoted_uses: std::collections::HashSet::new(),
-        };
+        let ssa_assign = ssa_stmt(assign, HashMap::new(), [(x, 1u32)].into_iter().collect());
+        let ssa_eval = ssa_stmt(eval_call, [(x, 1u32)].into_iter().collect(), HashMap::new());
 
         ssa.blocks.insert(
             entry,
@@ -6358,7 +6340,7 @@ mod tests {
     /// T104 / T105 sink tests.
     fn warnings_for_tainted_sink(sink: Statement, sink_uses: &[(&str, u32)]) -> Vec<TaintWarning> {
         use crate::cfg::{Function, Terminator};
-        use crate::ssa::{SsaBlock, SsaFunction, SsaStatement};
+        use crate::ssa::{SsaBlock, SsaFunction};
         use tcl_lexer::Span;
 
         let registry = CommandRegistry::build_default();
@@ -6384,23 +6366,19 @@ mod tests {
             });
         }
         let mut ssa = SsaFunction::trivial("::top", entry, cfg.block_names().to_vec());
-        let ssa_assign = SsaStatement {
-            statement: assign,
-            uses: HashMap::new(),
-            defs: [(ssa.intern_var("x"), 1u32)].into_iter().collect(),
-            may_defs: std::collections::HashSet::new(),
-            quoted_uses: std::collections::HashSet::new(),
-        };
-        let ssa_sink = SsaStatement {
-            statement: sink,
-            uses: sink_uses
+        let ssa_assign = ssa_stmt(
+            assign,
+            HashMap::new(),
+            [(ssa.intern_var("x"), 1u32)].into_iter().collect(),
+        );
+        let ssa_sink = ssa_stmt(
+            sink,
+            sink_uses
                 .iter()
                 .map(|&(n, v)| (ssa.intern_var(n), v))
                 .collect(),
-            defs: HashMap::new(),
-            may_defs: std::collections::HashSet::new(),
-            quoted_uses: std::collections::HashSet::new(),
-        };
+            HashMap::new(),
+        );
         ssa.blocks.insert(
             entry,
             SsaBlock {
@@ -6496,12 +6474,29 @@ mod tests {
         }
     }
 
+    /// A hand-built SSA statement with no may-defs, quoted uses or name-only
+    /// uses — the shape every fixture in this module wants.
+    fn ssa_stmt(
+        statement: Statement,
+        uses: HashMap<crate::ssa::Symbol, u32>,
+        defs: HashMap<crate::ssa::Symbol, u32>,
+    ) -> crate::ssa::SsaStatement {
+        crate::ssa::SsaStatement {
+            statement,
+            uses,
+            defs,
+            may_defs: std::collections::HashSet::new(),
+            quoted_uses: std::collections::HashSet::new(),
+            name_only_uses: std::collections::HashSet::new(),
+        }
+    }
+
     #[test]
     fn t106_double_encode_through_uri_encode() {
         // `set x [URI::encode $tainted]` stamps URL_ENCODED on x; passing
         // x back through `URI::encode` double-encodes → T106.
         use crate::cfg::{Function, Terminator};
-        use crate::ssa::{SsaBlock, SsaFunction, SsaStatement};
+        use crate::ssa::{SsaBlock, SsaFunction};
         use tcl_lexer::Span;
 
         let mut registry = CommandRegistry::build_default();
@@ -6545,27 +6540,13 @@ mod tests {
         let mut ssa = SsaFunction::trivial("::top", entry, cfg.block_names().to_vec());
         let x = ssa.intern_var("x");
         let y = ssa.intern_var("y");
-        let ssa_s0 = SsaStatement {
-            statement: s0,
-            uses: HashMap::new(),
-            defs: [(x, 1u32)].into_iter().collect(),
-            may_defs: std::collections::HashSet::new(),
-            quoted_uses: std::collections::HashSet::new(),
-        };
-        let ssa_s1 = SsaStatement {
-            statement: s1,
-            uses: [(x, 1u32)].into_iter().collect(),
-            defs: [(y, 1u32)].into_iter().collect(),
-            may_defs: std::collections::HashSet::new(),
-            quoted_uses: std::collections::HashSet::new(),
-        };
-        let ssa_s2 = SsaStatement {
-            statement: s2,
-            uses: [(y, 1u32)].into_iter().collect(),
-            defs: HashMap::new(),
-            may_defs: std::collections::HashSet::new(),
-            quoted_uses: std::collections::HashSet::new(),
-        };
+        let ssa_s0 = ssa_stmt(s0, HashMap::new(), [(x, 1u32)].into_iter().collect());
+        let ssa_s1 = ssa_stmt(
+            s1,
+            [(x, 1u32)].into_iter().collect(),
+            [(y, 1u32)].into_iter().collect(),
+        );
+        let ssa_s2 = ssa_stmt(s2, [(y, 1u32)].into_iter().collect(), HashMap::new());
         ssa.blocks.insert(
             entry,
             SsaBlock {
@@ -6681,6 +6662,7 @@ mod tests {
                 defs: HashMap::new(),
                 may_defs: std::collections::HashSet::new(),
                 quoted_uses: std::collections::HashSet::new(),
+                name_only_uses: std::collections::HashSet::new(),
             }]
         });
         let d = w.iter().find(|w| w.code == DiagCode::W313).expect("W313");
@@ -6709,19 +6691,18 @@ mod tests {
         let w = w313_warnings(|ssa| {
             let base = ssa.intern_var("base");
             let p = ssa.intern_var("p");
-            let s0 = SsaStatement {
-                statement: assign,
-                uses: [(base, 0u32)].into_iter().collect(),
-                defs: [(p, 1u32)].into_iter().collect(),
-                may_defs: std::collections::HashSet::new(),
-                quoted_uses: std::collections::HashSet::new(),
-            };
+            let s0 = ssa_stmt(
+                assign,
+                [(base, 0u32)].into_iter().collect(),
+                [(p, 1u32)].into_iter().collect(),
+            );
             let s1 = SsaStatement {
                 statement: file_call(&["delete", "$p"]),
                 uses: [(p, 1u32)].into_iter().collect(),
                 defs: HashMap::new(),
                 may_defs: std::collections::HashSet::new(),
                 quoted_uses: std::collections::HashSet::new(),
+                name_only_uses: std::collections::HashSet::new(),
             };
             vec![s0, s1]
         });
@@ -6753,6 +6734,7 @@ mod tests {
                     defs: HashMap::new(),
                     may_defs: std::collections::HashSet::new(),
                     quoted_uses: std::collections::HashSet::new(),
+                    name_only_uses: std::collections::HashSet::new(),
                 }]
             })
             .is_empty()
@@ -6807,7 +6789,7 @@ mod tests {
     #[test]
     fn const_assignment_is_not_tainted() {
         use crate::cfg::{Function, Terminator};
-        use crate::ssa::{SsaBlock, SsaFunction, SsaStatement};
+        use crate::ssa::{SsaBlock, SsaFunction};
         use tcl_lexer::Span;
 
         let registry = CommandRegistry::build_default();
@@ -6835,13 +6817,7 @@ mod tests {
 
         let mut ssa = SsaFunction::trivial("::top", entry, cfg.block_names().to_vec());
         let x = ssa.intern_var("x");
-        let ssa_stmt = SsaStatement {
-            statement: stmt,
-            uses: HashMap::new(),
-            defs: [(x, 1u32)].into_iter().collect(),
-            may_defs: std::collections::HashSet::new(),
-            quoted_uses: std::collections::HashSet::new(),
-        };
+        let ssa_stmt = ssa_stmt(stmt, HashMap::new(), [(x, 1u32)].into_iter().collect());
         ssa.blocks.insert(
             entry,
             SsaBlock {
@@ -6865,7 +6841,7 @@ mod tests {
     #[test]
     fn t102_emitted_for_tainted_regexp_pattern() {
         use crate::cfg::{Function, Terminator};
-        use crate::ssa::{SsaBlock, SsaFunction, SsaStatement};
+        use crate::ssa::{SsaBlock, SsaFunction};
         use tcl_lexer::Span;
 
         let registry = CommandRegistry::build_default();
@@ -6913,20 +6889,16 @@ mod tests {
 
         let mut ssa = SsaFunction::trivial("::top", entry, cfg.block_names().to_vec());
         let pattern = ssa.intern_var("pattern");
-        let ssa_assign = SsaStatement {
-            statement: assign,
-            uses: HashMap::new(),
-            defs: [(pattern, 1u32)].into_iter().collect(),
-            may_defs: std::collections::HashSet::new(),
-            quoted_uses: std::collections::HashSet::new(),
-        };
-        let ssa_regexp = SsaStatement {
-            statement: regexp_call,
-            uses: [(pattern, 1u32)].into_iter().collect(),
-            defs: HashMap::new(),
-            may_defs: std::collections::HashSet::new(),
-            quoted_uses: std::collections::HashSet::new(),
-        };
+        let ssa_assign = ssa_stmt(
+            assign,
+            HashMap::new(),
+            [(pattern, 1u32)].into_iter().collect(),
+        );
+        let ssa_regexp = ssa_stmt(
+            regexp_call,
+            [(pattern, 1u32)].into_iter().collect(),
+            HashMap::new(),
+        );
 
         ssa.blocks.insert(
             entry,
@@ -6963,7 +6935,7 @@ mod tests {
     #[test]
     fn t102_suppressed_with_terminator() {
         use crate::cfg::{Function, Terminator};
-        use crate::ssa::{SsaBlock, SsaFunction, SsaStatement};
+        use crate::ssa::{SsaBlock, SsaFunction};
         use tcl_lexer::Span;
 
         let registry = CommandRegistry::build_default();
@@ -7011,20 +6983,16 @@ mod tests {
 
         let mut ssa = SsaFunction::trivial("::top", entry, cfg.block_names().to_vec());
         let pattern = ssa.intern_var("pattern");
-        let ssa_assign = SsaStatement {
-            statement: assign,
-            uses: HashMap::new(),
-            defs: [(pattern, 1u32)].into_iter().collect(),
-            may_defs: std::collections::HashSet::new(),
-            quoted_uses: std::collections::HashSet::new(),
-        };
-        let ssa_regexp = SsaStatement {
-            statement: regexp_call,
-            uses: [(pattern, 1u32)].into_iter().collect(),
-            defs: HashMap::new(),
-            may_defs: std::collections::HashSet::new(),
-            quoted_uses: std::collections::HashSet::new(),
-        };
+        let ssa_assign = ssa_stmt(
+            assign,
+            HashMap::new(),
+            [(pattern, 1u32)].into_iter().collect(),
+        );
+        let ssa_regexp = ssa_stmt(
+            regexp_call,
+            [(pattern, 1u32)].into_iter().collect(),
+            HashMap::new(),
+        );
 
         ssa.blocks.insert(
             entry,

--- a/rust/tcl-compiler/src/type_infer.rs
+++ b/rust/tcl-compiler/src/type_infer.rs
@@ -1774,6 +1774,7 @@ mod tests {
             defs: defs.iter().map(|&(n, v)| (ssa.intern_var(n), v)).collect(),
             may_defs: std::collections::HashSet::new(),
             quoted_uses: std::collections::HashSet::new(),
+            name_only_uses: std::collections::HashSet::new(),
         }
     }
 

--- a/rust/tcl-compiler/tests/optimiser.rs
+++ b/rust/tcl-compiler/tests/optimiser.rs
@@ -703,6 +703,70 @@ fn branch_condition_ending_in_a_nested_empty_pair_rewrites_the_whole_word() {
     );
 }
 
+/// Issue #1934 — a constant reaching an `incr` folds through it and the whole
+/// snippet collapses.
+///
+/// `incr` is not a *load* of its target, it names the cell it mutates, and
+/// O102 only ever recognised a syntactic literal as a reaching definition. So
+/// the chain stopped dead at the `incr`: nothing folded, and the one thing the
+/// optimiser did emit was a hint on `incr a` whose recorded payload (`1` over
+/// the whole statement) would have produced a bare `1` in command position.
+///
+/// SCCP has always proved the value — `Statement::Incr` is a transfer function
+/// there. What was missing was a consumer asking it per SSA value: the
+/// name-keyed projection the other O100 forms read drops any variable whose
+/// versions hold different constants, which is exactly a counter.
+#[test]
+fn incr_of_a_constant_folds_through_to_its_reads() {
+    let registry = static_context_for(TCL).commands();
+    for (src, single, fixpoint) in [
+        (
+            "set a 1\nincr a\nputs \"$a\"",
+            "set a 1\nincr a\nputs 2",
+            "puts 2",
+        ),
+        (
+            "set a 1\nincr a\nputs $a",
+            "set a 1\nincr a\nputs 2",
+            "puts 2",
+        ),
+        (
+            "set a 1\nincr a 5\nputs $a",
+            "set a 1\nincr a 5\nputs 6",
+            "puts 6",
+        ),
+    ] {
+        assert_eq!(optimised(src, TCL), single, "single pass over {src:?}");
+        let (fixed, opts) = optimise_source_multipass(src, registry, None, 5);
+        // Deletion leaves the blank lines behind, as every other multipass
+        // case in this file does; what matters is that the feeding statements
+        // are gone and the read carries the folded value.
+        assert_eq!(fixed.trim(), fixpoint, "fixpoint over {src:?}");
+        assert!(
+            !fixed.contains("incr"),
+            "the dead `incr` survived: {fixed:?}"
+        );
+        assert!(
+            !fixed.contains("set a"),
+            "the dead store survived: {fixed:?}"
+        );
+        let codes: Vec<&str> = opts.iter().map(|o| o.code.as_str()).collect();
+        assert!(
+            codes.contains(&"O100"),
+            "the fold is an O100 (a constant SCCP proved), not an O102 (a \
+             written-out literal forwarded): {codes:?}",
+        );
+    }
+}
+
+/// The counterpart: a target whose value SCCP cannot prove folds nothing, and
+/// the `incr` survives untouched.
+#[test]
+fn incr_of_an_unproven_value_folds_nothing() {
+    let src = "proc f {n} {\n    incr n\n    puts $n\n}";
+    assert_eq!(optimised(src, TCL), src, "a parameter is not a constant");
+}
+
 #[test]
 fn constant_propagation_into_commands_o100() {
     // tclsh: x=42 ⇒ `puts 42`. (The single-def literal is forwarded via O102 and

--- a/rust/tcl-explorer/src/serialise.rs
+++ b/rust/tcl-explorer/src/serialise.rs
@@ -1311,6 +1311,12 @@ pub fn serialise_optimisations(result: &ExplorerResult, li: &LineIndex, source: 
                 "message": o.message,
                 "range": range_dict(o.span, li, source),
                 "replacement": o.replacement,
+                // Informational rather than actionable, and its span is the
+                // whole consuming statement rather than a sub-word. Without
+                // this the view is indistinguishable from an applicable
+                // rewrite — which is how a hint-only O102 came to be read as a
+                // one-click fix (issue #1934). The LSP has always sent it.
+                "hintOnly": o.hint_only,
             })
         })
         .collect();
@@ -1342,6 +1348,7 @@ pub fn serialise_optimiser_passes(result: &ExplorerResult, li: &LineIndex, sourc
                     "message": o.message,
                     "range": range_dict(o.span, li, source),
                     "replacement": o.replacement,
+                    "hintOnly": o.hint_only,
                 })
             })
             .collect();
@@ -1740,6 +1747,7 @@ fn def_kind_label(kind: tcl_compiler::def_use::DefKind) -> &'static str {
 fn use_kind_label(kind: tcl_compiler::def_use::UseKind) -> &'static str {
     match kind {
         tcl_compiler::def_use::UseKind::Operand => "operand",
+        tcl_compiler::def_use::UseKind::VariableName => "variable-name",
         tcl_compiler::def_use::UseKind::PhiIncoming => "phi-incoming",
         tcl_compiler::def_use::UseKind::Terminator => "terminator",
     }
@@ -1749,6 +1757,7 @@ fn use_class_label(class: tcl_compiler::ssa::UseClass) -> &'static str {
     match class {
         tcl_compiler::ssa::UseClass::Substituted => "substituted",
         tcl_compiler::ssa::UseClass::Quoted => "quoted",
+        tcl_compiler::ssa::UseClass::Name => "name",
     }
 }
 


### PR DESCRIPTION
## Summary

Two passes were reading a statement's arguments by rules the rest of the compiler no longer uses. Different codes, same shape of defect.

Closes #1934. Closes #1851.

### #1934 — `set a 1; incr a; puts "$a"`

Two facts were missing, and together they made the most ordinary snippet in Tcl optimise to **nothing** while emitting wrong advice about it.

**A variable name is not an operand.** `incr a` names the cell it mutates; there is no `$a` word in it. The def-use chains recorded that read as `UseKind::Operand` like any other, so O102 offered to forward `a`'s single reaching literal into it — `1`, over the whole of `incr a`, which is neither an increment nor a command. Unreachable behind the `hint_only` guard, but a wrong payload one guard from being applied, and wrong advice under any profile.

The SSA scan now classifies those reads `UseClass::Name` — the registry's `ArgRole::VarRead` positions, its `READS_BEFORE_WRITE` targets, `DESTROYS_VARIABLE` targets, and `Statement::Incr`'s own target — carried on `SsaStatement::name_only_uses` and stamped as `UseKind::VariableName`. A name reached both ways in one statement (`lappend a $a`) stays `Operand`: the definite operand is the stronger fact, as `Substituted` already outranks `Quoted`.

The rule for consumers is mechanical: match `Operand | VariableName` where the question is *"is this value consumed"* (liveness — ADCE, the shimmer sharing walk), and `Operand` alone where it is *"may I rewrite this use"*. `UseKind` is matched exhaustively everywhere, so a future variant cannot be added without every consumer deciding.

**A computed definition can still be constant.** SCCP has always modelled `incr` as a transfer function, so it knows the read sees `2`. Nothing asked it: O102 recognises only a syntactic literal, and the name-keyed projection the other O100 forms read (`sccp_constants_for`) drops any variable whose versions hold different constants — which is every counter. A def-use consumer already knows which version it is inlining, so it can index the lattice by `(symbol, version)` and get an answer where the name-keyed map has none.

That is a *fold*, not a *forward*, so it is reported as **O100** rather than widening O102's "single reaching literal" contract. Two existing tests caught the first attempt, which had O102 claiming sites O100/O116 owned.

With it, the whole chain runs:

| | single pass | fixpoint |
|---|---|---|
| `set a 1` / `incr a` / `puts "$a"` | `puts 2` | `puts 2` |
| `set a 1` / `incr a 5` / `puts $a` | `puts 6` | `puts 6` |

O100 inlines, then O108/O109 remove the dead `set`/`incr`.

Also: a hint-only forward now carries **no replacement** — its span is the whole consuming statement, so the literal was never a valid replacement for it — and the compiler explorer reports `hintOnly` alongside the range, as the language server always has. That combination is why the hint read as a one-click fix in the report.

### #1851 — S100 where S101 is correct

`ShimmerFacts::record_use_targets` decides whether a loop-invariant value is converted to more than one intrep inside a loop; `effective_in_loop` turns that into the S100/S101 split. It read the flat argument text, by two rules the emitting passes had already left behind:

- **Nested substitutions did not count.** `puts [list [llength $x]]` converts `x` to a list exactly as `llength $x` does — Tcl runs the inner command either way — but the walk saw one word, `[list [llength $x]]`, which does not start with `$`. Nothing recorded, target set below two, per-iteration conversion reported S100.
- **Braced words did count.** A `Statement::Call`'s `args` are de-braced, so `lindex {$x} 0` looked like a live `$x`. #1850 gave the emitting passes that gate and left this function alone because it does not emit — but a spurious target flips the same judgement.

Both now go through the owners the rest of the shimmer machinery already consults: `word_subst::lifted_calls` (the walk `check_lifted_calls` / `push_lifted_reads` have used since #1826 / #1848) and `hints::inert_braced_args`. A lifted call needs no gate of its own — its argument words are raw source with the braces still on, so the `$` test declines them, which is the reasoning `inert_braced_args` already records for its own scope.

### Incidental

`taint.rs`'s test fixtures repeated the whole `SsaStatement` literal 14 times; adding a field to each is what pushed one test over `clippy::too_many_lines`. Extracted to one `ssa_stmt(statement, uses, defs)` helper rather than shaving the test.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

```
cargo test -p tcl-compiler                       # 66 targets, 0 failures
cargo test -p tcl-lsp-core -p tcl-explorer       # 36 targets, 0 failures
make prep-pr                                     # exit 0
cargo clippy --workspace --all-targets           # clean, no new allows
```

Tests added:

- `no_o1xx_targets_a_variable_name_argument` — eight commands that take a variable name (`incr`, `append`, `lappend`, `dict incr`, `info exists`, `unset`, `binary scan`, `regexp ->`); no O1xx may forward the literal into that argument.
- `a_value_operand_beside_a_name_argument_still_forwards` — the guard is about the position, not the command.
- `a_computed_definition_forwards_the_constant_sccp_proved`, `a_hint_only_forward_carries_no_replacement`.
- `incr_of_a_constant_folds_through_to_its_reads` — end-to-end, single pass and fixpoint, asserting the code is O100.
- `incr_of_an_unproven_value_folds_nothing` — a parameter is not a constant; the `incr` survives untouched.
- `a_nested_conversion_in_a_loop_classifies_as_s101_like_the_direct_one` — all three spellings of the issue's reproducer pinned against each other. **Verified non-vacuous**: with the lift removed, the two nested rows report S100, exactly the issue's table.
- `a_braced_argument_contributes_no_use_target`.

Corpus signal for the shimmer half: 60 tcllib modules under `tcl9.0` give 54 S100 / 45 S101 with the fix in. I could not produce a trustworthy before/after pair in this environment (a debug-build `tcl diag` is ~2 s/file and some files are far slower), so the classification evidence here is the unit-level reproducer rather than a corpus delta I cannot stand behind.

## Compiler / diagnostics checklist

- [x] Did this change alter a compiler fact contract? **Yes** — `UseKind` gains a variant and the def-use chains now distinguish operand uses from name uses; O100 gains a per-SSA-value form and O102's hint-only payload is dropped.
- [x] Owning design doc updated: `docs/design/compiler/ssa-construction.md` § *Operand uses and name uses are different facts*, with the consumer rule.
- [x] Diagnostic/optimisation code pages updated: `docs/kcs/codes/kcs-optimisation-o100-constant-propagation.md` (the per-read form) and `kcs-optimisation-o102-load-forwarding.md` (name positions are not operands; hints carry no payload).
- [x] No new design doc, so nothing to link from `docs/design/README.md`.

## Follow-up filed

#1943 — `incr`'s fold lives in `sccp.rs` as compiler-local per-command code, alongside `llength` / `string length` / `expr` / `list` matched by name in the same transfer function. That is the shape the registry invariant exists to prevent, and `const_fold` cannot express a read-modify-write on a named target. Filed rather than widened into this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F6pDxCsXjcTW4A9rTTpQS7

---
_Generated by [Claude Code](https://claude.ai/code/session_01F6pDxCsXjcTW4A9rTTpQS7)_