### PR TITLE
fix(runtime): preserve byte-valued script completions

### DIFF
--- a/docs/design/family-b-routing.md
+++ b/docs/design/family-b-routing.md
@@ -14,6 +14,15 @@ traits, each generic over an associated `Value`. Both the bytecode VM (`tcl-vm`,
 `Value = Rc<Obj>`) and `runtime/rust` (`Value = *mut TclObj`) satisfy all of
 them, so a consumer generic over the traits drives either runtime:
 
+`ScriptCompletion` is the corresponding host/embedding boundary: a shared
+`Completion<Vec<u8>>` whose result and return-options fields hold exact Tcl
+string-representation bytes. Runtime engines snapshot into it before the
+outermost evaluation publishes Tcl's error globals and resets the live
+exception state, then perform that ordinary publication before returning to a
+host. UTF-8 or another text conversion belongs only in an explicitly textual
+host adapter; native, WASM, CLI, and library consumers do not each invent a
+result/error conversion policy.
+
 | Trait | Surface |
 |-------|---------|
 | `VarStore` | `get`/`set`/`unset`/`exists` + explicit array-element access, addressed by `FrameId`; `unset_command` preserves immutable-cell refusals for command consumers; `ArrayTarget` and the `*_at` rungs preserve a located array cell across callbacks when the runtime has stable `VarId`s |

--- a/runtime/rust/examples/run_script.rs
+++ b/runtime/rust/examples/run_script.rs
@@ -55,9 +55,10 @@
 //! with `TCL_TOMMATH_DIR` set — `make runtime-rust-test` does — or expect
 //! every expression to fail.
 
-use std::io::Read;
+use std::io::{self, Read, Write};
 
 use tcl_runtime::interp::{Code, Interp};
+use tcl_runtime::{CompletionCode, ScriptCompletion};
 
 /// The recursive tree-walking interpreter uses native stack per Tcl call level,
 /// so honouring the 1000-deep `interp recursionlimit` (a *catchable* error)
@@ -75,6 +76,43 @@ fn main() {
         .join()
         .expect("eval thread panicked");
     std::process::exit(code);
+}
+
+/// Write one byte-valued result as a host line without interpreting it as
+/// UTF-8. The process adapter owns the prefix/newline framing; the runtime API
+/// owns the exact completion bytes.
+fn write_result_line(output: &mut impl Write, prefix: &[u8], result: &[u8]) -> io::Result<()> {
+    output.write_all(prefix)?;
+    output.write_all(result)?;
+    output.write_all(b"\n")
+}
+
+/// Apply the documented dev-runner echo/error policy to a byte completion.
+fn report_completion(completion: &ScriptCompletion, quiet: bool) -> io::Result<i32> {
+    report_completion_to(
+        completion,
+        quiet,
+        &mut std::io::stdout().lock(),
+        &mut std::io::stderr().lock(),
+    )
+}
+
+/// Writer-parameterised core of [`report_completion`], kept separate from the
+/// process handles so the byte contract is testable without descriptor
+/// redirection.
+fn report_completion_to(
+    completion: &ScriptCompletion,
+    quiet: bool,
+    stdout: &mut impl Write,
+    stderr: &mut impl Write,
+) -> io::Result<i32> {
+    if completion.code == CompletionCode::Error {
+        return write_result_line(stderr, b"error: ", &completion.result).map(|()| 1);
+    }
+    if !quiet && !completion.result.is_empty() {
+        write_result_line(stdout, b"", &completion.result)?;
+    }
+    Ok(0)
 }
 
 /// Evaluate the script (or stdin) and return the process exit code. Runs on the
@@ -149,11 +187,18 @@ fn run() -> i32 {
         interp.set_runtime_version(v);
     }
     if init && interp.init_library() == Code::Error {
-        eprintln!(
-            "init error: {}",
-            String::from_utf8_lossy(&interp.result_bytes())
+        return write_result_line(
+            &mut std::io::stderr().lock(),
+            b"init error: ",
+            &interp.result_bytes(),
+        )
+        .map_or_else(
+            |error| {
+                eprintln!("run_script: cannot write completion: {error}");
+                2
+            },
+            |()| 1,
         );
-        return 1;
     }
     // Optionally pre-load tcltest and source the backend-constraint overlay so
     // tests the running backend cannot support are skipped. Loading tcltest
@@ -163,28 +208,60 @@ fn run() -> i32 {
         let pre = format!(
             "package require tcltest\nnamespace import -force ::tcltest::*\nsource {overlay}\n"
         );
-        if interp.eval_str(pre.as_bytes()) == Code::Error {
-            eprintln!(
-                "backend-constraint overlay error: {}",
-                String::from_utf8_lossy(&interp.result_bytes())
+        let completion = interp.eval_completion(pre.as_bytes());
+        if completion.code == CompletionCode::Error {
+            return write_result_line(
+                &mut std::io::stderr().lock(),
+                b"backend-constraint overlay error: ",
+                &completion.result,
+            )
+            .map_or_else(
+                |error| {
+                    eprintln!("run_script: cannot write completion: {error}");
+                    2
+                },
+                |()| 1,
             );
-            return 1;
         }
     }
-    let code = match &path {
-        Some(p) => interp.eval_sourced(&src, p.as_bytes()),
-        None => interp.eval_str(&src),
+    let completion = match &path {
+        Some(p) => interp.eval_sourced_completion(&src, p.as_bytes()),
+        None => interp.eval_completion(&src),
     };
-    let result = interp.result_bytes();
-    if code == Code::Error {
-        eprintln!("error: {}", String::from_utf8_lossy(&result));
-        return 1;
-    }
     // Print the script's final result (if any), like an interactive evaluation
     // — unless `--quiet` asked for `tclsh script.tcl`'s actual non-interactive
     // contract instead (stdout carries only `puts` output).
-    if !quiet && !result.is_empty() {
-        println!("{}", String::from_utf8_lossy(&result));
+    report_completion(&completion, quiet).unwrap_or_else(|error| {
+        eprintln!("run_script: cannot write completion: {error}");
+        2
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{report_completion_to, CompletionCode, ScriptCompletion};
+
+    #[test]
+    fn result_and_error_lines_preserve_non_utf8_bytes() {
+        const VALUE: &[u8] = &[0xff, 0x00, b'A', 0x80];
+
+        let success = ScriptCompletion::new(CompletionCode::Ok, VALUE.to_vec(), Vec::new());
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+        assert_eq!(
+            report_completion_to(&success, false, &mut stdout, &mut stderr).unwrap(),
+            0
+        );
+        assert_eq!(stdout, [VALUE, b"\n"].concat());
+        assert!(stderr.is_empty());
+
+        let failure = ScriptCompletion::new(CompletionCode::Error, VALUE.to_vec(), Vec::new());
+        stdout.clear();
+        assert_eq!(
+            report_completion_to(&failure, false, &mut stdout, &mut stderr).unwrap(),
+            1
+        );
+        assert!(stdout.is_empty());
+        assert_eq!(stderr, [b"error: ".as_slice(), VALUE, b"\n"].concat());
     }
-    0
 }

--- a/runtime/rust/src/completion.rs
+++ b/runtime/rust/src/completion.rs
@@ -1,0 +1,43 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Byte-preserving completion capture at the public runtime boundary.
+//!
+//! The tree-walking runtime keeps an interpreter-owned result object
+//! internally. This module projects the existing Family-B object completion to
+//! the public byte boundary, so object-handle consumers and byte-oriented
+//! embedders observe the same code, result, and return-options snapshot.
+
+use tcl_runtime_api::ScriptCompletion;
+
+use crate::interp::{Code as RuntimeCode, Interp};
+use crate::obj;
+
+/// Snapshot one completion as exact, owned Tcl string-representation bytes.
+pub(crate) fn capture_bytes(interp: &mut Interp, code: RuntimeCode) -> ScriptCompletion {
+    let completion = crate::state_traits::capture_completion(interp, code);
+    let result = obj::bytes_of(completion.result);
+    let options = obj::bytes_of(completion.options);
+    // SAFETY: `capture_completion` returned one owned reference to each object;
+    // both byte projections are complete, so release those references now.
+    unsafe {
+        obj::decr_ref_count(completion.result);
+        obj::decr_ref_count(completion.options);
+    }
+    ScriptCompletion::new(completion.code, result, options)
+}

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -2485,15 +2485,7 @@ impl Interp {
     /// level leaves exactly the error state its interpreted twin would.
     pub(crate) fn codegen_activation_leave(&mut self, code: Code) {
         self.eval_depth.set(self.eval_depth.get().saturating_sub(1));
-        if self.eval_depth.get() != 0 {
-            return;
-        }
-        if code == Code::Error {
-            self.publish_error();
-        }
-        if !self.bg_queue.borrow().is_empty() {
-            self.process_bg_errors();
-        }
+        self.finish_outermost_eval(code);
     }
 
     /// Record the activation `Tcl_PushCallFrame` adds to the namespace token a
@@ -2788,10 +2780,14 @@ impl Interp {
         }
     }
 
-    /// `source`: evaluate `script` as a sourced file named `name`, tracking it on
-    /// the script stack (`info script`). A top-level `return` ends the file (the
-    /// return boundary maps `return` → Ok); other codes propagate.
-    pub fn eval_sourced(&mut self, script: &[u8], name: &[u8]) -> Code {
+    /// Evaluate one source boundary, projecting its completion before an
+    /// outermost error is published and its live return-options state reset.
+    fn eval_sourced_boundary<T>(
+        &mut self,
+        script: &[u8],
+        name: &[u8],
+        project: impl FnOnce(&mut Self, Code) -> T,
+    ) -> T {
         self.script_stack.borrow_mut().push(name.to_vec());
         // A `source`d file is its own `info frame` level: `type source` + the
         // file path, inheriting the enclosing proc/level. Its commands are
@@ -2800,9 +2796,33 @@ impl Interp {
         frame.kind = FrameKind::Source;
         frame.file = Some(Rc::from(name));
         frame.line_base = 0;
-        let code = self.eval_framed(script, frame);
+        let code = self.eval_framed_unpublished(script, frame);
         self.script_stack.borrow_mut().pop();
-        self.settle_return(code)
+        let code = self.settle_return(code);
+        let projected = project(self, code);
+        self.finish_outermost_eval(code);
+        projected
+    }
+
+    /// `source`: evaluate `script` as a sourced file named `name`, tracking it on
+    /// the script stack (`info script`). A top-level `return` ends the file (the
+    /// return boundary maps `return` → Ok); other codes propagate.
+    pub fn eval_sourced(&mut self, script: &[u8], name: &[u8]) -> Code {
+        self.eval_sourced_boundary(script, name, |_, code| code)
+    }
+
+    /// Evaluate a sourced script and return its owned, byte-preserving
+    /// completion.
+    ///
+    /// The source return boundary is settled before the snapshot. An uncaught
+    /// error is published to Tcl's globals only after its live options,
+    /// including `-during`, have been captured.
+    pub fn eval_sourced_completion(
+        &mut self,
+        script: &[u8],
+        name: &[u8],
+    ) -> tcl_runtime_api::ScriptCompletion {
+        self.eval_sourced_boundary(script, name, crate::completion::capture_bytes)
     }
 
     /// `info script` — the file currently being sourced (empty at top level).
@@ -5885,6 +5905,20 @@ impl Interp {
 
     // -- eval -----------------------------------------------------------------
 
+    /// Evaluate through the common outer boundary, projecting the live
+    /// completion before applying its publication tail.
+    fn eval_str_boundary<T>(
+        &mut self,
+        src: &[u8],
+        project: impl FnOnce(&mut Self, Code) -> T,
+    ) -> T {
+        let owned = self.cmd_frames.borrow().is_empty().then(CmdFrame::root);
+        let code = self.eval_script_mode_unpublished(src, owned, false);
+        let projected = project(self, code);
+        self.finish_outermost_eval(code);
+        projected
+    }
+
     /// Evaluate a whole script; the result is left in the interp result. Returns
     /// the completion code of the last command (or `Ok` for an empty script).
     ///
@@ -5894,20 +5928,37 @@ impl Interp {
     /// `cmdFramePtr` level. A proc body / `eval` / `source` body gets its own
     /// frame via [`eval_framed`](Self::eval_framed).
     pub fn eval_str(&mut self, src: &[u8]) -> Code {
-        let owned = self.cmd_frames.borrow().is_empty().then(CmdFrame::root);
-        self.eval_script(src, owned)
+        self.eval_str_boundary(src, |_, code| code)
+    }
+
+    /// Evaluate a script and return an owned, byte-preserving completion.
+    ///
+    /// This is the public host/embedding boundary. The result and live return
+    /// options are captured before an outermost error is published and resets
+    /// the exception state; Tcl's error globals are still published before this
+    /// method returns. No text encoding is applied.
+    pub fn eval_completion(&mut self, script: &[u8]) -> tcl_runtime_api::ScriptCompletion {
+        self.eval_str_boundary(script, crate::completion::capture_bytes)
     }
 
     /// Evaluate `src` as the body of its own `info frame` level (`frame` is
     /// pushed for the duration). Used by proc calls, `eval`/`uplevel`, and
     /// `source`.
     fn eval_framed(&mut self, src: &[u8], mut frame: CmdFrame) -> Code {
+        frame.proc_line_base = frame.line_base;
+        self.eval_script(src, Some(frame))
+    }
+
+    /// [`Self::eval_framed`] before its outermost publication tail. This is
+    /// reserved for a source boundary, which must settle `return` first and may
+    /// snapshot the resulting completion before publication.
+    fn eval_framed_unpublished(&mut self, src: &[u8], mut frame: CmdFrame) -> Code {
         // A freshly pushed frame is its own `codePtr->source`, so `errorLine` is
         // measured from this body's base (an inline `catch`/`if` body, by
         // contrast, shares the enclosing frame via `eval_shared_located_body` and
         // keeps the proc's `proc_line_base`).
         frame.proc_line_base = frame.line_base;
-        self.eval_script(src, Some(frame))
+        self.eval_script_mode_unpublished(src, Some(frame), false)
     }
 
     /// The shared command loop. If `owned` is `Some`, it is pushed as this
@@ -5925,6 +5976,21 @@ impl Interp {
     /// [`eval_command_subst`](Self::eval_command_subst)); the caller sets up and
     /// restores the shared frame's `line_base`.
     fn eval_script_mode(
+        &mut self,
+        src: &[u8],
+        owned: Option<CmdFrame>,
+        advance_shared: bool,
+    ) -> Code {
+        let code = self.eval_script_mode_unpublished(src, owned, advance_shared);
+        self.finish_outermost_eval(code);
+        code
+    }
+
+    /// The shared command loop through depth/frame unwind, stopping before the
+    /// outermost publication tail. Public result adapters use this seam to
+    /// snapshot live return options; ordinary evaluators immediately pass the
+    /// code to [`Self::finish_outermost_eval`].
+    fn eval_script_mode_unpublished(
         &mut self,
         src: &[u8],
         owned: Option<CmdFrame>,
@@ -5963,19 +6029,26 @@ impl Interp {
             self.cmd_frames.borrow_mut().pop();
         }
         self.eval_depth.set(self.eval_depth.get() - 1);
-        // The outermost eval publishes the accumulated trace to the globals so
-        // an uncaught error leaves `::errorInfo`/`::errorCode` set, exactly as a
-        // `catch` would (`catch` publishes earlier, at depth > 0).
-        if self.eval_depth.get() == 0 && last == Code::Error {
+        last
+    }
+
+    /// Apply the one outermost-evaluation tail after any result/options
+    /// projection has observed the live completion state.
+    fn finish_outermost_eval(&mut self, code: Code) {
+        if self.eval_depth.get() != 0 {
+            return;
+        }
+        // Publish the accumulated trace to the globals so an uncaught error
+        // leaves `::errorInfo`/`::errorCode` set, exactly as a `catch` would.
+        if code == Code::Error {
             self.publish_error();
         }
         // Between top-level commands, drain any queued background errors with the
         // current handler — the event loop's behaviour, so errors from one
         // command don't leak into a later command's intercepted handler.
-        if self.eval_depth.get() == 0 && !self.bg_queue.borrow().is_empty() {
+        if !self.bg_queue.borrow().is_empty() {
             self.process_bg_errors();
         }
-        last
     }
 
     /// A `CmdFrame` for an `eval` body, inheriting the current frame's

--- a/runtime/rust/src/lib.rs
+++ b/runtime/rust/src/lib.rs
@@ -109,6 +109,7 @@ pub mod cmd_zlib;
 // imports (`rust/tcl-compiler` codegen), distinct from `capi`'s `Tcl_*` surface.
 pub mod codegen_abi;
 pub mod codegen_native;
+mod completion;
 pub mod counters;
 pub mod dict;
 // The Tcl 9 stdlib embedded in the binary, seeded into the WASM VFS so the
@@ -147,6 +148,8 @@ mod typed_value;
 pub mod value_ops;
 pub mod vars;
 mod version;
+
+pub use tcl_runtime_api::{Code as CompletionCode, ScriptCompletion};
 
 #[cfg(test)]
 mod tests {

--- a/runtime/rust/tests/script_completion_bytes.rs
+++ b/runtime/rust/tests/script_completion_bytes.rs
@@ -1,0 +1,310 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use tcl_host_native::NativeHost;
+use tcl_platform::{Capabilities, Clock, Env, Filesystem, Host, Process, StdIo};
+use tcl_runtime::interp::{Code, Interp};
+use tcl_runtime::obj::TclObj;
+use tcl_runtime::CompletionCode;
+
+const NON_UTF8_VALUE: &[u8] = &[0xff, 0x00, b'A', 0x80];
+
+fn binary_success(interp: &mut Interp, _argv: &[*mut TclObj]) -> Code {
+    interp.set_result_bytes(NON_UTF8_VALUE);
+    Code::Ok
+}
+
+fn binary_error(interp: &mut Interp, _argv: &[*mut TclObj]) -> Code {
+    interp.set_result_bytes(NON_UTF8_VALUE);
+    Code::Error
+}
+
+fn dict_value(dict: &[u8], key: &[u8]) -> Vec<u8> {
+    let fields = tcl_runtime::parse::split_list(dict).expect("completion options are a Tcl dict");
+    assert_eq!(
+        fields.len() % 2,
+        0,
+        "completion options have key/value pairs"
+    );
+    fields
+        .chunks_exact(2)
+        .find_map(|pair| (pair[0] == key).then(|| pair[1].clone()))
+        .unwrap_or_else(|| {
+            panic!(
+                "completion options are missing {}",
+                String::from_utf8_lossy(key)
+            )
+        })
+}
+
+/// A native host whose platform facilities remain real while stdout/stderr are
+/// byte captures. This exercises the same `puts` capability route as the
+/// command-line runner without redirecting process-global descriptors.
+struct CaptureHost {
+    native: NativeHost,
+    stdout: RefCell<Vec<u8>>,
+}
+
+impl CaptureHost {
+    fn new() -> Self {
+        Self {
+            native: NativeHost::new(),
+            stdout: RefCell::new(Vec::new()),
+        }
+    }
+
+    fn stdout(&self) -> Vec<u8> {
+        self.stdout.borrow().clone()
+    }
+}
+
+impl StdIo for CaptureHost {
+    fn write_stdout(&self, bytes: &[u8]) {
+        self.stdout.borrow_mut().extend_from_slice(bytes);
+    }
+
+    fn write_stderr(&self, _bytes: &[u8]) {}
+}
+
+impl Host for CaptureHost {
+    fn capabilities(&self) -> Capabilities {
+        self.native.capabilities()
+    }
+
+    fn clock(&self) -> &dyn Clock {
+        self.native.clock()
+    }
+
+    fn stdio(&self) -> &dyn StdIo {
+        self
+    }
+
+    fn env(&self) -> &dyn Env {
+        self.native.env()
+    }
+
+    fn filesystem(&self) -> Option<&dyn Filesystem> {
+        self.native.filesystem()
+    }
+
+    fn process(&self) -> Option<&dyn Process> {
+        self.native.process()
+    }
+}
+
+#[test]
+fn script_completion_preserves_non_utf8_success_and_error_values() {
+    let mut interp = Interp::new();
+    interp.register_builtin(b"binary_success", binary_success);
+    interp.register_builtin(b"binary_error", binary_error);
+
+    let success = interp.eval_completion(b"binary_success");
+    assert_eq!(success.code, CompletionCode::Ok);
+    assert_eq!(success.result, NON_UTF8_VALUE);
+    assert!(!success.options.is_empty());
+
+    let failure = interp.eval_sourced_completion(b"binary_error", b"binary-error.tcl");
+    assert_eq!(failure.code, CompletionCode::Error);
+    assert_eq!(failure.result, NON_UTF8_VALUE);
+    assert!(
+        failure
+            .options
+            .windows(NON_UTF8_VALUE.len())
+            .any(|window| window == NON_UTF8_VALUE),
+        "the byte-valued error must stay exact inside -errorinfo too"
+    );
+}
+
+#[test]
+fn raw_byte_puts_and_final_completion_share_the_lossless_boundary() {
+    let host = Rc::new(CaptureHost::new());
+    let mut interp = Interp::new();
+    interp.set_host(host.clone());
+    interp.register_builtin(b"binary_success", binary_success);
+
+    let completion = interp.eval_completion(b"puts -nonewline [binary_success]");
+    assert_eq!(completion.code, CompletionCode::Ok);
+    assert!(completion.result.is_empty());
+    assert_eq!(host.stdout(), NON_UTF8_VALUE);
+}
+
+#[test]
+fn completion_captures_live_error_options_before_publishing_globals() {
+    let mut interp = Interp::new();
+    interp.register_builtin(b"binary_success", binary_success);
+
+    // Tcl 9.0.4 oracle (catching this same script in a fresh child interp):
+    // 1 BOOM {-errorinfo {CUSTOM INFO} -errorcode {CUSTOM CODE} -code 1
+    //         -level 0 -errorstack {} -errorline 1}
+    let completion = interp.eval_completion(
+        b"return -code error -level 0 -errorinfo {CUSTOM INFO} \
+          -errorcode {CUSTOM CODE} [binary_success]",
+    );
+    assert_eq!(completion.code, CompletionCode::Error);
+    assert_eq!(completion.result, NON_UTF8_VALUE);
+    assert_eq!(dict_value(&completion.options, b"-code"), b"1");
+    assert_eq!(dict_value(&completion.options, b"-level"), b"0");
+    assert_eq!(
+        dict_value(&completion.options, b"-errorcode"),
+        b"CUSTOM CODE"
+    );
+    assert_eq!(
+        dict_value(&completion.options, b"-errorinfo"),
+        b"CUSTOM INFO"
+    );
+
+    // Capturing does not replace Tcl's ordinary outermost publication step.
+    assert_eq!(interp.eval_str(b"set ::errorCode"), Code::Ok);
+    assert_eq!(interp.result_bytes(), b"CUSTOM CODE");
+    assert_eq!(interp.eval_str(b"set ::errorInfo"), Code::Ok);
+    assert_eq!(interp.result_bytes(), b"CUSTOM INFO");
+}
+
+#[test]
+fn completion_preserves_the_during_chain_before_publication() {
+    let mut interp = Interp::new();
+    let completion = interp.eval_completion(
+        b"try {return -code error -level 0 -errorinfo {INNER INFO} \
+            -errorcode {INNER CODE} INNER} \
+          on error {} {return -code error -level 0 -errorinfo {OUTER INFO} \
+            -errorcode {OUTER CODE} OUTER}",
+    );
+
+    // Tcl 9.0.4 reports OUTER with OUTER CODE and this exact nested exception:
+    // -during {-errorinfo {INNER INFO\n    ("try" body line 1)}
+    //          -errorcode {INNER CODE} -code 1 -level 0 -errorstack {}
+    //          -errorline 1}
+    assert_eq!(completion.code, CompletionCode::Error);
+    assert_eq!(completion.result, b"OUTER");
+    assert_eq!(
+        dict_value(&completion.options, b"-errorcode"),
+        b"OUTER CODE"
+    );
+    // The runtime does not yet add Tcl's try-specific errorInfo frame; the
+    // boundary must nevertheless retain the live custom value byte-for-byte.
+    assert_eq!(
+        dict_value(&completion.options, b"-errorinfo"),
+        b"OUTER INFO"
+    );
+    let during = dict_value(&completion.options, b"-during");
+    assert_eq!(dict_value(&during, b"-code"), b"1");
+    assert_eq!(dict_value(&during, b"-level"), b"0");
+    assert_eq!(dict_value(&during, b"-errorcode"), b"INNER CODE");
+    assert_eq!(dict_value(&during, b"-errorinfo"), b"INNER INFO");
+}
+
+#[test]
+fn completion_exposes_every_tcl_completion_code_and_return_options() {
+    struct Case {
+        script: &'static [u8],
+        code: CompletionCode,
+        result: &'static [u8],
+        option_code: &'static [u8],
+        level: &'static [u8],
+    }
+    let cases = [
+        Case {
+            script: b"return VALUE",
+            code: CompletionCode::Return,
+            result: b"VALUE",
+            option_code: b"0",
+            level: b"1",
+        },
+        Case {
+            script: b"break",
+            code: CompletionCode::Break,
+            result: b"",
+            option_code: b"3",
+            level: b"0",
+        },
+        Case {
+            script: b"continue",
+            code: CompletionCode::Continue,
+            result: b"",
+            option_code: b"4",
+            level: b"0",
+        },
+        Case {
+            script: b"return -code 37 -level 0 VALUE",
+            code: CompletionCode::Other(37),
+            result: b"VALUE",
+            option_code: b"37",
+            level: b"0",
+        },
+    ];
+
+    // Exact Tcl 9.0.4 catch oracles, in case order:
+    // 2 VALUE {-code 0 -level 1}
+    // 3 {}    {-code 3 -level 0}
+    // 4 {}    {-code 4 -level 0}
+    // 37 VALUE {-code 37 -level 0}
+    for case in cases {
+        let completion = Interp::new().eval_completion(case.script);
+        assert_eq!(
+            completion.code,
+            case.code,
+            "script: {}",
+            String::from_utf8_lossy(case.script)
+        );
+        assert_eq!(
+            completion.result,
+            case.result,
+            "script: {}",
+            String::from_utf8_lossy(case.script)
+        );
+        assert_eq!(dict_value(&completion.options, b"-code"), case.option_code);
+        assert_eq!(dict_value(&completion.options, b"-level"), case.level);
+    }
+}
+
+#[test]
+fn sourced_completion_settles_return_before_snapshot_and_publication() {
+    let mut interp = Interp::new();
+
+    let ordinary = interp.eval_sourced_completion(b"return VALUE", b"ordinary.tcl");
+    assert_eq!(ordinary.code, CompletionCode::Ok);
+    assert_eq!(ordinary.result, b"VALUE");
+    assert_eq!(dict_value(&ordinary.options, b"-code"), b"0");
+    assert_eq!(dict_value(&ordinary.options, b"-level"), b"0");
+
+    // Tcl 9.0.4: sourcing a file containing this command is caught as
+    // `37 VALUE {-code 37 -level 0}`.
+    let other =
+        interp.eval_sourced_completion(b"return -code 37 -level 1 VALUE", b"other-code.tcl");
+    assert_eq!(other.code, CompletionCode::Other(37));
+    assert_eq!(other.result, b"VALUE");
+    assert_eq!(dict_value(&other.options, b"-code"), b"37");
+    assert_eq!(dict_value(&other.options, b"-level"), b"0");
+
+    let failure = interp.eval_sourced_completion(
+        b"return -code error -level 1 -errorinfo {SOURCE INFO} \
+          -errorcode {SOURCE CODE} FAILURE",
+        b"error-code.tcl",
+    );
+    assert_eq!(failure.code, CompletionCode::Error);
+    assert_eq!(failure.result, b"FAILURE");
+    assert_eq!(dict_value(&failure.options, b"-code"), b"1");
+    assert_eq!(dict_value(&failure.options, b"-level"), b"0");
+    assert_eq!(dict_value(&failure.options, b"-errorcode"), b"SOURCE CODE");
+    assert_eq!(dict_value(&failure.options, b"-errorinfo"), b"SOURCE INFO");
+    assert_eq!(interp.eval_str(b"set ::errorCode"), Code::Ok);
+    assert_eq!(interp.result_bytes(), b"SOURCE CODE");
+}

--- a/rust/tcl-runtime-api/src/lib.rs
+++ b/rust/tcl-runtime-api/src/lib.rs
@@ -41,6 +41,16 @@ pub use tcl_core_types::{
     Code, CommandId, Completion, FrameId, GLOBAL_FRAME, NsId, ROOT_NS, VarId,
 };
 
+/// An owned, byte-preserving script completion for host and embedding
+/// boundaries.
+///
+/// `result` is the Tcl result (the error message for [`Code::Error`]) and
+/// `options` is its return-options dict, both projected as their exact Tcl
+/// string-representation bytes. Runtime engines must construct this before a
+/// host adapter chooses any text encoding; a terminal, JavaScript bridge, or
+/// other explicitly textual consumer may decode the byte fields afterwards.
+pub type ScriptCompletion = Completion<Vec<u8>>;
+
 /// A command-level variable removal rejected by the store.
 ///
 /// Storage-only consumers use [`VarStore::unset`] when they have already


### PR DESCRIPTION
## Summary

- add `ScriptCompletion`, a shared byte-valued completion record in `tcl-runtime-api`
- expose completion-aware evaluation entry points from the standalone runtime and capture live Tcl return options before publication resets interpreter state
- make `run_script` write final results and errors as raw bytes, including nested `-during` options and sourced completion settlement
- document the shared semantic owner and cover success, error, return, break, continue, custom codes, sourced scripts, and CLI byte paths

This keeps completion semantics in the runtime API so embedders and command-line consumers observe the same Tcl result bytes and option dictionaries. The distinct command-specific `try` error-info frame gap remains tracked by #1929.

## Validation

- `make rust-check`
- `make prep-pr` (30/30 smoke tests)
- `make test-spectcl-compat` (20 + 3 + 1 + 4 + 2 tests)
- exact Tcl 9.0.4 completion oracles and focused native/WASM/runtime tests

Closes #1950