### PR TITLE
TclOO callback prefixes: an expanded word is not a callback slot (#1703, #1704)

### DIFF
--- a/docs/design/contracts/tcloo-implementation.md
+++ b/docs/design/contracts/tcloo-implementation.md
@@ -75,13 +75,19 @@ Three conditions bound it, and each abstains rather than guessing:
 - **A sole substitution.** A compound outer word changes the prefix after the
   substitution runs — `[list [self] tick]Suffix` invokes `tickSuffix` — so only
   a whole-word `[…]` is an exact representation of the built command.
-- **Not `{*}`-expanded.** `{*}` splices the value into the argument list, so the
-  registry's role indices no longer describe where anything landed:
-  `lsort -command {*}[list [self] compare] $items` runs the *object command* as
-  the comparator and passes `compare` as an ordinary argument. Reading the word
-  as if it were the callback slot invents a reference — and rename would rewrite
-  it. The compiler's own prefix scan has gated on this since #978; the
-  navigation scan gained the same gate in #1704.
+- **Not `{*}`-expanded, at any level.** `{*}` splices the value into the
+  argument list, so the registry's role indices no longer describe where
+  anything landed: `lsort -command {*}[list [self] compare] $items` runs the
+  *object command* as the comparator and passes `compare` as an ordinary
+  argument. Reading the word as if it were the callback slot invents a
+  reference — and rename would rewrite it. One expansion invalidates every
+  *later* index too, not just its own word, so the check is "every word up to
+  this one is written out", and it is applied at the consumer's callback slot,
+  inside the built prefix, and again at each `WRAPS_COMMAND_PREFIX` hop:
+  `after idle [namespace code {*}[list my tick]]` gives `namespace code` two
+  arguments and errors rather than dispatching anything. The compiler's own
+  prefix scan has gated on this since #978; the navigation scan gained the same
+  gate in #1704.
 - **One unambiguous same-scope constant**, for a prefix stored in a variable
   first (`set cb [list [self] tick]; bind .w <Button-1> $cb`). Every write to
   the name is a candidate: more than one write, a dynamic write, a scope alias

--- a/docs/design/contracts/tcloo-implementation.md
+++ b/docs/design/contracts/tcloo-implementation.md
@@ -58,6 +58,40 @@ go-to-definition, and call-hierarchy resolve them across files through the
 workspace index — and rename and references can never disagree about a
 `superclass` / `mixin` / `inherit` site.
 
+### Callback prefixes that name a method (`references.rs`)
+
+A method reached through a callback prefix — `after 0 [list [self] tick]`,
+`fileevent $s readable [namespace code [list my read]]`, `socket -server
+[namespace code [list my connect]] $port` — is a method reference, and the four
+navigation providers resolve it through one owner
+(`tcl_lsp_core::references::callback_targets_from_command`). Recognition is
+registry data throughout: the *slot* is an `ArgRole::Body` or
+`ArgRole::CommandPrefix` position, the *builder* carries
+`BUILDS_COMMAND_PREFIX` (`list`), and the *wrapper* carries
+`WRAPS_COMMAND_PREFIX` (`namespace code`). No consumer names a command.
+
+Three conditions bound it, and each abstains rather than guessing:
+
+- **A sole substitution.** A compound outer word changes the prefix after the
+  substitution runs — `[list [self] tick]Suffix` invokes `tickSuffix` — so only
+  a whole-word `[…]` is an exact representation of the built command.
+- **Not `{*}`-expanded.** `{*}` splices the value into the argument list, so the
+  registry's role indices no longer describe where anything landed:
+  `lsort -command {*}[list [self] compare] $items` runs the *object command* as
+  the comparator and passes `compare` as an ordinary argument. Reading the word
+  as if it were the callback slot invents a reference — and rename would rewrite
+  it. The compiler's own prefix scan has gated on this since #978; the
+  navigation scan gained the same gate in #1704.
+- **One unambiguous same-scope constant**, for a prefix stored in a variable
+  first (`set cb [list [self] tick]; bind .w <Button-1> $cb`). Every write to
+  the name is a candidate: more than one write, a dynamic write, a scope alias
+  in the frame, or a qualified or array name and the variable is omitted, so
+  reassignment, branch joins and parameters abstain without a target.
+
+A class system whose definer the analyser does not model records no `ClassDef`
+at all, so none of this is reachable in such a file however well-formed its
+callbacks are — `::clay::define` is the corpus example (#1956).
+
 ### LSP analysis layer (`rust/tcl-compiler/src/analyser/`)
 
 The analyser (`oo.rs`, `class_hierarchy.rs`) recognises `oo::class create` /

--- a/rust/tcl-lsp-core/src/references.rs
+++ b/rust/tcl-lsp-core/src/references.rs
@@ -2427,6 +2427,17 @@ fn callback_targets_from_command(
         let Some(&body_tok) = cmd.argv.get(idx + 1) else {
             continue;
         };
+        // `{*}` splices the word's value into the argument list, so the
+        // registry's role indices no longer describe where anything landed:
+        // `lsort -command {*}[list [self] compare] $items` runs the *object
+        // command* as the comparator and passes `compare` as a separate
+        // argument. Reading the word as if it were the callback slot invents a
+        // reference to `compare` — and Rename would rewrite it. The compiler's
+        // own prefix scan has gated on this since #978
+        // (`signature_scan::command_prefix`); this scan had not.
+        if word_is_expanded(cmd, idx + 1) {
+            continue;
+        }
         if body_tok.kind == TokenType::Var && cmd.single_token_word.get(idx + 1) == Some(&true) {
             // A stored callback is accepted only when exactly one static
             // assignment to this local spelling precedes the use.  The
@@ -2461,6 +2472,17 @@ fn callback_targets_from_command(
         out.extend(command_prefix_targets_from_word(ctx, &body_tok, 0));
     }
     out
+}
+
+/// Whether word `word_idx` of `cmd` is `{*}`-expanded.
+///
+/// `expand_word` is `None` for the overwhelming majority of commands — no word
+/// uses expansion — and a per-word flag list otherwise.
+fn word_is_expanded(cmd: &tcl_compiler::segmenter::SegmentedCommand, word_idx: usize) -> bool {
+    cmd.expand_word
+        .as_ref()
+        .and_then(|flags| flags.get(word_idx).copied())
+        .unwrap_or(false)
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -6399,6 +6421,103 @@ mod tests {
         );
     }
 
+    /// Issues #1703 / #1704 asked for "at least one tcllib-shaped fixture",
+    /// and the suite met that only with hand-written imitations. This reads
+    /// the real files the issues cite.
+    ///
+    /// Gated on corpus presence with a loud skip, matching
+    /// `rust/tcl-lsp-db/tests/compiler_check_corpus.rs`.
+    #[test]
+    fn the_real_tcllib_callback_shapes_resolve_to_their_methods() {
+        let corpus = std::env::var_os("TCLLIB_2_0_DIR").map_or_else(
+            || std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../tmp/tcllib-2.0"),
+            std::path::PathBuf::from,
+        );
+        // (file, method declared in the file, a method named by a callback
+        // prefix inside it). `cat.tcl` is the `after … [namespace code [list
+        // my Post $c]]` shape from #1703; `httpd.tcl` is the `socket -server
+        // [namespace code [list my connect]]` CommandPrefix shape.
+        // `httpd.tcl` carries the `socket -server [namespace code [list my
+        // connect]]` shape the issues also cite, but it defines its classes
+        // with `::clay::define`, which the analyser records no class for at
+        // all — `all_classes` is empty for that file, so there is no method to
+        // navigate from and the shape is unreachable for reasons that have
+        // nothing to do with callback prefixes. Filed as #1956 rather than
+        // asserted here.
+        let (relative, method) = ("modules/virtchannel_base/cat.tcl", "Post");
+        {
+            let path = corpus.join(relative);
+            let Ok(src) = std::fs::read_to_string(&path) else {
+                eprintln!(
+                    "skip: {} not present (fetch tcllib 2.0 under tmp/, or set TCLLIB_2_0_DIR)",
+                    path.display()
+                );
+                return;
+            };
+            let analysis = analyse(&src);
+            let declaration = src
+                .find(&format!("method {method} "))
+                .unwrap_or_else(|| panic!("{relative} declares `method {method}`"));
+            let line = u32::try_from(src[..declaration].lines().count() - 1).expect("line fits");
+            let column = u32::try_from(
+                src[..declaration]
+                    .rsplit('\n')
+                    .next()
+                    .unwrap_or_default()
+                    .len()
+                    + "method ".len(),
+            )
+            .expect("column fits");
+            let refs = references(
+                &src,
+                tcl_registry::model::ingress::resolve_environment("tcl").analyser_profile(),
+                line,
+                column,
+                &analysis,
+                true,
+            );
+            assert!(
+                refs.len() > 1,
+                "{relative}: `{method}` must reach its callback prefix as well as its \
+                 declaration, got {refs:?}"
+            );
+        }
+    }
+
+    /// Issue #1704 — a `{*}`-expanded callback word must abstain.
+    ///
+    /// `{*}` splices the word's value into the argument list, so the registry's
+    /// role indices no longer describe where anything landed. Reading the word
+    /// as if it were the callback slot is not merely unjustified, it invents
+    /// references: after expansion `lsort -command {*}[list [self] compare]
+    /// $items` runs the bare *object command* as the comparator and passes
+    /// `compare` as a separate argument, so `compare` is not dispatched at all
+    /// — and Rename would have rewritten it.
+    #[test]
+    fn an_expanded_callback_word_invents_no_reference() {
+        for src in [
+            // The comparator is the object command; `compare` is an argument.
+            "oo::class create C {\n    method compare {a b} { return 0 }\n    method sort {items} {\n        lsort -command {*}[list [self] compare] $items\n    }\n}\n",
+            // Same rule for a Body slot, where the arity happens to work out.
+            "oo::class create C {\n    method tick {} { return 1 }\n    method wire {} {\n        after idle {*}[list [self] tick]\n    }\n}\n",
+        ] {
+            let refs = references(
+                src,
+                tcl_registry::model::ingress::resolve_environment("tcl").analyser_profile(),
+                1,
+                11,
+                &analyse(src),
+                true,
+            );
+            assert!(
+                !refs.iter().any(|r| r.start_line == 3),
+                "an expanded word is not a callback slot: {src:?} gave {refs:?}"
+            );
+        }
+    }
+
+    /// The gate is about expansion, not about the shape around it: the same
+    /// prefix written as a sole substitution still resolves.
     #[test]
     fn references_reach_a_list_built_self_command_prefix() {
         // CommandPrefix is distinct from Body: the registry says this word is

--- a/rust/tcl-lsp-core/src/references.rs
+++ b/rust/tcl-lsp-core/src/references.rs
@@ -2435,7 +2435,7 @@ fn callback_targets_from_command(
         // reference to `compare` — and Rename would rewrite it. The compiler's
         // own prefix scan has gated on this since #978
         // (`signature_scan::command_prefix`); this scan had not.
-        if word_is_expanded(cmd, idx + 1) {
+        if !positions_are_literal_through(cmd, idx + 1) {
             continue;
         }
         if body_tok.kind == TokenType::Var && cmd.single_token_word.get(idx + 1) == Some(&true) {
@@ -2474,15 +2474,26 @@ fn callback_targets_from_command(
     out
 }
 
-/// Whether word `word_idx` of `cmd` is `{*}`-expanded.
+/// Whether every word of `cmd` up to and including `upto` is written out
+/// rather than `{*}`-expanded.
+///
+/// A consumer that reads word *N* is relying on the registry's role indices,
+/// and those describe words. `{*}` splices a value's elements into the
+/// argument list, so one expansion at or before *N* makes every later index
+/// unreliable — not just the expanded word itself. Checking the whole prefix
+/// is what makes `[namespace code {*}[list my tick]]` abstain: the expansion
+/// is at the wrapper's body position, and after it `namespace code` has two
+/// arguments and errors rather than dispatching anything (issue #1704).
 ///
 /// `expand_word` is `None` for the overwhelming majority of commands — no word
 /// uses expansion — and a per-word flag list otherwise.
-fn word_is_expanded(cmd: &tcl_compiler::segmenter::SegmentedCommand, word_idx: usize) -> bool {
+fn positions_are_literal_through(
+    cmd: &tcl_compiler::segmenter::SegmentedCommand,
+    upto: usize,
+) -> bool {
     cmd.expand_word
         .as_ref()
-        .and_then(|flags| flags.get(word_idx).copied())
-        .unwrap_or(false)
+        .is_none_or(|flags| flags.iter().take(upto + 1).all(|expanded| !expanded))
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -2536,6 +2547,11 @@ fn command_prefix_targets_from_word(
     };
     let traits = invocation.semantics.traits;
 
+    // The built prefix's own words are read by position too, so an expansion
+    // inside it is as disqualifying as one at the consumer's callback slot.
+    if !positions_are_literal_through(builder, 2) {
+        return Vec::new();
+    }
     if traits.contains(Traits::BUILDS_COMMAND_PREFIX) {
         if let (Some(receiver), Some(&method_tok)) = (builder.texts.get(1), builder.argv.get(2))
             && method_tok.kind == TokenType::Esc
@@ -2582,7 +2598,9 @@ fn command_prefix_targets_from_word(
             let Some(&body) = builder.argv.get(idx + 1) else {
                 return Vec::new();
             };
-            if builder.single_token_word.get(idx + 1) == Some(&true) {
+            if builder.single_token_word.get(idx + 1) == Some(&true)
+                && positions_are_literal_through(builder, idx + 1)
+            {
                 command_prefix_targets_from_word(ctx, &body, depth + 1)
             } else {
                 Vec::new()
@@ -6500,6 +6518,12 @@ mod tests {
             "oo::class create C {\n    method compare {a b} { return 0 }\n    method sort {items} {\n        lsort -command {*}[list [self] compare] $items\n    }\n}\n",
             // Same rule for a Body slot, where the arity happens to work out.
             "oo::class create C {\n    method tick {} { return 1 }\n    method wire {} {\n        after idle {*}[list [self] tick]\n    }\n}\n",
+            // Codex review on #1957: inside a `WRAPS_COMMAND_PREFIX` wrapper.
+            // `namespace code` then has two arguments and errors rather than
+            // dispatching anything, so there is nothing to reference.
+            "oo::class create C {\n    method tick {} { return 1 }\n    method wire {} {\n        after idle [namespace code {*}[list my tick]]\n    }\n}\n",
+            // And inside the builder itself: the receiver is no longer word 1.
+            "oo::class create C {\n    method tick {} { return 1 }\n    method wire {} {\n        after idle [list {*}$prefix tick]\n    }\n}\n",
         ] {
             let refs = references(
                 src,


### PR DESCRIPTION
## Summary

Both issues are **already implemented** on `rust` — the registry-driven walk, the `list` / `namespace code` trait recognition, the one-hop stored-constant flow and its abstention set all exist, with named tests for every shape either issue lists. I verified that before writing anything (`cargo test -p tcl-lsp-core --lib stored_callback` — 6 passed; the `references` module — 150 passed).

What was left is one gap the acceptance criteria name explicitly, plus the corpus fixture neither issue got.

Closes #1703. Closes #1704.

### The gap: `{*}` expansion

#1704 requires that `{*}` expansion "abstain without invented references". It did not, and the consequence is worse than an unjustified reference:

```tcl
oo::class create C {
    method compare {a b} { return 0 }
    method sort {items} {
        lsort -command {*}[list [self] compare] $items
    }
}
```

`{*}` splices the value into the argument list, so this runs `lsort -command <obj> compare $items` — the comparator is the bare **object command**, and `compare` is an ordinary argument that is never dispatched as a method. The scan reported a reference to `compare` anyway, and **rename would have rewritten it**, corrupting a working program.

Measured before and after, on that source and on the `after idle {*}[list [self] tick]` Body-slot form:

| | before | after |
|---|---|---|
| sole substitution | reference | reference |
| `{*}`-expanded | reference | **abstains** |

The fix is the gate the compiler's own prefix scan has applied since #978 (`signature_scan::command_prefix` checks `words.expanded`): read `SegmentedCommand::expand_word`. It goes in `callback_targets_from_command`, the one owner all three consumers share, so Find References, the cursor path and the stored-prefix path abstain together rather than disagreeing.

### The fixture

Both issues ask for "at least one tcllib-shaped fixture", and the suite met that only with hand-written imitations. This adds a corpus-gated test over the real file, with a loud skip when the corpus is absent — the convention `compiler_check_corpus.rs` uses.

It covers `virtchannel_base/cat.tcl` (`after $delay [namespace code [list my Post $c]]`) **only**. `httpd/httpd.tcl` carries the other cited shape (`socket -server [namespace code [list my connect]]`), but it defines its classes with `::clay::define`, and the analyser records **no class at all** for that file:

| file | definer | classes recorded |
|---|---|---|
| `cat.tcl` | `oo::class create` | 1 |
| `httpd.tcl` | `::clay::define` | **0** |

So it is unreachable for a reason that has nothing to do with callback prefixes — there is no class to navigate from. Filed as #1956 rather than asserted here or quietly dropped.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

```
cargo test -p tcl-lsp-core                      # 34 targets, 0 failures
cargo test -p tcl-lsp-server --test e2e tcloo   # 69 passed
make prep-pr                                    # exit 0
cargo clippy -p tcl-lsp-core --all-targets      # clean
```

Tests added:

- `an_expanded_callback_word_invents_no_reference` — the `lsort -command` misalignment above and the `after idle` Body form. Both produced a reference before the gate.
- `the_real_tcllib_callback_shapes_resolve_to_their_methods` — corpus-gated over `cat.tcl`.

## Compiler / diagnostics checklist

- [x] Did this change alter a compiler fact contract? No new fact — it consumes an existing one (`SegmentedCommand::expand_word`) that the compiler-side scan already consulted. The owning doc `docs/design/contracts/tcloo-implementation.md` gains a *Callback prefixes that name a method* section stating the three conditions that bound the walk and why each abstains, since that contract was only in code comments.
- [x] No diagnostic or optimisation code added or changed.
- [x] No new design doc.

## Follow-up filed

#1956 — `::clay::define` declares no class to the analyser, so method navigation is inert in clay-based files. Found by this PR's corpus test; the shape of a fix is known (a `DefinitionBodyGrammar` plus a `DefinerFamily` arm, per the registry invariant), but whether clay belongs in the registry or in a SpecTcl pack is a call worth making first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F6pDxCsXjcTW4A9rTTpQS7

---
_Generated by [Claude Code](https://claude.ai/code/session_01F6pDxCsXjcTW4A9rTTpQS7)_