### PR TITLE
ci: parallelise feature-isolated native release builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,12 @@ on:
   # maintainer kick off the same CI graph from the Actions tab instead of
   # having to push a throwaway commit just to re-send the event.
   #
-  # NOTE: workflow_dispatch lets you pick any ref, tags included, and every
-  # release/publish job is gated on `startsWith(github.ref, 'refs/tags/v')`.
-  # Dispatching against a `v*` tag therefore re-runs create-release and the
-  # marketplace publishes. Dispatch against a branch unless you mean that.
+  # NOTE: workflow_dispatch lets you pick any ref, tags included. Release and
+  # publish jobs are gated on `startsWith(github.ref, 'refs/tags/v')`; the one
+  # branch exception is an explicit read-only native-build proof that uploads
+  # only one-day workflow artifacts. Dispatching against a `v*` tag re-runs
+  # create-release and the marketplace publishes. Dispatch against a branch
+  # unless you mean that.
   workflow_dispatch:
     inputs:
       rust_tests_runner:
@@ -26,9 +28,14 @@ on:
         options:
           - tank
           - hosted
+      native_release_build_proof:
+        description: Build the feature-isolated native release matrix without publishing
+        required: true
+        default: false
+        type: boolean
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && inputs.native_release_build_proof && !startsWith(github.ref, 'refs/tags/v') && 'native-release-proof' || 'ordinary' }}-${{ github.ref }}
   cancel-in-progress: true
 
 # The repo's own build-hygiene contract (scripts/dev/agent-build-env.sh):
@@ -2218,8 +2225,9 @@ jobs:
           gh release upload "$tag" install.sh --clobber
 
   # ---------------------------------------------------------------------
-  # build-server-matrix — compile the four native programs for every supported
-  # platform. Linux x86_64 and aarch64 build natively inside UBI 8 to retain a
+  # build-server-matrix — compile each native program independently for every
+  # supported platform. Linux x86_64 and aarch64 build natively inside UBI 8
+  # to retain a
   # GLIBC_2.28 ABI floor; RISC-V uses an Ubuntu 22.04 container's glibc 2.35
   # cross sysroot because EL8 did not ship a RISC-V architecture. No Zig or
   # separately downloaded libc is involved. Each leg smoke-tests its binary
@@ -2237,18 +2245,18 @@ jobs:
   # Every consumer that attaches these bytes to a Release keeps its explicit
   # `create-release` plus test/portability dependencies below.
   build-server-matrix:
-    if: startsWith(github.ref, 'refs/tags/v')
+    name: native ${{ matrix.platform.id }} / ${{ matrix.program.id }}
+    if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.native_release_build_proof)
     needs: [channel]
     strategy:
       fail-fast: false
-      # One job per target triple (not per OS): the old 3-leg matrix built up
-      # to 12 binaries serially on one runner (4 bins x 3 Linux triples), so
-      # the whole release waited on the slowest leg.  Per-triple legs make the
-      # wall-clock the slowest SINGLE triple's 4 builds, at the cost of extra
-      # (parallel, cheap) runners.  Keep this list and the Makefile's
-      # SERVER_TARGET_MAP in sync (7 triples total).
+      # Cargo unions dependency features across roots in one invocation. Keep
+      # one program per job so release bytes retain their independently-built
+      # feature graphs, while the runner matrix removes the old four-command
+      # serial critical path. Keep the platform list and the Makefile's
+      # SERVER_TARGET_MAP in sync (7 triples total), and keep all four programs.
       matrix:
-        include:
+        platform:
           - os: macos-latest
             id: darwin-arm64
             target: aarch64-apple-darwin
@@ -2276,7 +2284,20 @@ jobs:
           - os: windows-latest
             id: win32-arm64
             target: aarch64-pc-windows-msvc
-    runs-on: ${{ matrix.os }}
+        program:
+          - package: tcl-lsp-server
+            binary: tcl-lsp-server
+            id: server
+          - package: tcl-mcp
+            binary: tcl-mcp
+            id: mcp
+          - package: tcl-cli
+            binary: tcl
+            id: tcl
+          - package: f5-cli
+            binary: f5-query
+            id: f5
+    runs-on: ${{ matrix.platform.os }}
     permissions:
       contents: read
     steps:
@@ -2296,6 +2317,10 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           toolchain: stable
+          # Keep registry caching, but never restore compiled target trees here.
+          # A host-built build script can require a newer glibc than UBI 8 and
+          # cannot safely cross the host/container or platform matrix boundary.
+          cache-targets: false
 
       # Use the runner's architecture-matched UBI image, so x86_64 and aarch64
       # both link against the maintained EL8 glibc 2.28 ABI without a cross
@@ -2303,11 +2328,13 @@ jobs:
       # only the distro C toolchain lives in the container. aarch64 overrides
       # the local-development cross-linker from .cargo/config.toml with native
       # `gcc`/`ar`.
-      - name: Build GNU/Linux binaries against glibc 2.28
-        if: matrix.ubi8
+      - name: Build GNU/Linux program against glibc 2.28
+        if: matrix.platform.ubi8
         env:
-          TARGET: ${{ matrix.target }}
-          TCL_LSP_VERSION: ${{ github.ref_name }}
+          TARGET: ${{ matrix.platform.target }}
+          PACKAGE: ${{ matrix.program.package }}
+          BINARY: ${{ matrix.program.binary }}
+          TCL_LSP_VERSION: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || 'v0.0.0-proof' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -2317,6 +2344,8 @@ jobs:
           export GIT_HASH="${GITHUB_SHA:0:8}"
           docker run --rm \
             --env TARGET \
+            --env PACKAGE \
+            --env BINARY \
             --env TCL_LSP_VERSION \
             --env GIT_HASH \
             --env CARGO_HOME=/cargo \
@@ -2337,12 +2366,9 @@ jobs:
                 export AR_aarch64_unknown_linux_gnu=ar
               fi
               rustup target add "$TARGET"
-              cargo build -p tcl-lsp-server --release --target "$TARGET"
-              cargo build -p tcl-mcp --release --target "$TARGET"
-              cargo build -p tcl-cli --release --target "$TARGET"
-              cargo build -p f5-cli --release --target "$TARGET"
+              cargo build -p "$PACKAGE" --release --target "$TARGET"
               expected="${TCL_LSP_VERSION#v}+g$GIT_HASH"
-              scripts/verify-native-versions.sh \
+              TCL_LSP_RELEASE_BINARIES="$BINARY" scripts/verify-native-versions.sh \
                 "$expected" "target/$TARGET/release"
             '
 
@@ -2350,17 +2376,21 @@ jobs:
       # ships a complete glibc 2.35 cross toolchain. Keep it inside a container
       # rather than pinning the outer GitHub runner to an aging image. The QEMU
       # handshake runs in the same container so it uses that matching sysroot.
-      - name: Build RISC-V GNU/Linux binaries against glibc 2.35
-        if: matrix.riscv_glibc
+      - name: Build RISC-V GNU/Linux program against glibc 2.35
+        if: matrix.platform.riscv_glibc
         env:
-          TARGET: ${{ matrix.target }}
-          TCL_LSP_VERSION: ${{ github.ref_name }}
+          TARGET: ${{ matrix.platform.target }}
+          PACKAGE: ${{ matrix.program.package }}
+          BINARY: ${{ matrix.program.binary }}
+          TCL_LSP_VERSION: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || 'v0.0.0-proof' }}
         shell: bash
         run: |
           set -euo pipefail
           export GIT_HASH="${GITHUB_SHA:0:8}"
           docker run --rm \
             --env TARGET \
+            --env PACKAGE \
+            --env BINARY \
             --env TCL_LSP_VERSION \
             --env GIT_HASH \
             --env CARGO_HOME=/cargo \
@@ -2385,80 +2415,77 @@ jobs:
               test -f "$(gcc -print-file-name=Scrt1.o)"
               test -f "$(riscv64-linux-gnu-gcc -print-file-name=Scrt1.o)"
               rustup target add "$TARGET"
-              cargo build -p tcl-lsp-server --release --target "$TARGET"
-              cargo build -p tcl-mcp --release --target "$TARGET"
-              cargo build -p tcl-cli --release --target "$TARGET"
-              cargo build -p f5-cli --release --target "$TARGET"
+              cargo build -p "$PACKAGE" --release --target "$TARGET"
               expected="${TCL_LSP_VERSION#v}+g$GIT_HASH"
-              scripts/verify-native-versions.sh \
+              TCL_LSP_RELEASE_BINARIES="$BINARY" scripts/verify-native-versions.sh \
                 "$expected" "target/$TARGET/release" \
                 qemu-riscv64 -L /usr/riscv64-linux-gnu
-              scripts/verify-glibc-baseline.sh 2.35 \
-                "target/$TARGET/release/tcl-lsp-server" \
-                "target/$TARGET/release/tcl-mcp" \
-                "target/$TARGET/release/tcl" \
-                "target/$TARGET/release/f5-query"
-              make server-cross-test
+              if [[ "$BINARY" == tcl-lsp-server ]]; then
+                make server-cross-test
+              fi
             '
 
       # Stamp the release version into every user-facing binary. The
       # tcl-version crate prefers this over `git describe`; without it a tag
       # build would still be correct, but this avoids depending on the checkout
       # having tags fetched.
-      - name: Cross-compile native binaries (server + mcp + CLIs)
-        if: matrix.ubi8 != true && matrix.riscv_glibc != true
+      - name: Cross-compile native program
+        if: matrix.platform.ubi8 != true && matrix.platform.riscv_glibc != true
         env:
-          TCL_LSP_VERSION: ${{ github.ref_name }}
+          TCL_LSP_VERSION: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || 'v0.0.0-proof' }}
         shell: bash
         run: |
           set -euo pipefail
-          t="${{ matrix.target }}"
-          echo "==> $t"
+          t="${{ matrix.platform.target }}"
+          echo "==> $t / ${{ matrix.program.package }}"
           rustup target add "$t"
-          cargo build -p tcl-lsp-server --release --target "$t"
-          cargo build -p tcl-mcp --release --target "$t"
-          cargo build -p tcl-cli --release --target "$t"
-          cargo build -p f5-cli --release --target "$t"
+          cargo build -p "${{ matrix.program.package }}" --release --target "$t"
+
+      - name: Verify native program version
+        if: >-
+          matrix.platform.ubi8 != true && matrix.platform.riscv_glibc != true &&
+          ((runner.arch == 'X64' && startsWith(matrix.platform.target, 'x86_64-')) ||
+          (runner.arch == 'ARM64' && startsWith(matrix.platform.target, 'aarch64-')))
+        env:
+          BINARY: ${{ matrix.program.binary }}
+          TARGET: ${{ matrix.platform.target }}
+          TCL_LSP_VERSION: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || 'v0.0.0-proof' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          expected="${TCL_LSP_VERSION#v}+g${GITHUB_SHA:0:8}"
+          TCL_LSP_RELEASE_BINARIES="$BINARY" scripts/verify-native-versions.sh \
+            "$expected" "target/$TARGET/release"
 
       - name: Verify GNU/Linux glibc ABI ceiling
-        if: matrix.glibc_max
+        if: matrix.platform.glibc_max
         shell: bash
         run: |
           set -euo pipefail
-          t="${{ matrix.target }}"
-          scripts/verify-glibc-baseline.sh "${{ matrix.glibc_max }}" \
-            "target/$t/release/tcl-lsp-server" \
-            "target/$t/release/tcl-mcp" \
-            "target/$t/release/tcl" \
-            "target/$t/release/f5-query"
+          t="${{ matrix.platform.target }}"
+          scripts/verify-glibc-baseline.sh "${{ matrix.platform.glibc_max }}" \
+            "target/$t/release/${{ matrix.program.binary }}"
 
       # scripts/test-cross-server.sh tests whatever is already built and skips
       # absent triples loudly, so each per-triple leg smoke-tests just its own
       # binary (natively or under QEMU where runnable).
       - name: Smoke-test built binaries
-        if: matrix.riscv_glibc != true
+        if: matrix.program.id == 'server' && matrix.platform.riscv_glibc != true
         shell: bash
         run: make server-cross-test
 
       - name: Upload server binaries
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          # Per-triple artifact; downstream consumers merge `server-bins-*`
-          # so the per-triple split is invisible to them.
-          name: server-bins-${{ matrix.id }}
+          # Per-triple/program artifacts have disjoint filenames; downstream
+          # consumers merge `server-bins-*` into the original directory shape.
+          name: server-bins-${{ matrix.platform.id }}-${{ matrix.program.id }}
           # Common ancestor of all matched files is `target/`, so the artifact
           # stores `<triple>/release/<exe>` — build-vsix restores tcl-lsp-server
-          # under `target/`; the tcl-mcp / tcl / f5-query binaries ride along for
-          # publish-native-binaries to attach as standalone release assets.
+          # under `target/`; the four independent jobs merge before packaging.
           path: |
-            target/*/release/tcl-lsp-server
-            target/*/release/tcl-lsp-server.exe
-            target/*/release/tcl-mcp
-            target/*/release/tcl-mcp.exe
-            target/*/release/tcl
-            target/*/release/tcl.exe
-            target/*/release/f5-query
-            target/*/release/f5-query.exe
+            target/*/release/${{ matrix.program.binary }}
+            target/*/release/${{ matrix.program.binary }}.exe
           if-no-files-found: error
           retention-days: 1
 

--- a/docs/design/contracts/release-and-publish.md
+++ b/docs/design/contracts/release-and-publish.md
@@ -134,11 +134,28 @@ a CI publish job fails.
 
 ### Native build overlap and release gating
 
-The tag-only `build-server-matrix` job is a read-only producer of short-lived
+For a tag, `build-server-matrix` is a read-only producer of short-lived
 workflow artefacts. It starts after `channel`, while the validation jobs and
-`create-release` run in parallel. The producer has only `contents: read`
-permission and no `environment`, `secrets.*`, release upload, or OIDC step, so
-its workflow artefacts cannot become release assets on their own.
+`create-release` run in parallel. Its platform and program axes run each of
+the four shipping Cargo roots on a separate runner. This removes the serial
+four-build critical path without Cargo unioning one program's dependency
+features into another program's release bytes. The producer has only
+`contents: read` permission and no `environment`, `secrets.*`, release upload,
+or OIDC step, so its workflow artefacts cannot become release assets on their
+own. Cargo registry downloads may be cached, but compiled target directories
+are not: host build scripts cannot safely cross into the UBI 8 environment or
+between platform legs without weakening the release's glibc contract.
+
+A branch `workflow_dispatch` may opt into `native_release_build_proof`. It
+runs that same read-only matrix with a synthetic development version so every
+target's build timing and each architecture-matched binary's reported version
+can be validated before the next tag. A fixed proof-or-ordinary discriminator
+precedes the ref in its concurrency group, so arbitrary branch names cannot
+make ordinary branch CI and the proof cancel each other. Every release,
+portability, packaging, checksum, cleanup, and marketplace consumer remains
+`v*`-gated, so proof artifacts expire after one day and cannot publish.
+On a tag, the proof input does not select that distinct group: a dispatched tag
+retains the normal tag concurrency and publishing semantics described above.
 
 The release graph keeps the handoff explicit: `linux-release-portability`
 waits for both `create-release` and the matrix; `publish-native-binaries`,
@@ -179,8 +196,9 @@ other non-glibc systems are not native-binary targets; their packagers can build
 from source, and the separately published WASI server remains available to
 hosts that choose a WebAssembly runtime.
 
-`scripts/verify-glibc-baseline.sh` inspects the versioned ELF imports for all
-four native programs in every Linux matrix leg and again after artifact fan-in.
+`scripts/verify-glibc-baseline.sh` inspects the selected program's versioned
+ELF imports in each Linux matrix leg, then all four programs again after
+artifact fan-in.
 `scripts/test-linux-distro-compat.sh` then completes an LSP initialize exchange
 with the exact x86_64 release server in a compact matrix spanning Ubuntu,
 Debian, EL8/Oracle, Amazon Linux, openSUSE, Fedora, and Arch. The tag-only

--- a/docs/kcs/kcs-howto-build-multiplatform-vsix.md
+++ b/docs/kcs/kcs-howto-build-multiplatform-vsix.md
@@ -122,7 +122,12 @@ The real release artefacts are built by CI: the tag-triggered
 `build-server-matrix` job starts after the tag channel is classified and
 compiles the Darwin and Windows binaries on native
 runners, the x86_64/aarch64 GNU/Linux binaries in architecture-matched UBI 8
-containers, and RISC-V with Ubuntu 22.04's packaged cross toolchain. The matrix
+containers, and RISC-V with Ubuntu 22.04's packaged cross toolchain. Its
+platform and program axes build `tcl-lsp-server`, `tcl-mcp`, `tcl`, and
+`f5-query` independently and concurrently, preserving each program's Cargo
+feature graph. A branch workflow dispatch can enable the read-only
+`native_release_build_proof` input to exercise those builds without creating
+or publishing a release. The matrix
 uploads only short-lived workflow artefacts; the
 `linux-release-portability` fan-in waits for the release gate and enforces
 those Linux ABI floors before

--- a/scripts/dev/test-release-dependency-graph.sh
+++ b/scripts/dev/test-release-dependency-graph.sh
@@ -92,9 +92,9 @@ matrix=$(require_job build-server-matrix)
 matrix_without_comments=$(printf '%s\n' "$matrix" | sed -E 's/[[:space:]]+#.*$//')
 
 case "$matrix_without_comments" in
-    *"    if: startsWith(github.ref, 'refs/tags/v')"*) ;;
+    *"    if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.native_release_build_proof)"*) ;;
     *)
-        echo "build-server-matrix must remain tag-gated" >&2
+        echo "build-server-matrix must remain tag-gated except for explicit proof dispatches" >&2
         exit 1
         ;;
 esac
@@ -128,6 +128,128 @@ if printf '%s\n' "$matrix_without_comments" | grep -Eq '^[[:space:]]+environment
 fi
 if ! printf '%s\n' "$matrix_without_comments" | grep -Eq '^[[:space:]]+retention-days: 1$'; then
     echo "build-server-matrix artifacts must keep the one-day retention bound" >&2
+    exit 1
+fi
+
+# The setup action caches target directories by default. Those contain host
+# build scripts, which cannot cross safely into the UBI 8 build environment or
+# between platform legs. Registry caching remains useful and safe.
+rust_setup=$(printf '%s\n' "$matrix_without_comments" | awk '
+    $0 == "      - name: Set up Rust" { reading = 1 }
+    reading && $0 != "      - name: Set up Rust" && /^      - / { exit }
+    reading { print }
+')
+if [ "$(printf '%s\n' "$rust_setup" | grep -cF '          cache-targets: false')" -ne 1 ]; then
+    echo "build-server-matrix must disable compiled Cargo target caching" >&2
+    exit 1
+fi
+
+platform_count=$(printf '%s\n' "$matrix_without_comments" | grep -c '^          - os:')
+if [ "$platform_count" -ne 7 ]; then
+    echo "build-server-matrix must retain exactly seven platform rows" >&2
+    exit 1
+fi
+for mapping in \
+    'macos-latest|darwin-arm64|aarch64-apple-darwin|none|' \
+    'macos-latest|darwin-x64|x86_64-apple-darwin|none|' \
+    'ubuntu-24.04|linux-x64|x86_64-unknown-linux-gnu|ubi8|2.28' \
+    'ubuntu-24.04-arm|linux-arm64|aarch64-unknown-linux-gnu|ubi8|2.28' \
+    'ubuntu-24.04|linux-riscv64|riscv64gc-unknown-linux-gnu|riscv_glibc|2.35' \
+    'windows-latest|win32-x64|x86_64-pc-windows-msvc|none|' \
+    'windows-latest|win32-arm64|aarch64-pc-windows-msvc|none|'; do
+    os=${mapping%%|*}
+    rest=${mapping#*|}
+    id=${rest%%|*}
+    rest=${rest#*|}
+    target=${rest%%|*}
+    rest=${rest#*|}
+    mode=${rest%%|*}
+    ceiling=${rest#*|}
+    platform_block=$(printf '%s\n' "$matrix_without_comments" | awk -v id="$id" '
+        $0 == "            id: " id { found = 1; print previous; print; next }
+        found && /^          - os:/ { exit }
+        found { print }
+        { previous = $0 }
+    ')
+    if [ -z "$platform_block" ] ||
+        ! printf '%s\n' "$platform_block" | grep -Fqx "          - os: $os" ||
+        ! printf '%s\n' "$platform_block" | grep -Fqx "            id: $id" ||
+        ! printf '%s\n' "$platform_block" | grep -Fqx "            target: $target"; then
+        echo "build-server-matrix is missing platform mapping $mapping" >&2
+        exit 1
+    fi
+    if [ "$mode" = none ]; then
+        if printf '%s\n' "$platform_block" | grep -Eq '^[[:space:]]+(ubi8|riscv_glibc|glibc_max):'; then
+            echo "non-Linux platform $id must not declare a glibc build mode" >&2
+            exit 1
+        fi
+    elif ! printf '%s\n' "$platform_block" | grep -Fqx "            $mode: true" ||
+        ! printf '%s\n' "$platform_block" | grep -Fqx "            glibc_max: \"$ceiling\""; then
+        echo "Linux platform $id has the wrong build mode or glibc ceiling" >&2
+        exit 1
+    fi
+    if ! grep -Fq "${target}:${id}" "$REPO_ROOT/Makefile"; then
+        echo "build-server-matrix platform $target:$id is absent from SERVER_TARGET_MAP" >&2
+        exit 1
+    fi
+done
+
+program_count=$(printf '%s\n' "$matrix_without_comments" | grep -c '^          - package:')
+if [ "$program_count" -ne 4 ]; then
+    echo "build-server-matrix must define exactly four independent program rows" >&2
+    exit 1
+fi
+for mapping in \
+    'tcl-lsp-server|tcl-lsp-server|server' \
+    'tcl-mcp|tcl-mcp|mcp' \
+    'tcl-cli|tcl|tcl' \
+    'f5-cli|f5-query|f5'; do
+    package=${mapping%%|*}
+    rest=${mapping#*|}
+    binary=${rest%%|*}
+    id=${rest##*|}
+    if ! printf '%s\n' "$matrix_without_comments" | awk \
+        -v package="$package" -v binary="$binary" -v id="$id" '
+            $0 == "          - package: " package { package_seen = 1; next }
+            package_seen && $0 == "            binary: " binary { binary_seen = 1; next }
+            package_seen && binary_seen && $0 == "            id: " id { found = 1 }
+            package_seen && /^          - package:/ { exit }
+            END { exit !found }
+        '; then
+        echo "build-server-matrix is missing program mapping $mapping" >&2
+        exit 1
+    fi
+done
+
+# A multi-root Cargo invocation unions dependency features and changes the
+# shipping graph. Each matrix leg must select only its one program root.
+if printf '%s\n' "$matrix_without_comments" |
+    grep -Eq 'cargo build -p (tcl-lsp-server|tcl-mcp|tcl-cli|f5-cli)'; then
+    echo "build-server-matrix must select the matrix package, not hard-code or combine roots" >&2
+    exit 1
+fi
+package_builds=$(printf '%s\n' "$matrix_without_comments" |
+    grep -cF 'cargo build -p "$PACKAGE" --release --target "$TARGET"')
+matrix_builds=$(printf '%s\n' "$matrix_without_comments" |
+    grep -cF 'cargo build -p "${{ matrix.program.package }}" --release --target "$t"')
+if [ "$package_builds" -ne 2 ] || [ "$matrix_builds" -ne 1 ]; then
+    echo "each native build path must invoke Cargo once for its matrix program" >&2
+    exit 1
+fi
+if ! printf '%s\n' "$matrix_without_comments" |
+    grep -Fq 'name: server-bins-${{ matrix.platform.id }}-${{ matrix.program.id }}'; then
+    echo "native artifacts must be unique per platform and program" >&2
+    exit 1
+fi
+concurrency_group=$(grep '^  group:' "$WORKFLOW")
+if ! printf '%s\n' "$concurrency_group" | grep -Fqx \
+    "  group: \${{ github.workflow }}-\${{ github.event_name == 'workflow_dispatch' && inputs.native_release_build_proof && !startsWith(github.ref, 'refs/tags/v') && 'native-release-proof' || 'ordinary' }}-\${{ github.ref }}"; then
+    echo "proof and ordinary runs need fixed, unambiguous concurrency discriminators before the ref" >&2
+    exit 1
+fi
+if ! printf '%s\n' "$matrix_without_comments" |
+    grep -Fq "if: matrix.program.id == 'server' && matrix.platform.riscv_glibc != true"; then
+    echo "only server legs may run the cross-server smoke test" >&2
     exit 1
 fi
 
@@ -176,5 +298,36 @@ require_needs cleanup-old-artifacts build-vsix build-claude-skills build-jetbrai
     build-sublime build-zed publish-checksums
 require_needs cleanup-untagged-artifacts build-vsix build-claude-skills \
     build-jetbrains build-sublime build-zed publish-checksums
+
+# The proof dispatch may build read-only workflow artifacts from a branch, but
+# no release or publishing consumer may become reachable on that ref.
+for job in create-release linux-release-portability publish-native-binaries \
+    build-vsix build-jetbrains build-sublime build-claude-skills build-zed \
+    publish-checksums publish-vsix-marketplace publish-vsix-openvsx \
+    publish-jetbrains-marketplace cleanup-old-artifacts \
+    cleanup-untagged-artifacts; do
+    if ! require_job "$job" | grep -Fq "startsWith(github.ref, 'refs/tags/v')"; then
+        echo "$job must remain unreachable from a branch proof dispatch" >&2
+        exit 1
+    fi
+done
+
+verify_versions=$REPO_ROOT/scripts/verify-native-versions.sh
+if output=$(TCL_LSP_RELEASE_BINARIES= "$verify_versions" 0 /nonexistent 2>&1); then
+    echo "verify-native-versions must reject an empty matrix selection" >&2
+    exit 1
+fi
+if ! printf '%s\n' "$output" | grep -Fq 'selected no binaries'; then
+    echo "verify-native-versions did not diagnose an empty matrix selection" >&2
+    exit 1
+fi
+if output=$(TCL_LSP_RELEASE_BINARIES=not-a-binary "$verify_versions" 0 /nonexistent 2>&1); then
+    echo "verify-native-versions must reject an unknown matrix binary" >&2
+    exit 1
+fi
+if ! printf '%s\n' "$output" | grep -Fq 'unsupported native release binary'; then
+    echo "verify-native-versions did not diagnose an unknown matrix binary" >&2
+    exit 1
+fi
 
 echo "release dependency graph contract passed"

--- a/scripts/verify-native-versions.sh
+++ b/scripts/verify-native-versions.sh
@@ -4,10 +4,14 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-# Verify the version reported at runtime by every native release binary.
+# Verify the version reported at runtime by native release binaries.
 #
 # Usage:
 #   scripts/verify-native-versions.sh VERSION BINDIR [RUNNER [ARG...]]
+#
+# By default all four shipping binaries are required. A feature-isolated
+# matrix leg sets TCL_LSP_RELEASE_BINARIES to one or more space-separated
+# names from that same set.
 #
 # RUNNER is optional. For example, a RISC-V build can be checked with:
 #   scripts/verify-native-versions.sh 2.2.1+g12345678 DIR \
@@ -29,8 +33,32 @@ bindir="$2"
 shift 2
 runner=("$@")
 
-for binary in tcl-lsp-server tcl-mcp tcl f5-query; do
-	if [[ ! -x "$bindir/$binary" ]]; then
+read -r -a binaries <<<"${TCL_LSP_RELEASE_BINARIES-tcl-lsp-server tcl-mcp tcl f5-query}"
+if [[ ${#binaries[@]} -eq 0 ]]; then
+	printf 'error: TCL_LSP_RELEASE_BINARIES selected no binaries\n' >&2
+	exit 2
+fi
+
+native_executable() {
+	local binary="$1"
+	if [[ -x "$bindir/$binary" ]]; then
+		printf '%s\n' "$bindir/$binary"
+	elif [[ -x "$bindir/$binary.exe" ]]; then
+		printf '%s\n' "$bindir/$binary.exe"
+	else
+		return 1
+	fi
+}
+
+for binary in "${binaries[@]}"; do
+	case "$binary" in
+		tcl-lsp-server | tcl-mcp | tcl | f5-query) ;;
+		*)
+			printf 'error: unsupported native release binary: %s\n' "$binary" >&2
+			exit 2
+			;;
+	esac
+	if ! native_executable "$binary" >/dev/null; then
 		printf 'error: executable release binary not found: %s\n' "$bindir/$binary" >&2
 		exit 2
 	fi
@@ -60,15 +88,20 @@ frame() {
 	printf 'Content-Length: %d\r\n\r\n%s' "${#body}" "$body"
 }
 
-lsp_request='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":null,"rootUri":null,"capabilities":{}}}'
-lsp_output="$(frame "$lsp_request" | run_binary "$bindir/tcl-lsp-server" 2>/dev/null || true)"
-require_version tcl-lsp-server "$lsp_output"
-
-mcp_request='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"release-check","version":"0"}}}'
-mcp_output="$(printf '%s\n' "$mcp_request" | run_binary "$bindir/tcl-mcp" 2>/dev/null | head -1 || true)"
-require_version tcl-mcp "$mcp_output"
-
-for binary in tcl f5-query; do
-	output="$(run_binary "$bindir/$binary" --version 2>&1 || true)"
+for binary in "${binaries[@]}"; do
+	executable="$(native_executable "$binary")"
+	case "$binary" in
+		tcl-lsp-server)
+			request='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":null,"rootUri":null,"capabilities":{}}}'
+			output="$(frame "$request" | run_binary "$executable" 2>/dev/null || true)"
+			;;
+		tcl-mcp)
+			request='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"release-check","version":"0"}}}'
+			output="$(printf '%s\n' "$request" | run_binary "$executable" 2>/dev/null | head -1 || true)"
+			;;
+		tcl | f5-query)
+			output="$(run_binary "$executable" --version 2>&1 || true)"
+			;;
+	esac
 	require_version "$binary" "$output"
 done


### PR DESCRIPTION
## Summary

- split the seven-platform native release matrix across four independent program jobs per platform
- preserve one Cargo root per invocation so dependency features cannot leak between shipping binaries
- add a branch-only, read-only proof dispatch for measuring the complete 28-leg matrix before a tag
- keep artifact fan-in paths, server smoke tests, Linux ABI ceilings, and every release/publish gate intact
- make the native version verifier select one validated binary per producer leg while retaining its all-four default
- strengthen the release-graph contract around exact platforms, programs, feature isolation, proof concurrency, and tag-only consumers

## Experimental evidence

A controlled x86_64 experiment first tested one Cargo invocation containing all four roots:

- four separate release invocations: 1101.64s and 545 compile events
- one combined invocation: 754.62s and 335 compile events (31.5% faster)
- all four output hashes, build IDs, `.text`, and `.rodata` changed

A same-target control rebuilt `tcl-lsp-server` alone and reproduced the original binary byte-for-byte. The combined invocation had unioned `f5-cli`'s Tokio networking features into the server graph, so that approach was rejected. This change instead parallelises the original feature-isolated invocations without changing their roots.

The explicit proof dispatch will provide the authoritative hosted-runner wall time, queue/setup/build breakdown, architecture-matched version checks, Linux ABI checks, server handshakes, and artifact layout before merge.

## Verification

- `make prep-pr`
- `make rust-check`
- `make check-release-dependency-graph`
- shell syntax checks for both changed scripts
- release-graph negative controls for combined roots, missing programs, platform drift, proof concurrency drift, and invalid binary selection

Closes #1978
