### PR TITLE
docs(ci): define and prove LSP E2E no-op path

### DIFF
--- a/docs/design/contracts/test-tiers-and-ci-gates.md
+++ b/docs/design/contracts/test-tiers-and-ci-gates.md
@@ -31,6 +31,10 @@ classifier and manifests from the PR base commit. An incomplete changed-file
 list, malformed closure, or absent base-copy runs the whole archive lane. The
 required aggregate job always reports a status; when the closure is unaffected,
 only its archive, partition, and proof-transfer steps are skipped.
+Validate that no-op path in Actions with a change outside both committed
+closures: the archive producer and all three partition jobs must succeed
+without building, uploading, downloading, or running the archive, and the
+required aggregate must still succeed after checking every upstream result.
 
 ## Decision rules / contracts
 


### PR DESCRIPTION
## Summary\n\n- document the required unaffected-path validation for the native LSP E2E lane\n- use this docs-only change as the post-merge no-op experiment for #1974\n- retain the required aggregate check while proving that archive build, transfer, and execution steps do not run\n\n## Local validation\n\n- \n-  (30/30 smoke tests)\n\n## Experimental proof\n\n[Actions run 34252522471](https://github.com/bitwisecook/tcl-lsp/actions/runs/34252522471) exercised the post-merge classifier with this docs-only change:\n\n- archive: 5s; checkout, toolchain, archive build, partition proof, archive upload, and proof upload all skipped\n- partitions: 3s, 3s, and 6s; checkout, setup, downloads, listing, execution, result recording, and uploads all skipped\n- required aggregate: 5s and successful; proof downloads and verification skipped after checking every upstream result\n\nThe no-op lane's end-to-end critical path was 22s. The full controlled #1975 run required about 6m16s for archive + slowest partition + aggregate, so the unaffected path removes about 5m54s from critical path and roughly 13 runner-minutes while retaining the required status.\n\nTracks #1974.