### PR TITLE
wasm codegen: a tier may only register a definition it can quote (#1896)

### DIFF
--- a/docs/design/compiler/wasm-native-lowering-plan.md
+++ b/docs/design/compiler/wasm-native-lowering-plan.md
@@ -164,6 +164,37 @@ body that ever runs is a `DirectProc` — the single-statement
 `return [expr {$a + $b}]` shape — called directly from top level. Every other
 emitted proc function is dead weight in the module.
 
+### 2.3a A tier may only register a definition it can quote
+
+Both tiers that register a `proc` themselves — the native tier's
+`NativeOp::DefineProc` and the general tier's `tcl_codegen_proc_register` —
+hand the runtime a name, a parameter list and a body text taken from the
+surviving `ir::Procedure`. `Procedure` records the **written** words. Lowering
+may have compiled the body from a value it materialised instead — a
+const-mapped `$body`, or a `[subst -nocommands …]` template — and it records
+the original word beside that compiled body rather than the text it compiled.
+
+Registering the written word in that case is wrong twice over: `info body`
+reports the substitution rather than the body, and any later run of the source
+body — a step trace, or a declined native entry — evaluates that substitution
+**in the procedure's own frame**, where the variables it names do not exist.
+
+The rule is therefore that a tier may register a definition only when the
+statement wrote every word out and wrote the parameter list and body the
+`Procedure` recorded; anything else keeps the generic invocation, where the
+runtime's own `proc` evaluates the word at the call site as Tcl does. It is
+one predicate, `native_lowering::lower::definition_words_are_written_out`,
+called by both tiers — a second copy is a second thing to go out of step,
+which is how the general tier came to have no check at all (#1774 / #1895
+for the native tier, #1896 for the general one).
+
+The general tier's path is unreachable today, and by a stronger coincidence
+than #1896 records: a substituted word in a definition also defeats the
+enclosing function's command-binding proof, so no
+`StructuredLowering(Proc)` operation is recorded for the statement at all.
+That is two independent proofs happening to agree, not a design, and P5's plan
+to make procedure bodies proven removes it.
+
 ### 2.4 The analysis tier is a second, string-keyed proof channel
 
 `function_facts` (`backend.rs`) builds `direct_assignments`, `operations`,

--- a/rust/tcl-compiler/src/codegen/wasm/backend.rs
+++ b/rust/tcl-compiler/src/codegen/wasm/backend.rs
@@ -247,6 +247,11 @@ struct FunctionFacts {
     leaf_invocations: HashMap<(u32, u32), WasmLeafInvokePlan>,
     /// Typed reasons a leaf statement stayed on the source-span eval fallback.
     leaf_declines: HashMap<(u32, u32), WasmLeafInvokeDecline>,
+    /// Spans of `proc` definitions that wrote every word out, so this tier may
+    /// register the definition itself instead of leaving it to the runtime's
+    /// own `proc` (issue #1896). Decided while planning, where the statement's
+    /// structured words are still to hand.
+    literal_proc_definitions: HashSet<(u32, u32)>,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -606,6 +611,17 @@ impl WasmEmitter {
         };
         match operation {
             SemanticOperationId::StructuredLowering(LoweringHookId::Proc) => {
+                // Only a definition whose words were all written out. Otherwise
+                // `Procedure` holds the *written* word while the body was
+                // compiled from a value this tier materialised, and registering
+                // that word reports the wrong `info body` and leaves any later
+                // run of the source body evaluating a substitution in the
+                // procedure's own frame (issue #1896). The generic invocation
+                // below hands the word to the runtime's `proc`, which evaluates
+                // it at the call site as Tcl does.
+                if !self.facts.literal_proc_definitions.contains(&span_key(span)) {
+                    return false;
+                }
                 let Some(proc) = self.procedures_by_span.get(&span_key(span)).cloned() else {
                     return false;
                 };
@@ -1464,12 +1480,15 @@ fn function_facts(
             if bindings.is_original_builtin_at(block, stmt_idx, command)
                 && mutations.trusts(bare)
                 && let Some(tokens) = tokens
-                && let Ok(RegistryInvocationResolution::Resolved(invocation)) =
-                    resolve_command_tokens(registry, unit.semantic_facts.context(), tokens)
             {
-                facts
-                    .operations
-                    .insert(span_key(statement.span()), invocation.operation);
+                record_operation(
+                    &mut facts,
+                    module,
+                    registry,
+                    unit.semantic_facts.context(),
+                    statement.span(),
+                    tokens,
+                );
             }
             // Generic prebuilt-argv invocation is the normal leaf-command path
             // and needs no binding proof: the runtime resolves the command head
@@ -1593,6 +1612,61 @@ fn plan_leaf_statement(
             );
         }
     }
+}
+
+/// Record the semantic operation a proven statement resolves to, and — for a
+/// `proc` definition — whether this tier may register it itself.
+///
+/// The literal-definition verdict is decided here rather than at emit time
+/// because this is where the statement's structured words are still to hand;
+/// the emitter sees only spans and the surviving [`crate::ir::Procedure`].
+fn record_operation(
+    facts: &mut FunctionFacts,
+    module: &Module,
+    registry: &CommandRegistry,
+    context: Option<tcl_registry::model::semantic::SemanticContext>,
+    span: Span,
+    tokens: &crate::ir::CommandTokens,
+) {
+    let Ok(RegistryInvocationResolution::Resolved(invocation)) =
+        resolve_command_tokens(registry, context, tokens)
+    else {
+        return;
+    };
+    facts.operations.insert(span_key(span), invocation.operation);
+    if invocation.operation == SemanticOperationId::StructuredLowering(LoweringHookId::Proc)
+        && proc_definition_is_written_out(module, span, tokens)
+    {
+        facts.literal_proc_definitions.insert(span_key(span));
+    }
+}
+
+/// Whether the `proc` statement at `span` wrote every word out, against the
+/// [`crate::ir::Procedure`] that survived for it.
+///
+/// The general tier's half of the rule the native tier applies in
+/// `native_lowering::lower::lower_definition`; both call the same predicate so
+/// the two cannot drift (issue #1896).
+fn proc_definition_is_written_out(
+    module: &crate::ir::Module,
+    span: Span,
+    tokens: &crate::ir::CommandTokens,
+) -> bool {
+    let Some(procedure) = module
+        .procedures
+        .values()
+        .find(|procedure| procedure.span == span)
+    else {
+        return false;
+    };
+    let Some(body_source) = procedure.body_source.as_deref() else {
+        return false;
+    };
+    crate::native_lowering::lower::definition_words_are_written_out(
+        tokens.words(),
+        &procedure.params_raw,
+        body_source,
+    )
 }
 
 const fn abi_value_type(value: CodegenAbiValueType) -> ValType {
@@ -2373,6 +2447,125 @@ mod tests {
         let mut declines = facts.leaf_declines.values().copied().collect::<Vec<_>>();
         assert_eq!(declines.len(), 1, "expected exactly one declined statement");
         declines.pop().expect("one decline")
+    }
+
+    /// The `proc` statement inside `unit`, with the tokens the front end kept.
+    fn proc_statement_tokens(unit: &FunctionUnit) -> Vec<(Span, &crate::ir::CommandTokens)> {
+        let mut found = Vec::new();
+        for block in unit.cfg.reverse_postorder() {
+            let Some(cfg_block) = unit.cfg.blocks.get(&block) else {
+                continue;
+            };
+            for statement in &cfg_block.statements {
+                if let Statement::Call {
+                    span,
+                    command,
+                    tokens: Some(tokens),
+                    ..
+                } = statement
+                    && command == "proc"
+                {
+                    found.push((*span, tokens));
+                }
+            }
+        }
+        found
+    }
+
+    /// Issue #1896 — a definition whose body word is a substitution must not be
+    /// registered by this tier.
+    ///
+    /// The reproducer from the issue. `Procedure` records the *written* word
+    /// `${body}` while the body this module compiled came from `return hello`,
+    /// so registering it would report that word as `info body`, and any later
+    /// run of the source body would evaluate the substitution in `p`'s own
+    /// frame, where `body` does not exist.
+    ///
+    /// Asserted against the rule rather than against the emitted module,
+    /// because the emit path is unreachable today: every substituted word in a
+    /// definition also defeats the enclosing function's binding proof, so no
+    /// `StructuredLowering(Proc)` operation is recorded to gate. That is a
+    /// coincidence of two independent proofs, not a design — the point of the
+    /// guard is that it already holds when procedure bodies become proven.
+    #[test]
+    fn a_substituted_definition_body_is_left_to_the_runtimes_own_proc() {
+        let registry = CommandRegistry::build_default();
+        let unit = CompilationUnit::build_for(
+            "proc make {} { set body {return hello} ; proc p {x} $body }\n",
+            &registry,
+            false,
+        );
+        let procedure = unit
+            .ir_module
+            .procedures
+            .get("::p")
+            .expect("the inner definition survives as a procedure");
+        assert_eq!(
+            procedure.body_source.as_deref(),
+            Some("${body}"),
+            "the fixture must record the written word rather than the compiled \
+             body, else this proves nothing",
+        );
+
+        let enclosing = unit.procedures.get("::make").expect("the enclosing body");
+        let definition = proc_statement_tokens(enclosing)
+            .into_iter()
+            .find(|(span, _)| *span == procedure.span)
+            .expect("the inner `proc` statement kept its tokens");
+        assert!(
+            !proc_definition_is_written_out(&unit.ir_module, definition.0, definition.1),
+            "a substituted body word must keep the generic invocation",
+        );
+    }
+
+    /// The same proof, on a body that *is* written out, still binds — so the
+    /// rule is about substitution rather than a blanket refusal to register
+    /// anything defined inside a procedure.
+    #[test]
+    fn a_written_out_definition_body_still_binds() {
+        let registry = CommandRegistry::build_default();
+        let unit = CompilationUnit::build_for(
+            "proc make {} { proc p {x} {return $x} }\n",
+            &registry,
+            false,
+        );
+        let procedure = unit.ir_module.procedures.get("::p").expect("procedure");
+        let enclosing = unit.procedures.get("::make").expect("the enclosing body");
+        let definition = proc_statement_tokens(enclosing)
+            .into_iter()
+            .find(|(span, _)| *span == procedure.span)
+            .expect("the inner `proc` statement kept its tokens");
+        assert!(
+            proc_definition_is_written_out(&unit.ir_module, definition.0, definition.1),
+            "a written-out definition is exactly what this tier may register",
+        );
+
+        // And the reachable end of it: the fact the emitter consults is set.
+        let facts = function_facts(
+            enclosing,
+            &unit.ir_module,
+            &registry,
+            &unit.command_mutations,
+            false,
+        );
+        assert!(
+            facts.literal_proc_definitions.contains(&span_key(procedure.span)),
+            "the guard must not refuse a definition it should register: {:?}",
+            facts.literal_proc_definitions,
+        );
+    }
+
+    /// A top-level written-out definition is registered too — the guard is
+    /// about the words, not about where the definition sits.
+    #[test]
+    fn a_top_level_written_out_definition_is_registered() {
+        let facts = top_level_facts("proc p {x} {return $x}\n");
+        assert_eq!(
+            facts.literal_proc_definitions.len(),
+            1,
+            "{:?}",
+            facts.literal_proc_definitions,
+        );
     }
 
     /// A leaf command whose words all compile selects a plan and records no

--- a/rust/tcl-compiler/src/codegen/wasm/backend.rs
+++ b/rust/tcl-compiler/src/codegen/wasm/backend.rs
@@ -619,7 +619,11 @@ impl WasmEmitter {
                 // procedure's own frame (issue #1896). The generic invocation
                 // below hands the word to the runtime's `proc`, which evaluates
                 // it at the call site as Tcl does.
-                if !self.facts.literal_proc_definitions.contains(&span_key(span)) {
+                if !self
+                    .facts
+                    .literal_proc_definitions
+                    .contains(&span_key(span))
+                {
                     return false;
                 }
                 let Some(proc) = self.procedures_by_span.get(&span_key(span)).cloned() else {
@@ -1633,7 +1637,9 @@ fn record_operation(
     else {
         return;
     };
-    facts.operations.insert(span_key(span), invocation.operation);
+    facts
+        .operations
+        .insert(span_key(span), invocation.operation);
     if invocation.operation == SemanticOperationId::StructuredLowering(LoweringHookId::Proc)
         && proc_definition_is_written_out(module, span, tokens)
     {
@@ -2549,7 +2555,9 @@ mod tests {
             false,
         );
         assert!(
-            facts.literal_proc_definitions.contains(&span_key(procedure.span)),
+            facts
+                .literal_proc_definitions
+                .contains(&span_key(procedure.span)),
             "the guard must not refuse a definition it should register: {:?}",
             facts.literal_proc_definitions,
         );

--- a/rust/tcl-compiler/src/native_lowering/lower.rs
+++ b/rust/tcl-compiler/src/native_lowering/lower.rs
@@ -895,28 +895,15 @@ impl<'a> Lowerer<'a> {
         // A body the front end never captured (a synthetic or dynamic one)
         // has nothing for the runtime to bind; keep the generic invocation.
         let body_source = procedure.body_source.clone()?;
-        // The runtime's `proc` still owns every error this form can raise, so
-        // only the exact `proc name params body` shape is taken.
-        let [head, name, params, body] = invoke.original_words.as_slice() else {
-            return None;
-        };
-        let _ = head;
         // Every word this hands the runtime has to be the word the statement
-        // actually writes. `Procedure` records the *written* name, parameter
-        // list and body text, but lowering may have compiled the body from a
-        // value it materialised instead — a const-mapped `$body`, or a
-        // `[subst -nocommands …]` template — and it records the original word
-        // beside that compiled body, not the text it compiled. Registering
-        // that word would report the wrong `info body`, and any later run of
-        // the source body (a step trace, or a declined entry) would evaluate
-        // the substitution *in the procedure's own frame*, where its operands
-        // do not exist. A substituted word therefore keeps the generic
-        // invocation, and the runtime's own `proc` — which evaluates the word
-        // at the call site, as Tcl does — defines the procedure.
-        if !is_written_literal(name) || !word_is_literally(params, &procedure.params_raw) {
-            return None;
-        }
-        if !word_is_literally(body, &body_source) {
+        // actually writes; a substituted one keeps the generic invocation, and
+        // the runtime's own `proc` — which evaluates the word at the call site,
+        // as Tcl does — defines the procedure.
+        if !definition_words_are_written_out(
+            &invoke.original_words,
+            &procedure.params_raw,
+            &body_source,
+        ) {
             return None;
         }
         self.emit(NativeOp::DefineProc {
@@ -2003,6 +1990,38 @@ fn word_is_literally(word: &WordExpr, recorded: &str) -> bool {
         WordExpr::Literal { text, .. } | WordExpr::BracedLiteral { text, .. } => text == recorded,
         _ => false,
     }
+}
+
+/// Whether a `proc name params body` statement wrote every word out, and wrote
+/// the parameter list and body the surviving [`crate::ir::Procedure`] recorded.
+///
+/// The condition under which a tier may register a definition itself rather
+/// than leave it to the runtime's own `proc`. `Procedure` records the
+/// *written* name, parameter list and body text, but a lowering may have
+/// compiled the body from a value it materialised instead — a const-mapped
+/// `$body`, or a `[subst -nocommands …]` template — recording the original
+/// word beside that compiled body rather than the text it compiled.
+/// Registering that word would report the wrong `info body`, and any later run
+/// of the source body (a step trace, or a declined native entry) would
+/// evaluate the substitution *in the procedure's own frame*, where its
+/// operands do not exist.
+///
+/// Shared by the native tier and the general wasm tier because it is one rule:
+/// a second copy is a second thing to go out of step, and the general tier had
+/// no check at all (issue #1896).
+pub(crate) fn definition_words_are_written_out(
+    words: &[WordExpr],
+    params_raw: &str,
+    body_source: &str,
+) -> bool {
+    // The runtime's `proc` owns every error the other shapes can raise, so
+    // only the exact four-word form is taken.
+    let [_head, name, params, body] = words else {
+        return false;
+    };
+    is_written_literal(name)
+        && word_is_literally(params, params_raw)
+        && word_is_literally(body, body_source)
 }
 
 /// The 1-based line of `offset` within the body that opens at `origin`.


### PR DESCRIPTION
## Summary

Closes #1896.

`try_emit_direct_operation` handed the runtime `tcl_codegen_proc_register(name, params_raw, body_source)` straight from the surviving `ir::Procedure`, with no check that the statement wrote those words out.

`Procedure` records the **written** words. Lowering may have compiled the body from a value it materialised instead — a const-mapped `$body`, or a `[subst -nocommands …]` template — recording the original word beside that compiled body rather than the text it compiled:

```tcl
proc make {} { set body {return hello} ; proc p {x} $body }
```

records `body_source: Some("${body}")` while the compiled body came from `return hello`. Registering that word reports the wrong `info body`, and any later run of the source body — a step trace, or a declined native entry — evaluates the substitution **in `p`'s own frame**, where `body` does not exist.

### One rule, one owner

The native tier already refuses this (#1774 / #1895). Rather than a second copy of the condition, its check is lifted to `native_lowering::lower::definition_words_are_written_out` and both tiers call it — a second copy is a second thing to go out of step, which is exactly how this tier came to have no check at all.

The general tier decides the verdict while *planning*, where the statement's structured words are still to hand (`record_operation`), and records it as `FunctionFacts::literal_proc_definitions`; the emitter, which sees only spans and the surviving `Procedure`, consults that fact.

### On testing an unreachable path

The path stays unreachable, and by a **stronger** coincidence than the issue records. #1896 names two conditions (materialisation only inside a procedure body; no procedure-body site is proven). Measuring five shapes shows a third and simpler one: a substituted word in a definition also defeats the enclosing function's command-binding proof, so no `StructuredLowering(Proc)` operation is recorded for the statement at all.

| source | `Procedure` for `::p` | operation recorded |
|---|---|---|
| `proc p {x} {return $x}` | `body_source: "return $x"` | yes → registered |
| `proc make {} { proc p {x} {return $x} }` | `body_source: "return $x"` | yes → registered |
| `proc make {} { set body {…} ; proc p {x} $body }` | `body_source: "${body}"` | **none** |
| `proc make {body} { proc p {x} $body }` | no `::p` at all | none |
| `proc make {} { set n p ; proc $n {x} {…} }` | no `::p` at all | none |
| `proc make {} { proc p {x} [subst -nocommands {…}] }` | no `::p` at all | none |

So asserting on an emitted module would be vacuous, and would stay vacuous while silently proving nothing. The tests assert the **rule** against the issue's own reproducer instead — the shape that does record a `Procedure` with a substituted `body_source` — plus the reachable positive end, which is the risk this change actually introduces: over-refusing a definition it should register.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

```
cargo test -p tcl-compiler          # 6354 tests across 20 targets, 0 failures
make rust-check                     # exit 0 (fmt + clippy + drift; mirrors pr-gate)
make prep-pr                        # exit 0
```

Tests added (`codegen/wasm/backend.rs`):

- `a_substituted_definition_body_is_left_to_the_runtimes_own_proc` — the issue's reproducer. Asserts the fixture really records `body_source: Some("${body}")` before asserting anything about it, so it cannot quietly go vacuous, then that the rule refuses it.
- `a_written_out_definition_body_still_binds` — the same proof on a written-out body still binds, and the fact the emitter consults is set. The rule is about substitution, not a blanket refusal to register anything defined inside a procedure.
- `a_top_level_written_out_definition_is_registered` — and it is about the words, not about where the definition sits.

**Verified non-vacuous**: weakening `definition_words_are_written_out` to drop the body comparison fails the new test *and* the native tier's existing `a_definition_declines_a_body_the_statement_does_not_write_out` — which also confirms the lifted predicate really is serving both tiers.

## Compiler / diagnostics checklist

- [x] Did this change alter a compiler fact contract? **Yes, narrowly** — `FunctionFacts` gains `literal_proc_definitions`, a span-keyed verdict the emitter consumes. No analysis result changes; no currently-emitted module changes, since the gated path is unreachable.
- [x] No diagnostic or optimisation code added or changed.
- [x] Owning design doc updated: `docs/design/compiler/wasm-native-lowering-plan.md` § 2.3a *A tier may only register a definition it can quote* — the rule, why registering a substituted word is wrong twice over, that it is one shared predicate, and that the general tier's unreachability is a coincidence of independent proofs that P5 removes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F6pDxCsXjcTW4A9rTTpQS7

---
_Generated by [Claude Code](https://claude.ai/code/session_01F6pDxCsXjcTW4A9rTTpQS7)_