### PR TITLE
tcl diag: analyse a lone-CR document the way the editor does (#1799)

### DIFF
--- a/docs/design/contracts/dialect-detection.md
+++ b/docs/design/contracts/dialect-detection.md
@@ -244,12 +244,20 @@ extension, then the `tcl8.6` fallback decide.  This keeps `tcl diag`
 and the editor reporting the same set for the same file — an `.irul`
 input gets full iRules analysis without any flag.
 
-They also read the same *analysis form* of the document. `collect_rows`
-normalises lone `\r` once at the top (`tcl_lexer::normalise_lone_cr`) and
-derives both the line index and the analysis inputs from it, the way the
-server does at every entry point that reaches the analyser. A bare `\r` ends
-a command for `tclsh` but is horizontal whitespace to the lexer, so on the raw
-form an old-Mac document parses as one command — inventing findings, hiding
-real ones — and `LineIndex` (which starts a line only after a `\n`) reports
-whatever survives at line 1. The pass is byte-length preserving, so every span
-stays valid against the raw text (issue #1799).
+They also read the same *analysis form* of the document.
+`InputDocument::analysis_source()` rewrites lone `\r` to `\n`
+(`tcl_lexer::normalise_lone_cr`), and every CLI path that parses, detects or
+analyses reads it rather than `InputDocument::source`:
+
+| consumer | why it must |
+|---|---|
+| `effective_dialect` | `detect_dialect`'s directive, shebang and version-guard tiers scan by line, and `lines()` splits on `\n` only — on the raw form the whole file is line 1 and those tiers see nothing |
+| `collect_rows` | a bare `\r` ends a command for `tclsh` but is horizontal whitespace to the lexer, so the raw form parses as one command: findings invented, real ones hidden |
+| `document_proc_names`, `cross_file_call_site_evidence` | the same mis-parse hides a multi-file compilation's declarations and call sites, so `tcl diag a.tcl b.tcl` draws different conclusions from its `\n` twin |
+
+`source` stays the bytes the caller supplied, because the byte-backed encoding
+diagnostics describe the file on disk. The pass is byte-length preserving, so
+every span stays valid against either form, and
+`LineIndex::new(normalise_lone_cr(t))` is byte-identical to
+`LineIndex::new_lsp(t)` — which is what makes the CLI's line model and the
+client's coincide (issue #1799).

--- a/docs/design/contracts/dialect-detection.md
+++ b/docs/design/contracts/dialect-detection.md
@@ -243,3 +243,13 @@ in-source signals (comment directive, shebang, content), then the file
 extension, then the `tcl8.6` fallback decide.  This keeps `tcl diag`
 and the editor reporting the same set for the same file — an `.irul`
 input gets full iRules analysis without any flag.
+
+They also read the same *analysis form* of the document. `collect_rows`
+normalises lone `\r` once at the top (`tcl_lexer::normalise_lone_cr`) and
+derives both the line index and the analysis inputs from it, the way the
+server does at every entry point that reaches the analyser. A bare `\r` ends
+a command for `tclsh` but is horizontal whitespace to the lexer, so on the raw
+form an old-Mac document parses as one command — inventing findings, hiding
+real ones — and `LineIndex` (which starts a line only after a `\n`) reports
+whatever survives at line 1. The pass is byte-length preserving, so every span
+stays valid against the raw text (issue #1799).

--- a/rust/tcl-cli-support/src/input.rs
+++ b/rust/tcl-cli-support/src/input.rs
@@ -88,6 +88,31 @@ pub struct InputDocument {
 }
 
 impl InputDocument {
+    /// The document as everything that *analyses* it must read it: lone `\r`
+    /// rewritten to `\n`.
+    ///
+    /// A bare `\r` terminates a command in `tclsh` — scripts are read under
+    /// `-translation auto` — but the lexer treats it as horizontal whitespace,
+    /// so on the raw form an old-Mac document parses as one command. That
+    /// breaks more than the diagnostics: `detect_dialect` scans by *line* for
+    /// its directive, shebang and version-guard tiers, and Rust's `lines()`
+    /// splits on `\n` only, so the whole file reads as line 1 and those tiers
+    /// see nothing.
+    ///
+    /// The server normalises at every entry point that reaches the analyser
+    /// (`DocumentState::normalised_for_analysis`), and detection there runs on
+    /// the normalised text. This is the CLI's one place to do the same, so a
+    /// verb gets it by asking rather than by remembering (issue #1799).
+    ///
+    /// [`Self::source`] stays the bytes the caller supplied — the byte-backed
+    /// encoding diagnostics describe the file on disk and must not be
+    /// rewritten. The pass is byte-length preserving, so a span computed
+    /// against this text is equally valid against `source`.
+    #[must_use]
+    pub fn analysis_source(&self) -> std::borrow::Cow<'_, str> {
+        tcl_lexer::normalise_lone_cr(&self.source)
+    }
+
     /// The analysis dialect for this document.
     ///
     /// An explicitly-passed `--dialect` wins; otherwise the registry's
@@ -108,7 +133,7 @@ impl InputDocument {
         // lands (ledger row T4, P1) — resolving it here would change what
         // an unstated document is analysed as.
         crate::environment::profile_for_dialect(tcl_registry::dialects::detect_dialect(
-            &self.source,
+            &self.analysis_source(),
             self.filename(),
             "tcl8.6",
         ))

--- a/rust/tcl-cli/src/commands/diag.rs
+++ b/rust/tcl-cli/src/commands/diag.rs
@@ -166,7 +166,7 @@ fn cross_file_call_site_evidence(
     for document in documents {
         let dialect = document.effective_dialect(dialect_override);
         merged.merge_from(&tcl_compiler::unit_scope::scan_source_call_sites(
-            &document.source,
+            &document.analysis_source(),
             &registry_for_dialect(dialect.name),
             dialect,
             &known,
@@ -183,7 +183,7 @@ fn document_proc_names(
     dialect: &'static tcl_dialect::DialectProfile,
 ) -> Vec<String> {
     tcl_compiler::signature_scan::extract_signatures(
-        &document.source,
+        &document.analysis_source(),
         &registry_for_dialect(dialect.name),
     )
     .procs
@@ -205,23 +205,12 @@ fn collect_rows(
     disabled: &HashSet<String>,
     external_call_sites: Option<&CallSiteEvidence>,
 ) -> Vec<Row> {
-    // The *analysis* form of the document, not the bytes on disk. A lone `\r`
-    // terminates a command for `tclsh` — `Tcl_OpenFileChannel` reads scripts
-    // under `-translation auto` — but the lexer treats it as horizontal
-    // whitespace, so an unnormalised CR-terminated file parses as one command:
-    // findings are invented, real ones hidden, and `LineIndex` (which starts a
-    // line only after a `\n`) reports every one of them on line 1, column *n*.
-    // The server normalises at every entry point that reaches the analyser
-    // (`DocumentState::normalised_for_analysis`), so without this the CLI and
-    // the editor disagree about the same file (issue #1799).
-    //
-    // Safe to apply here because `normalise_lone_cr` is byte-length preserving:
-    // every span stays valid against the raw text, and
+    // The *analysis* form of the document, not the bytes on disk — see
+    // `InputDocument::analysis_source`. `LineIndex` is built over it too:
     // `LineIndex::new(normalise_lone_cr(t))` is byte-identical to
     // `LineIndex::new_lsp(t)`, so the lexer's line model and the client's
-    // coincide. An LF or CRLF document contains no lone `\r` and comes back
-    // borrowed, so this costs one scan and no allocation for almost every file.
-    let source = tcl_lexer::normalise_lone_cr(document.source.as_str());
+    // coincide (issue #1799).
+    let source = document.analysis_source();
     let source = source.as_ref();
     let line_index = LineIndex::new(source);
     let mut rows: Vec<Row> = Vec::new();

--- a/rust/tcl-cli/src/commands/diag.rs
+++ b/rust/tcl-cli/src/commands/diag.rs
@@ -205,7 +205,24 @@ fn collect_rows(
     disabled: &HashSet<String>,
     external_call_sites: Option<&CallSiteEvidence>,
 ) -> Vec<Row> {
-    let source = document.source.as_str();
+    // The *analysis* form of the document, not the bytes on disk. A lone `\r`
+    // terminates a command for `tclsh` — `Tcl_OpenFileChannel` reads scripts
+    // under `-translation auto` — but the lexer treats it as horizontal
+    // whitespace, so an unnormalised CR-terminated file parses as one command:
+    // findings are invented, real ones hidden, and `LineIndex` (which starts a
+    // line only after a `\n`) reports every one of them on line 1, column *n*.
+    // The server normalises at every entry point that reaches the analyser
+    // (`DocumentState::normalised_for_analysis`), so without this the CLI and
+    // the editor disagree about the same file (issue #1799).
+    //
+    // Safe to apply here because `normalise_lone_cr` is byte-length preserving:
+    // every span stays valid against the raw text, and
+    // `LineIndex::new(normalise_lone_cr(t))` is byte-identical to
+    // `LineIndex::new_lsp(t)`, so the lexer's line model and the client's
+    // coincide. An LF or CRLF document contains no lone `\r` and comes back
+    // borrowed, so this costs one scan and no allocation for almost every file.
+    let source = tcl_lexer::normalise_lone_cr(document.source.as_str());
+    let source = source.as_ref();
     let line_index = LineIndex::new(source);
     let mut rows: Vec<Row> = Vec::new();
 
@@ -309,25 +326,17 @@ fn collect_rows(
     }
 
     // The `SslicTcl` loader's own `SSLIC1xxx` findings, the same projection the
-    // server publishes. The loader reads the *analysis* form — a lone `\r`
-    // terminates a command for `tclsh`, but the lexer treats it as horizontal
-    // whitespace, so without this a CR-terminated document collapses into one
-    // command and the findings are nonsense. `normalise_lone_cr` rewrites each
-    // lone `\r` to `\n` byte-for-byte, so the spans it returns address the same
-    // offsets as `source`. They are mapped with a line index over that same
-    // normalised text, because `LineIndex` starts a line only after a `\n` —
-    // over the raw bytes every finding in a CR-terminated document would land
-    // on line 1. The editor shows these on the client's own lines, where a
-    // lone CR *is* an end of line, so this is what makes the two agree.
+    // server publishes. It reads the same normalised `source` and maps through
+    // the same `line_index` as every other code here — the loader used to
+    // normalise for itself (#1794), which was correct but left every other code
+    // on the raw form.
     if sslictcl {
-        let loader_text = tcl_lexer::normalise_lone_cr(source);
-        let loader_lines = LineIndex::new(&loader_text);
         for d in tcl_lsp_core::sslictcl_diagnostics::diagnostics(
-            &loader_text,
+            source,
             disabled,
             &result.suppressed_lines,
         ) {
-            let pos = loader_lines.position_at_utf16(d.span.start(), &loader_text);
+            let pos = line_index.position_at_utf16(d.span.start(), source);
             rows.push(Row {
                 line: pos.line + 1,
                 column: pos.character.get() + 1,

--- a/rust/tcl-cli/tests/cli.rs
+++ b/rust/tcl-cli/tests/cli.rs
@@ -507,6 +507,74 @@ fn diag_reads_a_cr_terminated_sslictcl_document_the_way_the_editor_does() {
     );
 }
 
+/// Issue #1799 — every code on the `tcl diag` path, not only `SSLIC1xxx`,
+/// must read the analysis form of a lone-CR document.
+///
+/// The loader branch normalised for itself (#1794) and left the analyser and
+/// compiler-checks passes reading the raw bytes. That diverged from the editor
+/// twice over: the lexer treats a bare `\r` as horizontal whitespace, so the
+/// whole file parsed as one command — inventing findings and hiding real ones —
+/// and `LineIndex` starts a line only after a `\n`, so whatever survived was
+/// reported at line 1.
+///
+/// The reproducer is the issue's own: an unclosed bracket on the second line.
+#[test]
+fn diag_reads_a_cr_terminated_tcl_document_the_way_the_editor_does() {
+    let lf = "set a 1\nset b [\nputs $a\n";
+    let cr = lf.replace('\n', "\r");
+
+    let lf_rows = tcl_diag_rows("lf", lf);
+    let cr_rows = tcl_diag_rows("cr", &cr);
+
+    assert!(
+        lf_rows.contains(&("E201".to_owned(), 2)),
+        "the `\\n` form is the reference reading: {lf_rows:?}"
+    );
+    assert_eq!(
+        cr_rows, lf_rows,
+        "a lone-CR document must read identically to the `\\n` one"
+    );
+    // The two specific ways the raw form diverged, named so a regression is
+    // legible rather than just "the vectors differ".
+    assert!(
+        cr_rows.iter().all(|(_, line)| *line > 1),
+        "no finding may collapse onto line 1: {cr_rows:?}"
+    );
+    assert!(
+        !cr_rows.iter().any(|(code, _)| code == "E003"),
+        "parsing the file as one command invents an arity error: {cr_rows:?}"
+    );
+}
+
+/// Run `tcl diag --json` over one `.tcl` document written to a scratch file and
+/// return every row as a `(code, line)` pair in report order.
+fn tcl_diag_rows(tag: &str, text: &str) -> Vec<(String, u64)> {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("clock")
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!("tcl-cli-cr-{tag}-{nanos}"));
+    std::fs::create_dir_all(&dir).expect("scratch dir");
+    let path = dir.join("doc.tcl");
+    std::fs::write(&path, text).expect("write document");
+
+    let out = run_tcl_allow_failure(&["diag", path.to_str().expect("utf-8 path"), "--json"]);
+    let report: serde_json::Value = serde_json::from_slice(&out).expect("diag JSON");
+    let rows = report[0]["diagnostics"]
+        .as_array()
+        .expect("diagnostics array")
+        .iter()
+        .map(|d| {
+            (
+                d["code"].as_str().expect("code").to_owned(),
+                d["line"].as_u64().expect("line"),
+            )
+        })
+        .collect();
+    std::fs::remove_dir_all(&dir).ok();
+    rows
+}
+
 /// Run `tcl diag --json` over one `.sslictcl` document written to a scratch
 /// file (so the dialect routes by extension, not by content signature), and
 /// return its `SSLIC*` rows as `(code, line)` pairs in report order.

--- a/rust/tcl-cli/tests/cli.rs
+++ b/rust/tcl-cli/tests/cli.rs
@@ -546,6 +546,85 @@ fn diag_reads_a_cr_terminated_tcl_document_the_way_the_editor_does() {
     );
 }
 
+/// #1799 review — dialect *detection* must read the analysis form too.
+///
+/// `detect_dialect`'s directive, shebang and version-guard tiers scan by line,
+/// and Rust's `lines()` splits on `\n` only, so on the raw form of an old-Mac
+/// document the whole file is line 1 and those tiers see nothing. The document
+/// below is routed to `f5-irules` by its content, and under the wrong dialect
+/// `when` and `HTTP::uri` are unknown commands.
+#[test]
+fn diag_detects_the_dialect_of_a_cr_terminated_document() {
+    let lf = "# ordinary header\nwhen HTTP_REQUEST {\n    set u [HTTP::uri]\n}\n";
+    let cr = lf.replace('\n', "\r");
+
+    let lf_rows = tcl_diag_rows("dialect-lf", lf);
+    let cr_rows = tcl_diag_rows("dialect-cr", &cr);
+
+    assert_eq!(
+        cr_rows, lf_rows,
+        "the dialect a lone-CR document resolves to must match its `\\n` twin"
+    );
+    assert!(
+        !cr_rows.iter().any(|(code, _)| code == "W123"),
+        "resolving as generic Tcl makes the iRules commands unknown: {cr_rows:?}"
+    );
+}
+
+/// #1799 review — the cross-file evidence scans must read the analysis form.
+///
+/// `tcl diag a.tcl b.tcl` is one compilation (#977): the declared-procedure set
+/// and the call-site scan decide what may be folded. On the raw form of a
+/// lone-CR pair both scans parse each file as one command, so the caller in the
+/// second file is invisible and the fold the pair should retract survives.
+///
+/// This is `diag_shares_call_sites_across_inputs` over the same fixtures with
+/// every `\n` rewritten to `\r`.
+#[test]
+fn diag_shares_call_sites_across_cr_terminated_inputs() {
+    let lib = std::fs::read_to_string(fixtures_dir().join("issue977Lib.tcl")).expect("lib fixture");
+    let main =
+        std::fs::read_to_string(fixtures_dir().join("issue977Main.tcl")).expect("main fixture");
+
+    let alone = multi_file_diag_text("cr-alone", &[("issue977Lib.tcl", &lib.replace('\n', "\r"))]);
+    assert!(
+        alone.contains("I230"),
+        "the library alone still has only agreeing callers: {alone}"
+    );
+    let together = multi_file_diag_text(
+        "cr-together",
+        &[
+            ("issue977Lib.tcl", &lib.replace('\n', "\r")),
+            ("issue977Main.tcl", &main.replace('\n', "\r")),
+        ],
+    );
+    assert!(
+        !together.contains("I230"),
+        "the `dev` call in the second file must be visible on the CR form too: {together}"
+    );
+}
+
+/// Write each `(name, text)` into one scratch directory, run `tcl diag` over
+/// all of them in order, and return the combined report text.
+fn multi_file_diag_text(tag: &str, files: &[(&str, &str)]) -> String {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("clock")
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!("tcl-cli-multi-{tag}-{nanos}"));
+    std::fs::create_dir_all(&dir).expect("scratch dir");
+    let mut args: Vec<String> = vec!["diag".to_owned()];
+    for (name, text) in files {
+        let path = dir.join(name);
+        std::fs::write(&path, text).expect("write document");
+        args.push(path.to_str().expect("utf-8 path").to_owned());
+    }
+    let borrowed: Vec<&str> = args.iter().map(String::as_str).collect();
+    let out = String::from_utf8(run_tcl_allow_failure(&borrowed)).expect("utf-8 output");
+    std::fs::remove_dir_all(&dir).ok();
+    out
+}
+
 /// Run `tcl diag --json` over one `.tcl` document written to a scratch file and
 /// return every row as a `(code, line)` pair in report order.
 fn tcl_diag_rows(tag: &str, text: &str) -> Vec<(String, u64)> {


### PR DESCRIPTION
## Summary

`collect_rows` handed the analyser and the compiler-checks pass the document's **raw** text, so `tcl diag` / `lint` / `validate` diverged from the server twice over on a file with lone `\r` line endings.

Closes #1799.

A bare `\r` terminates a command in `tclsh` — scripts are read under `-translation auto` — but the lexer treats it as horizontal whitespace, so the whole file parsed as one command. And `LineIndex::new` starts a line only after a `\n`, so whatever survived was reported at line 1.

Measured on the issue's own reproducer (`set a 1\rset b [\rputs $a\r`):

| | Output |
|---|---|
| **Before** | `1:9 E003 Too many arguments for 'set': expected at most 2, got 5`<br>`1:15 E201 missing close-bracket`<br>`1:22 W210 Variable 'a' is read before it is set` |
| **After** | `2:5 W211 Variable 'b' is set but never used`<br>`2:7 E201 missing close-bracket` |

Two of the three findings before were fiction — the arity error and the read-before-set both come from the file collapsing into one command — and the real one was on the wrong line.

Only the SslicTcl branch was correct: #1794 normalised for the loader because the same bug made `SSLIC` findings nonsense, and deliberately did not widen. This normalises once at the top instead and derives both the line index and the analysis inputs from it, which is what the server does at every entry point that reaches the analyser (`DocumentState::normalised_for_analysis`). The loader branch then reads the same `source` and maps through the same `line_index` as every other code, so its local normalisation goes.

Safe on this path for the two reasons `normalise_lone_cr`'s doc comment states: it is byte-length preserving, so every span stays valid against the raw text, and `LineIndex::new(normalise_lone_cr(t))` is byte-identical to `LineIndex::new_lsp(t)`, so the lexer's line model and the client's coincide. An LF or CRLF document contains no lone `\r` and comes back borrowed, so this costs one scan and no allocation for almost every file.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

```
cargo test -p tcl-cli --test cli diag_reads_a_cr_terminated   # 2 passed
make prep-pr                                                  # exit 0
cargo clippy -p tcl-cli --all-targets                         # clean
```

Test added: `diag_reads_a_cr_terminated_tcl_document_the_way_the_editor_does`, the sibling of the existing `.sslictcl` one. It asserts the lone-CR reading is identical to the `\n` reading, and names the two ways the raw form diverged so a regression is legible rather than just "the vectors differ" — nothing on line 1, and no `E003`.

**Verified non-vacuous.** With the normalisation removed it fails with exactly the defect:

```
assertion `left == right` failed: a lone-CR document must read identically to the `\n` one
  left: [("E003", 1), ("E201", 1), ("W210", 1)]
 right: [("W211", 2), ("E201", 2)]
```

## Compiler / diagnostics checklist

- [x] Did this change alter a compiler fact contract? No — the compiler is fed the text it should always have had. The owning doc `docs/design/contracts/dialect-detection.md` § *Command-line tools* gains the analysis-form rule and why it is safe.
- [x] No diagnostic or optimisation code added or changed.
- [x] No new design doc.

## Follow-up filed

#1953 — six more CLI verbs read the raw form (`minimize`, `compile`, `graphs`, `diff`, `pkg discover`, `misc`). Two of them **transform** the document, so there it is wrong *output* rather than a wrong report. Filed with the per-site inventory rather than widened into this change, which is scoped to what #1799 describes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F6pDxCsXjcTW4A9rTTpQS7

---
_Generated by [Claude Code](https://claude.ai/code/session_01F6pDxCsXjcTW4A9rTTpQS7)_