### PR TITLE
Address three review findings that landed with #1952 and #1942

### DIFF
--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/CompilerExplorerToolWindowFactory.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/CompilerExplorerToolWindowFactory.kt
@@ -34,8 +34,6 @@ import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowFactory
 import com.intellij.platform.lsp.api.LspServer
-import com.intellij.platform.lsp.api.LspServerManager
-import com.intellij.platform.lsp.api.LspServerState
 import com.intellij.ui.content.ContentFactory
 import com.intellij.ui.jcef.JBCefBrowser
 import com.intellij.ui.jcef.JBCefBrowserBase
@@ -46,9 +44,6 @@ import org.cef.handler.CefLoadHandlerAdapter
 
 private val LOG = Logger.getInstance("com.tcllsp.jetbrains.CompilerExplorer")
 
-/** How long [CompilerExplorerPanel.awaitRunningServer] waits for the lazily
- *  started Tcl LSP server to reach Running before giving up. */
-private const val SERVER_WAIT_TIMEOUT_MS = 10_000L
 
 class CompilerExplorerToolWindowFactory : ToolWindowFactory, DumbAware {
 
@@ -266,63 +261,20 @@ internal class CompilerExplorerPanel(private val project: Project) : Disposable 
         }
     }
 
-    /**
-     * Resolve a running Tcl LSP server, kicking it and waiting briefly if one
-     * isn't ready yet. Returns null only after a real timeout.
-     *
-     * The LSP server starts lazily on the first Tcl editor (see
-     * [TclLspServerSupportProvider]). When the explorer tool window is restored
-     * on IDE startup it pushes its first compile before that server has
-     * finished initialising, which previously surfaced a spurious "LSP server
-     * not running" error in the output pane. Poll for a Running server instead;
-     * this runs on the [runCompile] background thread, so the sleep is safe.
-     */
-    @Suppress("UnstableApiUsage")
-    private fun awaitRunningServer(timeoutMs: Long = SERVER_WAIT_TIMEOUT_MS): LspServer? {
-        val manager = LspServerManager.getInstance(project)
-        fun running(): LspServer? =
-            manager.getServersForProvider(TclLspServerSupportProvider::class.java)
-                .firstOrNull { it.state == LspServerState.Running }
-
-        running()?.let { return it }
-
-        // Kick the lazily-started server before the clock starts, so a busy EDT
-        // during startup can't eat the timeout budget before the start request
-        // even runs. invokeAndWait is safe here: this runs on a pooled thread,
-        // never the EDT, so it can't deadlock against the dispatch it waits on.
-        ApplicationManager.getApplication().invokeAndWait {
-            manager.startServersIfNeeded(TclLspServerSupportProvider::class.java)
-        }
-
-        // Monotonic clock: a wall-clock adjustment must not distort the wait.
-        val deadlineNanos = System.nanoTime() + timeoutMs * 1_000_000
-        while (System.nanoTime() < deadlineNanos) {
-            if (project.isDisposed) return null
-            try {
-                Thread.sleep(150)
-            } catch (e: InterruptedException) {
-                // Preserve cancellation semantics for the pooled-thread task.
-                Thread.currentThread().interrupt()
-                return null
-            }
-            running()?.let { return it }
-        }
-        return null
-    }
-
     private fun runCompile(source: String, dialect: String) {
         // IntelliJ's pooled executor rather than the FJP common pool: the
-        // awaitRunningServer wait can block this task for several seconds, which
+        // awaitRunningTclLspServer wait can block this task for several seconds,
+        // which
         // would otherwise starve unrelated common-pool work.
         ApplicationManager.getApplication().executeOnPooledThread {
             try {
                 sendStatusToWebview("compiling")
 
-                val server = awaitRunningServer()
+                val server = awaitRunningTclLspServer(project)
                 if (server == null) {
                     sendErrorToWebview(
                         "Tcl LSP server did not become ready within " +
-                            "${SERVER_WAIT_TIMEOUT_MS / 1000}s — it may still be " +
+                            "${TCL_LSP_SERVER_WAIT_TIMEOUT_MS / 1000}s — it may still be " +
                             "starting up, or be disabled or not installed."
                     )
                     return@executeOnPooledThread
@@ -381,7 +333,7 @@ internal class CompilerExplorerPanel(private val project: Project) : Disposable 
         // reveal an unrelated span there.
         val origin = sourceFile
         ApplicationManager.getApplication().executeOnPooledThread {
-            val server = awaitRunningServer()
+            val server = awaitRunningTclLspServer(project)
             if (server == null) {
                 sendErrorToWebview("Tcl LSP server did not become ready — cannot render $label.")
                 return@executeOnPooledThread

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/SpecStudioToolWindowFactory.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/SpecStudioToolWindowFactory.kt
@@ -173,9 +173,16 @@ internal class SpecStudioPanel(private val project: Project) : Disposable {
         // argument list free of nulls across the Gson boundary.
         val args: List<Any> = if (dialect == null) listOf(uri) else listOf(uri, dialect)
         ApplicationManager.getApplication().executeOnPooledThread {
-            val server = LspServerManager.getInstance(project)
-                .getServersForProvider(TclLspServerSupportProvider::class.java)
-                .firstOrNull { it.state == LspServerState.Running } ?: return@executeOnPooledThread
+            // Start the server and wait, rather than give up on one that has
+            // not started yet. The server is launched lazily by the first Tcl
+            // editor, so in a project with no Tcl file already open the studio
+            // is the first thing to want it — and a dropped pin is never
+            // retried, leaving the sample under generic Tcl for the rest of
+            // the session. Same wait the Compiler Explorer has always used.
+            val server = awaitRunningTclLspServer(project) ?: run {
+                SPEC_LOG.warn("No Tcl LSP server to pin the Spec Studio sample dialect on")
+                return@executeOnPooledThread
+            }
             try {
                 server.sendRequestSync(LspServer.DEFAULT_REQUEST_TIMEOUT_MS) { lsp4j ->
                     lsp4j.workspaceService.executeCommand(

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/SpecStudioToolWindowFactory.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/SpecStudioToolWindowFactory.kt
@@ -34,6 +34,7 @@ import org.eclipse.lsp4j.FileEvent
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.Comparator
+import java.util.concurrent.atomic.AtomicLong
 
 private val SPEC_LOG = Logger.getInstance("com.tcllsp.jetbrains.SpecStudio")
 
@@ -62,6 +63,23 @@ internal class SpecStudioPanel(private val project: Project) : Disposable {
         "stub" to sessionDir.resolve("generated-stub.tcl"),
     )
     private var disposed = false
+
+    /**
+     * Which sample-dialect pin is the studio's current intent.
+     *
+     * Each pin now waits for the lazily-started LSP server, so two can be in
+     * flight at once — the one sent when the studio mounts, and one from a
+     * picker change made while that is still waiting.  They are independent
+     * pooled tasks with no ordering between them, so without this the initial
+     * dialect could be applied *after* the newer selection and leave the sample
+     * disagreeing with the UI until the user changed it again (PR #1960
+     * review).  A pin claims a generation before it is dispatched and rechecks
+     * it before sending, so only the newest intent reaches the server.
+     */
+    private val dialectPinGeneration = AtomicLong()
+
+    /** Serialises the recheck with the send it guards. */
+    private val dialectPinLock = Any()
 
     init {
         Disposer.register(this, browser)
@@ -172,6 +190,10 @@ internal class SpecStudioPanel(private val project: Project) : Disposable {
         // the server reads an absent dialect as a clear, and this keeps the
         // argument list free of nulls across the Gson boundary.
         val args: List<Any> = if (dialect == null) listOf(uri) else listOf(uri, dialect)
+        // Claimed here, not inside the task: the order pins are *requested* in
+        // is the studio's intent, and the order the pooled tasks happen to run
+        // in is not.
+        val generation = dialectPinGeneration.incrementAndGet()
         ApplicationManager.getApplication().executeOnPooledThread {
             // Start the server and wait, rather than give up on one that has
             // not started yet. The server is launched lazily by the first Tcl
@@ -183,14 +205,22 @@ internal class SpecStudioPanel(private val project: Project) : Disposable {
                 SPEC_LOG.warn("No Tcl LSP server to pin the Spec Studio sample dialect on")
                 return@executeOnPooledThread
             }
-            try {
-                server.sendRequestSync(LspServer.DEFAULT_REQUEST_TIMEOUT_MS) { lsp4j ->
-                    lsp4j.workspaceService.executeCommand(
-                        ExecuteCommandParams("tcl-lsp.setDocumentDialectOverride", args)
-                    )
+            // Recheck under the lock rather than before it: a bare check
+            // leaves the window between the check and the send, which is
+            // exactly where a newer pin would overtake this one.
+            synchronized(dialectPinLock) {
+                if (dialectPinGeneration.get() != generation) {
+                    return@executeOnPooledThread
                 }
-            } catch (error: Exception) {
-                SPEC_LOG.warn("Could not set the Spec Studio sample dialect", error)
+                try {
+                    server.sendRequestSync(LspServer.DEFAULT_REQUEST_TIMEOUT_MS) { lsp4j ->
+                        lsp4j.workspaceService.executeCommand(
+                            ExecuteCommandParams("tcl-lsp.setDocumentDialectOverride", args)
+                        )
+                    }
+                } catch (error: Exception) {
+                    SPEC_LOG.warn("Could not set the Spec Studio sample dialect", error)
+                }
             }
         }
     }

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/TclLspServerWait.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/TclLspServerWait.kt
@@ -1,0 +1,80 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package com.tcllsp.jetbrains
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.project.Project
+import com.intellij.platform.lsp.api.LspServer
+import com.intellij.platform.lsp.api.LspServerManager
+import com.intellij.platform.lsp.api.LspServerState
+
+/** How long [awaitRunningTclLspServer] waits for the lazily started Tcl LSP
+ *  server to reach Running before giving up. */
+internal const val TCL_LSP_SERVER_WAIT_TIMEOUT_MS = 10_000L
+
+/**
+ * Resolve a running Tcl LSP server, kicking it and waiting briefly if one
+ * isn't ready yet. Returns null only after a real timeout.
+ *
+ * The server starts lazily on the first Tcl editor (see
+ * [TclLspServerSupportProvider]), so a tool window that talks to it before the
+ * user has opened a Tcl file finds nothing running. Every such caller has to
+ * start it and wait rather than give up, or its request is silently dropped
+ * and nothing retries it: the Compiler Explorer restored on IDE startup
+ * reported a spurious "LSP server not running", and Spec Studio's dialect pin
+ * left the sample under generic Tcl until the selector was touched again.
+ *
+ * Must be called off the EDT — it sleeps. `invokeAndWait` for the start
+ * request is safe for that reason: a pooled thread cannot deadlock against
+ * the dispatch it waits on.
+ */
+@Suppress("UnstableApiUsage")
+internal fun awaitRunningTclLspServer(
+    project: Project,
+    timeoutMs: Long = TCL_LSP_SERVER_WAIT_TIMEOUT_MS,
+): LspServer? {
+    val manager = LspServerManager.getInstance(project)
+    fun running(): LspServer? =
+        manager.getServersForProvider(TclLspServerSupportProvider::class.java)
+            .firstOrNull { it.state == LspServerState.Running }
+
+    running()?.let { return it }
+
+    // Kick the lazily-started server before the clock starts, so a busy EDT
+    // during startup can't eat the timeout budget before the start request
+    // even runs.
+    ApplicationManager.getApplication().invokeAndWait {
+        manager.startServersIfNeeded(TclLspServerSupportProvider::class.java)
+    }
+
+    // Monotonic clock: a wall-clock adjustment must not distort the wait.
+    val deadlineNanos = System.nanoTime() + timeoutMs * 1_000_000
+    while (System.nanoTime() < deadlineNanos) {
+        if (project.isDisposed) return null
+        try {
+            Thread.sleep(150)
+        } catch (e: InterruptedException) {
+            // Preserve cancellation semantics for the pooled-thread task.
+            Thread.currentThread().interrupt()
+            return null
+        }
+        running()?.let { return it }
+    }
+    return null
+}

--- a/rust/tcl-cli/gui/explorer-core.js
+++ b/rust/tcl-cli/gui/explorer-core.js
@@ -532,12 +532,23 @@ function renderInterproc() {
 }
 
 // Optimiser
+// The replacement cell for one optimisation.
+//
+// A `hintOnly` entry carries no replacement: its range spans the whole
+// consuming statement, so the literal was never a valid edit for it (#1934).
+// Rendering the usual arrow-and-value for one shows advice as an edit to an
+// empty string — a deletion — which is the opposite of what it means.
+function optReplacementHtml(o) {
+  if (o.hintOnly) return '<span class="opt-repl opt-hint">hint only</span>';
+  return '<span class="opt-repl">\u2192 ' + esc(o.replacement) + '</span>';
+}
+
 function renderOpt() {
   var pane = $('#pane-opt');
   if (!data.optimisations.length) { pane.innerHTML = '<div class="empty-state">No optimiser rewrites</div>'; return; }
   var html = '<div class="section-header">Rewrites</div>';
   for (var o of data.optimisations) {
-    html += '<div class="opt-item"' + sourceRangeAttrs(o.range) + '><span class="opt-code">' + esc(o.code) + '</span><span class="opt-msg">' + esc(o.message) + ' <span style="color:var(--text-dim); font-size:10px">[' + spanLabel(o.range) + ']</span></span><span class="opt-repl">\u2192 ' + esc(o.replacement) + '</span></div>';
+    html += '<div class="opt-item"' + sourceRangeAttrs(o.range) + '><span class="opt-code">' + esc(o.code) + '</span><span class="opt-msg">' + esc(o.message) + ' <span style="color:var(--text-dim); font-size:10px">[' + spanLabel(o.range) + ']</span></span>' + optReplacementHtml(o) + '</div>';
   }
   if (data.optimisedSource) { html += '<div class="section-header">Source Diff</div>' + buildOptDiffView(); }
   pane.innerHTML = html;
@@ -560,7 +571,7 @@ function renderOptimiserPasses() {
       continue;
     }
     for (var o of p.optimisations) {
-      html += '<div class="opt-item"' + sourceRangeAttrs(o.range) + '><span class="opt-code">' + esc(o.code) + '</span><span class="opt-msg">' + esc(o.message) + ' <span style="color:var(--text-dim); font-size:10px">[' + spanLabel(o.range) + ']</span></span><span class="opt-repl">→ ' + esc(o.replacement) + '</span></div>';
+      html += '<div class="opt-item"' + sourceRangeAttrs(o.range) + '><span class="opt-code">' + esc(o.code) + '</span><span class="opt-msg">' + esc(o.message) + ' <span style="color:var(--text-dim); font-size:10px">[' + spanLabel(o.range) + ']</span></span>' + optReplacementHtml(o) + '</div>';
     }
   }
   pane.innerHTML = html;

--- a/rust/tcl-cli/gui/index.html
+++ b/rust/tcl-cli/gui/index.html
@@ -472,6 +472,8 @@ textarea#source::placeholder { color: var(--text-dim); }
 .opt-item .opt-code { font-weight: 600; color: var(--green); flex-shrink: 0; min-width: 32px; }
 .opt-item .opt-msg { color: var(--text); flex: 1; }
 .opt-item .opt-repl { color: var(--green); font-size: 11px; }
+/* A hint is advice, not an edit: it must not read as a green rewrite. */
+.opt-item .opt-repl.opt-hint { color: var(--text-dim); font-style: italic; }
 .shimmer-item {
   padding: 4px 6px;
   border-radius: 4px;

--- a/rust/tcl-explorer/src/view_tree.rs
+++ b/rust/tcl-explorer/src/view_tree.rs
@@ -1032,26 +1032,39 @@ fn build_unit_scope(d: &Value) -> Vec<ViewNode> {
 
 // --- Optimiser / GVN / shimmer / taint / iRules / callouts ---
 
+/// One optimisation's label and details, shared by the flat rewrite list and
+/// the per-pass pipeline.
+///
+/// A `hintOnly` entry carries no replacement: its range spans the whole
+/// consuming statement, so the literal was never a valid edit for it (#1934).
+/// Rendering the usual `code message -> replacement` for one shows advice as a
+/// rewrite to the empty string — a deletion — which is the opposite of what it
+/// means, so the arrow is dropped and the row says what it is.
+fn opt_leaf(o: &Value) -> ViewNode {
+    let hint_only = o.get("hintOnly").and_then(Value::as_bool).unwrap_or(false);
+    let (tail, replacement) = if hint_only {
+        (" (hint only)".to_owned(), "(none — hint only)".to_owned())
+    } else {
+        (format!(" \u{2192} {}", s(o, "replacement")), s(o, "replacement"))
+    };
+    ViewNode::leaf(
+        format!("{} {}{tail}", s(o, "code"), s(o, "message")),
+        vec![
+            det("code", s(o, "code")),
+            det("message", s(o, "message")),
+            det("replacement", replacement),
+            det("range", rng(&o["range"])),
+        ],
+        Some(if hint_only { "yellow" } else { "green" }),
+    )
+    .with_range(&o["range"])
+}
+
 fn build_opt(d: &Value) -> Vec<ViewNode> {
     let out: Vec<ViewNode> = arr(d, "optimisations")
         .iter()
         .map(|o| {
-            ViewNode::leaf(
-                format!(
-                    "{} {} → {}",
-                    s(o, "code"),
-                    s(o, "message"),
-                    s(o, "replacement")
-                ),
-                vec![
-                    det("code", s(o, "code")),
-                    det("message", s(o, "message")),
-                    det("replacement", s(o, "replacement")),
-                    det("range", rng(&o["range"])),
-                ],
-                Some("green"),
-            )
-            .with_range(&o["range"])
+            opt_leaf(o)
         })
         .collect();
     if out.is_empty() {
@@ -1177,22 +1190,7 @@ fn build_optimiser_passes(d: &Value) -> Vec<ViewNode> {
             let opts: Vec<ViewNode> = arr(p, "optimisations")
                 .iter()
                 .map(|o| {
-                    ViewNode::leaf(
-                        format!(
-                            "{} {} → {}",
-                            s(o, "code"),
-                            s(o, "message"),
-                            s(o, "replacement")
-                        ),
-                        vec![
-                            det("code", s(o, "code")),
-                            det("message", s(o, "message")),
-                            det("replacement", s(o, "replacement")),
-                            det("range", rng(&o["range"])),
-                        ],
-                        Some("green"),
-                    )
-                    .with_range(&o["range"])
+                    opt_leaf(o)
                 })
                 .collect();
             let count = s(p, "count");
@@ -1727,6 +1725,68 @@ mod tests {
 
     fn data(src: &str) -> Value {
         serialise_result(&run_pipeline(src, "tcl8.6"))
+    }
+
+    /// A hint is advice, not an edit, and the row must not read as one.
+    ///
+    /// A `hintOnly` optimisation carries no replacement — its range spans the
+    /// whole consuming statement, so the literal was never a valid edit for it
+    /// (#1934). Rendering the usual `code message -> replacement` gives
+    /// `-> ` with nothing after it, which reads as a rewrite to the empty
+    /// string: a deletion, and the opposite of what the entry means.
+    #[test]
+    fn a_hint_only_optimisation_is_not_rendered_as_a_rewrite() {
+        let d = data("set n 7\nputs \"n=$n\"\n");
+        let hints: Vec<&Value> = d["optimisations"]
+            .as_array()
+            .expect("the opt payload is a list")
+            .iter()
+            .filter(|o| o.get("hintOnly").and_then(Value::as_bool).unwrap_or(false))
+            .collect();
+        assert!(
+            !hints.is_empty(),
+            "the fixture must produce a hint-only entry, else this proves nothing: {:?}",
+            d["optimisations"],
+        );
+
+        for o in hints {
+            let node = opt_leaf(o);
+            assert!(
+                node.label.ends_with("(hint only)"),
+                "a hint must say so: {:?}",
+                node.label,
+            );
+            assert!(
+                !node.label.contains('\u{2192}'),
+                "and must not carry the rewrite arrow: {:?}",
+                node.label,
+            );
+            let replacement = node
+                .detail
+                .iter()
+                .find(|(k, _)| k == "replacement")
+                .map(|(_, v)| v.as_str())
+                .expect("every optimisation row details its replacement");
+            assert!(
+                !replacement.is_empty(),
+                "the detail row must explain the absence rather than show a blank edit",
+            );
+        }
+    }
+
+    /// The ordinary case still renders as a rewrite.
+    #[test]
+    fn an_applicable_optimisation_still_shows_its_replacement() {
+        let o = serde_json::json!({
+            "code": "O100",
+            "message": "Inline the constant",
+            "replacement": "7",
+            "hintOnly": false,
+            "range": Value::Null,
+        });
+        let node = opt_leaf(&o);
+        assert!(node.label.contains("\u{2192} 7"), "{:?}", node.label);
+        assert!(!node.label.contains("hint only"), "{:?}", node.label);
     }
 
     /// A row that shows a range must also *carry* it.

--- a/rust/tcl-explorer/src/view_tree.rs
+++ b/rust/tcl-explorer/src/view_tree.rs
@@ -1045,7 +1045,10 @@ fn opt_leaf(o: &Value) -> ViewNode {
     let (tail, replacement) = if hint_only {
         (" (hint only)".to_owned(), "(none — hint only)".to_owned())
     } else {
-        (format!(" \u{2192} {}", s(o, "replacement")), s(o, "replacement"))
+        (
+            format!(" \u{2192} {}", s(o, "replacement")),
+            s(o, "replacement"),
+        )
     };
     ViewNode::leaf(
         format!("{} {}{tail}", s(o, "code"), s(o, "message")),
@@ -1061,12 +1064,7 @@ fn opt_leaf(o: &Value) -> ViewNode {
 }
 
 fn build_opt(d: &Value) -> Vec<ViewNode> {
-    let out: Vec<ViewNode> = arr(d, "optimisations")
-        .iter()
-        .map(|o| {
-            opt_leaf(o)
-        })
-        .collect();
+    let out: Vec<ViewNode> = arr(d, "optimisations").iter().map(opt_leaf).collect();
     if out.is_empty() {
         vec![ViewNode::note("(no optimiser rewrites)", "dim")]
     } else {
@@ -1187,12 +1185,7 @@ fn build_optimiser_passes(d: &Value) -> Vec<ViewNode> {
     let out: Vec<ViewNode> = arr(d, "optimiserPasses")
         .iter()
         .map(|p| {
-            let opts: Vec<ViewNode> = arr(p, "optimisations")
-                .iter()
-                .map(|o| {
-                    opt_leaf(o)
-                })
-                .collect();
+            let opts: Vec<ViewNode> = arr(p, "optimisations").iter().map(opt_leaf).collect();
             let count = s(p, "count");
             ViewNode::branch(
                 format!("{} ({count})", s(p, "label")),

--- a/rust/tcl-spec-studio/web/src/nativeEditorHost.ts
+++ b/rust/tcl-spec-studio/web/src/nativeEditorHost.ts
@@ -89,6 +89,16 @@ export async function mountEditors(options: EditorHostOptions): Promise<EditorHo
   for (const surface of Object.keys(texts) as Surface[]) {
     bridge.postMessage({ type: "surfaceUpdate", surface, text: texts[surface] });
   }
+  // The selection the studio mounts with, not just the ones it changes to.
+  //
+  // `setDialect` is called from the picker's change handler alone, so without
+  // this the host never hears the initial dialect — the default, or one
+  // restored from a previous session — and the sample is materialised as
+  // `test.tcl` and analysed as generic Tcl until the user touches the selector.
+  // The Monaco host has no equivalent gap: it sets the language id when it
+  // builds the model. Sent with the opening surface texts because it is the
+  // same kind of fact: the state the surfaces start in.
+  bridge.postMessage({ type: "dialectUpdate", dialect: options.dialect });
   options.report("using the IDE's native file editor beside Spec Studio", "ok");
 
   return {


### PR DESCRIPTION
## Summary

Codex raised these on #1952 (one P2) and #1942 (two P1s); both merged before they were dealt with. All three are confirmed against the code, and all three are user-visible.

### A hint rendered as a deletion — #1952, P2

#1934 gave a `hint_only` forward an empty replacement, because its range spans the whole consuming statement and the literal was never a valid edit for it, and exposed `hintOnly` in the explorer payload. Neither renderer read the flag:

| renderer | before | after |
|---|---|---|
| `explorer-core.js` `renderOpt` / `renderOptimiserPasses` | `→ ` (arrow, nothing after it) | `hint only`, dim italic rather than green |
| `view_tree.rs` `build_opt` / `build_optimiser_passes` | `O102 Forward literal load of 'n' → ` | `O102 Forward literal load of 'n' (hint only)`, row yellow, detail row reads `(none — hint only)` |

An arrow pointing at nothing reads as a rewrite to the empty string — a deletion — which is precisely backwards for advice. Each front end now routes both of its call sites through one helper, so the flat rewrite list and the per-pass pipeline cannot drift apart.

### The Spec Studio sample's dialect was never sent at mount — #1942, P1

`EditorHost.setDialect` is called from the dialect picker's `change` handler alone (`studio.ts`), so `nativeEditorHost`'s `mountEditors` never heard the selection it mounted with — the default, or one restored from a previous session. The sample is materialised as `test.tcl`, so it was analysed as generic Tcl until the user touched the selector, which is the exact failure #1931 exists to prevent.

The initial `dialectUpdate` now goes out beside the opening `surfaceUpdate` messages, which are the same kind of fact: the state the surfaces start in. The Monaco host has no equivalent gap — it sets the language id when it builds the model.

### The JetBrains pin was dropped when the server had not started — #1942, P1

The LSP server starts lazily on the first Tcl editor (`TclLspServerSupportProvider.fileOpened`), so in a project with no supported Tcl file already open the Studio is the first thing to want it. `applySampleDialect` returned early on finding none `Running`, and nothing retries — the sample stayed under generic Tcl for the rest of the session even after opening the Test file started the server.

The Compiler Explorer already solved this with `awaitRunningServer` (added when the restored-on-startup explorer reported a spurious "LSP server not running"). Rather than a second copy going out of step with the first, it is lifted to `TclLspServerWait.kt` as `awaitRunningTclLspServer` and both call it. `notifyPack` keeps its direct lookup deliberately: a pack notification to a server that has not started yet is covered by the scan it performs at initialisation.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

```
cargo test -p tcl-explorer --lib                       # 98 passed, 0 failed
cd rust/tcl-spec-studio/web && npm test                # 121 passed, 0 failed
cd rust/tcl-spec-studio/web && npm run lint            # eslint + prettier clean
cd rust/tcl-spec-studio/web && npx tsc --noEmit        # clean
cd editors/jetbrains && ./gradlew compileKotlin        # BUILD SUCCESSFUL
make prep-pr                                           # exit 0
```

The JetBrains build is worth calling out: `build-jetbrains` is `skipped` on pull requests, so a Kotlin break here would not surface until release. It compiles. It took three attempts for environmental reasons only — the sandbox ran out of disk mid-extraction of the IDEA distribution, and Maven Central returned 429 on the first retry.

Tests added (`rust/tcl-explorer/src/view_tree.rs`):

- `a_hint_only_optimisation_is_not_rendered_as_a_rewrite` — runs the real pipeline over `set n 7; puts "n=$n"` (the case Codex named), asserts the fixture actually produces a hint-only entry before asserting anything about it, then that the row says `(hint only)`, carries no arrow, and details a non-empty explanation rather than a blank edit.
- `an_applicable_optimisation_still_shows_its_replacement` — the ordinary case is untouched.

The two JS renderers have no unit harness (`rust/tcl-cli/gui/test/` holds only a boot smoke test), so they are covered by inspection and by sharing the single helper with the tested shape.

## Compiler / diagnostics checklist

- [x] Did this change alter a compiler fact contract? **No** — it consumes `hintOnly`, which #1952 already added to the payload, and changes no analysis.
- [x] No diagnostic or optimisation code added or changed.
- [x] No new design doc; no owning doc states the explorer's row format or the editors' mount sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F6pDxCsXjcTW4A9rTTpQS7

---
_Generated by [Claude Code](https://claude.ai/code/session_01F6pDxCsXjcTW4A9rTTpQS7)_