### PR TITLE
JetBrains: paint semantic tokens in colours the stock schemes actually fill

### DIFF
--- a/docs/kcs/README.md
+++ b/docs/kcs/README.md
@@ -107,6 +107,9 @@ symptom with several possible causes worth telling apart. See rule 13 in
   when (and when not) to restart the Tcl Language Server.
 - [kcs-qa-query-vs-grep-vs-rename.md](kcs-qa-query-vs-grep-vs-rename.md) —
   which `f5` verb to pick for filter / find / rename tasks.
+- [kcs-qa-what-sets-tcl-colours-in-jetbrains.md](kcs-qa-what-sets-tcl-colours-in-jetbrains.md)
+  — the two layers that colour a Tcl file in a JetBrains IDE, and which
+  Language Defaults entry each kind of token uses.
 - [kcs-qa-tcl-lsp-annotations.md](kcs-qa-tcl-lsp-annotations.md) — which
   `# tcl-lsp:` and `# noqa` comments the analyser understands.
 - [kcs-qa-does-the-server-follow-rename-and-interp-alias.md](kcs-qa-does-the-server-follow-rename-and-interp-alias.md)

--- a/docs/kcs/kcs-qa-what-sets-tcl-colours-in-jetbrains.md
+++ b/docs/kcs/kcs-qa-what-sets-tcl-colours-in-jetbrains.md
@@ -1,0 +1,57 @@
+# KCS: What sets the colours of a Tcl file in a JetBrains IDE?
+
+> **Audience:** User
+> **Type:** Q&A
+
+## Applies to
+
+JetBrains
+
+## Question
+
+What decides how a Tcl file is coloured in a JetBrains IDE, and where do I
+change those colours?
+
+## Answer
+
+Two layers colour a Tcl file, and both draw on your own editor colour
+scheme. The plugin ships no colours of its own.
+
+The **bundled TextMate grammar** colours the file the moment it opens. It
+reaches keywords, strings, numbers, comments, and `proc` names.
+
+**Semantic tokens** from the Tcl Language Server are painted over the top.
+The server knows what each word means, so this layer reaches built-in
+commands, your own procs, variables, parameters, operators, iRule events,
+regular expressions, and `format` specifiers. Switch it off under **Settings
+→ Tools → Tcl Language Server → Features → Semantic tokens**.
+
+Every colour comes from **Settings → Editor → Color Scheme → Language
+Defaults**. Change an entry there and every Tcl token that uses it follows.
+
+| Tcl token | Language Defaults entry |
+|---|---|
+| built-in command, your own proc, iRule event handler | **Identifiers → Function declaration** |
+| variable, proc parameter | **Classes → Instance field** |
+| `proc`, `if`, `foreach`, and the other control commands | **Keyword** |
+| string | **String → String text** |
+| number, BIG-IP port, route domain | **Number** |
+| comment | **Comments → Line comment** |
+| backslash escape, `format` and `clock` specifier | **String → Escape sequence → Valid** |
+| namespace, BIG-IP pool, monitor, profile | **Classes → Class reference** |
+
+Two entries stay deliberately plain, because the IDE leaves the same tokens
+plain in its own languages: an operator such as `+` uses **Braces and
+Operators → Operation sign**, and a TclOO class name uses **Classes → Class
+name**. Give either one a foreground on that page if you want it coloured.
+
+With **Semantic tokens** switched off, only the grammar layer remains.
+Built-in command names and variables then stay in the plain text colour.
+The IDE's TextMate support maps those scopes to scheme entries the stock
+schemes leave unpainted, and no plugin can change that table.
+
+## Related
+
+- [KCS index](README.md)
+- [Glossary](../GLOSSARY.md)
+- [feature — Semantic tokens](features/kcs-feature-semantic-tokens.md)

--- a/docs/kcs/kcs-qa-what-sets-tcl-colours-in-jetbrains.md
+++ b/docs/kcs/kcs-qa-what-sets-tcl-colours-in-jetbrains.md
@@ -40,10 +40,12 @@ Defaults**. Change an entry there and every Tcl token that uses it follows.
 | backslash escape, `format` and `clock` specifier | **String → Escape sequence → Valid** |
 | namespace, BIG-IP pool, monitor, profile | **Classes → Class reference** |
 
-Two entries stay deliberately plain, because the IDE leaves the same tokens
-plain in its own languages: an operator such as `+` uses **Braces and
+Some entries are plain in a stock scheme, because the IDE leaves the same
+tokens plain in its own languages: an operator such as `+` uses **Braces and
 Operators → Operation sign**, and a TclOO class name uses **Classes → Class
-name**. Give either one a foreground on that page if you want it coloured.
+name**. On the **Classic Light** scheme, command names are plain as well —
+that scheme colours no function name in any language, Java included. Give any
+of those entries a foreground on the same page if you want it coloured.
 
 With **Semantic tokens** switched off, only the grammar layer remains.
 Built-in command names and variables then stay in the plain text colour.

--- a/editors/jetbrains/README.md
+++ b/editors/jetbrains/README.md
@@ -22,9 +22,15 @@ See the [Installation Guide](../../INSTALL-editors.md) for full details.
 Everything the IDE's LSP client asks for is supported:
 
 - **Syntax highlighting** via the bundled TextMate grammar, which the
-  plugin registers with the IDE's TextMate service at startup
+  plugin registers with the IDE's TextMate service at startup — it colours
+  keywords, strings, numbers, comments, and `proc` names
 - **Semantic highlighting** from the language server's own tokens, layered
-  over the grammar (toggle it under Features → Semantic tokens)
+  over the grammar (toggle it under Features → Semantic tokens). The colours
+  are your scheme's own, on the **Settings → Editor → Color Scheme → Language
+  Defaults** page: a Tcl built-in, a user proc and an iRule event handler use
+  **Identifiers → Function declaration**, a variable or a parameter uses
+  **Classes → Instance field**, and `proc`, `if` and the other control
+  commands use **Keyword**. Retune those entries to recolour Tcl.
 - **Diagnostics** with 30+ configurable rules
 - **Auto-completion** for commands, subcommands, variables, and switches
 - **Hover** with command help and proc signatures

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/TclSemanticTokens.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/TclSemanticTokens.kt
@@ -37,13 +37,18 @@ import com.tcllsp.jetbrains.settings.TclLspSettings
  * having no semantic highlighting at all.
  *
  * A key the stock schemes give no foreground to leaves its token in the plain
- * text colour, so the ordinary parts of a Tcl file need a key that is painted
- * everywhere. FUNCTION_CALL, PREDEFINED_SYMBOL, LOCAL_VARIABLE, PARAMETER,
+ * text colour, so the ordinary parts of a Tcl file need a key those schemes
+ * paint. FUNCTION_CALL, PREDEFINED_SYMBOL, LOCAL_VARIABLE, PARAMETER,
  * IDENTIFIER and OPERATION_SIGN are not: they stay unused except where the
  * IDE leaves the same token plain in its own languages too (an `operator`, a
  * bare name in a config file). So every command head — built-in, user proc,
  * method, or iRule event handler — is FUNCTION_DECLARATION, the key the
  * platform's own LSP default gives the `function` type.
+ *
+ * The classic `Default` scheme ("Classic Light") is the one that still leaves
+ * a command head plain, and deliberately: it defines neither function key, so
+ * a Java method name is plain there too. Painting Tcl's commands anyway would
+ * be our colour rather than the scheme author's.
  *
  * The palette is smaller than the legend, so several Tcl types share a key,
  * the same collapsing the VS Code extension does with `semanticTokenScopes`.

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/TclSemanticTokens.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/TclSemanticTokens.kt
@@ -36,71 +36,83 @@ import com.tcllsp.jetbrains.settings.TclLspSettings
  * IDE paints in the default foreground, which is indistinguishable from
  * having no semantic highlighting at all.
  *
- * The keys the platform offers are a general-purpose set, so several Tcl
- * types share one — the regexp operators are all `OPERATION_SIGN`, the
- * `format`/`clock`/`binary` specifiers all read as escapes inside a string.
- * That is the same collapsing the VS Code extension does with its
- * `semanticTokenScopes` mapping.
+ * A key the stock schemes give no foreground to leaves its token in the plain
+ * text colour, so the ordinary parts of a Tcl file need a key that is painted
+ * everywhere. FUNCTION_CALL, PREDEFINED_SYMBOL, LOCAL_VARIABLE, PARAMETER,
+ * IDENTIFIER and OPERATION_SIGN are not: they stay unused except where the
+ * IDE leaves the same token plain in its own languages too (an `operator`, a
+ * bare name in a config file). So every command head — built-in, user proc,
+ * method, or iRule event handler — is FUNCTION_DECLARATION, the key the
+ * platform's own LSP default gives the `function` type.
+ *
+ * The palette is smaller than the legend, so several Tcl types share a key,
+ * the same collapsing the VS Code extension does with `semanticTokenScopes`.
+ * The colours stay the user's: every key is a stock one, retuned on the
+ * scheme's Language Defaults page.
  */
 // @generated-check:semantic-token-colors — keys are verified against the
 // server legend by `cargo xtask gen-jetbrains-catalog`.
 internal val SEMANTIC_TOKEN_COLORS: Map<String, TextAttributesKey> = mapOf(
-    // Core Tcl.
+    // Core Tcl. Every command head is a declaration key; the variable-shaped
+    // types share the field key, which stock schemes colour.
     "keyword" to Colors.KEYWORD,
-    "function" to Colors.FUNCTION_CALL,
-    "variable" to Colors.LOCAL_VARIABLE,
+    "function" to Colors.FUNCTION_DECLARATION,
+    "method" to Colors.FUNCTION_DECLARATION,
+    "variable" to Colors.INSTANCE_FIELD,
+    "parameter" to Colors.INSTANCE_FIELD,
     "string" to Colors.STRING,
     "number" to Colors.NUMBER,
     "comment" to Colors.LINE_COMMENT,
     "namespace" to Colors.CLASS_REFERENCE,
     "operator" to Colors.OPERATION_SIGN,
     "escape" to Colors.VALID_STRING_ESCAPE,
-    "parameter" to Colors.PARAMETER,
-    "method" to Colors.INSTANCE_METHOD,
     "class" to Colors.CLASS_NAME,
     "object" to Colors.CLASS_REFERENCE,
     "decorator" to Colors.METADATA,
     "enumMember" to Colors.CONSTANT,
     "property" to Colors.INSTANCE_FIELD,
-    // iRule events (`when HTTP_REQUEST`) — a tag-like name, not a call.
-    "event" to Colors.MARKUP_TAG,
+    // An iRule event block is a handler definition, not a tag.
+    "event" to Colors.FUNCTION_DECLARATION,
 
-    // Regular-expression interiors.
+    // Regular-expression interiors, mirroring IntelliJ's own RegExp
+    // highlighter: meta characters and quantifiers read as keywords,
+    // classes and escapes as string escapes.
     "regexp" to Colors.STRING,
-    "regexpGroup" to Colors.OPERATION_SIGN,
-    "regexpCharClass" to Colors.CONSTANT,
-    "regexpQuantifier" to Colors.OPERATION_SIGN,
-    "regexpAnchor" to Colors.OPERATION_SIGN,
+    "regexpGroup" to Colors.KEYWORD,
+    "regexpQuantifier" to Colors.KEYWORD,
+    "regexpAnchor" to Colors.KEYWORD,
+    "regexpAlternation" to Colors.KEYWORD,
+    "regexpCharClass" to Colors.VALID_STRING_ESCAPE,
     "regexpEscape" to Colors.VALID_STRING_ESCAPE,
-    "regexpBackref" to Colors.CONSTANT,
-    "regexpAlternation" to Colors.OPERATION_SIGN,
+    "regexpBackref" to Colors.VALID_STRING_ESCAPE,
 
-    // `format` / `clock` / `binary` specifiers, all inside a string literal.
+    // `format` / `clock` / `binary` specifiers, all inside a string literal —
+    // IntelliJ paints a whole Java format specifier as a string escape.
     "formatPercent" to Colors.VALID_STRING_ESCAPE,
     "formatSpec" to Colors.VALID_STRING_ESCAPE,
-    "formatFlag" to Colors.OPERATION_SIGN,
+    "formatFlag" to Colors.VALID_STRING_ESCAPE,
     "formatWidth" to Colors.NUMBER,
     "clockPercent" to Colors.VALID_STRING_ESCAPE,
     "clockSpec" to Colors.VALID_STRING_ESCAPE,
-    "clockModifier" to Colors.OPERATION_SIGN,
+    "clockModifier" to Colors.VALID_STRING_ESCAPE,
     "binarySpec" to Colors.VALID_STRING_ESCAPE,
     "binaryCount" to Colors.NUMBER,
-    "binaryFlag" to Colors.OPERATION_SIGN,
+    "binaryFlag" to Colors.VALID_STRING_ESCAPE,
 
     // APL — the iApp presentation sublanguage.
     "aplSection" to Colors.KEYWORD,
-    "aplSectionName" to Colors.CLASS_NAME,
-    "aplFieldType" to Colors.CLASS_REFERENCE,
+    "aplSectionName" to Colors.FUNCTION_DECLARATION,
+    "aplFieldType" to Colors.KEYWORD,
     "aplFieldName" to Colors.INSTANCE_FIELD,
-    "aplAttribute" to Colors.MARKUP_ATTRIBUTE,
+    "aplAttribute" to Colors.METADATA,
     "aplDefine" to Colors.KEYWORD,
     "aplDefineName" to Colors.CONSTANT,
     "aplDirective" to Colors.METADATA,
     "aplOptional" to Colors.OPERATION_SIGN,
-    "aplValidator" to Colors.STATIC_METHOD,
+    "aplValidator" to Colors.FUNCTION_DECLARATION,
 
     // BIG-IP configuration objects and the values that name them.
-    "partition" to Colors.CLASS_NAME,
+    "partition" to Colors.CLASS_REFERENCE,
     "pool" to Colors.CLASS_REFERENCE,
     "monitor" to Colors.CLASS_REFERENCE,
     "profile" to Colors.CLASS_REFERENCE,
@@ -116,17 +128,11 @@ internal val SEMANTIC_TOKEN_COLORS: Map<String, TextAttributesKey> = mapOf(
 
 /**
  * Semantic-token overrides for the modifiers the server sets alongside a
- * type (`legend_token_modifiers`). Only the pairs that carry real meaning in
- * an IntelliJ colour scheme are listed; anything else falls through to the
- * type's own colour.
+ * type (`legend_token_modifiers`). Only a pair that resolves to a different
+ * key than the type itself is worth listing; anything else falls through to
+ * the type's own colour.
  */
 private val SEMANTIC_TOKEN_MODIFIER_COLORS: Map<Pair<String, String>, TextAttributesKey> = mapOf(
-    // A command head resolving to a registry built-in, versus a user proc.
-    ("function" to "defaultLibrary") to Colors.PREDEFINED_SYMBOL,
-    ("method" to "defaultLibrary") to Colors.PREDEFINED_SYMBOL,
-    // The name token of a `proc`/`method` definition, versus a call site.
-    ("function" to "definition") to Colors.FUNCTION_DECLARATION,
-    ("method" to "definition") to Colors.FUNCTION_DECLARATION,
     // A variable the theme should not present as mutable.
     ("variable" to "readonly") to Colors.CONSTANT,
 )

--- a/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/TclSemanticTokensTest.kt
+++ b/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/TclSemanticTokensTest.kt
@@ -4,14 +4,20 @@
 package com.tcllsp.jetbrains
 
 import com.intellij.openapi.editor.DefaultLanguageHighlighterColors as Colors
+import com.intellij.openapi.editor.colors.TextAttributesKey
+import org.w3c.dom.Element
+import javax.xml.parsers.DocumentBuilderFactory
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 /**
- * The colour map is only reachable through [TclSemanticTokens], and the
- * modifier half of it decides whether a built-in reads differently from a
- * user proc — the distinction the server goes to the trouble of publishing.
+ * The colour map is only reachable through [TclSemanticTokens], and the key it
+ * picks decides whether a token is visible at all: a key no stock scheme
+ * paints leaves the token in the plain text colour, which is the "only numbers
+ * are coloured" bug.
  */
 class TclSemanticTokensTest {
 
@@ -20,28 +26,40 @@ class TclSemanticTokensTest {
     @Test
     fun aTokenTypeGetsItsMappedColour() {
         assertEquals(Colors.KEYWORD, tokens.getTextAttributesKey("keyword", emptyList()))
-        assertEquals(Colors.MARKUP_TAG, tokens.getTextAttributesKey("event", emptyList()))
+        assertEquals(Colors.FUNCTION_DECLARATION, tokens.getTextAttributesKey("event", emptyList()))
         assertEquals(Colors.NUMBER, tokens.getTextAttributesKey("port", emptyList()))
     }
 
+    /**
+     * A built-in, a call and a definition all read as a command head, so they
+     * share the one key stock schemes actually colour.
+     */
     @Test
-    fun aModifierTheServerSetsOverridesTheTypeColour() {
+    fun everyCommandHeadReadsAsADeclaration() {
         val call = tokens.getTextAttributesKey("function", emptyList())
         val builtin = tokens.getTextAttributesKey("function", listOf("defaultLibrary"))
         val definition = tokens.getTextAttributesKey("function", listOf("definition"))
 
-        assertEquals(Colors.FUNCTION_CALL, call)
-        assertEquals(Colors.PREDEFINED_SYMBOL, builtin)
+        assertEquals(Colors.FUNCTION_DECLARATION, call)
+        assertEquals(Colors.FUNCTION_DECLARATION, builtin)
         assertEquals(Colors.FUNCTION_DECLARATION, definition)
-        assertNotEquals(call, builtin)
-        assertNotEquals(call, definition)
+    }
+
+    @Test
+    fun aModifierTheServerSetsOverridesTheTypeColour() {
+        val assigned = tokens.getTextAttributesKey("variable", listOf("declaration"))
+        val readonly = tokens.getTextAttributesKey("variable", listOf("readonly"))
+
+        assertEquals(Colors.INSTANCE_FIELD, assigned)
+        assertEquals(Colors.CONSTANT, readonly)
+        assertNotEquals(assigned, readonly)
     }
 
     @Test
     fun aModifierWithNoRuleOfItsOwnKeepsTheTypeColour() {
         assertEquals(
-            Colors.LOCAL_VARIABLE,
-            tokens.getTextAttributesKey("variable", listOf("declaration")),
+            Colors.INSTANCE_FIELD,
+            tokens.getTextAttributesKey("parameter", listOf("declaration")),
         )
     }
 
@@ -50,11 +68,125 @@ class TclSemanticTokensTest {
         // Not every type needs its own key — the platform's palette is
         // smaller than the legend — but a map that collapsed to one key would
         // paint the whole file in a single colour and still pass the coverage
-        // gate in xtask.
+        // gate in xtask. The map yields 13 keys today.
         assertEquals(
             true,
             SEMANTIC_TOKEN_COLORS.values.distinct().size >= 10,
             "the legend must map onto a range of colours, not a single key",
         )
+    }
+
+    /**
+     * The regression: a key that no stock scheme gives a foreground to paints
+     * the token in the plain text colour, so the file looks unhighlighted even
+     * though the server is publishing tokens. Both stock schemes are checked
+     * because several keys are coloured in only one of them.
+     */
+    @Test
+    fun everyCoreTokenIsColouredByTheStockSchemes() {
+        val core = listOf(
+            "keyword", "function", "variable", "parameter",
+            "string", "number", "comment", "escape", "event",
+        )
+        for (scheme in listOf(darculaScheme(), intellijLightScheme())) {
+            for (type in core) {
+                val key = assertNotNull(SEMANTIC_TOKEN_COLORS[type], "$type has no colour")
+                assertTrue(
+                    scheme.paints(key),
+                    "the ${scheme.name} scheme leaves $type (${key.externalName}) " +
+                        "in the plain text colour",
+                )
+            }
+        }
+    }
+
+    /** A stock scheme, resolving an attribute through its parent scheme. */
+    private class Scheme(
+        val name: String,
+        private val foregrounds: Map<String, String>,
+        private val parent: Scheme?,
+    ) {
+        /**
+         * Whether some key in [key]'s fallback chain has a foreground. The
+         * generic keys are skipped: `DEFAULT_IDENTIFIER` and `TEXT` *are* the
+         * plain text colour, so a key reaching a foreground only through them
+         * is exactly the token that looks unhighlighted.
+         */
+        fun paints(key: TextAttributesKey): Boolean {
+            var current: TextAttributesKey? = key
+            while (current != null) {
+                if (current.externalName !in GENERIC_KEYS && foreground(current.externalName) != null) {
+                    return true
+                }
+                current = current.fallbackAttributeKey
+            }
+            return false
+        }
+
+        private fun foreground(name: String): String? =
+            foregrounds[name] ?: parent?.foreground(name)
+    }
+
+    private companion object {
+        val GENERIC_KEYS = setOf("DEFAULT_IDENTIFIER", "TEXT")
+
+        /** `<scheme>` elements of a colour-scheme resource in the IDE's `app.jar`. */
+        fun schemeElements(resource: String): List<Element> {
+            val stream = assertNotNull(
+                TclSemanticTokensTest::class.java.classLoader.getResourceAsStream(resource),
+                "$resource is not on the test classpath",
+            )
+            val root = stream.use {
+                DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(it).documentElement
+            }
+            if (root.tagName == "scheme") {
+                return listOf(root)
+            }
+            val children = root.getElementsByTagName("scheme")
+            return (0 until children.length).map { children.item(it) as Element }
+        }
+
+        /** Every `<option name=…><value><option name="FOREGROUND" value=…>` in a scheme. */
+        fun foregrounds(scheme: Element): Map<String, String> {
+            val attributes = scheme.getElementsByTagName("attributes")
+            if (attributes.length == 0) {
+                return emptyMap()
+            }
+            val options = (attributes.item(0) as Element).getElementsByTagName("option")
+            return (0 until options.length)
+                .map { options.item(it) as Element }
+                .filter { it.parentNode === attributes.item(0) }
+                .mapNotNull { option ->
+                    val value = option.getElementsByTagName("option")
+                    (0 until value.length)
+                        .map { value.item(it) as Element }
+                        .firstOrNull { it.getAttribute("name") == "FOREGROUND" }
+                        ?.let { option.getAttribute("name") to it.getAttribute("value") }
+                }
+                .toMap()
+        }
+
+        fun defaultScheme(named: String): Scheme {
+            val schemes = schemeElements("DefaultColorSchemesManager.xml")
+                .associateBy { it.getAttribute("name") }
+            val scheme = assertNotNull(schemes[named], "no stock $named scheme")
+            val parent = schemes[scheme.getAttribute("parent_scheme")]
+            return Scheme(
+                named,
+                foregrounds(scheme),
+                parent?.let { Scheme(it.getAttribute("name"), foregrounds(it), null) },
+            )
+        }
+
+        fun darculaScheme(): Scheme = defaultScheme("Darcula")
+
+        fun intellijLightScheme(): Scheme {
+            val scheme = schemeElements("themes/Light.xml").single()
+            return Scheme(
+                scheme.getAttribute("name"),
+                foregrounds(scheme),
+                defaultScheme("Default"),
+            )
+        }
     }
 }

--- a/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/TclSemanticTokensTest.kt
+++ b/editors/jetbrains/src/test/kotlin/com/tcllsp/jetbrains/TclSemanticTokensTest.kt
@@ -9,9 +9,9 @@ import org.w3c.dom.Element
 import javax.xml.parsers.DocumentBuilderFactory
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
-import kotlin.test.assertTrue
 
 /**
  * The colour map is only reachable through [TclSemanticTokens], and the key it
@@ -79,8 +79,9 @@ class TclSemanticTokensTest {
     /**
      * The regression: a key that no stock scheme gives a foreground to paints
      * the token in the plain text colour, so the file looks unhighlighted even
-     * though the server is publishing tokens. Both stock schemes are checked
-     * because several keys are coloured in only one of them.
+     * though the server is publishing tokens. Each scheme is paired with the
+     * core types it is expected to leave plain, so a type quietly losing its
+     * colour fails here whichever scheme drops it.
      */
     @Test
     fun everyCoreTokenIsColouredByTheStockSchemes() {
@@ -88,16 +89,38 @@ class TclSemanticTokensTest {
             "keyword", "function", "variable", "parameter",
             "string", "number", "comment", "escape", "event",
         )
-        for (scheme in listOf(darculaScheme(), intellijLightScheme())) {
-            for (type in core) {
-                val key = assertNotNull(SEMANTIC_TOKEN_COLORS[type], "$type has no colour")
-                assertTrue(
-                    scheme.paints(key),
-                    "the ${scheme.name} scheme leaves $type (${key.externalName}) " +
-                        "in the plain text colour",
-                )
+        val schemes = listOf(
+            darculaScheme() to emptySet(),
+            intellijLightScheme() to emptySet(),
+            // The classic scheme paints no function name in any language;
+            // `classicLightPaintsNoFunctionNameInAnyLanguage` pins that.
+            classicLightScheme() to setOf("function", "event"),
+        )
+        for ((scheme, expectedPlain) in schemes) {
+            val plain = core.filterNot { type ->
+                scheme.paints(assertNotNull(SEMANTIC_TOKEN_COLORS[type], "$type has no colour"))
             }
+            assertEquals(
+                expectedPlain,
+                plain.toSet(),
+                "the ${scheme.name} scheme leaves a different set of core tokens " +
+                    "in the plain text colour than expected",
+            )
         }
+    }
+
+    /**
+     * Why the classic scheme's exception is the scheme's own choice and not a
+     * key chosen badly: it gives a foreground to neither function key, so no
+     * stock key paints a command head there. Colouring one would mean picking
+     * a colour its author deliberately left out.
+     */
+    @Test
+    fun classicLightPaintsNoFunctionNameInAnyLanguage() {
+        val classic = classicLightScheme()
+
+        assertFalse(classic.paints(Colors.FUNCTION_DECLARATION))
+        assertFalse(classic.paints(Colors.FUNCTION_CALL))
     }
 
     /** A stock scheme, resolving an attribute through its parent scheme. */
@@ -179,6 +202,9 @@ class TclSemanticTokensTest {
         }
 
         fun darculaScheme(): Scheme = defaultScheme("Darcula")
+
+        /** The scheme the picker calls "Classic Light". */
+        fun classicLightScheme(): Scheme = defaultScheme("Default")
 
         fun intellijLightScheme(): Scheme {
             val scheme = schemeElements("themes/Light.xml").single()


### PR DESCRIPTION
## Summary

- A Tcl file in a JetBrains IDE showed **only its numbers coloured** (reported against 2.2.4). The semantic-token map picked `TextAttributesKey`s that no stock scheme gives a foreground to, so the IDE painted those tokens in the plain text colour — indistinguishable from no semantic highlighting at all. `NUMBER` is one of the few keys the `Default` scheme fills in, which is why numbers survived.

  | Token | Old key | In the stock schemes |
  |---|---|---|
  | `set`, `puts` (command head) | `FUNCTION_CALL` | no foreground anywhere |
  | `$a` | `LOCAL_VARIABLE` | no foreground anywhere |
  | built-in (`defaultLibrary`) | `PREDEFINED_SYMBOL` | italic only, no foreground |
  | `+` | `OPERATION_SIGN` | no foreground anywhere |
  | iRule event | `MARKUP_TAG` | grey *background* inherited from `Default` |
  | `1`, `2` | `NUMBER` | coloured — the only survivor |

- Every legend type now maps to a key the stock schemes paint, and **only to stock keys**: no plugin-owned `TextAttributesKey`s and no Color Scheme page of our own, so the user's scheme and its **Language Defaults** page keep control of every colour. Command heads — built-in, user proc, method, and iRule event handler — take `FUNCTION_DECLARATION`, the key the platform's own LSP default gives the `function` type; variables and parameters take `INSTANCE_FIELD`; regex meta characters read as keywords and character classes as string escapes, mirroring IntelliJ's own RegExp highlighter; `format`/`clock`/`binary` specifiers read as string escapes.

- The four `defaultLibrary` / `definition` modifier rules are dropped — they now resolve to the same key as the type itself, so they were dead rules.

- Some tokens stay on keys a stock scheme leaves plain, deliberately, because the IDE leaves the same tokens plain in its own languages: an `operator` (`Braces and Operators → Operation sign`) and a TclOO `class` (`Classes → Class name`) everywhere, and command heads on the classic `Default` scheme — **Classic Light** — which colours no function name in any language, Java's included. All are named in the docs so they can be retuned.

- The TextMate grammar layer is unchanged and still the floor (keywords, strings, numbers, comments, `proc` names). It cannot be pushed further: IntelliJ's TextMate support resolves scopes through a hard-coded table (`TextMateDefaultColorsProvider`) that sends `support.function` → `FUNCTION_CALL` and `variable` → `LOCAL_VARIABLE`, the same uncoloured keys, and the only override path is hard-coded hex in the bundle, which would not follow the user's theme.

- Docs: `editors/jetbrains/README.md` now names the Language Defaults entry each kind of token uses, and a new KCS Q&A note documents the two colour layers, the Classic Light caveat, and the grammar-only limitation. No fixed-issue note — KCS describes current state.

The mapping evidence came from the real scheme XMLs (`Default`, `Darcula`, `IntelliJ Light`, New-UI `Dark`/`Light`, `High contrast`) extracted from the IU-2025.3 SDK, and from disassembling `LspSemanticTokensSupport.getTextAttributesKey` to see what the platform does for LSP servers by default.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

```
make prep-pr                                          # exit 0
cargo xtask gen-jetbrains-catalog --check             # OK: in sync with the legend
cargo xtask kcs-index-links                           # KCS docs checks passed
cd editors/jetbrains && ./gradlew --no-daemon --offline test --rerun-tasks
                                                      # 82 tests, 0 failures, 0 errors
```

`everyCoreTokenIsColouredByTheStockSchemes` walks each mapped key's `getFallbackAttributeKey()` chain against the `Darcula`, `IntelliJ Light` and classic `Default` scheme XMLs shipped inside the IDE's `app.jar`, skipping `DEFAULT_IDENTIFIER` and `TEXT` — those *are* the plain text colour, so a key that reaches a foreground only through them is exactly the bug. Each scheme is paired with the core types it is expected to leave plain (empty, empty, and `{function, event}`), so a type that quietly loses its colour in any of the three fails. `classicLightPaintsNoFunctionNameInAnyLanguage` pins why that exception exists. Mutation-checked: mapping `variable` back to `LOCAL_VARIABLE` fails with *"the Darcula scheme leaves variable (DEFAULT_LOCAL_VARIABLE) in the plain text colour"*.

Not verified: the rendered result in a running IDE — none can be launched in this environment. The user-facing claim rests on the scheme XMLs plus that fallback-chain logic.

## Compiler / diagnostics checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [ ] Did this change alter a compiler fact contract? — no, this is editor-side presentation only; the server legend is untouched.
- [ ] If yes, I updated the owning design doc under `docs/design/compiler/` or `docs/design/contracts/`. — n/a
- [ ] If I added or changed a diagnostic or optimisation code, I updated its page under `docs/kcs/codes/` and linked it from `docs/kcs/codes/README.md`. — n/a
- [x] If I added a design doc, I linked it from `docs/design/README.md` (`cargo xtask kcs-index-links` enforces this). — no design doc; the new KCS note is linked from `docs/kcs/README.md` and the gate passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SVME5CRaqZsqyuwEYUY736