### PR TITLE
fix(ci): keep Cargo target locks out of descendants

### DIFF
--- a/docs/design/contracts/tank-persistent-cargo-target.md
+++ b/docs/design/contracts/tank-persistent-cargo-target.md
@@ -28,6 +28,11 @@ only a compatibility fallback; it must not be shared by two registrations.
 
 ## Lifecycle safety
 
+The wrapper process retains the target lock for each Cargo command, but closes
+the descriptor in the command process. Compiler-cache daemons and other
+descendants may outlive Cargo without retaining the target lock into the next
+CI step.
+
 The runner job concurrency group remains `tank`, with `queue: max` and
 `cancel-in-progress: false`. Cargo commands hold the target's advisory
 `flock`; the bounded janitor examines only old, correctly marked direct

--- a/scripts/dev/persistent-cargo-target.sh
+++ b/scripts/dev/persistent-cargo-target.sh
@@ -368,15 +368,16 @@ with_lock() {
     owned_mode "$target" 700
     lock=$target/$LOCK
     valid_lock "$lock" || die "target lock is missing or unsafe: $lock"
-    # Keep the descriptor open for the complete child process.  A janitor can
-    # therefore skip this target without guessing whether Cargo is active.
+    # Keep the descriptor open in this wrapper for the complete command.  The
+    # command itself must not inherit it: compiler-cache daemons can outlive
+    # Cargo and would otherwise retain the lock into the following CI step.
     exec 9<>"$lock"
     opened_lock_ok 9 "$lock" || {
         exec 9>&-
         die "target lock changed while opening: $lock"
     }
     flock -n 9 || die "target is already locked: $target"
-    "$@"
+    "$@" 9>&-
 }
 
 [ "$#" -ge 1 ] || die "usage: $SELF prepare|janitor|with-lock ..."

--- a/scripts/dev/test-persistent-cargo-target.sh
+++ b/scripts/dev/test-persistent-cargo-target.sh
@@ -82,6 +82,24 @@ report=$(TCL_LSP_TANK_TARGET_ROOT="$TARGET_ROOT" bash "$HELPER" report "$target_
 grep -q 'target_bytes=' <<< "$report" || fail "final target size was not reported"
 grep -q 'free_kb=' <<< "$report" || fail "final free space was not reported"
 bash "$HELPER" with-lock "$target_a" true
+# The wrapper, rather than the command descriptor, owns the lock for the
+# command's lifetime.
+ready=$ROOT/with-lock-ready
+bash "$HELPER" with-lock "$target_a" bash -c 'touch "$1"; sleep 1' -- "$ready" &
+holder=$!
+for _ in $(seq 1 100); do
+    [ -e "$ready" ] && break
+    sleep 0.01
+done
+[ -e "$ready" ] || fail "with-lock command did not start"
+expect_failure bash "$HELPER" with-lock "$target_a" true
+wait "$holder"
+# A command may leave a long-lived helper behind.  That descendant must not
+# inherit the advisory descriptor after the wrapper command has returned.
+bash "$HELPER" with-lock "$target_a" bash -c 'sleep 2 &'
+if ! bash "$HELPER" with-lock "$target_a" true; then
+    fail "a surviving command descendant retained the target lock"
+fi
 chmod 644 "$target_a/.tcl-lsp-cargo-target.lock"
 expect_failure bash "$HELPER" with-lock "$target_a" true
 chmod 600 "$target_a/.tcl-lsp-cargo-target.lock"


### PR DESCRIPTION
## Root cause

The persistent target wrapper held file descriptor 9 while launching Cargo. Long-lived descendants such as `sccache` inherited that descriptor, so after the Cargo process exited they could keep the target lock held into the following doctest step. Production run [34226830925](https://github.com/bitwisecook/tcl-lsp/actions/runs/34226830925) exposed this after the broad nextest suite completed successfully.

## Fix

- retain the advisory lock in the wrapper for the complete command lifetime;
- close descriptor 9 only in the launched command and all of its descendants;
- prove a concurrent command remains blocked while the wrapper command is active;
- prove a surviving background descendant cannot retain the lock after the wrapper command returns;
- document the descriptor-isolation requirement.

## Verification

- `bash scripts/dev/test-persistent-cargo-target.sh`
- `make rust-check`
- `make prep-pr` — 30/30 smoke tests passed
- `git diff --check`

Follow-up for #1955 and #1959.
