### PR TITLE
Speed SslicTcl source-data checks

### DIFF
--- a/rust/tcl-sslictcl/scripts/generate-source-data.sh
+++ b/rust/tcl-sslictcl/scripts/generate-source-data.sh
@@ -109,12 +109,30 @@ for pem in "$RAW"/pem/*.pem; do
         fingerprint="$(sha256_digest "$der")"
         der_base64="$(base64_file "$der")"
         spki_sha256="$(openssl x509 -in "$cert" -pubkey -noout | openssl pkey -pubin -outform DER 2>/dev/null | sha256_digest)"
-        subject_key_id="$(openssl x509 -in "$cert" -noout -ext subjectKeyIdentifier 2>/dev/null | awk '/Subject Key Identifier/{getline; gsub(/[^0-9A-Fa-f]/, ""); print tolower($0)}')"
-        not_before_text="$(openssl x509 -in "$cert" -noout -startdate | sed 's/^notBefore=//')"
-        not_after_text="$(openssl x509 -in "$cert" -noout -enddate | sed 's/^notAfter=//')"
+        # Fetch the textual fields in one OpenSSL invocation.  These values
+        # are independent of the DER output above, and parsing them together
+        # avoids four process launches for every certificate while retaining
+        # the same fail-closed handling for malformed certificates.
+        metadata="$TMP/metadata"
+        metadata_errors="$TMP/metadata-errors"
+        if ! openssl x509 -in "$cert" -noout -subject -nameopt RFC2253 \
+            -startdate -enddate -ext subjectKeyIdentifier > "$metadata" 2> "$metadata_errors"; then
+            cat "$metadata_errors" >&2
+            exit 1
+        fi
+        IFS=$'\t' read -r subject not_before_text not_after_text subject_key_id <<< "$(awk '
+            /^subject=/ {subject = $0; sub(/^subject=/, "", subject)}
+            /^notBefore=/ {not_before = $0; sub(/^notBefore=/, "", not_before)}
+            /^notAfter=/ {not_after = $0; sub(/^notAfter=/, "", not_after)}
+            /Subject Key Identifier:/ {
+                getline
+                gsub(/[^0-9A-Fa-f]/, "")
+                subject_key_id = tolower($0)
+            }
+            END {printf "%s\t%s\t%s\t%s\n", subject, not_before, not_after, subject_key_id}
+        ' "$metadata")"
         not_before="$(date_to_epoch "$not_before_text")"
         not_after="$(date_to_epoch "$not_after_text")"
-        subject="$(openssl x509 -in "$cert" -noout -subject -nameopt RFC2253 | sed 's/^subject=//')"
         printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' "$fingerprint" "$der_base64" "$spki_sha256" "$subject_key_id" "$not_before" "$not_after" "$subject" >> "$MATERIAL_TSV"
     done
 done


### PR DESCRIPTION
## Root cause

The deterministic SslicTcl source-data gate parsed every PEM certificate four separate times to obtain subject, start date, end date, and subject-key identifier. Those independent `openssl x509` launches dominated an otherwise small transformation and cost roughly one minute in every `rust-check`/`pr-gate`.

## Fix

Request the four textual fields in one fail-closed OpenSSL invocation and parse its labelled output into the same row. DER, fingerprint, public-key hashing, date conversion, missing-SKI handling, provenance, and every generated output comparison remain unchanged.

Tracks #1976; the issue will be closed with the final root-cause/fix note after this PR is green and merged.

## Experimental proof

- Baseline generator: 60.32s.
- Candidate trials: 40.00s and 37.86s (37.2–33.7% faster).
- Both paths reported exactly 629 anchors and 231 material exceptions.
- Candidate `--check` compared all three generated JSON files byte-for-byte with the existing committed outputs.
- `make rust-check`: passed on Rust 1.98.1.
- `make prep-pr`: passed; 30/30 smoke tests passed.
- Worktree stayed clean after codegen and formatting.