### PR TITLE
fix(tclvm): centralise channel output encoding

### DIFF
--- a/docs/design/contracts/shared-utility-contracts-rust.md
+++ b/docs/design/contracts/shared-utility-contracts-rust.md
@@ -49,6 +49,7 @@ entry point, or gate moves without this contract being updated.
 | trace argument decoding | `rust/tcl-cmd-core/src/trace.rs` | `TraceKind`; `resolve_option`; `resolve_type`; `parse_ops`; `parse_legacy_variable_ops`; `legacy_ops_letters`; `callback_op_word` | option surface per release (the 8.x-only `variable`/`vdelete`/`vinfo` forms) | none |
 | sort numeric parsing | `rust/tcl-cmd-core/src/sort.rs` | `parse_wide`; `parse_real` | `NumberSyntax` per release | none |
 | command errors | `rust/tcl-cmd-core/src/error.rs` | `CmdError`; `wrong_args`; `bad_choice` | invariant | none |
+| channel output configuration / encoding | `rust/tcl-platform/src/lib.rs`; `rust/tcl-cmd-core/src/channel.rs`; `rust/tcl-registry/src/commands/tcl/fconfigure_.rs` | `SystemEncoding`; `Host::system_encoding`; `ChannelConfig`; `StandardChannelConfigs`; `OpenAccess`; `resolve_open_access_mode`; `ChannelDirection`; `ChannelEncoding`; `EncodingProfile`; `OutputTranslation`; `resolve_fconfigure_option`; `config_list`; `config_value`; `set_config_value`; `encode_output`; `encode_output_bytes`; `EncodedOutput`; `EILSEQ_ERROR_CODE` | system encoding per host locale and interpreter tree; option availability per dialect profile; open-access validation and profile/binary defaults per Tcl release; mutable direction-specific state per channel | none |
 | expression grammar / evaluation | `rust/tcl-syntax/src/expr/parser.rs`; `rust/tcl-syntax/src/expr/eval.rs`; `rust/tcl-registry/src/expr_surface.rs` | `parse_expr`; `eval`; `RuntimeExprSurface` | `RuntimeExprSurface` per release | none |
 | expr math functions and the `rand` generator | `rust/tcl-syntax/src/expr/mathfunc.rs`; `rust/tcl-syntax/src/expr/rand.rs` | `NumValue`; `dispatch`; `dispatch_with_backend_int_width`; `try_dispatch_with_backend_int_width`; `IntWidth`; `MathFuncError`; `MathFuncSince`; `spec`; `all`; `added_in`; `seed_from_wide`; `next_draw`; `seed_and_draw` | `MathFuncSince` per release for the function surface and `IntWidth` for `int()`'s width; the Park-Miller generator is release-invariant | none |
 | command / word segmentation | `rust/tcl-lexer/src/script.rs`; `rust/tcl-compiler/src/segmenter.rs`; `rust/tcl-compiler/src/parsing/syntax/build.rs`; `rust/tcl-compiler/src/parsing/syntax/segment.rs` | `group_commands`; `CommandSpan`; `WordSpan`; `WordKind`; `SegmentedCommand`; `segment_commands` | `LexerConfig` per document dialect | `xtask-segmentation-drift` |
@@ -479,6 +480,21 @@ entry point, or gate moves without this contract being updated.
 
 ### `tcl-cmd-core` — portable command logic
 
+- `channel` owns output-facing channel configuration and encoding. The host
+  supplies one typed `SystemEncoding`; `ChannelConfig` derives Tcl 8/Tcl 9
+  profile defaults, retains each channel's input/output translation and common
+  encoding, and `StandardChannelConfigs` owns the predefined handle defaults.
+  The command registry resolves the dialect-filtered `fconfigure` option into
+  a typed operation; `config_list`, `config_value`, and `set_config_value` own
+  its runtime-neutral state policy. `OpenAccess` and
+  `resolve_open_access_mode` normalise both simple and Tcl-list access modes so
+  handle permissions, creation flags, direction, and binary configuration
+  cannot diverge between adapters. `encode_output` and `encode_output_bytes`
+  return raw bytes together with a possible conversion error, preserving Tcl's
+  successfully converted prefix before `POSIX EILSEQ`. Runtime channel tables
+  own handles, sharing topology, and mutable instances of this state, but do
+  not reimplement access modes, encoders, binary mode, locale interpretation,
+  translation, option availability, or conversion-profile policy.
 - `namespace` — the pure `::` byte-ops `tail` / `qualifiers`
   (`last_sep_run`: colon runs are one separator) plus the
   `Namespaces`-generic cores. Runtime name resolution routes through

--- a/runtime/rust/Cargo.lock
+++ b/runtime/rust/Cargo.lock
@@ -252,6 +252,7 @@ dependencies = [
  "tcl-registry",
  "tcl-runtime-api",
  "tcl-syntax",
+ "tcl-test-support",
 ]
 
 [[package]]
@@ -270,6 +271,13 @@ dependencies = [
  "libm",
  "tcl-dialect",
  "tcl-lexer",
+]
+
+[[package]]
+name = "tcl-test-support"
+version = "0.1.0"
+dependencies = [
+ "tcl-dialect",
 ]
 
 [[package]]

--- a/runtime/rust/Cargo.toml
+++ b/runtime/rust/Cargo.toml
@@ -115,6 +115,9 @@ flate2 = { version = "1", default-features = false, features = ["rust_backend"] 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tcl-host-native = { path = "../../rust/tcl-host-native" }
 
+[dev-dependencies]
+tcl-test-support = { path = "../../rust/tcl-test-support" }
+
 [lib]
 name = "tcl_runtime"
 # rlib for `cargo test`; cdylib/staticlib for the eventual whole-program link

--- a/runtime/rust/src/cmd_chan.rs
+++ b/runtime/rust/src/cmd_chan.rs
@@ -22,16 +22,21 @@
 //! `stdout`/`stderr` go through the host's [`StdIo`](tcl_platform::StdIo)
 //! capability (so the browser routes them to a console import). File channels
 //! (`open` → `fileN` ids backed by a buffered reader or a write/append handle)
-//! still use `std::fs` directly — the streaming channel layer over the host
-//! (handle table + buffering + encoding/EOL) is the deferred net-new piece
-//! that needs both the per-interp channel state and a streaming host I/O seam.
-//! `fconfigure` accepts and ignores the translation/encoding/buffering options
-//! (UTF-8 internal; no CRLF translation on Unix) so library channel setup
-//! succeeds.
+//! still use `std::fs` directly. Channel configuration and conversion semantics
+//! come from `tcl-cmd-core`; this adapter owns only handles and raw byte sinks.
 
+use std::cell::{Cell, RefCell};
 use std::collections::BTreeMap;
 use std::fs::{File, OpenOptions};
 use std::io::{BufRead, BufReader, Cursor, Read, Seek, Write};
+use std::rc::Rc;
+
+use tcl_cmd_core::channel::{
+    channel_output_error, config_list, config_value, encode_output_bytes, resolve_open_access_mode,
+    set_config_value, ChannelConfig, OpenAccess, StandardChannelConfigs,
+};
+use tcl_cmd_core::CmdError;
+use tcl_platform::SystemEncoding;
 
 use crate::interp::{obj_bytes, Code, Interp};
 use crate::obj::TclObj;
@@ -48,46 +53,116 @@ pub struct ChanState {
     reader: Option<Box<dyn ReadSeek>>,
     writer: Option<File>,
     eof: bool,
+    config: ChannelConfig,
 }
 
 /// The interpreter's channel table (`fileN` → state) + id counter.
-#[derive(Default)]
 pub struct ChannelTable {
     map: BTreeMap<Vec<u8>, ChanState>,
     next: usize,
+    standard: Rc<RefCell<StandardChannelConfigs>>,
+    system_encoding: Rc<Cell<SystemEncoding>>,
+    owns_process_state: bool,
 }
 
 impl ChannelTable {
+    pub(crate) fn new(version: tcl_dialect::TclVersion, system: SystemEncoding) -> Self {
+        Self {
+            map: BTreeMap::new(),
+            next: 0,
+            standard: Rc::new(RefCell::new(StandardChannelConfigs::new(version, system))),
+            system_encoding: Rc::new(Cell::new(system)),
+            owns_process_state: true,
+        }
+    }
+
+    pub(crate) fn share_process_state_from(&mut self, parent: &Self) {
+        self.standard = Rc::clone(&parent.standard);
+        self.system_encoding = Rc::clone(&parent.system_encoding);
+        self.owns_process_state = false;
+    }
+
+    pub(crate) fn reset_process_state_if_owner(
+        &self,
+        version: tcl_dialect::TclVersion,
+        system: SystemEncoding,
+    ) {
+        if self.owns_process_state {
+            self.system_encoding.set(system);
+            *self.standard.borrow_mut() = StandardChannelConfigs::new(version, system);
+        }
+    }
+
+    pub(crate) fn reset_standard_channels_if_owner(&self, version: tcl_dialect::TclVersion) {
+        if self.owns_process_state {
+            *self.standard.borrow_mut() =
+                StandardChannelConfigs::new(version, self.system_encoding.get());
+        }
+    }
+
+    pub(crate) fn system_encoding(&self) -> SystemEncoding {
+        self.system_encoding.get()
+    }
+
+    pub(crate) fn set_system_encoding(&self, encoding: SystemEncoding) {
+        self.system_encoding.set(encoding);
+    }
+
     pub(crate) fn names(&self) -> Vec<Vec<u8>> {
         self.map.keys().cloned().collect()
     }
 
+    fn config(&self, id: &[u8]) -> Option<ChannelConfig> {
+        if let Ok(name) = core::str::from_utf8(id) {
+            if let Some(config) = self.standard.borrow().get(name) {
+                return Some(config);
+            }
+        }
+        self.map.get(id).map(|state| state.config)
+    }
+
+    fn set_config(&mut self, id: &[u8], config: ChannelConfig) -> bool {
+        if let Ok(name) = core::str::from_utf8(id) {
+            if self.standard.borrow_mut().set(name, config) {
+                return true;
+            }
+        }
+        let Some(state) = self.map.get_mut(id) else {
+            return false;
+        };
+        state.config = config;
+        true
+    }
+
     /// Open `path` for `mode` (`r`/`w`/`a`/`r+`/`w+`/`a+`), returning the id.
-    pub(crate) fn open(&mut self, path: &str, mode: &[u8]) -> std::io::Result<Vec<u8>> {
-        let read = mode.first() == Some(&b'r') || mode.contains(&b'+');
-        let write =
-            mode.first() == Some(&b'w') || mode.first() == Some(&b'a') || mode.contains(&b'+');
-        let append = mode.first() == Some(&b'a');
-        let truncate = mode.first() == Some(&b'w');
-        let create = write;
+    pub(crate) fn open(
+        &mut self,
+        path: &str,
+        access: OpenAccess,
+        version: tcl_dialect::TclVersion,
+    ) -> std::io::Result<Vec<u8>> {
+        let config = ChannelConfig::for_open_access(version, self.system_encoding.get(), access);
         let mut opts = OpenOptions::new();
-        opts.read(read || !write)
-            .write(write)
-            .append(append)
-            .truncate(truncate && !append)
-            .create(create);
+        opts.read(access.is_readable())
+            .write(access.is_writable())
+            .append(access.appends())
+            .truncate(access.truncates())
+            .create(access.creates())
+            .create_new(access.creates() && access.is_exclusive());
         let file = opts.open(path)?;
-        let state = if write {
+        let state = if access.is_writable() {
             ChanState {
                 reader: None,
                 writer: Some(file),
                 eof: false,
+                config,
             }
         } else {
             ChanState {
                 reader: Some(Box::new(BufReader::new(file))),
                 writer: None,
                 eof: false,
+                config,
             }
         };
         Ok(self.insert(state))
@@ -103,11 +178,17 @@ impl ChannelTable {
 
     /// Register a read-only channel over an in-memory buffer (a file read whole
     /// from the host filesystem capability — the VFS read path).
-    fn open_mem(&mut self, bytes: Vec<u8>) -> Vec<u8> {
+    fn open_mem(
+        &mut self,
+        bytes: Vec<u8>,
+        version: tcl_dialect::TclVersion,
+        access: OpenAccess,
+    ) -> Vec<u8> {
         self.insert(ChanState {
             reader: Some(Box::new(Cursor::new(bytes))),
             writer: None,
             eof: false,
+            config: ChannelConfig::for_open_access(version, self.system_encoding.get(), access),
         })
     }
 }
@@ -255,7 +336,13 @@ fn open_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     let Ok(path_s) = core::str::from_utf8(&path) else {
         return interp.set_error(b"invalid file name");
     };
-    let opened = interp.channels.borrow_mut().open(path_s, &mode);
+    let mode_string = String::from_utf8_lossy(&mode);
+    let version = interp.runtime_version();
+    let access = match resolve_open_access_mode(version, &mode_string) {
+        Ok(access) => access,
+        Err(error) => return report_cmd_error(interp, error),
+    };
+    let opened = interp.channels.borrow_mut().open(path_s, access, version);
     match opened {
         Ok(id) => {
             interp.set_result_bytes(&id);
@@ -267,8 +354,7 @@ fn open_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             // VFS). For read modes, read it whole and back the channel with that
             // buffer. Native is unaffected — `std::fs` succeeded there, or the
             // file genuinely does not exist (the VFS read then fails too).
-            let read_only =
-                mode.first() != Some(&b'w') && mode.first() != Some(&b'a') && !mode.contains(&b'+');
+            let read_only = access.is_readable() && !access.is_writable();
             let vfs_bytes = if read_only {
                 interp
                     .host()
@@ -279,7 +365,10 @@ fn open_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             };
             match vfs_bytes {
                 Some(bytes) => {
-                    let id = interp.channels.borrow_mut().open_mem(bytes);
+                    let id = interp
+                        .channels
+                        .borrow_mut()
+                        .open_mem(bytes, version, access);
                     interp.set_result_bytes(&id);
                     Code::Ok
                 }
@@ -436,60 +525,76 @@ pub(crate) fn puts_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         [ch, s] => (obj_bytes(*ch), obj_bytes(*s)),
         _ => return interp.wrong_args(usage),
     };
-    // `None` ⇒ no such channel; `Some(Err)` ⇒ write failed. The standard sinks
-    // go through the host's StdIo capability (the browser routes them to a
-    // console import); file channels write their `File` directly (the streaming
-    // channel layer over the host is the deferred net-new piece).
-    let result: Option<std::io::Result<()>> = match chan.as_slice() {
+    let config = interp.channels.borrow().config(&chan);
+    let Some(config) = config else {
+        return no_channel(interp, &chan);
+    };
+    if chan == b"stdin" {
+        return interp.set_error(b"channel \"stdin\" wasn't opened for writing");
+    }
+    let encoded = encode_output_bytes(&string, newline, config);
+    enum RawWrite {
+        Done(std::io::Result<()>),
+        NotWritable,
+        NoChannel,
+    }
+    let write_result = match chan.as_slice() {
         b"stdout" => {
-            write_std(interp, &string, newline, false);
-            Some(Ok(()))
+            write_std(interp, &encoded.bytes, false);
+            RawWrite::Done(Ok(()))
         }
         b"stderr" => {
-            write_std(interp, &string, newline, true);
-            Some(Ok(()))
+            write_std(interp, &encoded.bytes, true);
+            RawWrite::Done(Ok(()))
         }
         _ => {
             let mut channels = interp.channels.borrow_mut();
-            channels
-                .map
-                .get_mut(&chan)
-                .and_then(|s| s.writer.as_mut())
-                .map(|w| write_to(w, &string, newline))
+            match channels.map.get_mut(&chan) {
+                Some(state) => match state.writer.as_mut() {
+                    Some(writer) => RawWrite::Done(writer.write_all(&encoded.bytes)),
+                    None => RawWrite::NotWritable,
+                },
+                None => RawWrite::NoChannel,
+            }
         }
     };
-    match result {
-        None => no_channel(interp, &chan),
-        Some(Err(_)) => interp.set_error(b"error writing to channel"),
-        Some(Ok(())) => {
-            interp.set_result_bytes(b"");
-            Code::Ok
+    let write_result = match write_result {
+        RawWrite::Done(result) => result,
+        RawWrite::NotWritable => {
+            return interp.set_error(
+                format!(
+                    "channel \"{}\" wasn't opened for writing",
+                    String::from_utf8_lossy(&chan)
+                )
+                .as_bytes(),
+            );
         }
+        RawWrite::NoChannel => return no_channel(interp, &chan),
+    };
+    if write_result.is_err() {
+        return interp.set_error(b"error writing to channel");
     }
+    if let Some(error) = encoded.error {
+        return report_cmd_error(interp, channel_output_error(&name_for_error(&chan), error));
+    }
+    interp.set_result_bytes(b"");
+    Code::Ok
 }
 
-fn write_to(w: &mut impl Write, bytes: &[u8], newline: bool) -> std::io::Result<()> {
-    w.write_all(bytes)?;
-    if newline {
-        w.write_all(b"\n")?;
-    }
-    Ok(())
+fn name_for_error(bytes: &[u8]) -> String {
+    String::from_utf8_lossy(bytes).into_owned()
 }
 
 /// `puts` to a standard sink (`stdout`/`stderr`) via the host's StdIo capability.
 /// Infallible at this layer — a console sink swallows write errors (the prior
 /// `std::io::stdout()` path's `EPIPE` was likewise effectively unobserved).
-fn write_std(interp: &Interp, bytes: &[u8], newline: bool, err: bool) {
-    let mut buf = bytes.to_vec();
-    if newline {
-        buf.push(b'\n');
-    }
+fn write_std(interp: &Interp, bytes: &[u8], err: bool) {
     let host = interp.host();
     let stdio = host.stdio();
     if err {
-        stdio.write_stderr(&buf);
+        stdio.write_stderr(bytes);
     } else {
-        stdio.write_stdout(&buf);
+        stdio.write_stdout(bytes);
     }
 }
 
@@ -538,23 +643,69 @@ fn eof_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     }
 }
 
-/// `fconfigure channelId ?option ?value? ...?` — accept + ignore the standard
-/// options (no CRLF translation, UTF-8 encoding); report queried options blank.
+/// `fconfigure channelId ?option ?value? ...?` — the registry resolves the
+/// dialect-specific option surface and the shared command owner applies it.
 fn fconfigure_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     if argv.len() < 2 {
         return interp.wrong_args(b"fconfigure channelId ?-option value ...?");
     }
     let id = obj_bytes(argv[1]);
-    if id != b"stdout"
-        && id != b"stderr"
-        && id != b"stdin"
-        && !interp.channels.borrow().map.contains_key(&id)
-    {
+    let Some(mut config) = interp.channels.borrow().config(&id) else {
         return no_channel(interp, &id);
+    };
+    let version = interp.runtime_version();
+    let name = String::from_utf8_lossy(&id);
+    match &argv[2..] {
+        [] => {
+            interp.set_result_bytes(config_list(version, &name, config).as_bytes());
+            Code::Ok
+        }
+        [option] => {
+            let word = obj_bytes(*option);
+            let word = String::from_utf8_lossy(&word);
+            match tcl_registry::commands::tcl::resolve_fconfigure_option(
+                interp.dialect_profile(),
+                &word,
+            ) {
+                Ok(option) => {
+                    interp.set_result_bytes(config_value(option, &name, config).as_bytes());
+                    Code::Ok
+                }
+                Err(error) => report_cmd_error(interp, error),
+            }
+        }
+        pairs if pairs.len() % 2 == 0 => {
+            for pair in pairs.chunks_exact(2) {
+                let option_word = obj_bytes(pair[0]);
+                let option_word = String::from_utf8_lossy(&option_word);
+                let option = match tcl_registry::commands::tcl::resolve_fconfigure_option(
+                    interp.dialect_profile(),
+                    &option_word,
+                ) {
+                    Ok(option) => option,
+                    Err(error) => return report_cmd_error(interp, error),
+                };
+                let value = obj_bytes(pair[1]);
+                let value = String::from_utf8_lossy(&value);
+                let configured = set_config_value(version, &mut config, option, &value);
+                let _ = interp.channels.borrow_mut().set_config(&id, config);
+                if let Err(error) = configured {
+                    return report_cmd_error(interp, error);
+                }
+            }
+            interp.set_result_bytes(b"");
+            Code::Ok
+        }
+        _ => interp.wrong_args(b"fconfigure channelId ?-option value ...?"),
     }
-    // A single-option query returns a (blank) value; sets are accepted silently.
-    interp.set_result_bytes(b"");
-    Code::Ok
+}
+
+fn report_cmd_error(interp: &mut Interp, error: CmdError) -> Code {
+    let (message, code) = error.into_parts();
+    match code {
+        Some(code) => interp.error_with_code(message.as_bytes(), code.as_bytes()),
+        None => interp.set_error(message.as_bytes()),
+    }
 }
 
 fn fblocked_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {

--- a/runtime/rust/src/cmd_fs.rs
+++ b/runtime/rust/src/cmd_fs.rs
@@ -857,7 +857,10 @@ fn file_tempfile(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     }
     // Native channels are backed by the same path; a VFS host can still use
     // the created path for subsequent file queries even if streaming is absent.
-    let opened = interp.channels.borrow_mut().open(&path, b"w+");
+    let version = interp.runtime_version();
+    let access = tcl_cmd_core::channel::resolve_open_access_mode(version, "w+")
+        .expect("the literal w+ access mode is valid");
+    let opened = interp.channels.borrow_mut().open(&path, access, version);
     match opened {
         Ok(id) => {
             interp.set_result_bytes(&id);

--- a/runtime/rust/src/cmd_misc.rs
+++ b/runtime/rust/src/cmd_misc.rs
@@ -18,10 +18,10 @@
 
 //! Small host/misc commands needed to bootstrap the real library (M2).
 //!
-//! `encoding` is near-trivial because UTF-8 is the internal string rep (the
-//! cross-cutting contract): `convertto`/`convertfrom` pass through, `system` is
-//! `utf-8`, and `dirs` is a no-op store (we don't load encoding files). C ref
-//! `tclEncoding.c`. Non-UTF-8 codecs are a deferred edge translation.
+//! `encoding` keeps UTF-8 as the internal string representation while its
+//! mutable `system` value seeds new channel conversions. `dirs` is a no-op
+//! store because this runtime does not load encoding files. C ref
+//! `tclEncoding.c`.
 
 use crate::interp::{obj_bytes, Code, Interp};
 use crate::obj::TclObj;
@@ -147,10 +147,33 @@ fn encoding_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             interp.set_result_bytes(b"");
             Code::Ok
         }
-        b"system" => {
-            interp.set_result_bytes(b"utf-8");
-            Code::Ok
-        }
+        b"system" => match argv {
+            [_, _] => {
+                interp.set_result_bytes(interp.system_encoding().as_str().as_bytes());
+                Code::Ok
+            }
+            [_, _, value] => {
+                let value = obj_bytes(*value);
+                let value = String::from_utf8_lossy(&value);
+                match tcl_cmd_core::channel::resolve_system_encoding(&value) {
+                    Ok(encoding) => {
+                        interp.set_system_encoding(encoding);
+                        interp.set_result_bytes(b"");
+                        Code::Ok
+                    }
+                    Err(error) => {
+                        let (message, code) = error.into_parts();
+                        match code {
+                            Some(code) => {
+                                interp.error_with_code(message.as_bytes(), code.as_bytes())
+                            }
+                            None => interp.set_error(message.as_bytes()),
+                        }
+                    }
+                }
+            }
+            _ => interp.wrong_args(b"encoding system ?encoding?"),
+        },
         b"names" => {
             interp.set_result_bytes(b"utf-8 unicode ascii iso8859-1");
             Code::Ok

--- a/runtime/rust/src/codegen_abi.rs
+++ b/runtime/rust/src/codegen_abi.rs
@@ -2132,8 +2132,51 @@ mod tests {
     use crate::counters;
     use crate::interp::Code;
     use std::cell::RefCell;
+    use std::rc::Rc;
+    use tcl_dialect::TclVersion;
+    use tcl_host_native::NativeHost;
+    use tcl_platform::{Capabilities, Clock, Env, Filesystem, Host, Process, StdIo};
     use tcl_runtime_api::codegen_abi::{NATIVE_PROC_STATUS_DECLINED, NATIVE_PROC_STATUS_RAN};
     use tcl_runtime_api::guard::GuardDomain;
+
+    struct CaptureHost {
+        native: NativeHost,
+        stdout: Rc<RefCell<Vec<u8>>>,
+    }
+
+    impl StdIo for CaptureHost {
+        fn write_stdout(&self, bytes: &[u8]) {
+            self.stdout.borrow_mut().extend_from_slice(bytes);
+        }
+
+        fn write_stderr(&self, _bytes: &[u8]) {}
+    }
+
+    impl Host for CaptureHost {
+        fn capabilities(&self) -> Capabilities {
+            self.native.capabilities()
+        }
+
+        fn clock(&self) -> &dyn Clock {
+            self.native.clock()
+        }
+
+        fn stdio(&self) -> &dyn StdIo {
+            self
+        }
+
+        fn env(&self) -> &dyn Env {
+            self.native.env()
+        }
+
+        fn filesystem(&self) -> Option<&dyn Filesystem> {
+            self.native.filesystem()
+        }
+
+        fn process(&self) -> Option<&dyn Process> {
+            self.native.process()
+        }
+    }
 
     /// Run `body` under the alloc/free counters and assert zero residual — the
     /// codegen ABI's references must balance exactly like the rest of the runtime.
@@ -2782,6 +2825,47 @@ mod tests {
             // idempotent (unlike mixing it with individual handle releases).
             tcl_completion_release(&mut completion);
             release_words(&words);
+            tcl_runtime_set_current_interp(ptr::null_mut());
+            tcl_runtime_delete_interp(interp);
+        });
+    }
+
+    #[test]
+    fn compiled_puts_uses_channel_conversion_and_balances_its_owned_value() {
+        leak_free(|| unsafe {
+            let stdout = Rc::new(RefCell::new(Vec::new()));
+            let interp = tcl_runtime_create_interp();
+            (*interp).set_runtime_version(TclVersion::V9_0);
+            (*interp).set_host(Rc::new(CaptureHost {
+                native: NativeHost::new(),
+                stdout: Rc::clone(&stdout),
+            }));
+            tcl_runtime_set_current_interp(interp);
+
+            assert_eq!(
+                tcl_eval_code(box_str(b"fconfigure stdout -translation binary")),
+                0
+            );
+            assert_eq!(tcl_codegen_puts(owned_word(&[0xff, b'A'])), 0);
+            assert_eq!(&*stdout.borrow(), &[0xff, b'A', b'\n']);
+
+            assert_eq!(
+                tcl_eval_code(box_str(
+                    b"fconfigure stdout -translation lf -encoding iso8859-1 -profile strict"
+                )),
+                0
+            );
+            assert_eq!(tcl_codegen_puts(owned_word("A\u{0178}B".as_bytes())), 1);
+            assert_eq!(&*stdout.borrow(), &[0xff, b'A', b'\n', b'A']);
+            assert_eq!(
+                (*interp).result_bytes(),
+                b"error writing \"stdout\": invalid or incomplete multibyte or wide character"
+            );
+            assert_eq!(
+                (*interp).error_code(),
+                b"POSIX EILSEQ {invalid or incomplete multibyte or wide character}"
+            );
+
             tcl_runtime_set_current_interp(ptr::null_mut());
             tcl_runtime_delete_interp(interp);
         });

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -1243,6 +1243,7 @@ impl Interp {
     /// no process-host values are ever installed, even transiently.
     pub fn with_host(host: Rc<dyn tcl_platform::Host>) -> Interp {
         let result = obj::new_obj();
+        let system_encoding = host.system_encoding();
         // SAFETY: `result` is freshly created; the interp takes the owning ref.
         unsafe { obj::incr_ref_count(result) };
         let mut guards = GuardManager::default();
@@ -1263,7 +1264,10 @@ impl Interp {
                 DEFAULT_RUNTIME_VERSION,
             )),
             script_stack: RefCell::new(Vec::new()),
-            channels: RefCell::new(crate::cmd_chan::ChannelTable::default()),
+            channels: RefCell::new(crate::cmd_chan::ChannelTable::new(
+                DEFAULT_RUNTIME_VERSION,
+                system_encoding,
+            )),
             return_code: Cell::new(Code::Ok),
             return_level: Cell::new(1),
             traces: RefCell::new(crate::cmd_trace::TraceTable::default()),
@@ -1346,7 +1350,11 @@ impl Interp {
     /// a restricted one). Interior-mutable since the interp is shared via `Rc`.
     pub fn set_host(&self, host: Rc<dyn tcl_platform::Host>) {
         self.invalidate_interpreter_policy();
+        let system_encoding = host.system_encoding();
         *self.0.host.borrow_mut() = host;
+        self.channels
+            .borrow()
+            .reset_process_state_if_owner(self.runtime_version(), system_encoding);
         let mut interp = self.clone();
         interp.rebootstrap_host_globals();
         if interp.is_safe.get() {
@@ -1410,6 +1418,9 @@ impl Interp {
             .dialect_point
             .set(Some(crate::environment::surface_point(profile)));
         self.0.runtime_version.set(version);
+        self.channels
+            .borrow()
+            .reset_standard_channels_if_owner(version);
         self.namespaces.borrow_mut().ns_var_global_fallback =
             version.namespace_var_global_fallback();
         self.write_release_globals();
@@ -1424,6 +1435,18 @@ impl Interp {
     #[must_use]
     pub fn runtime_version(&self) -> tcl_dialect::TclVersion {
         self.0.runtime_version.get()
+    }
+
+    /// The mutable `encoding system` value shared by this interpreter tree.
+    #[must_use]
+    pub(crate) fn system_encoding(&self) -> tcl_platform::SystemEncoding {
+        self.channels.borrow().system_encoding()
+    }
+
+    /// Replace the system encoding used to initialise subsequently opened
+    /// channels. Existing channel handles retain their own configuration.
+    pub(crate) fn set_system_encoding(&self, encoding: tcl_platform::SystemEncoding) {
+        self.channels.borrow().set_system_encoding(encoding);
     }
 
     /// The dialect profile this interpreter validates its command surface
@@ -7273,6 +7296,10 @@ impl Interp {
         // The whole profile is inherited, not just the release, so a child's
         // command-surface availability gate agrees too (issue #1463).
         child.set_dialect_profile(self.dialect_profile());
+        child
+            .channels
+            .borrow_mut()
+            .share_process_state_from(&self.channels.borrow());
         // `Interp::new` already gave the child its own predefined globals
         // (`tcl_platform`, `env`, argv, …). The full `init.tcl`
         // (package/auto-load) remains deferred.

--- a/runtime/rust/tests/script_completion_bytes.rs
+++ b/runtime/rust/tests/script_completion_bytes.rs
@@ -19,6 +19,7 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
+use tcl_dialect::TclVersion;
 use tcl_host_native::NativeHost;
 use tcl_platform::{Capabilities, Clock, Env, Filesystem, Host, Process, StdIo};
 use tcl_runtime::interp::{Code, Interp};
@@ -144,6 +145,183 @@ fn raw_byte_puts_and_final_completion_share_the_lossless_boundary() {
     assert_eq!(completion.code, CompletionCode::Ok);
     assert!(completion.result.is_empty());
     assert_eq!(host.stdout(), NON_UTF8_VALUE);
+}
+
+#[test]
+fn binary_channel_output_uses_the_shared_tcl9_conversion_boundary() {
+    let host = Rc::new(CaptureHost::new());
+    let mut interp = Interp::new();
+    interp.set_runtime_version(TclVersion::V9_0);
+    interp.set_host(host.clone());
+
+    let completion = interp.eval_completion(
+        b"fconfigure stdout -translation binary; \
+          puts -nonewline [binary format H* ff41]",
+    );
+    assert_eq!(completion.code, CompletionCode::Ok);
+    assert_eq!(host.stdout(), [0xff, b'A']);
+}
+
+#[test]
+fn binary_open_mode_uses_the_shared_byte_preserving_configuration() {
+    let mut interp = Interp::new();
+    interp.set_runtime_version(TclVersion::V9_0);
+    let stem = format!("tcl-runtime-binary-open-{}", std::process::id());
+    let path = std::env::temp_dir().join(format!("{stem}-simple"));
+    let list_path = std::env::temp_dir().join(format!("{stem}-list"));
+    let rdwr_path = std::env::temp_dir().join(format!("{stem}-rdwr"));
+    let script = format!(
+        "set f [open {} wb]; \
+         puts -nonewline $f [binary format H* ff41]; close $f; \
+         set f [open {} {{WRONLY CREAT TRUNC {{BINARY}}}}]; \
+         puts -nonewline $f [binary format H* ff41]; close $f; \
+         set f [open {} {{RDWR CREAT TRUNC BINARY}}]; \
+         puts -nonewline $f [binary format H* ff41]; close $f",
+        tcl_syntax::list::list_element(&path.to_string_lossy()),
+        tcl_syntax::list::list_element(&list_path.to_string_lossy()),
+        tcl_syntax::list::list_element(&rdwr_path.to_string_lossy()),
+    );
+    let completion = interp.eval_completion(script.as_bytes());
+    assert_eq!(completion.code, CompletionCode::Ok);
+    for output in [&path, &list_path, &rdwr_path] {
+        assert_eq!(
+            std::fs::read(output).expect("read binary output"),
+            [0xff, b'A']
+        );
+        std::fs::remove_file(output).expect("remove binary output");
+    }
+}
+
+#[test]
+fn open_access_validation_tracks_the_runtime_release() {
+    let mut interp = Interp::new();
+    let path =
+        std::env::temp_dir().join(format!("tcl-runtime-open-release-{}", std::process::id()));
+    std::fs::write(&path, b"seed").expect("create access-mode fixture");
+
+    interp.set_runtime_version(TclVersion::V8_6);
+    let repeated = interp.eval_completion(
+        format!(
+            "set f [open {} {{RDONLY WRONLY}}]; \
+             puts -nonewline $f x; close $f",
+            tcl_syntax::list::list_element(&path.to_string_lossy()),
+        )
+        .as_bytes(),
+    );
+    assert_eq!(repeated.code, CompletionCode::Ok);
+    assert_eq!(
+        interp
+            .eval_completion(
+                b"set m \"\\{RDONLY\"; catch {open ignored $m} msg opts; \
+                  dict get $opts -errorcode"
+            )
+            .result,
+        b"TCL VALUE LIST BRACE"
+    );
+
+    interp.set_runtime_version(TclVersion::V9_0);
+    assert_eq!(
+        interp
+            .eval_completion(
+                b"set m \"\\{RDONLY\"; catch {open ignored $m} msg opts; \
+                  dict get $opts -errorcode"
+            )
+            .result,
+        b"TCL OPENMODE INVALID"
+    );
+    std::fs::remove_file(path).expect("remove access-mode fixture");
+}
+
+#[test]
+fn child_configuration_updates_the_shared_standard_channel_handle() {
+    let host = Rc::new(CaptureHost::new());
+    let mut interp = Interp::new();
+    interp.set_runtime_version(TclVersion::V9_0);
+    interp.set_host(host.clone());
+
+    let completion = interp.eval_completion(
+        b"interp create child; \
+          child eval {fconfigure stdout -translation binary}; \
+          puts -nonewline [binary format H* ff]",
+    );
+    assert_eq!(completion.code, CompletionCode::Ok);
+    assert_eq!(host.stdout(), [0xff]);
+}
+
+#[test]
+fn strict_conversion_writes_its_prefix_and_reports_structured_eilseq() {
+    let host = Rc::new(CaptureHost::new());
+    let mut interp = Interp::new();
+    interp.set_runtime_version(TclVersion::V9_0);
+    interp.set_host(host.clone());
+
+    let completion = interp.eval_completion(
+        b"fconfigure stdout -encoding iso8859-1 -profile strict; \
+          set c [catch {puts -nonewline \"A\\u0178B\"} m o]; \
+          set ::observedCode [dict get $o -errorcode]; set c",
+    );
+    assert_eq!(completion.code, CompletionCode::Ok);
+    assert_eq!(completion.result, b"1");
+    assert_eq!(host.stdout(), b"A");
+    assert_eq!(interp.eval_str(b"set m"), Code::Ok);
+    assert_eq!(
+        interp.result_bytes(),
+        b"error writing \"stdout\": invalid or incomplete multibyte or wide character"
+    );
+    assert_eq!(interp.eval_str(b"set ::observedCode"), Code::Ok);
+    assert_eq!(
+        interp.result_bytes(),
+        b"POSIX EILSEQ {invalid or incomplete multibyte or wide character}"
+    );
+}
+
+#[test]
+fn configuration_errors_keep_their_structured_tcl_identity() {
+    let mut interp = Interp::new();
+    interp.set_runtime_version(TclVersion::V9_0);
+    let completion = interp.eval_completion(
+        b"catch {fconfigure stdout -profile bogus} m o; \
+          list $m [dict get $o -errorcode]",
+    );
+    assert_eq!(completion.code, CompletionCode::Ok);
+    assert_eq!(
+        completion.result,
+        b"{bad profile name \"bogus\": must be replace, strict, or tcl8} {TCL ENCODING PROFILE bogus}"
+    );
+    assert_eq!(
+        interp
+            .eval_completion(b"encoding system ascii; encoding system {}; encoding system")
+            .result,
+        b"iso8859-1"
+    );
+}
+
+#[test]
+fn mutable_system_encoding_is_shared_and_only_seeds_future_channels() {
+    let host = Rc::new(CaptureHost::new());
+    let mut interp = Interp::new();
+    interp.set_runtime_version(TclVersion::V9_0);
+    interp.set_host(host);
+    let path = std::env::temp_dir().join(format!(
+        "tcl-runtime-system-encoding-{}",
+        std::process::id()
+    ));
+    let script = format!(
+        "set before [fconfigure stdout -encoding]; \
+         encoding system iso8859-1; \
+         interp create child; \
+         set childSystem [child eval {{encoding system}}]; \
+         set f [open {} w]; \
+         set opened [fconfigure $f -encoding]; \
+         puts -nonewline $f \\u00ff; close $f; \
+         list $before [fconfigure stdout -encoding] $childSystem $opened",
+        tcl_syntax::list::list_element(&path.to_string_lossy()),
+    );
+    let completion = interp.eval_completion(script.as_bytes());
+    assert_eq!(completion.code, CompletionCode::Ok);
+    assert_eq!(completion.result, b"utf-8 utf-8 iso8859-1 iso8859-1");
+    assert_eq!(std::fs::read(&path).expect("read encoded file"), [0xff]);
+    std::fs::remove_file(path).expect("remove encoded file");
 }
 
 #[test]

--- a/runtime/rust/tests/tcltest_channel_output.rs
+++ b/runtime/rust/tests/tcltest_channel_output.rs
@@ -1,0 +1,191 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use std::cell::RefCell;
+use std::path::Path;
+use std::rc::Rc;
+
+use tcl_dialect::TclVersion;
+use tcl_host_native::NativeHost;
+use tcl_platform::{Capabilities, Clock, Env, Filesystem, Host, HostError, Process, StdIo};
+use tcl_runtime::interp::{Code, Interp};
+use tcl_test_support::{locate_source_tree, upstream_test_definition};
+
+struct CaptureHost {
+    native: NativeHost,
+    stdout: RefCell<Vec<u8>>,
+    tcl_library: String,
+}
+
+impl CaptureHost {
+    fn new(tcl_library: String) -> Self {
+        Self {
+            native: NativeHost::new(),
+            stdout: RefCell::new(Vec::new()),
+            tcl_library,
+        }
+    }
+}
+
+impl StdIo for CaptureHost {
+    fn write_stdout(&self, bytes: &[u8]) {
+        self.stdout.borrow_mut().extend_from_slice(bytes);
+    }
+
+    fn write_stderr(&self, _bytes: &[u8]) {}
+}
+
+impl Env for CaptureHost {
+    fn get(&self, key: &str) -> Option<String> {
+        if key == "TCL_LIBRARY" {
+            Some(self.tcl_library.clone())
+        } else {
+            self.native.env().get(key)
+        }
+    }
+
+    fn set(&self, key: &str, value: &str) {
+        self.native.env().set(key, value);
+    }
+
+    fn vars(&self) -> Vec<(String, String)> {
+        let mut vars = self.native.env().vars();
+        vars.retain(|(key, _)| key != "TCL_LIBRARY");
+        vars.push(("TCL_LIBRARY".to_owned(), self.tcl_library.clone()));
+        vars
+    }
+
+    fn cwd(&self) -> Result<String, HostError> {
+        self.native.env().cwd()
+    }
+
+    fn chdir(&self, path: &str) -> Result<(), HostError> {
+        self.native.env().chdir(path)
+    }
+
+    fn current_exe(&self) -> Option<String> {
+        self.native.env().current_exe()
+    }
+}
+
+impl Host for CaptureHost {
+    fn capabilities(&self) -> Capabilities {
+        self.native.capabilities()
+    }
+
+    fn clock(&self) -> &dyn Clock {
+        self.native.clock()
+    }
+
+    fn stdio(&self) -> &dyn StdIo {
+        self
+    }
+
+    fn env(&self) -> &dyn Env {
+        self
+    }
+
+    fn system_encoding(&self) -> tcl_platform::SystemEncoding {
+        self.native.system_encoding()
+    }
+
+    fn filesystem(&self) -> Option<&dyn Filesystem> {
+        self.native.filesystem()
+    }
+
+    fn process(&self) -> Option<&dyn Process> {
+        self.native.process()
+    }
+}
+
+#[test]
+fn upstream_channel_output_cases_use_real_tcltest() {
+    let repository = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let Some(source_tree) = locate_source_tree(&repository, TclVersion::V9_0, None)
+        .expect("Tcl 9 source tree discovery")
+    else {
+        eprintln!("skipping: no Tcl 9.0.4 source tree available");
+        return;
+    };
+    assert_eq!(source_tree.patchlevel, "9.0.4", "real-library oracle pin");
+
+    let io_source = std::fs::read_to_string(source_tree.tests_dir().join("io.test"))
+        .expect("read pinned io.test");
+    let io_39_14 = upstream_test_definition(&io_source, "test io-39.14 {", "test io-39.15 {")
+        .expect("extract io-39.14");
+    let io_39_15 = upstream_test_definition(&io_source, "test io-39.15 {", "test io-39.16 {")
+        .expect("extract io-39.15");
+
+    let fixture =
+        std::env::temp_dir().join(format!("tcl-runtime-channel-oracle-{}", std::process::id()));
+    std::fs::create_dir_all(&fixture).expect("create channel oracle fixture");
+    let path1 = fixture.join("io-39.bin");
+    let path2 = fixture.join("io-75.bin");
+    let host = Rc::new(CaptureHost::new(
+        source_tree.library_dir().to_string_lossy().into_owned(),
+    ));
+    let mut interp = Interp::with_host(host.clone());
+    assert_eq!(
+        interp.eval_str(b"if {1} {set ::channel_oracle_ready 1}"),
+        Code::Ok,
+        "core command surface failed before init: {}",
+        String::from_utf8_lossy(&interp.result_bytes())
+    );
+    assert_eq!(
+        interp.init_library(),
+        Code::Ok,
+        "real Tcl init failed: {}",
+        String::from_utf8_lossy(&interp.result_bytes())
+    );
+
+    let script = format!(
+        "package require tcltest\n\
+         namespace import -force ::tcltest::*\n\
+         set path(test1) {}\n\
+         set path(test2) {}\n\
+         {io_39_14}\n\
+         {io_39_15}\n\
+         test io-75.9-runtime {{strict output conversion keeps its valid prefix}} -setup {{\n\
+             set f [open $path(test2) w]\n\
+             fconfigure $f -encoding iso8859-1 -profile strict\n\
+         }} -body {{\n\
+             set code [catch {{puts -nonewline $f \"A\\u2022\"}} msg opts]\n\
+             close $f\n\
+             list $code [string match {{error writing \"*\": invalid or incomplete multibyte or wide character}} $msg] [dict get $opts -errorcode]\n\
+         }} -result [list 1 1 {{POSIX EILSEQ {{invalid or incomplete multibyte or wide character}}}}]\n\
+         ::tcltest::cleanupTests\n",
+        tcl_syntax::list::list_element(&path1.to_string_lossy()),
+        tcl_syntax::list::list_element(&path2.to_string_lossy()),
+    );
+    assert_eq!(
+        interp.eval_str(script.as_bytes()),
+        Code::Ok,
+        "channel tcltest execution failed: {}",
+        String::from_utf8_lossy(&interp.result_bytes())
+    );
+    assert_eq!(
+        std::fs::read(&path2).expect("read strict output prefix"),
+        b"A"
+    );
+    let summary = String::from_utf8(host.stdout.borrow().clone()).expect("UTF-8 tcltest output");
+    assert!(
+        summary.contains("Total\t3\tPassed\t3\tSkipped\t0\tFailed\t0"),
+        "{summary}"
+    );
+    std::fs::remove_dir_all(fixture).expect("remove channel oracle fixture");
+}

--- a/rust/tcl-cmd-core/src/channel.rs
+++ b/rust/tcl-cmd-core/src/channel.rs
@@ -1,0 +1,1009 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Tcl channel configuration and output encoding.
+//!
+//! A channel's encoding, conversion profile, and newline translation are one
+//! stateful contract shared by every runtime adapter.  This module owns the
+//! release-aware defaults and pure text-to-byte conversion; runtimes retain
+//! the mutable configuration beside their handles and supply only the raw byte
+//! sink.
+
+use tcl_dialect::TclVersion;
+use tcl_platform::SystemEncoding;
+
+use crate::CmdError;
+
+/// Tcl's structured POSIX identity for an output conversion failure.
+pub const EILSEQ_ERROR_CODE: &str =
+    "POSIX EILSEQ {invalid or incomplete multibyte or wide character}";
+
+const EILSEQ_REASON: &str = "invalid or incomplete multibyte or wide character";
+
+/// A channel option understood by `fconfigure`, independent of a runtime's
+/// concrete channel table.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConfigOption {
+    Blocking,
+    Buffering,
+    BufferSize,
+    Encoding,
+    EofChar,
+    Profile,
+    Translation,
+}
+
+/// Encodings implemented by the native runtimes' channel boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChannelEncoding {
+    Utf8,
+    Iso88591,
+    Ascii,
+    Unicode,
+    /// Tcl 8's `binary` pseudo-encoding (low eight bits of each character).
+    Tcl8Binary,
+}
+
+impl ChannelEncoding {
+    /// Canonical Tcl spelling returned by `fconfigure -encoding`.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Utf8 => "utf-8",
+            Self::Iso88591 => "iso8859-1",
+            Self::Ascii => "ascii",
+            Self::Unicode => "unicode",
+            Self::Tcl8Binary => "binary",
+        }
+    }
+
+    fn from_system(encoding: SystemEncoding) -> Self {
+        match encoding {
+            SystemEncoding::Utf8 => Self::Utf8,
+            SystemEncoding::Iso88591 => Self::Iso88591,
+            SystemEncoding::Ascii => Self::Ascii,
+            SystemEncoding::Unicode => Self::Unicode,
+        }
+    }
+}
+
+/// Resolve an exact supported name for `encoding system`.
+///
+/// # Errors
+/// An unknown encoding, with Tcl's structured lookup identity.
+pub fn resolve_system_encoding(value: &str) -> Result<SystemEncoding, CmdError> {
+    match value {
+        "utf-8" => Ok(SystemEncoding::Utf8),
+        "" | "iso8859-1" => Ok(SystemEncoding::Iso88591),
+        "ascii" => Ok(SystemEncoding::Ascii),
+        "unicode" => Ok(SystemEncoding::Unicode),
+        _ => Err(CmdError::with_error_code(
+            format!("unknown encoding \"{value}\""),
+            tcl_syntax::list::join_list(["TCL", "LOOKUP", "ENCODING", value]),
+        )),
+    }
+}
+
+/// Tcl 9's output conversion profile.  Tcl 8 channels use `tcl8`
+/// conversion semantics implicitly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EncodingProfile {
+    Replace,
+    Strict,
+    Tcl8,
+}
+
+impl EncodingProfile {
+    /// Canonical Tcl spelling.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Replace => "replace",
+            Self::Strict => "strict",
+            Self::Tcl8 => "tcl8",
+        }
+    }
+}
+
+/// Newline translation retained by a channel.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutputTranslation {
+    Auto,
+    Cr,
+    Lf,
+    CrLf,
+}
+
+/// Which direction(s) one channel exposes. Tcl retains input and output
+/// newline modes independently and reports a two-element value for a
+/// bidirectional channel.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChannelDirection {
+    Input,
+    Output,
+    Bidirectional,
+}
+
+/// Normalised file-channel facts derived from Tcl's simple or list-form
+/// `open` access mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct OpenAccess {
+    direction: ChannelDirection,
+    flags: u8,
+}
+
+impl OpenAccess {
+    const APPEND: u8 = 1 << 0;
+    const TRUNCATE: u8 = 1 << 1;
+    const CREATE: u8 = 1 << 2;
+    const EXCLUSIVE: u8 = 1 << 3;
+    const BINARY: u8 = 1 << 4;
+
+    const fn new(direction: ChannelDirection, flags: u8) -> Self {
+        Self { direction, flags }
+    }
+
+    /// Whether the mode permits reads.
+    #[must_use]
+    pub const fn is_readable(self) -> bool {
+        matches!(
+            self.direction,
+            ChannelDirection::Input | ChannelDirection::Bidirectional
+        )
+    }
+
+    /// Whether the mode permits writes.
+    #[must_use]
+    pub const fn is_writable(self) -> bool {
+        matches!(
+            self.direction,
+            ChannelDirection::Output | ChannelDirection::Bidirectional
+        )
+    }
+
+    /// Whether writes append at the end of the file.
+    #[must_use]
+    pub const fn appends(self) -> bool {
+        self.flags & Self::APPEND != 0
+    }
+
+    /// Whether opening truncates an existing file.
+    #[must_use]
+    pub const fn truncates(self) -> bool {
+        self.flags & Self::TRUNCATE != 0
+    }
+
+    /// Whether opening creates a missing file.
+    #[must_use]
+    pub const fn creates(self) -> bool {
+        self.flags & Self::CREATE != 0
+    }
+
+    /// Whether creation fails if the file already exists.
+    #[must_use]
+    pub const fn is_exclusive(self) -> bool {
+        self.flags & Self::EXCLUSIVE != 0
+    }
+
+    /// Whether the channel starts with binary translation.
+    #[must_use]
+    pub const fn is_binary(self) -> bool {
+        self.flags & Self::BINARY != 0
+    }
+}
+
+impl OutputTranslation {
+    /// Canonical Tcl spelling returned by `fconfigure -translation`.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Auto => "auto",
+            Self::Cr => "cr",
+            Self::Lf => "lf",
+            Self::CrLf => "crlf",
+        }
+    }
+
+    fn line_ending(self) -> &'static str {
+        match self {
+            Self::Cr => "\r",
+            Self::CrLf => "\r\n",
+            Self::Auto | Self::Lf => "\n",
+        }
+    }
+}
+
+/// The mutable output-affecting configuration of one Tcl channel.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ChannelConfig {
+    pub encoding: ChannelEncoding,
+    pub profile: EncodingProfile,
+    pub direction: ChannelDirection,
+    pub input_translation: OutputTranslation,
+    /// The output direction consumed by [`encode_output`].
+    pub translation: OutputTranslation,
+}
+
+impl ChannelConfig {
+    /// Tcl defaults for a standard channel.  Standard error is replace-mode;
+    /// Tcl 9's other standard channels are strict.  Input retains `auto`
+    /// translation while output channels are normalised to the platform EOL.
+    #[must_use]
+    pub fn standard(version: TclVersion, system: SystemEncoding, name: &str) -> Self {
+        let profile = if version < TclVersion::V9_0 {
+            EncodingProfile::Tcl8
+        } else if name == "stderr" {
+            EncodingProfile::Replace
+        } else {
+            EncodingProfile::Strict
+        };
+        Self {
+            encoding: ChannelEncoding::from_system(system),
+            profile,
+            direction: if name == "stdin" {
+                ChannelDirection::Input
+            } else {
+                ChannelDirection::Output
+            },
+            input_translation: OutputTranslation::Auto,
+            translation: if name == "stdin" {
+                OutputTranslation::Auto
+            } else {
+                platform_translation()
+            },
+        }
+    }
+
+    /// Tcl defaults for a newly opened file channel.
+    #[must_use]
+    pub fn file(version: TclVersion, system: SystemEncoding, direction: ChannelDirection) -> Self {
+        Self {
+            encoding: ChannelEncoding::from_system(system),
+            profile: if version >= TclVersion::V9_0 {
+                EncodingProfile::Strict
+            } else {
+                EncodingProfile::Tcl8
+            },
+            direction,
+            input_translation: OutputTranslation::Auto,
+            translation: platform_translation(),
+        }
+    }
+
+    /// Tcl defaults for a channel opened with one normalised access mode.
+    #[must_use]
+    pub fn for_open_access(
+        version: TclVersion,
+        system: SystemEncoding,
+        access: OpenAccess,
+    ) -> Self {
+        let mut config = Self::file(version, system, access.direction);
+        if access.is_binary() {
+            config
+                .set_translation(version, "binary")
+                .expect("the literal binary translation is valid for every Tcl release");
+        }
+        config
+    }
+
+    /// Tcl's query form for `-translation`.
+    #[must_use]
+    pub fn translation_value(self) -> String {
+        match self.direction {
+            ChannelDirection::Input => self.input_translation.as_str().to_owned(),
+            ChannelDirection::Output => self.translation.as_str().to_owned(),
+            ChannelDirection::Bidirectional => tcl_syntax::list::join_list([
+                self.input_translation.as_str(),
+                self.translation.as_str(),
+            ]),
+        }
+    }
+
+    /// Apply an exact Tcl encoding name.
+    ///
+    /// # Errors
+    /// An unknown encoding, including Tcl 9's removed empty/`binary` spellings.
+    pub fn set_encoding(&mut self, version: TclVersion, value: &str) -> Result<(), CmdError> {
+        self.encoding = match value {
+            "utf-8" => ChannelEncoding::Utf8,
+            "iso8859-1" => ChannelEncoding::Iso88591,
+            "ascii" => ChannelEncoding::Ascii,
+            "unicode" => ChannelEncoding::Unicode,
+            "" | "binary" if version < TclVersion::V9_0 => ChannelEncoding::Tcl8Binary,
+            "" | "binary" => {
+                return Err(CmdError::new(format!(
+                    "unknown encoding \"{value}\": No longer supported.\n\tplease use either \"-translation binary\" or \"-encoding iso8859-1\""
+                )));
+            }
+            _ => {
+                return Err(CmdError::with_error_code(
+                    format!("unknown encoding \"{value}\""),
+                    tcl_syntax::list::join_list(["TCL", "LOOKUP", "ENCODING", value]),
+                ));
+            }
+        };
+        Ok(())
+    }
+
+    /// Apply an exact Tcl 9 conversion profile name.
+    ///
+    /// # Errors
+    /// A non-profile spelling.
+    pub fn set_profile(&mut self, value: &str) -> Result<(), CmdError> {
+        self.profile = match value {
+            "replace" => EncodingProfile::Replace,
+            "strict" => EncodingProfile::Strict,
+            "tcl8" => EncodingProfile::Tcl8,
+            _ => {
+                return Err(CmdError::with_error_code(
+                    format!("bad profile name \"{value}\": must be replace, strict, or tcl8"),
+                    tcl_syntax::list::join_list(["TCL", "ENCODING", "PROFILE", value]),
+                ));
+            }
+        };
+        Ok(())
+    }
+
+    /// Apply Tcl's one- or two-element translation value to the channel
+    /// directions it exposes. `binary` also selects the release's
+    /// byte-preserving encoding.
+    ///
+    /// # Errors
+    /// A malformed Tcl list or unknown translation spelling.
+    pub fn set_translation(&mut self, version: TclVersion, value: &str) -> Result<(), CmdError> {
+        let elements = tcl_syntax::list::split_list(value)
+            .map_err(|error| CmdError::new(error.message().to_owned()))?;
+        let (input, output) = match elements.as_slice() {
+            [one] => (Some(one.as_ref()), Some(one.as_ref())),
+            [input, output] => (
+                (!input.is_empty()).then(|| input.as_ref()),
+                (!output.is_empty()).then(|| output.as_ref()),
+            ),
+            _ => {
+                return Err(CmdError::new(
+                    "bad value for -translation: must be a one or two element list",
+                ));
+            }
+        };
+        if let Some(input) = input
+            && self.direction != ChannelDirection::Output
+        {
+            self.input_translation = parse_translation(input, true)?;
+            if input == "binary" {
+                self.encoding = if version >= TclVersion::V9_0 {
+                    ChannelEncoding::Iso88591
+                } else {
+                    ChannelEncoding::Tcl8Binary
+                };
+            }
+        }
+        if let Some(output) = output
+            && self.direction != ChannelDirection::Input
+        {
+            self.translation = parse_translation(output, false)?;
+            if output == "binary" {
+                self.encoding = if version >= TclVersion::V9_0 {
+                    ChannelEncoding::Iso88591
+                } else {
+                    ChannelEncoding::Tcl8Binary
+                };
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Resolve Tcl's simple or list-form `open` access mode once for every runtime.
+///
+/// # Errors
+/// A malformed Tcl list, illegal simple spelling, unknown list flag, missing
+/// direction, or conflicting direction flags.
+pub fn resolve_open_access_mode(version: TclVersion, access: &str) -> Result<OpenAccess, CmdError> {
+    if let Some(simple) = resolve_simple_open_access(access) {
+        return Ok(simple);
+    }
+    if access
+        .as_bytes()
+        .first()
+        .is_some_and(u8::is_ascii_lowercase)
+        || access.contains('+')
+    {
+        return Err(open_mode_error(
+            version,
+            format!("illegal access mode \"{access}\""),
+        ));
+    }
+
+    let flags = tcl_syntax::list::split_list(access).map_err(|error| {
+        let message = error.full_message(access);
+        if version >= TclVersion::V9_0 {
+            CmdError::with_error_code(message, "TCL OPENMODE INVALID")
+        } else {
+            CmdError::with_error_code(message, list_error_code(error))
+        }
+    })?;
+    let mut direction = None;
+    let mut access_flags = 0;
+    for flag in flags {
+        let flag = flag.as_ref();
+        match flag {
+            "RDONLY" | "WRONLY" | "RDWR" if version >= TclVersion::V9_0 && direction.is_some() => {
+                return Err(open_mode_error(
+                    version,
+                    format!(
+                        "invalid access mode \"{flag}\": modes RDONLY, RDWR, and WRONLY cannot be combined"
+                    ),
+                ));
+            }
+            "RDONLY" => direction = Some(ChannelDirection::Input),
+            "WRONLY" => direction = Some(ChannelDirection::Output),
+            "RDWR" => direction = Some(ChannelDirection::Bidirectional),
+            "APPEND" => access_flags |= OpenAccess::APPEND,
+            "BINARY" => access_flags |= OpenAccess::BINARY,
+            "CREAT" => access_flags |= OpenAccess::CREATE,
+            "EXCL" => access_flags |= OpenAccess::EXCLUSIVE,
+            "TRUNC" => access_flags |= OpenAccess::TRUNCATE,
+            "NOCTTY" | "NONBLOCK" => {}
+            _ => {
+                let choices = if version >= TclVersion::V9_0 {
+                    "APPEND, BINARY, CREAT, EXCL, NOCTTY, NONBLOCK, RDONLY, RDWR, TRUNC, or WRONLY"
+                } else {
+                    "RDONLY, WRONLY, RDWR, APPEND, BINARY, CREAT, EXCL, NOCTTY, NONBLOCK, or TRUNC"
+                };
+                return Err(open_mode_error(
+                    version,
+                    format!("invalid access mode \"{flag}\": must be {choices}"),
+                ));
+            }
+        }
+    }
+    direction.map_or_else(
+        || {
+            Err(CmdError::new(
+                "access mode must include either RDONLY, RDWR, or WRONLY",
+            ))
+        },
+        |direction| Ok(OpenAccess::new(direction, access_flags)),
+    )
+}
+
+fn open_mode_error(version: TclVersion, message: String) -> CmdError {
+    if version >= TclVersion::V9_0 {
+        CmdError::with_error_code(message, "TCL OPENMODE INVALID")
+    } else {
+        CmdError::new(message)
+    }
+}
+
+fn list_error_code(error: tcl_syntax::list::ListError) -> &'static str {
+    match error {
+        tcl_syntax::list::ListError::UnmatchedBrace => "TCL VALUE LIST BRACE",
+        tcl_syntax::list::ListError::UnmatchedQuote => "TCL VALUE LIST QUOTE",
+        tcl_syntax::list::ListError::BraceFollowedByJunk
+        | tcl_syntax::list::ListError::QuoteFollowedByJunk => "TCL VALUE LIST JUNK",
+    }
+}
+
+fn resolve_simple_open_access(access: &str) -> Option<OpenAccess> {
+    match access {
+        "r" => Some(OpenAccess::new(ChannelDirection::Input, 0)),
+        "rb" => Some(OpenAccess::new(ChannelDirection::Input, OpenAccess::BINARY)),
+        "r+" => Some(OpenAccess::new(ChannelDirection::Bidirectional, 0)),
+        "rb+" | "r+b" => Some(OpenAccess::new(
+            ChannelDirection::Bidirectional,
+            OpenAccess::BINARY,
+        )),
+        "w" => Some(OpenAccess::new(
+            ChannelDirection::Output,
+            OpenAccess::TRUNCATE | OpenAccess::CREATE,
+        )),
+        "wb" => Some(OpenAccess::new(
+            ChannelDirection::Output,
+            OpenAccess::TRUNCATE | OpenAccess::CREATE | OpenAccess::BINARY,
+        )),
+        "w+" => Some(OpenAccess::new(
+            ChannelDirection::Bidirectional,
+            OpenAccess::TRUNCATE | OpenAccess::CREATE,
+        )),
+        "wb+" | "w+b" => Some(OpenAccess::new(
+            ChannelDirection::Bidirectional,
+            OpenAccess::TRUNCATE | OpenAccess::CREATE | OpenAccess::BINARY,
+        )),
+        "a" => Some(OpenAccess::new(
+            ChannelDirection::Output,
+            OpenAccess::APPEND | OpenAccess::CREATE,
+        )),
+        "ab" => Some(OpenAccess::new(
+            ChannelDirection::Output,
+            OpenAccess::APPEND | OpenAccess::CREATE | OpenAccess::BINARY,
+        )),
+        "a+" => Some(OpenAccess::new(
+            ChannelDirection::Bidirectional,
+            OpenAccess::APPEND | OpenAccess::CREATE,
+        )),
+        "ab+" | "a+b" => Some(OpenAccess::new(
+            ChannelDirection::Bidirectional,
+            OpenAccess::APPEND | OpenAccess::CREATE | OpenAccess::BINARY,
+        )),
+        _ => None,
+    }
+}
+
+/// Mutable configuration of Tcl's three standard channel handles.
+///
+/// The runtime owns the sharing topology; this type owns their names and
+/// release-aware initial state so every adapter observes the same defaults.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StandardChannelConfigs {
+    stdin: ChannelConfig,
+    stdout: ChannelConfig,
+    stderr: ChannelConfig,
+}
+
+impl StandardChannelConfigs {
+    /// Construct the standard handles for one Tcl release and system encoding.
+    #[must_use]
+    pub fn new(version: TclVersion, system: SystemEncoding) -> Self {
+        Self {
+            stdin: ChannelConfig::standard(version, system, "stdin"),
+            stdout: ChannelConfig::standard(version, system, "stdout"),
+            stderr: ChannelConfig::standard(version, system, "stderr"),
+        }
+    }
+
+    /// Read a standard handle's configuration by its Tcl channel name.
+    #[must_use]
+    pub fn get(&self, name: &str) -> Option<ChannelConfig> {
+        match name {
+            "stdin" => Some(self.stdin),
+            "stdout" => Some(self.stdout),
+            "stderr" => Some(self.stderr),
+            _ => None,
+        }
+    }
+
+    /// Replace a standard handle's configuration by its Tcl channel name.
+    pub fn set(&mut self, name: &str, config: ChannelConfig) -> bool {
+        let target = match name {
+            "stdin" => &mut self.stdin,
+            "stdout" => &mut self.stdout,
+            "stderr" => &mut self.stderr,
+            _ => return false,
+        };
+        *target = config;
+        true
+    }
+}
+
+/// Whether `name` is one of Tcl's predefined standard channel handles.
+#[must_use]
+pub fn is_standard_channel(name: &str) -> bool {
+    matches!(name, "stdin" | "stdout" | "stderr")
+}
+
+/// Query one resolved `fconfigure` option.
+#[must_use]
+pub fn config_value(option: ConfigOption, name: &str, config: ChannelConfig) -> String {
+    match option {
+        ConfigOption::Blocking => "1".to_owned(),
+        ConfigOption::Buffering => channel_buffering(name).to_owned(),
+        ConfigOption::BufferSize => "4096".to_owned(),
+        ConfigOption::Encoding => config.encoding.as_str().to_owned(),
+        ConfigOption::EofChar => String::new(),
+        ConfigOption::Profile => config.profile.as_str().to_owned(),
+        ConfigOption::Translation => config.translation_value(),
+    }
+}
+
+/// Query the complete `fconfigure` option/value list for one channel.
+#[must_use]
+pub fn config_list(version: TclVersion, name: &str, config: ChannelConfig) -> String {
+    let mut result = format!(
+        "-blocking 1 -buffering {} -buffersize 4096 -encoding {} -eofchar {{}}",
+        channel_buffering(name),
+        config.encoding.as_str()
+    );
+    if version >= TclVersion::V9_0 {
+        result.push_str(" -profile ");
+        result.push_str(config.profile.as_str());
+    }
+    result.push_str(" -translation ");
+    result.push_str(&tcl_syntax::list::list_element(&config.translation_value()));
+    result
+}
+
+/// Apply one resolved `fconfigure` option to the retained channel state.
+///
+/// Options outside the byte-conversion subset are accepted for compatibility;
+/// their operational backing remains the adapter's responsibility.
+///
+/// # Errors
+/// An invalid encoding, conversion profile, or translation value.
+pub fn set_config_value(
+    version: TclVersion,
+    config: &mut ChannelConfig,
+    option: ConfigOption,
+    value: &str,
+) -> Result<(), CmdError> {
+    match option {
+        ConfigOption::Encoding => config.set_encoding(version, value),
+        ConfigOption::Profile => config.set_profile(value),
+        ConfigOption::Translation => config.set_translation(version, value),
+        ConfigOption::Blocking
+        | ConfigOption::Buffering
+        | ConfigOption::BufferSize
+        | ConfigOption::EofChar => Ok(()),
+    }
+}
+
+fn channel_buffering(name: &str) -> &'static str {
+    match name {
+        "stdin" | "stdout" => "line",
+        "stderr" => "none",
+        _ => "full",
+    }
+}
+
+fn parse_translation(value: &str, input: bool) -> Result<OutputTranslation, CmdError> {
+    match value {
+        "auto" if input => Ok(OutputTranslation::Auto),
+        "auto" | "platform" => Ok(platform_translation()),
+        "binary" | "lf" => Ok(OutputTranslation::Lf),
+        "cr" => Ok(OutputTranslation::Cr),
+        "crlf" => Ok(OutputTranslation::CrLf),
+        _ => Err(bad_translation()),
+    }
+}
+
+fn bad_translation() -> CmdError {
+    CmdError::new(
+        "bad value for -translation: must be one of auto, binary, cr, lf, crlf, or platform",
+    )
+}
+
+const fn platform_translation() -> OutputTranslation {
+    if cfg!(windows) {
+        OutputTranslation::CrLf
+    } else {
+        OutputTranslation::Lf
+    }
+}
+
+/// Encoded bytes plus an optional conversion failure that occurred after the
+/// returned prefix.  Tcl writes the representable prefix before reporting
+/// `EILSEQ`; the runtime sink therefore must consume `bytes` even when `error`
+/// is present.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EncodedOutput {
+    pub bytes: Vec<u8>,
+    pub error: Option<CmdError>,
+}
+
+/// Encode Tcl string text according to one channel's retained configuration.
+/// The optional `puts` newline participates in the same newline translation as
+/// embedded line feeds and is omitted if conversion fails first.
+#[must_use]
+pub fn encode_output(text: &str, newline: bool, config: ChannelConfig) -> EncodedOutput {
+    let ending = config.translation.line_ending();
+    let mut translated = String::with_capacity(text.len() + usize::from(newline));
+    for character in text.chars() {
+        if character == '\n' {
+            translated.push_str(ending);
+        } else {
+            translated.push(character);
+        }
+    }
+    if newline {
+        translated.push_str(ending);
+    }
+
+    if config.encoding == ChannelEncoding::Utf8 {
+        return EncodedOutput {
+            bytes: translated.into_bytes(),
+            error: None,
+        };
+    }
+
+    let mut bytes = Vec::with_capacity(translated.len());
+    for character in translated.chars() {
+        let point = u32::from(character);
+        match config.encoding {
+            ChannelEncoding::Iso88591 if point <= 0xff => {
+                bytes.push(u8::try_from(point).expect("checked Latin-1 scalar"));
+            }
+            ChannelEncoding::Ascii if point <= 0x7f => {
+                bytes.push(u8::try_from(point).expect("checked ASCII scalar"));
+            }
+            ChannelEncoding::Tcl8Binary => bytes.push(point.to_le_bytes()[0]),
+            ChannelEncoding::Unicode => {
+                let mut units = [0_u16; 2];
+                for unit in character.encode_utf16(&mut units) {
+                    bytes.extend_from_slice(&unit.to_ne_bytes());
+                }
+            }
+            ChannelEncoding::Iso88591 | ChannelEncoding::Ascii
+                if config.profile == EncodingProfile::Strict =>
+            {
+                return EncodedOutput {
+                    bytes,
+                    error: Some(CmdError::with_error_code(EILSEQ_REASON, EILSEQ_ERROR_CODE)),
+                };
+            }
+            ChannelEncoding::Iso88591 | ChannelEncoding::Ascii => bytes.push(b'?'),
+            ChannelEncoding::Utf8 => unreachable!("UTF-8 returned above"),
+        }
+    }
+    EncodedOutput { bytes, error: None }
+}
+
+/// Encode a runtime object's Tcl string bytes at the channel boundary.
+///
+/// Runtime-created Tcl strings are UTF-8 and take the Unicode conversion path.
+/// A C embedder can nevertheless supply an opaque invalid-UTF-8 string; the
+/// default UTF-8 channel preserves those bytes exactly, while a legacy target
+/// interprets each byte as its corresponding U+00XX character.
+#[must_use]
+pub fn encode_output_bytes(bytes: &[u8], newline: bool, config: ChannelConfig) -> EncodedOutput {
+    if let Ok(text) = core::str::from_utf8(bytes) {
+        return encode_output(text, newline, config);
+    }
+    if config.encoding != ChannelEncoding::Utf8 {
+        let text: String = bytes.iter().copied().map(char::from).collect();
+        return encode_output(&text, newline, config);
+    }
+
+    let ending = config.translation.line_ending().as_bytes();
+    let mut output = Vec::with_capacity(bytes.len() + usize::from(newline));
+    for &byte in bytes {
+        if byte == b'\n' {
+            output.extend_from_slice(ending);
+        } else {
+            output.push(byte);
+        }
+    }
+    if newline {
+        output.extend_from_slice(ending);
+    }
+    EncodedOutput {
+        bytes: output,
+        error: None,
+    }
+}
+
+/// Add the channel identity to a conversion failure after its representable
+/// prefix has been written, preserving the structured error code.
+#[must_use]
+pub fn channel_output_error(name: &str, error: CmdError) -> CmdError {
+    let (message, code) = error.into_parts();
+    let message = format!("error writing \"{name}\": {message}");
+    match code {
+        Some(code) => CmdError::with_error_code(message, code),
+        None => CmdError::new(message),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn binary_translation_is_release_aware() {
+        let mut nine = ChannelConfig::file(
+            TclVersion::V9_0,
+            SystemEncoding::Utf8,
+            ChannelDirection::Output,
+        );
+        nine.set_translation(TclVersion::V9_0, "binary").unwrap();
+        assert_eq!(nine.encoding.as_str(), "iso8859-1");
+        assert_eq!(nine.translation.as_str(), "lf");
+
+        let mut eight = ChannelConfig::file(
+            TclVersion::V8_6,
+            SystemEncoding::Utf8,
+            ChannelDirection::Output,
+        );
+        eight.set_translation(TclVersion::V8_6, "binary").unwrap();
+        assert_eq!(eight.encoding.as_str(), "binary");
+        assert_eq!(eight.profile.as_str(), "tcl8");
+    }
+
+    #[test]
+    fn strict_conversion_returns_the_written_prefix_and_eilseq() {
+        let config = ChannelConfig {
+            encoding: ChannelEncoding::Iso88591,
+            profile: EncodingProfile::Strict,
+            direction: ChannelDirection::Output,
+            input_translation: OutputTranslation::Auto,
+            translation: OutputTranslation::Lf,
+        };
+        let output = encode_output("A\u{178}B", true, config);
+        assert_eq!(output.bytes, b"A");
+        let error = output.error.expect("strict conversion failure");
+        assert_eq!(error.message(), EILSEQ_REASON);
+        assert_eq!(error.error_code(), Some(EILSEQ_ERROR_CODE));
+    }
+
+    #[test]
+    fn binary_and_explicit_utf8_are_distinct() {
+        let mut config = ChannelConfig::file(
+            TclVersion::V9_0,
+            SystemEncoding::Utf8,
+            ChannelDirection::Output,
+        );
+        config.set_translation(TclVersion::V9_0, "binary").unwrap();
+        assert_eq!(encode_output("ÿA", false, config).bytes, [0xff, b'A']);
+        config.set_encoding(TclVersion::V9_0, "utf-8").unwrap();
+        assert_eq!(encode_output("ÿA", false, config).bytes, [0xc3, 0xbf, b'A']);
+    }
+
+    #[test]
+    fn system_and_channel_encoding_errors_retain_tcl_identity() {
+        assert_eq!(resolve_system_encoding(""), Ok(SystemEncoding::Iso88591));
+        let system = resolve_system_encoding("bogus").expect_err("unknown system encoding");
+        assert_eq!(system.message(), "unknown encoding \"bogus\"");
+        assert_eq!(system.error_code(), Some("TCL LOOKUP ENCODING bogus"));
+
+        let mut config = ChannelConfig::file(
+            TclVersion::V9_0,
+            SystemEncoding::Utf8,
+            ChannelDirection::Output,
+        );
+        let profile = config.set_profile("bogus").expect_err("unknown profile");
+        assert_eq!(profile.error_code(), Some("TCL ENCODING PROFILE bogus"));
+        let binary = config
+            .set_encoding(TclVersion::V9_0, "binary")
+            .expect_err("Tcl 9 removed binary encoding");
+        assert!(binary.message().contains("-translation binary"));
+        assert_eq!(binary.error_code(), None);
+        let empty = config
+            .set_encoding(TclVersion::V9_0, "")
+            .expect_err("Tcl 9 removed the empty binary encoding");
+        assert!(empty.message().starts_with("unknown encoding \"\""));
+        assert!(empty.message().contains("-translation binary"));
+        assert_eq!(empty.error_code(), None);
+
+        let mut eight = config;
+        eight
+            .set_encoding(TclVersion::V8_6, "")
+            .expect("Tcl 8 empty encoding selects binary");
+        assert_eq!(eight.encoding, ChannelEncoding::Tcl8Binary);
+    }
+
+    #[test]
+    fn open_access_mode_uses_simple_and_tcl_list_grammars() {
+        for access in ["wb", "rb+", "r+b", "RDWR BINARY", "WRONLY {BINARY}"] {
+            let resolved = resolve_open_access_mode(TclVersion::V9_0, access)
+                .expect("valid binary access mode");
+            assert!(resolved.is_binary(), "{access:?}");
+        }
+        let list = resolve_open_access_mode(TclVersion::V9_0, "RDWR CREAT TRUNC")
+            .expect("valid access list");
+        assert!(list.is_readable());
+        assert!(list.is_writable());
+        assert!(list.creates());
+        assert!(list.truncates());
+        assert!(!list.appends());
+        assert!(!list.is_exclusive());
+        assert!(!list.is_binary());
+
+        let illegal =
+            resolve_open_access_mode(TclVersion::V9_0, "brw").expect_err("illegal simple mode");
+        assert_eq!(illegal.error_code(), Some("TCL OPENMODE INVALID"));
+        let unknown = resolve_open_access_mode(TclVersion::V9_0, "WRONLY BAD")
+            .expect_err("unknown list flag");
+        assert_eq!(unknown.error_code(), Some("TCL OPENMODE INVALID"));
+        assert!(
+            resolve_open_access_mode(TclVersion::V9_0, "RDONLY WRONLY")
+                .expect_err("conflicting list flags")
+                .message()
+                .contains("cannot be combined")
+        );
+        assert_eq!(
+            resolve_open_access_mode(TclVersion::V9_0, "BINARY")
+                .expect_err("missing direction")
+                .message(),
+            "access mode must include either RDONLY, RDWR, or WRONLY"
+        );
+
+        let eight = resolve_open_access_mode(TclVersion::V8_6, "RDONLY WRONLY")
+            .expect("Tcl 8 uses the last direction flag");
+        assert!(!eight.is_readable());
+        assert!(eight.is_writable());
+        let eight_unknown = resolve_open_access_mode(TclVersion::V8_6, "WRONLY BAD")
+            .expect_err("unknown Tcl 8 list flag");
+        assert_eq!(eight_unknown.error_code(), None);
+
+        let malformed_nine = resolve_open_access_mode(TclVersion::V9_0, "{RDONLY")
+            .expect_err("malformed Tcl 9 access list");
+        assert_eq!(malformed_nine.error_code(), Some("TCL OPENMODE INVALID"));
+        let malformed_eight = resolve_open_access_mode(TclVersion::V8_6, "{RDONLY")
+            .expect_err("malformed Tcl 8 access list");
+        assert_eq!(malformed_eight.error_code(), Some("TCL VALUE LIST BRACE"));
+    }
+
+    #[test]
+    fn opaque_invalid_utf8_remains_byte_exact_on_a_utf8_channel() {
+        let config = ChannelConfig::standard(TclVersion::V9_0, SystemEncoding::Utf8, "stdout");
+        assert_eq!(
+            encode_output_bytes(&[0xff, b'\n', 0x80], true, config).bytes,
+            [0xff, b'\n', 0x80, b'\n']
+        );
+    }
+
+    #[test]
+    fn replace_profile_and_crlf_translation_apply_to_all_newlines() {
+        let config = ChannelConfig {
+            encoding: ChannelEncoding::Ascii,
+            profile: EncodingProfile::Replace,
+            direction: ChannelDirection::Output,
+            input_translation: OutputTranslation::Auto,
+            translation: OutputTranslation::CrLf,
+        };
+        assert_eq!(
+            encode_output("A\u{178}\nB", true, config).bytes,
+            b"A?\r\nB\r\n"
+        );
+    }
+
+    #[test]
+    fn unicode_uses_native_endian_utf16() {
+        let config = ChannelConfig {
+            encoding: ChannelEncoding::Unicode,
+            profile: EncodingProfile::Strict,
+            direction: ChannelDirection::Output,
+            input_translation: OutputTranslation::Auto,
+            translation: OutputTranslation::Lf,
+        };
+        let mut expected = Vec::new();
+        expected.extend_from_slice(&u16::from(b'A').to_ne_bytes());
+        expected.extend_from_slice(&0x0178_u16.to_ne_bytes());
+        assert_eq!(encode_output("A\u{178}", false, config).bytes, expected);
+    }
+
+    #[test]
+    fn bidirectional_translation_retains_both_directions() {
+        let mut config = ChannelConfig::file(
+            TclVersion::V9_0,
+            SystemEncoding::Utf8,
+            ChannelDirection::Bidirectional,
+        );
+        assert_eq!(config.translation_value(), "auto lf");
+        config.set_translation(TclVersion::V9_0, "cr {}").unwrap();
+        assert_eq!(config.translation_value(), "cr lf");
+        config
+            .set_translation(TclVersion::V9_0, "binary {}")
+            .unwrap();
+        assert_eq!(config.translation_value(), "lf lf");
+        assert_eq!(config.encoding, ChannelEncoding::Iso88591);
+    }
+
+    #[test]
+    fn bidirectional_translation_commits_each_direction_in_order() {
+        let mut config = ChannelConfig::file(
+            TclVersion::V9_0,
+            SystemEncoding::Utf8,
+            ChannelDirection::Bidirectional,
+        );
+        assert!(
+            config
+                .set_translation(TclVersion::V9_0, "cr invalid")
+                .is_err()
+        );
+        assert_eq!(config.translation_value(), "cr lf");
+    }
+}

--- a/rust/tcl-cmd-core/src/lib.rs
+++ b/rust/tcl-cmd-core/src/lib.rs
@@ -37,6 +37,7 @@
 
 pub mod array;
 pub mod binary;
+pub mod channel;
 pub mod clock;
 pub mod dict;
 pub mod ensemble;

--- a/rust/tcl-host-native/src/lib.rs
+++ b/rust/tcl-host-native/src/lib.rs
@@ -41,6 +41,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use tcl_platform::{
     Capabilities, Clock, Env, ExecOutput, Filesystem, Host, HostError, Metadata, Process, StdIo,
+    SystemEncoding,
 };
 
 /// The native, std-backed host. Holds its capability objects so the `Host`
@@ -111,6 +112,14 @@ impl Host for NativeHost {
         &self.env
     }
 
+    fn system_encoding(&self) -> SystemEncoding {
+        let locale = ["LC_ALL", "LC_CTYPE", "LANG"]
+            .into_iter()
+            .filter_map(|key| self.env.get(key))
+            .find(|value| !value.is_empty());
+        locale_system_encoding(locale.as_deref())
+    }
+
     fn filesystem(&self) -> Option<&dyn Filesystem> {
         self.allow_filesystem.then_some(&self.fs as &dyn Filesystem)
     }
@@ -118,6 +127,28 @@ impl Host for NativeHost {
     fn process(&self) -> Option<&dyn Process> {
         self.allow_process.then_some(&self.process as &dyn Process)
     }
+}
+
+/// Resolve the locale spellings needed by the runtimes' current encoding
+/// surface.  Tcl's Unix bootstrap treats the process `C`/`POSIX` locale as
+/// ISO-8859-1; UTF-8 locales retain UTF-8.  Other code pages remain outside
+/// the runtimes' deliberately small encoding catalogue and conservatively use
+/// UTF-8 rather than inventing a lossy mapping.
+fn locale_system_encoding(locale: Option<&str>) -> SystemEncoding {
+    let Some(locale) = locale else {
+        return SystemEncoding::Iso88591;
+    };
+    let folded = locale.to_ascii_lowercase();
+    if folded == "c" || folded == "posix" {
+        return SystemEncoding::Iso88591;
+    }
+    if folded.contains("utf-8") || folded.contains("utf8") {
+        return SystemEncoding::Utf8;
+    }
+    if folded.contains("iso8859-1") || folded.contains("iso-8859-1") {
+        return SystemEncoding::Iso88591;
+    }
+    SystemEncoding::Utf8
 }
 
 /// Map a `std::io::Error` onto the host-neutral [`HostError`].
@@ -493,6 +524,28 @@ impl Process for NativeProcess {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn system_encoding_follows_tcl_unix_locale_defaults() {
+        assert_eq!(locale_system_encoding(None), SystemEncoding::Iso88591);
+        assert_eq!(locale_system_encoding(Some("C")), SystemEncoding::Iso88591);
+        assert_eq!(
+            locale_system_encoding(Some("POSIX")),
+            SystemEncoding::Iso88591
+        );
+        assert_eq!(
+            locale_system_encoding(Some("C.UTF-8")),
+            SystemEncoding::Utf8
+        );
+        assert_eq!(
+            locale_system_encoding(Some("en_GB.utf8")),
+            SystemEncoding::Utf8
+        );
+        assert_eq!(
+            locale_system_encoding(Some("en_US.ISO-8859-1")),
+            SystemEncoding::Iso88591
+        );
+    }
 
     #[cfg(unix)]
     #[test]

--- a/rust/tcl-platform/src/lib.rs
+++ b/rust/tcl-platform/src/lib.rs
@@ -172,6 +172,39 @@ pub struct ExecOutput {
     pub stderr: Vec<u8>,
 }
 
+/// The small, host-owned system-encoding vocabulary currently implemented by
+/// the Rust runtimes.
+///
+/// Tcl initialises standard and newly-opened channels from the platform's
+/// locale-dependent system encoding.  Keeping that fact on [`Host`] prevents
+/// command adapters from each interpreting `LC_ALL`/`LC_CTYPE`/`LANG` and lets
+/// browser/WASI hosts choose their deterministic UTF-8 default explicitly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SystemEncoding {
+    /// UTF-8 (`utf-8` in Tcl's encoding catalogue).
+    Utf8,
+    /// ISO-8859-1 (`iso8859-1`), Tcl's byte-for-byte Tcl 9 binary-channel
+    /// encoding and the Unix `C`/`POSIX` locale default.
+    Iso88591,
+    /// Seven-bit ASCII.
+    Ascii,
+    /// Native-endian UTF-16 (`unicode` in Tcl's encoding catalogue).
+    Unicode,
+}
+
+impl SystemEncoding {
+    /// Canonical Tcl encoding name.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Utf8 => "utf-8",
+            Self::Iso88591 => "iso8859-1",
+            Self::Ascii => "ascii",
+            Self::Unicode => "unicode",
+        }
+    }
+}
+
 /// Whole-file and directory access. Streaming channels (the per-fd table,
 /// buffering, encoding) layer on top separately; this is the stateless
 /// surface the path/`glob`/`file` commands need.
@@ -323,6 +356,12 @@ pub trait Host {
     fn stdio(&self) -> &dyn StdIo;
     /// Environment + working directory (always present).
     fn env(&self) -> &dyn Env;
+
+    /// Locale/platform encoding used for standard and newly-opened channels.
+    /// Restricted hosts have no process locale and therefore keep UTF-8.
+    fn system_encoding(&self) -> SystemEncoding {
+        SystemEncoding::Utf8
+    }
 
     /// The filesystem, or `None` on a host without one (e.g. a no-VFS browser).
     fn filesystem(&self) -> Option<&dyn Filesystem> {

--- a/rust/tcl-registry/src/commands/tcl/fconfigure_.rs
+++ b/rust/tcl-registry/src/commands/tcl/fconfigure_.rs
@@ -33,6 +33,10 @@
 //! `chan_.rs` documents for `chan`.
 
 use crate::prelude::*;
+use tcl_cmd_core::CmdError;
+use tcl_cmd_core::channel::ConfigOption;
+use tcl_cmd_core::prefix::OptionTable;
+use tcl_dialect::DialectProfile;
 use tcl_dialect::model::SpecSurface;
 
 const FORMS: &[FormSpec] = &[FormSpec {
@@ -213,19 +217,6 @@ const OPTIONS: &[OptionSpec] = &[
         min_abbrev: None,
     },
     OptionSpec {
-        name: "-translation",
-        value: OptionValue::Takes(OptionArg {
-            values: TRANSLATION_VALUES,
-            hint: "mode",
-            ..OptionArg::DEFAULT
-        }),
-        detail: "End-of-line translation mode; also accepts a {inTranslation outTranslation} two-element list to set input and output translation independently on a read-write channel (returned as a two-element list when queried). See the value list for per-mode behaviour and defaults.",
-        surface: None,
-        aliases: &[],
-        lifecycle: Lifecycle::UNSPECIFIED,
-        min_abbrev: None,
-    },
-    OptionSpec {
         name: "-profile",
         value: OptionValue::Takes(OptionArg {
             values: PROFILE_VALUES,
@@ -235,6 +226,19 @@ const OPTIONS: &[OptionSpec] = &[
         }),
         detail: "Encoding profile controlling how conversion errors on this channel's -encoding are handled (see PROFILES in encoding(n)). Defaults to strict.",
         surface: Some(SpecSurface::TCL90_PLUS),
+        aliases: &[],
+        lifecycle: Lifecycle::UNSPECIFIED,
+        min_abbrev: None,
+    },
+    OptionSpec {
+        name: "-translation",
+        value: OptionValue::Takes(OptionArg {
+            values: TRANSLATION_VALUES,
+            hint: "mode",
+            ..OptionArg::DEFAULT
+        }),
+        detail: "End-of-line translation mode; also accepts a {inTranslation outTranslation} two-element list to set input and output translation independently on a read-write channel (returned as a two-element list when queried). See the value list for per-mode behaviour and defaults.",
+        surface: None,
         aliases: &[],
         lifecycle: Lifecycle::UNSPECIFIED,
         min_abbrev: None,
@@ -277,6 +281,44 @@ const OPTIONS: &[OptionSpec] = &[
     },
 ];
 
+fn runtime_option(name: &str) -> Option<ConfigOption> {
+    match name {
+        "-blocking" => Some(ConfigOption::Blocking),
+        "-buffering" => Some(ConfigOption::Buffering),
+        "-buffersize" => Some(ConfigOption::BufferSize),
+        "-encoding" => Some(ConfigOption::Encoding),
+        "-eofchar" => Some(ConfigOption::EofChar),
+        "-profile" => Some(ConfigOption::Profile),
+        "-translation" => Some(ConfigOption::Translation),
+        _ => None,
+    }
+}
+
+/// Resolve an `fconfigure` option from the command registry's dialect-filtered
+/// descriptors, returning the typed operation consumed by both runtimes.
+///
+/// Channel-driver-specific options remain in the registry but are excluded
+/// here until a concrete runtime channel advertises the matching driver.
+///
+/// # Errors
+/// Tcl's canonical bad/ambiguous-option result for the active profile.
+pub fn resolve_fconfigure_option(
+    profile: &'static DialectProfile,
+    word: &str,
+) -> Result<ConfigOption, CmdError> {
+    let query = Some(profile.surface_query());
+    let available: Vec<&str> = OPTIONS
+        .iter()
+        .filter(|option| {
+            runtime_option(option.name).is_some()
+                && option.supports_dialect(query, Some(SpecSurface::ALL_TCL))
+        })
+        .map(|option| option.name)
+        .collect();
+    let index = OptionTable::abbreviating("option", &available).index_of_str(word)?;
+    Ok(runtime_option(available[index]).expect("runtime option list was filtered by this mapping"))
+}
+
 pub fn spec() -> CommandSpec {
     CommandSpec {
         name: "fconfigure",
@@ -306,5 +348,26 @@ pub fn spec() -> CommandSpec {
         }),
         forms: FORMS,
         ..CommandSpec::DEFAULT
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn runtime_options_are_resolved_from_the_active_registry_surface() {
+        let tcl9 = DialectProfile::find("tcl9.0").expect("Tcl 9 profile");
+        let tcl8 = DialectProfile::find("tcl8.6").expect("Tcl 8 profile");
+        assert_eq!(
+            resolve_fconfigure_option(tcl9, "-prof"),
+            Ok(ConfigOption::Profile)
+        );
+        assert_eq!(
+            resolve_fconfigure_option(tcl8, "-prof")
+                .expect_err("Tcl 8 has no profile option")
+                .message(),
+            "bad option \"-prof\": must be -blocking, -buffering, -buffersize, -encoding, -eofchar, or -translation"
+        );
     }
 }

--- a/rust/tcl-registry/src/commands/tcl/mod.rs
+++ b/rust/tcl-registry/src/commands/tcl/mod.rs
@@ -61,6 +61,7 @@ mod exit_;
 mod expr_;
 mod fblocked;
 mod fconfigure_;
+pub use fconfigure_::resolve_fconfigure_option;
 mod fcopy;
 mod file_;
 mod fileevent;

--- a/rust/tcl-test-support/src/lib.rs
+++ b/rust/tcl-test-support/src/lib.rs
@@ -117,6 +117,7 @@ pub enum OracleError {
     InvalidOverride(String),
     InvalidInterpreter(String),
     InvalidSourceTree(String),
+    InvalidTestDefinition(String),
 }
 
 impl fmt::Display for OracleError {
@@ -125,7 +126,8 @@ impl fmt::Display for OracleError {
             Self::Io { action, source } => write!(formatter, "{action}: {source}"),
             Self::InvalidOverride(message)
             | Self::InvalidInterpreter(message)
-            | Self::InvalidSourceTree(message) => formatter.write_str(message),
+            | Self::InvalidSourceTree(message)
+            | Self::InvalidTestDefinition(message) => formatter.write_str(message),
         }
     }
 }
@@ -134,11 +136,36 @@ impl std::error::Error for OracleError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::Io { source, .. } => Some(source),
-            Self::InvalidOverride(_) | Self::InvalidInterpreter(_) | Self::InvalidSourceTree(_) => {
-                None
-            }
+            Self::InvalidOverride(_)
+            | Self::InvalidInterpreter(_)
+            | Self::InvalidSourceTree(_)
+            | Self::InvalidTestDefinition(_) => None,
         }
     }
+}
+
+/// Extract one definition from a pinned upstream Tcl test file.
+///
+/// The adjacent definition marker is part of the contract: if an upstream
+/// refresh renames, removes, or reorders either definition, the focused test
+/// fails instead of silently running a hand-copied substitute.
+pub fn upstream_test_definition<'a>(
+    source: &'a str,
+    start_marker: &str,
+    next_marker: &str,
+) -> Result<&'a str, OracleError> {
+    let Some(start) = source.find(start_marker) else {
+        return Err(OracleError::InvalidTestDefinition(format!(
+            "pinned upstream test is missing {start_marker:?}"
+        )));
+    };
+    let after_start = &source[start + start_marker.len()..];
+    let Some(relative_end) = after_start.find(next_marker) else {
+        return Err(OracleError::InvalidTestDefinition(format!(
+            "pinned upstream test after {start_marker:?} is missing adjacent marker {next_marker:?}"
+        )));
+    };
+    Ok(&source[start..start + start_marker.len() + relative_end])
 }
 
 struct ReleaseLocation {
@@ -244,6 +271,26 @@ pub fn tclsh_from_source_tree(
         )));
     }
     Ok(interpreter)
+}
+
+/// Run a script with the exact interpreter and shared library built in a
+/// validated source tree.
+///
+/// This is the execution counterpart to [`tclsh_from_source_tree`]. Tests
+/// which consume upstream definitions should use the pair as one oracle
+/// selection rather than validating against one library and later executing
+/// with whatever dynamic library lookup happens to find.
+pub fn run_script_from_source_tree(
+    source_tree: &TclSourceTree,
+    version: TclVersion,
+    script: &[u8],
+) -> Result<ScriptOutcome, OracleError> {
+    let interpreter = tclsh_from_source_tree(source_tree, version)?;
+    run_script_with_library(
+        &interpreter.path,
+        script,
+        Some(source_tree.root.join("unix").as_path()),
+    )
 }
 
 /// Every available reference interpreter, in release order.
@@ -499,7 +546,8 @@ fn which_on_path(name: &str) -> Option<PathBuf> {
 mod tests {
     use super::{
         OracleError, locate_source_tree, patchlevel_from_header, reference_patchlevel,
-        reference_source_tag, validate_reference_source_tree, validate_source_tree,
+        reference_source_tag, upstream_test_definition, validate_reference_source_tree,
+        validate_source_tree,
     };
     use std::fs;
     use std::path::{Path, PathBuf};
@@ -507,6 +555,23 @@ mod tests {
     use tcl_dialect::TclVersion;
 
     const SOURCE_ENV_CHILD: &str = "TCL_TEST_SUPPORT_SOURCE_ENV_CHILD";
+
+    #[test]
+    fn upstream_definition_is_bounded_by_its_adjacent_marker() {
+        let source = "prefix\ntest one {body}\ntest two {body}\nsuffix";
+        assert_eq!(
+            upstream_test_definition(source, "test one", "test two").expect("definition"),
+            "test one {body}\n"
+        );
+        assert!(matches!(
+            upstream_test_definition(source, "test missing", "test two"),
+            Err(OracleError::InvalidTestDefinition(_))
+        ));
+        assert!(matches!(
+            upstream_test_definition(source, "test two", "test three"),
+            Err(OracleError::InvalidTestDefinition(_))
+        ));
+    }
 
     #[test]
     fn patchlevel_is_read_from_the_c_header() {

--- a/rust/tcl-vm-cli/src/main.rs
+++ b/rust/tcl-vm-cli/src/main.rs
@@ -149,7 +149,13 @@ fn usage() {
 /// Build a VM with the compiler-backed `CompileService` and stdout host
 /// output, at the requested runtime version (`None` keeps the VM default).
 fn new_vm(version: Option<TclVersion>) -> Vm {
-    let mut vm = Vm::with_output(Box::new(Stdout));
+    configure_vm(Vm::with_output(Box::new(Stdout)), version)
+}
+
+/// Attach the compiler/runtime services to an already-created VM. Tests pass
+/// a byte capture here so Tcl-originated REPL results still travel through the
+/// VM's configured standard channel.
+fn configure_vm(mut vm: Vm, version: Option<TclVersion>) -> Vm {
     // Default to the plain-Tcl 9.0 profile; `--tcl-version <x.y>` selects
     // another release's profile. The profile is resolved once and drives
     // BOTH halves (issue #1462): the runtime semantics (below) and the
@@ -211,11 +217,11 @@ fn run_script(vm: &mut Vm, src: &str) -> i32 {
     match result {
         Ok(comp) if comp.code.is_ok() => 0,
         Ok(comp) => {
-            eprintln!("{}", comp.result.to_str());
+            vm.report_stderr_text(&comp.result.to_str());
             1
         }
         Err(e) => {
-            eprintln!("{}", e.message);
+            vm.report_stderr_text(&e.message);
             1
         }
     }
@@ -312,11 +318,15 @@ fn repl_loop<R: std::io::BufRead, W: Write>(vm: &mut Vm, reader: &mut R, out: &m
             Ok(comp) if comp.code.is_ok() => {
                 let result = comp.result.to_str();
                 if !result.is_empty() {
-                    let _ = writeln!(out, "{result}");
+                    let _ = vm.write_stdout_text(&result, true);
                 }
             }
-            Ok(comp) => eprintln!("{}", comp.result.to_str()),
-            Err(e) => eprintln!("{}", e.message),
+            Ok(comp) => {
+                vm.report_stderr_text(&comp.result.to_str());
+            }
+            Err(e) => {
+                vm.report_stderr_text(&e.message);
+            }
         }
         buffer.clear();
         let _ = write!(out, "% ");
@@ -330,6 +340,22 @@ fn repl_loop<R: std::io::BufRead, W: Write>(vm: &mut Vm, reader: &mut R, out: &m
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    #[derive(Clone)]
+    struct Capture(Rc<RefCell<Vec<u8>>>);
+
+    impl Write for Capture {
+        fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+            self.0.borrow_mut().extend_from_slice(bytes);
+            Ok(bytes.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
 
     /// Drive `repl_loop` over a canned input script and return what it wrote to
     /// `out` (prompts + results), with a fresh compiler-backed VM.
@@ -339,11 +365,14 @@ mod tests {
 
     /// [`drive`] at an explicit runtime version (the `--tcl-version` path).
     fn drive_at(input: &str, version: Option<TclVersion>) -> String {
-        let mut vm = new_vm(version);
+        let bytes = Rc::new(RefCell::new(Vec::new()));
+        let capture = Capture(Rc::clone(&bytes));
+        let mut vm = configure_vm(Vm::with_output(Box::new(capture.clone())), version);
         let mut reader = std::io::Cursor::new(input.as_bytes().to_vec());
-        let mut out: Vec<u8> = Vec::new();
+        let mut out = capture;
         repl_loop(&mut vm, &mut reader, &mut out);
-        String::from_utf8(out).expect("utf-8")
+        let output = bytes.borrow().clone();
+        String::from_utf8(output).expect("utf-8")
     }
 
     #[test]

--- a/rust/tcl-vm-cli/tests/channel_output.rs
+++ b/rust/tcl-vm-cli/tests/channel_output.rs
@@ -1,0 +1,277 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Raw-byte end-to-end tests for the shipping native `TclVM` driver.
+
+use std::process::{Command, Output};
+
+fn run(script: &str, locale: &str) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_tclvm"))
+        .args(["-c", script])
+        .env("LC_ALL", locale)
+        .output()
+        .expect("run tclvm")
+}
+
+fn run_version(script: &str, locale: &str, version: &str) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_tclvm"))
+        .args(["--tcl-version", version, "-c", script])
+        .env("LC_ALL", locale)
+        .output()
+        .expect("run versioned tclvm")
+}
+
+#[test]
+fn binary_translation_and_explicit_utf8_match_tcl_9_bytes() {
+    // Tcl 9.0.4 io-39.14/io-39.15: binary translation selects the
+    // byte-preserving ISO-8859-1 channel encoding.
+    let binary = run(
+        "fconfigure stdout -translation binary; \
+         puts -nonewline [binary format H* ff41]",
+        "C.UTF-8",
+    );
+    assert!(binary.status.success(), "{:?}", binary.stderr);
+    assert_eq!(binary.stdout, [0xff, b'A']);
+
+    let utf8 = run(
+        "fconfigure stdout -encoding utf-8 -translation lf; \
+         puts -nonewline [binary format H* ff41]",
+        "C.UTF-8",
+    );
+    assert!(utf8.status.success(), "{:?}", utf8.stderr);
+    assert_eq!(utf8.stdout, [0xc3, 0xbf, b'A']);
+}
+
+#[test]
+fn strict_profile_writes_prefix_and_reports_structured_eilseq() {
+    // Tcl 9.0.4 io-75.9: strict conversion writes the representable prefix,
+    // then raises the POSIX EILSEQ completion without appending a newline.
+    let output = run(
+        "fconfigure stdout -encoding iso8859-1 -translation lf -profile strict; \
+         set c [catch {puts -nonewline \"A\\u0178B\"} m o]; \
+         fconfigure stdout -encoding utf-8; \
+         puts -nonewline \"\\n[list $c $m [dict get $o -errorcode]]\"",
+        "C.UTF-8",
+    );
+    assert!(output.status.success(), "{:?}", output.stderr);
+    assert_eq!(
+        output.stdout,
+        b"A\n1 {error writing \"stdout\": invalid or incomplete multibyte or wide character} {POSIX EILSEQ {invalid or incomplete multibyte or wide character}}"
+    );
+}
+
+#[test]
+fn configuration_errors_keep_their_structured_tcl_identity() {
+    let output = run(
+        "catch {fconfigure stdout -profile bogus} m o; \
+         puts -nonewline [list $m [dict get $o -errorcode]]",
+        "C.UTF-8",
+    );
+    assert!(output.status.success(), "{:?}", output.stderr);
+    assert_eq!(
+        output.stdout,
+        b"{bad profile name \"bogus\": must be replace, strict, or tcl8} {TCL ENCODING PROFILE bogus}"
+    );
+}
+
+#[test]
+fn binary_open_mode_and_child_standard_channel_configuration_persist() {
+    let output = run(
+        "set f [open /dev/stdout wb]; \
+         puts -nonewline $f [binary format H* ff]; close $f; \
+         set f [open /dev/stdout {WRONLY {BINARY}}]; \
+         puts -nonewline $f [binary format H* ff]; close $f; \
+         interp create child; \
+         child eval {fconfigure stdout -translation binary}; \
+         puts -nonewline [binary format H* ff]",
+        "C.UTF-8",
+    );
+    assert!(output.status.success(), "{:?}", output.stderr);
+    assert_eq!(output.stdout, [0xff, 0xff, 0xff]);
+}
+
+#[test]
+fn open_access_validation_tracks_the_runtime_release() {
+    let malformed_nine = run(
+        "set m \"\\{RDONLY\"; catch {open /dev/null $m} msg opts; \
+         puts -nonewline [dict get $opts -errorcode]",
+        "C.UTF-8",
+    );
+    assert!(
+        malformed_nine.status.success(),
+        "{:?}",
+        malformed_nine.stderr
+    );
+    assert_eq!(malformed_nine.stdout, b"TCL OPENMODE INVALID");
+
+    let repeated_eight = run_version(
+        "set f [open /dev/null {RDONLY WRONLY}]; \
+         puts -nonewline $f x; close $f; puts -nonewline ok",
+        "C.UTF-8",
+        "8.6",
+    );
+    assert!(
+        repeated_eight.status.success(),
+        "{:?}",
+        repeated_eight.stderr
+    );
+    assert_eq!(repeated_eight.stdout, b"ok");
+
+    let malformed_eight = run_version(
+        "set m \"\\{RDONLY\"; catch {open /dev/null $m} msg opts; \
+         puts -nonewline [dict get $opts -errorcode]",
+        "C.UTF-8",
+        "8.6",
+    );
+    assert!(
+        malformed_eight.status.success(),
+        "{:?}",
+        malformed_eight.stderr
+    );
+    assert_eq!(malformed_eight.stdout, b"TCL VALUE LIST BRACE");
+}
+
+#[test]
+fn mutable_system_encoding_is_shared_and_only_seeds_future_channels() {
+    let path = format!("/tmp/tclvm-system-{}", std::process::id());
+    let script = format!(
+        "set path {path}; \
+         set before [fconfigure stdout -encoding]; \
+         encoding system iso8859-1; \
+         interp create child; \
+         set childSystem [child eval {{encoding system}}]; \
+         set f [open $path w]; set opened [fconfigure $f -encoding]; \
+         puts -nonewline $f [binary format H* ff]; close $f; \
+         puts -nonewline [list $before [fconfigure stdout -encoding] \
+             $childSystem $opened]"
+    );
+    let output = run(&script, "C.UTF-8");
+    assert!(output.status.success(), "{:?}", output.stderr);
+    assert_eq!(output.stdout, b"utf-8 utf-8 iso8859-1 iso8859-1");
+    assert_eq!(std::fs::read(&path).expect("read encoded file"), [0xff]);
+    std::fs::remove_file(path).expect("remove encoded file");
+}
+
+#[test]
+fn binary_configuration_is_queried_and_worker_output_is_encoded_before_sharing() {
+    let query = run(
+        "fconfigure stdout -profile replace -encoding utf-8 -translation crlf; \
+         fconfigure stdout -translation binary; \
+         puts -nonewline [list [fconfigure stdout -encoding] \
+             [fconfigure stdout -translation] [fconfigure stdout -profile] \
+             [fconfigure stdout -eofchar]]",
+        "C.UTF-8",
+    );
+    assert!(query.status.success(), "{:?}", query.stderr);
+    assert_eq!(query.stdout, b"iso8859-1 lf replace {}");
+
+    let worker = run(
+        "set w [thread::create]; \
+         thread::send $w {fconfigure stdout -translation binary; \
+             puts -nonewline [binary format H* ff41]}; \
+         thread::release $w",
+        "C.UTF-8",
+    );
+    assert!(worker.status.success(), "{:?}", worker.stderr);
+    assert_eq!(worker.stdout, [0xff, b'A']);
+}
+
+#[test]
+fn c_locale_bootstrap_and_stderr_defaults_match_tcl_9() {
+    let c_locale = run("puts -nonewline [binary format H* ff41]", "C");
+    assert!(c_locale.status.success(), "{:?}", c_locale.stderr);
+    assert_eq!(c_locale.stdout, [0xff, b'A']);
+
+    let utf8_locale = run("puts -nonewline [binary format H* ff41]", "C.UTF-8");
+    assert!(utf8_locale.status.success(), "{:?}", utf8_locale.stderr);
+    assert_eq!(utf8_locale.stdout, [0xc3, 0xbf, b'A']);
+
+    let stderr = run(
+        "fconfigure stderr -encoding iso8859-1; \
+         puts -nonewline stderr \"A\\u0178B\"",
+        "C.UTF-8",
+    );
+    assert!(stderr.status.success(), "{:?}", stderr.stderr);
+    assert!(stderr.stdout.is_empty());
+    assert_eq!(stderr.stderr, b"A?B");
+}
+
+#[test]
+fn cli_errors_observe_mutated_standard_error_translation() {
+    let output = run(
+        "fconfigure stderr -translation crlf; error \"bad\\nthing\"",
+        "C.UTF-8",
+    );
+    assert_eq!(output.status.code(), Some(1));
+    assert!(output.stdout.is_empty());
+    assert_eq!(output.stderr, b"bad\r\nthing\r\n");
+}
+
+#[test]
+fn cli_strict_stderr_conversion_reports_tcl_fallback_marker() {
+    let output = run(
+        "fconfigure stderr -encoding iso8859-1 -translation crlf -profile strict; \
+         error \"A\\u0178B\"",
+        "C.UTF-8",
+    );
+    assert_eq!(output.status.code(), Some(1));
+    assert!(output.stdout.is_empty());
+    assert_eq!(output.stderr, b"A\r\n\t(encoding error in stderr)\r\n");
+}
+
+#[test]
+fn background_errors_observe_mutated_standard_error_translation() {
+    let output = run(
+        "interp bgerror {}; fconfigure stderr -translation crlf; \
+         after 0 {error \"bad\\nthing\"}; update",
+        "C.UTF-8",
+    );
+    assert!(output.status.success(), "{:?}", output.stderr);
+    assert!(
+        output.stderr.windows(2).any(|pair| pair == b"\r\n"),
+        "background error did not use CRLF: {:?}",
+        output.stderr
+    );
+    assert!(
+        output
+            .stderr
+            .iter()
+            .enumerate()
+            .all(|(index, byte)| *byte != b'\n' || index > 0 && output.stderr[index - 1] == b'\r'),
+        "background error bypassed channel translation: {:?}",
+        output.stderr
+    );
+    assert!(
+        output.stderr.ends_with(b"    (\"after\" script)\r\n"),
+        "unexpected background error: {:?}",
+        output.stderr
+    );
+}
+
+#[test]
+fn background_strict_stderr_conversion_reports_tcl_fallback_marker() {
+    let output = run(
+        "interp bgerror {}; \
+         fconfigure stderr -encoding iso8859-1 -translation crlf -profile strict; \
+         after 0 {error \"A\\u0178B\"}; update",
+        "C.UTF-8",
+    );
+    assert!(output.status.success(), "{:?}", output.stderr);
+    assert!(output.stdout.is_empty());
+    assert_eq!(output.stderr, b"A\r\n\t(encoding error in stderr)\r\n");
+}

--- a/rust/tcl-vm/src/cmd_chan.rs
+++ b/rust/tcl-vm/src/cmd_chan.rs
@@ -29,17 +29,44 @@
 use std::fs::OpenOptions;
 use std::io::Write as _;
 
+use tcl_cmd_core::CmdError;
+use tcl_cmd_core::channel::{
+    ChannelConfig, channel_output_error, config_list, config_value, encode_output,
+    is_standard_channel, resolve_open_access_mode, set_config_value,
+};
 use tcl_runtime_api::Completion;
 
+use crate::command::completion_from_cmd_error;
 use crate::interp::{Vm, err, ok};
 use crate::value::Value;
 
 /// An open file channel.
 pub(crate) enum Channel {
     /// A readable channel: whole-file contents with a byte cursor.
-    Read { data: Vec<u8>, pos: usize },
+    Read {
+        data: Vec<u8>,
+        pos: usize,
+        config: ChannelConfig,
+    },
     /// A writable (create/truncate or append) channel.
-    Write(std::fs::File),
+    Write {
+        file: std::fs::File,
+        config: ChannelConfig,
+    },
+}
+
+impl Channel {
+    fn config(&self) -> ChannelConfig {
+        match self {
+            Self::Read { config, .. } | Self::Write { config, .. } => *config,
+        }
+    }
+
+    fn set_config(&mut self, replacement: ChannelConfig) {
+        match self {
+            Self::Read { config, .. } | Self::Write { config, .. } => *config = replacement,
+        }
+    }
 }
 
 pub(crate) fn register(vm: &mut Vm) {
@@ -68,36 +95,37 @@ fn cmd_open(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     if name.starts_with('|') {
         return err("command pipelines are not supported");
     }
-    // Normalise an access-flag list (`{RDWR CREAT}`) down to the leading mode
-    // character set; the simple string forms map directly.
     let m = mode.trim();
-    let read = m.starts_with('r') || m.contains('+') || m.contains("RD");
-    let truncate = m.starts_with('w') || m.contains("TRUNC");
-    let append = m.starts_with('a') || m.contains("APPEND");
-    let writing = truncate || append || m.contains('+') || m.contains("WR");
+    let version = vm.runtime_version();
+    let access = match resolve_open_access_mode(version, m) {
+        Ok(access) => access,
+        Err(error) => return completion_from_cmd_error(error),
+    };
+    let config = ChannelConfig::for_open_access(version, vm.system_encoding(), access);
 
-    if read && !writing {
+    if access.is_readable() && !access.is_writable() {
         match std::fs::read(&name) {
             Ok(data) => {
-                let id = vm.add_channel(Channel::Read { data, pos: 0 });
+                let id = vm.add_channel(Channel::Read {
+                    data,
+                    pos: 0,
+                    config,
+                });
                 ok(Value::string(id))
             }
             Err(e) => err(format!("couldn't open \"{name}\": {}", io_reason(&e))),
         }
     } else {
         let mut opts = OpenOptions::new();
-        opts.write(true).create(true);
-        if append {
-            opts.append(true);
-        } else if truncate {
-            opts.truncate(true);
-        }
-        if read {
-            opts.read(true);
-        }
+        opts.read(access.is_readable())
+            .write(access.is_writable())
+            .append(access.appends())
+            .truncate(access.truncates())
+            .create(access.creates())
+            .create_new(access.creates() && access.is_exclusive());
         match opts.open(&name) {
             Ok(file) => {
-                let id = vm.add_channel(Channel::Write(file));
+                let id = vm.add_channel(Channel::Write { file, config });
                 ok(Value::string(id))
             }
             Err(e) => err(format!("couldn't open \"{name}\": {}", io_reason(&e))),
@@ -150,7 +178,7 @@ fn cmd_gets(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
         };
     }
     let line = match vm.channel_mut(&id) {
-        Some(Channel::Read { data, pos }) => {
+        Some(Channel::Read { data, pos, .. }) => {
             if *pos >= data.len() {
                 None
             } else {
@@ -169,7 +197,7 @@ fn cmd_gets(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
                 Some(s)
             }
         }
-        Some(Channel::Write(_)) => {
+        Some(Channel::Write { .. }) => {
             return err(format!("channel \"{id}\" wasn't opened for reading"));
         }
         None => return err(format!("can not find channel named \"{id}\"")),
@@ -216,7 +244,7 @@ fn cmd_read(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
         return ok(Value::string(""));
     }
     match vm.channel_mut(&id) {
-        Some(Channel::Read { data, pos }) => {
+        Some(Channel::Read { data, pos, .. }) => {
             let start = *pos;
             let end = match count {
                 Some(n) if n >= 0 => (start + usize::try_from(n).unwrap_or(0)).min(data.len()),
@@ -230,7 +258,7 @@ fn cmd_read(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
             *pos = end;
             ok(Value::string(s))
         }
-        Some(Channel::Write(_)) => err(format!("channel \"{id}\" wasn't opened for reading")),
+        Some(Channel::Write { .. }) => err(format!("channel \"{id}\" wasn't opened for reading")),
         None => err(format!("can not find channel named \"{id}\"")),
     }
 }
@@ -244,8 +272,8 @@ fn cmd_eof(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
         return ok(Value::bool(&*id == "stdin"));
     }
     match vm.channel_mut(&id) {
-        Some(Channel::Read { data, pos }) => ok(Value::bool(*pos >= data.len())),
-        Some(Channel::Write(_)) => ok(Value::bool(false)),
+        Some(Channel::Read { data, pos, .. }) => ok(Value::bool(*pos >= data.len())),
+        Some(Channel::Write { .. }) => ok(Value::bool(false)),
         None => err(format!("can not find channel named \"{id}\"")),
     }
 }
@@ -259,8 +287,8 @@ fn cmd_flush(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
         return ok(Value::empty());
     }
     match vm.channel_mut(&id) {
-        Some(Channel::Write(f)) => {
-            let _ = f.flush();
+        Some(Channel::Write { file, .. }) => {
+            let _ = file.flush();
             ok(Value::empty())
         }
         Some(Channel::Read { .. }) => ok(Value::empty()),
@@ -297,7 +325,7 @@ fn cmd_seek(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
         }
         _ => return err("wrong # args: should be \"seek channelId offset ?origin?\""),
     };
-    if let Some(Channel::Read { data, pos }) = vm.channel_mut(&id) {
+    if let Some(Channel::Read { data, pos, .. }) = vm.channel_mut(&id) {
         let base = match origin {
             1 => i64::try_from(*pos).unwrap_or(0),
             2 => i64::try_from(data.len()).unwrap_or(0),
@@ -309,65 +337,115 @@ fn cmd_seek(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     ok(Value::empty())
 }
 
-/// `fconfigure channelId ?option ?value?? ...` — channel options are accepted
-/// but not modelled; getters return conventional defaults.
-fn cmd_fconfigure(_vm: &mut Vm, args: &[Value]) -> Completion<Value> {
-    let Some((_chan, rest)) = args.split_first() else {
+/// `fconfigure channelId ?option ?value?? ...` — retain the options that
+/// affect byte output; conventional non-output options remain accepted.
+fn cmd_fconfigure(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
+    let Some((chan, rest)) = args.split_first() else {
         return err("wrong # args: should be \"fconfigure channelId ?-option value ...?\"");
     };
+    let id = chan.to_str().to_string();
+    let Some(mut config) = channel_config(vm, &id) else {
+        return err(format!("can not find channel named \"{id}\""));
+    };
+    let version = vm.runtime_version();
     match rest {
-        // Query all options: return a small conventional set.
-        [] => ok(Value::string(
-            "-blocking 1 -buffering full -encoding utf-8 -translation lf",
-        )),
-        // Query one option.
-        [opt] => ok(Value::string(match &*opt.to_str() {
-            "-blocking" => "1",
-            "-buffering" => "full",
-            "-buffersize" => "4096",
-            "-encoding" => "utf-8",
-            "-translation" => "lf",
-            // `-eofchar` and any unmodelled option report empty.
-            _ => "",
-        })),
-        // Setting one or more options: accepted, no-op.
-        _ => ok(Value::empty()),
+        [] => ok(Value::string(config_list(version, &id, config))),
+        [opt] => {
+            let option = match tcl_registry::commands::tcl::resolve_fconfigure_option(
+                vm.dialect_profile(),
+                &opt.to_str(),
+            ) {
+                Ok(option) => option,
+                Err(error) => return completion_from_cmd_error(error),
+            };
+            ok(Value::string(config_value(option, &id, config)))
+        }
+        values if values.len() % 2 == 0 => {
+            for pair in values.as_chunks::<2>().0 {
+                let option = match tcl_registry::commands::tcl::resolve_fconfigure_option(
+                    vm.dialect_profile(),
+                    &pair[0].to_str(),
+                ) {
+                    Ok(option) => option,
+                    Err(error) => return completion_from_cmd_error(error),
+                };
+                let configured = set_config_value(version, &mut config, option, &pair[1].to_str());
+                // Tcl preserves any direction changed before a later
+                // direction of the same translation value reports an error.
+                set_channel_config(vm, &id, config);
+                if let Err(error) = configured {
+                    return completion_from_cmd_error(error);
+                }
+            }
+            ok(Value::empty())
+        }
+        _ => err("wrong # args: should be \"fconfigure channelId ?-option value ...?\""),
+    }
+}
+
+fn channel_config(vm: &Vm, id: &str) -> Option<ChannelConfig> {
+    if is_std(id) {
+        vm.standard_channels.borrow().get(id)
+    } else {
+        vm.channel(id).map(Channel::config)
+    }
+}
+
+fn set_channel_config(vm: &mut Vm, id: &str, config: ChannelConfig) {
+    if is_std(id) {
+        let _ = vm.standard_channels.borrow_mut().set(id, config);
+    } else if let Some(channel) = vm.channel_mut(id) {
+        channel.set_config(config);
     }
 }
 
 /// True for a predefined standard channel name.
 pub(crate) fn is_std(id: &str) -> bool {
-    matches!(id, "stdin" | "stdout" | "stderr")
+    is_standard_channel(id)
 }
 
 /// Write `text` (optionally with a trailing newline) to channel `id`. Used by
 /// `puts`. Standard channels follow the VM's output / process stderr.
-pub(crate) fn chan_puts(vm: &mut Vm, id: &str, text: &str, newline: bool) -> Result<(), String> {
+pub(crate) fn chan_puts(vm: &mut Vm, id: &str, text: &str, newline: bool) -> Result<(), CmdError> {
+    if id == "stdin" {
+        return Err(CmdError::new("channel \"stdin\" wasn't opened for writing"));
+    }
+    let Some(config) = channel_config(vm, id) else {
+        return Err(CmdError::new(format!(
+            "can not find channel named \"{id}\""
+        )));
+    };
+    let encoded = encode_output(text, newline, config);
     match id {
-        "stdout" => {
-            vm.write_output(text, newline);
-            Ok(())
-        }
+        "stdout" => vm
+            .write_output_bytes(&encoded.bytes)
+            .map_err(|error| write_error(id, &error))?,
         "stderr" => {
-            eprint!("{text}");
-            if newline {
-                eprintln!();
-            }
-            Ok(())
+            vm.host().stdio().write_stderr(&encoded.bytes);
+            vm.host().stdio().flush_stderr();
         }
-        "stdin" => Err("channel \"stdin\" wasn't opened for writing".to_string()),
         _ => match vm.channel_mut(id) {
-            Some(Channel::Write(f)) => {
-                let _ = f.write_all(text.as_bytes());
-                if newline {
-                    let _ = f.write_all(b"\n");
-                }
-                Ok(())
-            }
+            Some(Channel::Write { file, .. }) => file
+                .write_all(&encoded.bytes)
+                .map_err(|error| write_error(id, &error))?,
             Some(Channel::Read { .. }) => {
-                Err(format!("channel \"{id}\" wasn't opened for writing"))
+                return Err(CmdError::new(format!(
+                    "channel \"{id}\" wasn't opened for writing"
+                )));
             }
-            None => Err(format!("can not find channel named \"{id}\"")),
+            None => {
+                return Err(CmdError::new(format!(
+                    "can not find channel named \"{id}\""
+                )));
+            }
         },
     }
+    if let Some(error) = encoded.error {
+        return Err(channel_output_error(id, error));
+    }
+    Ok(())
+}
+
+fn write_error(id: &str, error: &std::io::Error) -> CmdError {
+    CmdError::new(format!("error writing \"{id}\": {error}"))
 }

--- a/rust/tcl-vm/src/cmd_event.rs
+++ b/rust/tcl-vm/src/cmd_event.rs
@@ -343,7 +343,7 @@ fn report_bg_error(vm: &mut Vm, message: &str) {
         return;
     }
     let info = vm.take_error_info().unwrap_or_else(|| message.to_string());
-    eprintln!("{info}\n    (\"after\" script)");
+    vm.report_stderr_text(&format!("{info}\n    (\"after\" script)"));
 }
 
 // -- helpers ---------------------------------------------------------------

--- a/rust/tcl-vm/src/command.rs
+++ b/rust/tcl-vm/src/command.rs
@@ -25,11 +25,12 @@
 
 use std::rc::Rc;
 
+use tcl_cmd_core::CmdError;
 use tcl_runtime_api::{Code, Completion};
 use tcl_syntax::formal_params::{has_trailing_args, parse_formal_parameters};
 
 use crate::error::TclError;
-use crate::interp::{Vm, canonical_ns_name, err, key_holder_and_tail_unrooted, ok};
+use crate::interp::{Vm, canonical_ns_name, err, err_wrong_args, key_holder_and_tail_unrooted, ok};
 use crate::value::Value;
 
 /// A native builtin: receives argv *without* the command name (Tcl's `objv[1..]`).
@@ -1202,7 +1203,7 @@ fn cmd_puts(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     };
     match crate::cmd_chan::chan_puts(vm, &channel, &text, newline) {
         Ok(()) => ok(Value::empty()),
-        Err(e) => err(e),
+        Err(error) => completion_from_cmd_error(error),
     }
 }
 
@@ -1374,6 +1375,15 @@ pub(crate) fn options_dict(code: Code, level: i64, extra: &[(&str, Value)]) -> V
 pub(crate) fn err_with_code(message: impl Into<String>, code: &str) -> Completion<Value> {
     let options = options_dict(Code::Error, 0, &[("-errorcode", Value::string(code))]);
     Completion::new(Code::Error, Value::string(message.into()), options)
+}
+
+/// Convert a portable command-layer error without losing its Tcl identity.
+pub(crate) fn completion_from_cmd_error(error: CmdError) -> Completion<Value> {
+    let (message, code) = error.into_parts();
+    match code {
+        Some(code) => err_with_code(message, &code),
+        None => err(message),
+    }
 }
 
 /// An `ERROR` completion carrying a structured Tcl lookup error code.
@@ -1710,11 +1720,12 @@ fn cmd_time(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
 }
 
 /// `encoding subcommand ?arg …?` — matches the tree-walking runtime
-/// (`runtime/rust`): the internal string model is
-/// UTF-8, so `convertto`/`convertfrom` pass the data through unchanged, `system`
-/// reports `utf-8`, `names` lists the supported set, and `dirs` is accepted and
-/// ignored (no encoding-file search). This is a documented simplification — real
-/// codepage conversion (cp1252, shiftjis, …) is not implemented on either side.
+/// (`runtime/rust`): the internal string model is UTF-8, so
+/// `convertto`/`convertfrom` pass the data through unchanged, `system` reports
+/// the host's typed locale fact, `names` lists the supported channel encodings,
+/// and `dirs` is accepted and ignored (no encoding-file search). This is a
+/// documented simplification — real codepage conversion (cp1252, shiftjis, …)
+/// is not implemented on either side.
 /// `encoding`'s subcommand set, alphabetical as `TclMakeEnsemble` sorts it.
 /// 9.0's table also carries `profiles` and `user`, which need the encoding
 /// machinery this engine does not model; like its other ensembles it names
@@ -1748,7 +1759,23 @@ fn cmd_encoding(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
         };
     match canon {
         "dirs" => ok(Value::empty()),
-        "system" => ok(Value::string("utf-8")),
+        "system" => match args {
+            [_] => ok(Value::string(vm.system_encoding().as_str())),
+            [_, value] => match tcl_cmd_core::channel::resolve_system_encoding(&value.to_str()) {
+                Ok(encoding) => {
+                    vm.set_system_encoding(encoding);
+                    ok(Value::empty())
+                }
+                Err(error) => {
+                    let (message, code) = error.into_parts();
+                    match code {
+                        Some(code) => err_with_code(message, &code),
+                        None => err(message),
+                    }
+                }
+            },
+            _ => err_wrong_args("encoding system ?encoding?"),
+        },
         "names" => ok(Value::string("utf-8 unicode ascii iso8859-1")),
         // Unreachable: `ENCODING_SUBS` has exactly these five names.
         _ => {

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -545,6 +545,13 @@ pub struct Vm {
     /// an interp boundary, exactly as C Tcl's non-NRE cross-interp eval
     /// (tclsh-pinned).
     pub(crate) activation_depth: usize,
+    /// Mutable standard-channel handles shared by every interpreter in this
+    /// VM, just like the process-wide handles in C Tcl.
+    pub(crate) standard_channels: RefCell<tcl_cmd_core::channel::StandardChannelConfigs>,
+    /// Mutable `encoding system` state shared by the interpreter tree. The
+    /// host supplies its initial value; changing it affects only channels
+    /// opened afterwards.
+    system_encoding: tcl_platform::SystemEncoding,
     /// Cross-interp alias records for the target-death sweep. Appended when a
     /// [`Command::CrossAlias`] registers; entries are validated lazily at
     /// sweep time (a stale entry — alias since removed or source dead — is
@@ -1123,7 +1130,7 @@ pub struct InterpState {
     ns_script_frames: Vec<usize>,
     // Shared with child interpreters (`interp create`): a child writes `puts`
     // output to the same sink and compiles dynamic scripts with the same
-    // (stateless) compile service, so both are `Rc` rather than owned.
+    // (stateless) compile service, so these are `Rc` rather than owned.
     out: Rc<RefCell<Box<dyn Write>>>,
     compiler: Option<Rc<dyn CompileService<Module = ModuleAsm>>>,
     /// Optional debug hook fired once per source command (the execution-control
@@ -1629,11 +1636,12 @@ impl Vm {
     /// availability point becomes the builtin command-surface filter
     /// ([`Self::builtin_command_visible_for_surface`]).
     pub fn set_dialect_profile(&mut self, profile: &'static tcl_dialect::DialectProfile) {
+        let profile_changed = !std::ptr::eq(self.dialect_profile, profile);
         // The 8.4 `namespace path` tier gate (M10.1) and the availability
         // gate change resolution outcomes, so the command-resolution memo
         // (M16.4) must not survive a version flip.
         self.bump_cmd_epoch();
-        if !std::ptr::eq(self.dialect_profile, profile) {
+        if profile_changed {
             self.profile_generation = self.profile_generation.wrapping_add(1);
             // Dynamic modules and their precompiled-proc sidecars may contain
             // profile-sensitive lowerings. ProcDef retains source and is
@@ -1650,6 +1658,14 @@ impl Vm {
         self.profile_registry =
             (!profile.is_fallback()).then(|| crate::environment::store_for_profile(profile));
         self.runtime_version = profile.vm_runtime_version;
+        // Standard channels are VM-wide handles shared by the interpreter
+        // tree. Only a real profile change on the root establishes new
+        // release defaults: pinning a child must not replace the parent's
+        // live `fconfigure` state, and re-pinning the root to the same profile
+        // is not a channel lifecycle event.
+        if self.cur == ROOT_INTERP && profile_changed {
+            self.reset_standard_channel_configs();
+        }
         // Install the release's numeric grammar for this runtime: `0755` is 493
         // under 8.6 and 755 under 9.0, `0b`/`0o` exist from 8.5 and `0d` / `_`
         // separators from 9.0. C settles this at build time (`KILL_OCTAL`), so
@@ -1843,9 +1859,15 @@ impl Vm {
     /// A VM writing to an already-shared output sink.
     fn with_shared_output(out: Rc<RefCell<Box<dyn Write>>>) -> Self {
         static NEXT_VM_OWNER: AtomicU64 = AtomicU64::new(1);
+        let state = Box::new(InterpState::fresh(out));
+        let standard_channels = RefCell::new(tcl_cmd_core::channel::StandardChannelConfigs::new(
+            state.runtime_version,
+            state.host.system_encoding(),
+        ));
+        let system_encoding = state.host.system_encoding();
         let mut vm = Self {
             owner_nonce: NEXT_VM_OWNER.fetch_add(1, Ordering::Relaxed),
-            state: Box::new(InterpState::fresh(out)),
+            state,
             cur: ROOT_INTERP,
             interps: vec![InterpSlot {
                 parked: None,
@@ -1854,6 +1876,8 @@ impl Vm {
                 parent: None,
             }],
             activation_depth: 0,
+            standard_channels,
+            system_encoding,
             alias_backrefs: Vec::new(),
         };
         register_builtins(&mut vm);
@@ -2599,7 +2623,15 @@ impl Vm {
     /// [`NativeHost::sandboxed`](crate::host_native::NativeHost::sandboxed) to exercise
     /// the WASM-posture "unsupported" paths natively.
     pub fn set_host(&mut self, host: Rc<dyn Host>) {
+        let system_encoding = host.system_encoding();
         self.host = host;
+        // A child has its own host capability object but shares the VM's
+        // standard channel handles. Replacing a child's host therefore must
+        // not reset configuration established by the root or another child.
+        if self.cur == ROOT_INTERP {
+            self.system_encoding = system_encoding;
+            self.reset_standard_channel_configs();
+        }
         self.rebootstrap_host_globals();
         if self.is_safe {
             self.scrub_host_globals_for_safe();
@@ -10486,13 +10518,65 @@ impl Vm {
         self.write_scalar_from(0, "::errorInfo", Value::string(info));
     }
 
-    pub(crate) fn write_output(&mut self, s: &str, newline: bool) {
+    fn reset_standard_channel_configs(&mut self) {
+        *self.standard_channels.borrow_mut() = tcl_cmd_core::channel::StandardChannelConfigs::new(
+            self.runtime_version,
+            self.system_encoding,
+        );
+    }
+
+    /// The current `encoding system` value shared by this VM's interpreter
+    /// tree.
+    #[must_use]
+    pub(crate) const fn system_encoding(&self) -> tcl_platform::SystemEncoding {
+        self.system_encoding
+    }
+
+    /// Set the system encoding used by channels opened in the future. Existing
+    /// standard and file channel handles retain their current configuration.
+    pub(crate) fn set_system_encoding(&mut self, encoding: tcl_platform::SystemEncoding) {
+        self.system_encoding = encoding;
+    }
+
+    pub(crate) fn write_output_bytes(&mut self, bytes: &[u8]) -> io::Result<()> {
         let mut out = self.out.borrow_mut();
-        let _ = out.write_all(s.as_bytes());
-        if newline {
-            let _ = out.write_all(b"\n");
+        out.write_all(bytes)?;
+        out.flush()
+    }
+
+    /// Write Tcl-originated text through the mutable `stdout` channel.
+    /// Embedders and CLI adapters use this instead of bypassing `fconfigure`.
+    ///
+    /// # Errors
+    /// A channel conversion or raw sink failure.
+    pub fn write_stdout_text(
+        &mut self,
+        text: &str,
+        newline: bool,
+    ) -> Result<(), tcl_cmd_core::CmdError> {
+        crate::cmd_chan::chan_puts(self, "stdout", text, newline)
+    }
+
+    /// Write Tcl-originated diagnostics through the mutable `stderr` channel.
+    ///
+    /// # Errors
+    /// A channel conversion failure.
+    pub fn write_stderr_text(
+        &mut self,
+        text: &str,
+        newline: bool,
+    ) -> Result<(), tcl_cmd_core::CmdError> {
+        crate::cmd_chan::chan_puts(self, "stderr", text, newline)
+    }
+
+    /// Report a diagnostic through `stderr`, including Tcl's fallback marker
+    /// when strict channel conversion can write only a representable prefix.
+    /// The marker itself takes the configured newline translation, just like
+    /// Tcl's `Tcl_Main` and background-error reporter.
+    pub fn report_stderr_text(&mut self, text: &str) {
+        if self.write_stderr_text(text, true).is_err() {
+            let _ = self.write_stderr_text("\n\t(encoding error in stderr)", true);
         }
-        let _ = out.flush();
     }
 
     /// Register a freshly opened channel, returning its minted id (`file3`, …).
@@ -10507,6 +10591,11 @@ impl Vm {
     /// std channels, which callers handle by name).
     pub(crate) fn channel_mut(&mut self, id: &str) -> Option<&mut crate::cmd_chan::Channel> {
         self.channels.get_mut(id)
+    }
+
+    /// Borrow an open channel by id without mutating its handle.
+    pub(crate) fn channel(&self, id: &str) -> Option<&crate::cmd_chan::Channel> {
+        self.channels.get(id)
     }
 
     /// Close and drop a channel by id, returning `true` if it existed.
@@ -11329,6 +11418,55 @@ mod family_b_tests {
         let completion = vm.eval_source(script).expect("script compiles");
         assert_eq!(completion.code, Code::Ok, "{script}: {completion:?}");
         completion.result.to_str().to_string()
+    }
+
+    #[test]
+    fn only_a_changed_root_profile_reestablishes_standard_channel_defaults() {
+        let mut vm = Vm::new();
+        vm.set_compiler(Box::new(BytecodeCompileService::default()));
+        let v90 = tcl_registry::model::ingress::resolve_environment("tcl9.0").analyser_profile();
+        let v86 = tcl_registry::model::ingress::resolve_environment("tcl8.6").analyser_profile();
+        vm.set_dialect_profile(v90);
+
+        assert_eq!(
+            eval_value(
+                &mut vm,
+                "fconfigure stdout -encoding ascii -translation crlf -profile replace; \
+                 list [fconfigure stdout -encoding] [fconfigure stdout -translation] \
+                      [fconfigure stdout -profile]",
+            ),
+            "ascii crlf replace"
+        );
+
+        vm.set_dialect_profile(v90);
+        assert_eq!(
+            eval_value(
+                &mut vm,
+                "list [fconfigure stdout -encoding] [fconfigure stdout -translation] \
+                      [fconfigure stdout -profile]",
+            ),
+            "ascii crlf replace",
+            "re-pinning the root to the same profile reset live channel state"
+        );
+
+        let child = vm.create_child(Some("child".to_owned()), false);
+        assert!(vm.set_child_dialect_profile(&child, v86));
+        assert_eq!(
+            eval_value(
+                &mut vm,
+                "list [fconfigure stdout -encoding] [fconfigure stdout -translation] \
+                      [fconfigure stdout -profile]",
+            ),
+            "ascii crlf replace",
+            "pinning a child profile reset the VM-wide standard channel"
+        );
+
+        vm.set_dialect_profile(v86);
+        assert_eq!(
+            eval_value(&mut vm, "fconfigure stdout -translation"),
+            "lf",
+            "changing the root profile did not establish release defaults"
+        );
     }
 
     fn prepare_stale_hidden_proc(vm: &mut Vm) {

--- a/rust/tcl-vm/tests/run_script.rs
+++ b/rust/tcl-vm/tests/run_script.rs
@@ -1667,11 +1667,20 @@ fn set_inline_cmd_subst_expand() {
 
 /// `encoding` — matches the tree-walking runtime (`runtime/rust`): UTF-8
 /// internal model, so `convertto`/`convertfrom` pass data
-/// through, `system` is `utf-8`, `names` lists the supported set, `dirs` is
-/// ignored. (Real codepage conversion is unimplemented on both sides.)
+/// through, `system` retains the mutable channel default, `names` lists the
+/// supported set, and `dirs` is ignored. (Additional codepages remain
+/// unimplemented on both sides.)
 #[test]
 fn encoding_command() {
     assert_eq!(run("encoding system").1, "utf-8");
+    assert_eq!(
+        run("list [encoding system] [encoding system iso8859-1] [encoding system]").1,
+        "utf-8 {} iso8859-1"
+    );
+    assert_eq!(
+        run("encoding system ascii; encoding system {}; encoding system").1,
+        "iso8859-1"
+    );
     assert_eq!(run("encoding names").1, "utf-8 unicode ascii iso8859-1");
     assert_eq!(run("encoding convertto utf-8 abc").1, "abc");
     assert_eq!(run("encoding convertfrom utf-8 hello").1, "hello");

--- a/rust/tcl-vm/tests/tcltest_load.rs
+++ b/rust/tcl-vm/tests/tcltest_load.rs
@@ -30,7 +30,7 @@ use std::time::Duration;
 
 use tcl_compiler::compile_service::BytecodeCompileService;
 use tcl_dialect::{DialectProfile, TclVersion};
-use tcl_test_support::locate_source_tree;
+use tcl_test_support::{locate_source_tree, upstream_test_definition};
 use tcl_vm::{Value, Vm};
 
 fn configure_vm(mut vm: Vm, library: &Path) -> Vm {
@@ -47,23 +47,6 @@ fn configure_vm(mut vm: Vm, library: &Path) -> Vm {
 
 fn vm_for_library(library: &Path) -> Vm {
     configure_vm(Vm::new(), library)
-}
-
-/// Return one upstream Tcltest definition without re-stating its Tcl in this
-/// harness. The adjacent test marker guards the pinned-file shape as well as
-/// keeping execution limited to the selected definition.
-fn upstream_test_definition<'a>(source: &'a str, start_marker: &str, next_marker: &str) -> &'a str {
-    let start = source
-        .find(start_marker)
-        .unwrap_or_else(|| panic!("pinned upstream test is missing {start_marker:?}"));
-    let end = source
-        .find(next_marker)
-        .unwrap_or_else(|| panic!("pinned upstream test is missing {next_marker:?}"));
-    assert!(
-        start < end,
-        "pinned upstream test markers are out of order: {start_marker:?}, {next_marker:?}"
-    );
-    &source[start..end]
 }
 
 #[derive(Clone)]
@@ -221,7 +204,8 @@ fn run_upstream_definitions(
             }
             let test_path = source_tree.tests_dir().join(test_file);
             let test_source = fs::read_to_string(&test_path).expect("read pinned upstream test");
-            let definitions = upstream_test_definition(&test_source, start_marker, next_marker);
+            let definitions = upstream_test_definition(&test_source, start_marker, next_marker)
+                .expect("extract pinned upstream definition");
             let script = format!(
                 "package require tcltest\n\
                  namespace import -force ::tcltest::*\n\
@@ -252,6 +236,82 @@ fn run_upstream_definitions(
     };
     worker.join().expect("focused upstream worker panicked");
     Some(result)
+}
+
+/// Issue #1598: run the upstream binary/UTF-8 channel cases through the real
+/// Tcl 9.0.4 `init.tcl` and `tcltest`, then pin strict-profile prefix output
+/// with the same setup as upstream io-75.9.  The upstream io-75.9 body uses a
+/// bidirectional streaming channel, which this focused output change does not
+/// add, so its output half is retained here and the file prefix is inspected
+/// from Rust after tcltest closes it.
+#[test]
+fn upstream_channel_output_cases_use_real_tcltest() {
+    let repo_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let Some(source_tree) = locate_source_tree(&repo_root, TclVersion::V9_0, None)
+        .expect("Tcl 9 source tree discovery")
+    else {
+        eprintln!("skipping: no Tcl 9.0.4 source tree available");
+        return;
+    };
+    assert_eq!(source_tree.patchlevel, "9.0.4", "real-library oracle pin");
+
+    let io_source =
+        fs::read_to_string(source_tree.tests_dir().join("io.test")).expect("read pinned io.test");
+    let io_39_14 = upstream_test_definition(&io_source, "test io-39.14 {", "test io-39.15 {")
+        .expect("extract io-39.14");
+    let io_39_15 = upstream_test_definition(&io_source, "test io-39.15 {", "test io-39.16 {")
+        .expect("extract io-39.15");
+    let fixture = FixtureDir::new();
+    let path1 = fixture.0.join("io-39.bin");
+    let path2 = fixture.0.join("io-75.bin");
+    let bytes = Rc::new(RefCell::new(Vec::new()));
+    let mut vm = configure_vm(
+        Vm::with_output(Box::new(Capture(Rc::clone(&bytes)))),
+        &source_tree.library_dir(),
+    );
+    let init = vm.init_library();
+    assert!(
+        init.code.is_ok(),
+        "real Tcl 9.0.4 init.tcl failed: {}",
+        init.result.to_str()
+    );
+    let script = format!(
+        "package require tcltest\n\
+         namespace import -force ::tcltest::*\n\
+         set path(test1) {}\n\
+         set path(test2) {}\n\
+         {io_39_14}\n\
+         {io_39_15}\n\
+         test io-75.9-native {{strict output conversion keeps its valid prefix}} -setup {{\n\
+             set f [open $path(test2) w]\n\
+             fconfigure $f -encoding iso8859-1 -profile strict\n\
+         }} -body {{\n\
+             set code [catch {{puts -nonewline $f \"A\\u2022\"}} msg opts]\n\
+             close $f\n\
+             list $code [string match {{error writing \"*\": invalid or incomplete multibyte or wide character}} $msg] [dict get $opts -errorcode]\n\
+         }} -result [list 1 1 {{POSIX EILSEQ {{invalid or incomplete multibyte or wide character}}}}]\n\
+         ::tcltest::cleanupTests\n",
+        tcl_syntax::list::list_element(&path1.to_string_lossy()),
+        tcl_syntax::list::list_element(&path2.to_string_lossy()),
+    );
+    let completion = vm
+        .eval_source(&script)
+        .expect("compile upstream channel cases");
+    assert!(
+        completion.code.is_ok(),
+        "channel tcltest execution failed: {}",
+        completion.result.to_str()
+    );
+    assert_eq!(
+        fs::read(path2).expect("read strict output prefix"),
+        b"A",
+        "io-75.9 strict conversion must retain the valid byte prefix"
+    );
+    let summary = String::from_utf8(bytes.borrow().clone()).expect("tcltest output is UTF-8");
+    assert!(
+        summary.contains("Total\t3\tPassed\t3\tSkipped\t0\tFailed\t0"),
+        "{summary}"
+    );
 }
 
 /// The first upstream `set` definition reaches `cleanupTests` through the

--- a/scripts/dev/runtime-rust-path.sh
+++ b/scripts/dev/runtime-rust-path.sh
@@ -46,7 +46,7 @@ case "$PATH_TO_CLASSIFY" in
     rust/tcl-cmd-core/* | rust/tcl-core-types/* | rust/tcl-dialect/* | \
     rust/tcl-host-native/* | rust/tcl-lexer/* | rust/tcl-platform/* | \
     rust/tcl-regex/* | rust/tcl-registry/* | rust/tcl-runtime-api/* | \
-    rust/tcl-syntax/*)
+    rust/tcl-syntax/* | rust/tcl-test-support/*)
         exit 0
         ;;
     # Build inputs and the gate's own definition: a toolchain bump, a lockfile


### PR DESCRIPTION
## Summary

- centralise system encoding, channel configuration, open-mode parsing, output conversion, and Tcl error identity in `tcl-platform`, `tcl-cmd-core`, and the dialect-filtered command registry
- route native TclVM, standalone runtime, generated `puts`, CLI/background errors, and interpreter children through the same byte-preserving channel state
- validate Tcl 8.4–9.1 access/configuration differences and Tcl 9.0.4 output behaviour, including binary translation, strict conversion prefixes, and mutable system encoding
- centralise upstream Tcl test extraction/bootstrapping and extend standalone-runtime CI path ownership so these regressions run whenever shared dependencies change

Root cause: runtime adapters independently rendered Tcl byte strings through UTF-8 and duplicated channel/open configuration, so channel encoding was bypassed or ignored. The shared channel owner now produces raw encoded bytes and structured conversion errors for every consumer.

Closes #1598

## Validation

- [x] `make rust-check`
- [x] `make prep-pr` (30/30 smoke tests)
- [x] `make test-spectcl-compat` (SpecTcl 1.x/2.0 loader, goldens, real tclsh, source path, and corpus)
- [x] native channel-output suite (12/12)
- [x] standalone byte/completion suite (13/13)
- [x] Tcl 9.0.4-backed native and standalone `tcltest` regressions

## Compiler / diagnostics checklist

- [x] No compiler fact or diagnostic contract changed; the shared semantic-owner contract was updated.
- [x] No diagnostic or optimisation code was added or changed.
- [x] No new design document or KCS index entry was required.