### PR TITLE
expr: the radix hint follows C's switch over the prefix byte, lowercase only

### DIFF
--- a/rust/tcl-syntax/src/expr/syntax_error.rs
+++ b/rust/tcl-syntax/src/expr/syntax_error.rs
@@ -55,7 +55,9 @@ const MARK: &str = "_@_";
 /// C has arms for `b` and `o` and a `default` that fires only when the second
 /// character is a digit (legacy leading-zero octal). There is deliberately **no
 /// `x` arm**, so a bad hex numeral such as `0xg` keeps the plain `BAREWORD`
-/// code and gets no hint.
+/// code and gets no hint. C's `switch` is over bytes, so the arms are the
+/// lowercase letters alone: `0O8` and `0B2` are numerals the *lexer* accepts
+/// but the hint does not recognise, and they keep `BAREWORD` too.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum NumberHint {
     /// `0b…` with a non-binary digit.
@@ -98,8 +100,8 @@ impl NumberHint {
             return None;
         }
         match b[1] {
-            b'b' | b'B' => Some(Self::Binary),
-            b'o' | b'O' => Some(Self::Octal),
+            b'b' => Some(Self::Binary),
+            b'o' => Some(Self::Octal),
             c if c.is_ascii_digit() => Some(Self::Octal),
             _ => None,
         }
@@ -873,6 +875,61 @@ mod tests {
                 got_code,
                 format!("TCL PARSE EXPR {code}"),
                 "code for {source}"
+            );
+        }
+    }
+
+    /// The radix hint follows C's `switch (start[1])` exactly
+    /// (`tclCompExpr.c:785-808`), pinned against real `tclsh` output.
+    ///
+    /// Three things the switch does that a "looks like a bad number" guess
+    /// would not: it has no `x` arm at all, so `0xg` stays a plain bareword;
+    /// its arms are lowercase bytes, so `0O8` and `0B2` — spellings the lexer
+    /// accepts as radix prefixes — get no hint either; and the legacy
+    /// leading-zero arm fires only where the release still reads `08` as
+    /// octal, which is up to 8.6.
+    #[test]
+    fn the_radix_hint_matches_c_switch_over_the_prefix_byte() {
+        const OCTAL: &str = " (invalid octal number?)";
+        const BINARY: &str = " (invalid binary number?)";
+        // (expression, dialect, postscript suffix, error code)
+        let vectors = [
+            ("0o8", "tcl9.0", OCTAL, "TCL PARSE EXPR BADNUMBER OCTAL"),
+            ("0b2", "tcl9.0", BINARY, "TCL PARSE EXPR BADNUMBER BINARY"),
+            ("0o", "tcl9.0", OCTAL, "TCL PARSE EXPR BADNUMBER OCTAL"),
+            ("0b", "tcl9.0", BINARY, "TCL PARSE EXPR BADNUMBER BINARY"),
+            // No `x` arm: a bad hex numeral is an ordinary bareword.
+            ("0x", "tcl9.0", "", "TCL PARSE EXPR BAREWORD"),
+            ("0xg", "tcl9.0", "", "TCL PARSE EXPR BAREWORD"),
+            // The arms are lowercase bytes; the uppercase prefixes miss them.
+            ("0O8", "tcl9.0", "", "TCL PARSE EXPR BAREWORD"),
+            ("0B2", "tcl9.0", "", "TCL PARSE EXPR BAREWORD"),
+            // Legacy leading-zero octal, while the release still has it.
+            ("08", "tcl8.6", OCTAL, "TCL PARSE EXPR BADNUMBER OCTAL"),
+            ("09", "tcl8.6", OCTAL, "TCL PARSE EXPR BADNUMBER OCTAL"),
+            ("0O8", "tcl8.6", "", "TCL PARSE EXPR BAREWORD"),
+            // `0d` and `_` are 9.0 spellings; before that they are barewords
+            // with no hint, since neither is a `switch` arm.
+            ("0d9", "tcl8.6", "", "TCL PARSE EXPR BAREWORD"),
+            ("1_0", "tcl8.6", "", "TCL PARSE EXPR BAREWORD"),
+        ];
+        for (source, dialect, suffix, code) in vectors {
+            let error = ExprSyntaxError::diagnose(source, Some(dialect));
+            let message = error.message(source);
+            assert_eq!(
+                error.error_code(),
+                code,
+                "error code for expr {{{source}}} under {dialect}"
+            );
+            assert_eq!(
+                message,
+                format!(
+                    "invalid bareword \"{source}\"\n\
+                     in expression \"{source}\";\n\
+                     should be \"${source}\" or \"{{{source}}}\" \
+                     or \"{source}(...)\" or ...{suffix}"
+                ),
+                "message for expr {{{source}}} under {dialect}"
             );
         }
     }


### PR DESCRIPTION
## Summary

- #1419's "found but not fixed" note tracked the radix-invalid numeral path (`expr {0o8}` returning the string `0o8`). That is **already fixed** on `rust` — `0o8`, `0b2`, `0x`, `0xg` all raise C's error with C's message, `-errorcode` and `-errorinfo`, byte for byte. What was *not* right is which spellings earn the hint.

- `ParseExpr`'s bad-numeral hint is a `switch (start[1])` over bytes with a `case 'b'` and a `case 'o'` (`tclCompExpr.c:785-808`). `NumberHint::for_word` matched `b'B'` and `b'O'` too, so two spellings got a hint and a `BADNUMBER` code C never gives them:

  | expr | C 8.6 / 9.0 / 9.1 | before this PR |
  | --- | --- | --- |
  | `0O8` | `TCL PARSE EXPR BAREWORD`, no postscript | `TCL PARSE EXPR BADNUMBER OCTAL` + ` (invalid octal number?)` |
  | `0B2` | `TCL PARSE EXPR BAREWORD`, no postscript | `TCL PARSE EXPR BADNUMBER BINARY` + ` (invalid binary number?)` |

  These are spellings the *lexer* accepts as radix prefixes, so they look like botched numerals — but C's hint is a byte switch, not a numeral classification, and it does not see them. The module's doc comment already recorded the deliberately absent `x` arm (`0xg` stays a plain bareword); the uppercase letters are the same fact, now recorded and enforced beside it.

- The fix is the two match arms. The behaviour is dialect-independent, so it corrects every emulated release at once.

## Validation

A differential sweep of 48 numeral spellings (`0o8 0b2 0O8 0B2 0x 0X 0xg 0Xg 08 09 0d9 0D9 1_0 0o 0b 0 00 000 0og 0bx 0o8x 0b2x 0z 0_ 0e 0e_ 0xg8 0o18 0b12 07 0o7 0b1 0xf 0X1F 0B1 0O7 0d 0D 0.5 0x1p3 0o0 0b0 09.5 08.5 0_0 0o_1 0b_1 0x_1`), each run through `catch {expr $e} msg opts` and compared on outcome, `-errorcode` and postscript:

```
tclvm --tcl-version V  vs  tmp/tclV/unix/tclsh     8.5  8.6  9.0  9.1
before                                              2    2    2    2   divergences
after                                               0    0    0    0
```

On 8.5 the `-errorcode` column still differs (real 8.5 sets `NONE`; `TCL PARSE EXPR …` codes arrive in 8.6). That is a separate, pre-existing, release-wide gap, not a radix one — the messages and hints agree on 8.5 too, and I have left it alone rather than widening this change.

```
cargo test -p tcl-syntax -p tcl-vm -p tcl-dialect
make check-rust-pr                                  # clean
```

`the_radix_hint_matches_c_switch_over_the_prefix_byte` pins thirteen spellings, including every arm that must *not* fire, against real `tclsh` output. It fails with `left: "TCL PARSE EXPR BADNUMBER OCTAL", right: "TCL PARSE EXPR BAREWORD"` when the uppercase arms are restored, so it is not vacuous.

One pre-existing failure in this sandbox, present on `origin/rust` without this change and unrelated to it: `tcl-vm::word_value_resolution_e2e::vectors_match_real_tclsh` reports `[tclsh V8_6] a folded format result counts characters, not bytes — left: "5:café", right: "4:café"`. It is a conformance check against the *system* `tclsh8.6`, not the pinned tree, and CI is green on it.

## Compiler / diagnostics checklist

- [x] Did this change alter a compiler fact contract? **No.** It corrects an existing implementation to the C behaviour it already claims to model; the contract (`ParseExpr` parity) is unchanged, and the doc comment stating it is extended to cover the byte-switch detail.
- [x] No diagnostic or optimisation code added or changed. The affected value is a runtime Tcl `-errorcode` (`TCL PARSE EXPR …`), not a KCS diagnostic.
- [x] No new design doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F6pDxCsXjcTW4A9rTTpQS7

---
_Generated by [Claude Code](https://claude.ai/code/session_01F6pDxCsXjcTW4A9rTTpQS7)_