### PR TITLE
fix(runtime): align array trace validation with Tcl

### DIFF
--- a/docs/design/contracts/variable-trace-dispatch-and-introspection.md
+++ b/docs/design/contracts/variable-trace-dispatch-and-introspection.md
@@ -128,11 +128,20 @@ Where C commits the operation around the trace, the runtime must too:
   elements remain observable until their own turn, and an alias to an old
   element becomes dangling rather than retargeting a same-name element in a
   newly created array.
-* In `rust/tcl-vm`, every array subcommand implemented and advertised by the VM
-  adapter runs the array-operation trace through one LocateArray-equivalent
-  owner after dialect-aware subcommand and arity resolution. The target comes
-  from registry argument roles, so direct, lowered and dedicated-opcode
-  consumers agree. An operation reference retains the reached `VarId` and its
+* In both Tcl runtimes, every implemented and advertised array subcommand runs
+  the array-operation trace after dialect-aware subcommand and outer-arity
+  resolution. `InvocationFacts::sole_argument_index_for_roles` owns the arity
+  gate and projects the one `VarRead`/`VarWrite` operand, so neither adapter has
+  a second per-subcommand target table. `array for`'s two-variable list and
+  `array default`'s inner option are the two content validations which precede
+  `LocateArray`; a selected default option's narrower arity follows it. The
+  shared list codec owns `TCL VALUE LIST BRACE|QUOTE|JUNK`, and the portable
+  command layer owns `TCL LOOKUP INDEX …` and `TCL ARGUMENT FORMAT`; both
+  runtime adapters publish `CmdError` through one completion boundary so those
+  identities cannot be flattened to `NONE`. The standalone runtime fires
+  against the original target argv object, not a
+  reconstructed operand.
+* In `rust/tcl-vm`, the operation reference retains the reached `VarId` and its
   direct binding shell, so unset-and-recreate refills the same cell. That target
   is passed to the shared `array` core: `exists`/`size`/`names`, `get` key
   enumeration, and patterned `unset` retain it when a callback retargets an alias. Tcl
@@ -143,9 +152,8 @@ Where C commits the operation around the trace, the runtime must too:
   undefined trace/link shells, then skips or reads each candidate live; defining
   an existing shell does not invalidate the search and can make a later row
   visible.
-  `array for` validates its two-variable list before firing, as Tcl does. Tcl
-  9's `array default` is not yet in the adapter surface. This describes the VM
-  change only; tree-walker parity remains tracked separately.
+  Tcl 9's `array default` is not yet in the VM adapter surface. Stable
+  operation identity in the standalone tree walker remains tracked separately.
 * **A trace a callback removes does not fire in the same pass**, whether it is
   older and not yet reached or newer and already run; one a callback adds does
   not fire until the next access. `trace info` reflects both at once. This

--- a/docs/design/family-b-routing.md
+++ b/docs/design/family-b-routing.md
@@ -122,7 +122,10 @@ Shared in `tcl-cmd-core`:
   `VarStore::array_keys` — the **enumeration** surface the otherwise-listing-free
   state traits expose, returning an array's element keys (or `None` for a
   scalar/unset, the existence signal). `ArrayTarget` is the operation-scoped
-  LocateArray result. A stable-cell runtime retains the cell and its direct
+  LocateArray result. Both adapters select the array-operation trace operand
+  through `InvocationFacts::sole_argument_index_for_roles`; the helper applies
+  the dialect-selected member arity and resolver-first argument roles before
+  returning an argv index. A stable-cell runtime retains the cell and its direct
   binding shell across the command, and routes `exists`/`size`/`names`, the
   key half of `get`, and patterned `unset` through its `VarId`; the shared core
   deliberately re-resolves the spelling for `get` values and whole-array

--- a/runtime/rust/src/cmd_array.rs
+++ b/runtime/rust/src/cmd_array.rs
@@ -23,6 +23,8 @@
 //! Implemented: `set`/`get`/`names`/`exists`/`size`/`unset`. (`statistics`,
 //! `nextelement`/`startsearch` searches, `-exact`/`-regexp` name modes follow.)
 
+use tcl_registry::{ArgRole, InvocationWord, InvocationWords};
+
 use crate::interp::{new_string, obj_bytes, Code, Interp};
 use crate::obj::TclObj;
 
@@ -32,33 +34,11 @@ pub fn install(interp: &mut Interp) {
 }
 
 /// This build's `array` subcommands, in the order the unknown-subcommand
-/// message lists them, each with the `argv` index its array name sits at —
-/// `array default <sub> <name>` names its array one word later than the rest.
-///
-/// One table, two consumers: the message below and [`array_name_index`], which
-/// is what makes the variable's `array` traces fire for every subcommand. A
-/// subcommand added to the message without a row here would silently stop
-/// being trace-visible.
-const SUBCOMMANDS: &[(&[u8], usize)] = &[
-    (b"default", 3),
-    (b"exists", 2),
-    (b"for", 2),
-    (b"get", 2),
-    (b"names", 2),
-    (b"set", 2),
-    (b"size", 2),
-    (b"unset", 2),
+/// message lists them. Their argument shapes and variable roles live in the
+/// registry rather than a second runtime table.
+const SUBCOMMANDS: &[&[u8]] = &[
+    b"default", b"exists", b"for", b"get", b"names", b"set", b"size", b"unset",
 ];
-
-/// The `argv` index of `sub`'s array name, or `None` when `sub` is not a
-/// subcommand of this build — C resolves the subcommand index *before* calling
-/// `LocateArray`, so an unknown subcommand fires no trace.
-fn array_name_index(sub: &[u8]) -> Option<usize> {
-    SUBCOMMANDS
-        .iter()
-        .find(|(name, _)| *name == sub)
-        .map(|(_, index)| *index)
-}
 
 /// The subcommand names alone, for the shared ensemble scan and its miss
 /// sentence — `array` is a `TclMakeEnsemble` command, so both belong to
@@ -68,12 +48,56 @@ fn array_name_index(sub: &[u8]) -> Option<usize> {
 /// must not reach `for`, and `array d` must not be made ambiguous by
 /// `default`.
 fn subcommand_names(interp: &Interp) -> &'static [&'static [u8]] {
-    let table: Vec<&'static [u8]> = SUBCOMMANDS.iter().map(|(name, _)| *name).collect();
-    crate::environment::release_subcommands(
-        interp.runtime_version().dialect_profile_name(),
-        "array",
-        &table,
-    )
+    crate::environment::release_subcommands(interp.dialect_profile().name, "array", SUBCOMMANDS)
+}
+
+/// Resolve the selected member's sole array operand through the active
+/// dialect's registry facts. The returned index addresses this command's
+/// complete `argv`, preserving the caller's original Tcl object for trace
+/// lookup and callback spelling.
+fn array_trace_target_index(interp: &Interp, argv: &[*mut TclObj], sub: &[u8]) -> Option<usize> {
+    let canonical = core::str::from_utf8(sub).ok()?;
+    let words: Vec<InvocationWord<'_>> = std::iter::once(InvocationWord::Literal(canonical))
+        .chain(argv[2..].iter().map(|_| InvocationWord::Dynamic))
+        .collect();
+    let profile = interp.dialect_profile();
+    let resolved = crate::environment::store_for_profile(profile)
+        .resolve_structured_invocation(
+            InvocationWords::structured(InvocationWord::Literal("array"), &words),
+            Some(crate::environment::surface_point(profile)),
+        )
+        .resolved()?;
+    if resolved.subcommand.resolved()?.canonical_name != canonical {
+        return None;
+    }
+    resolved
+        .facts()
+        .sole_argument_index_for_roles(words.len(), &[ArgRole::VarRead, ArgRole::VarWrite])
+        .and_then(|index| index.checked_add(1))
+}
+
+fn array_for_variables(interp: &mut Interp, argv: &[*mut TclObj]) -> Result<[Vec<u8>; 2], Code> {
+    let varlist = obj_bytes(argv[2]);
+    let variables = crate::parse::split_list(&varlist)
+        .map_err(|error| interp.report_list_error(&varlist, error))?;
+    variables.try_into().map_err(|_| {
+        interp.error_with_code(b"must have two variable names", b"TCL SYNTAX array for")
+    })
+}
+
+fn array_default_option(interp: &mut Interp, argv: &[*mut TclObj]) -> Result<&'static [u8], Code> {
+    // TIP 508's own option table (`tclVar.c`), resolved with
+    // `Tcl_GetIndexFromObj(…, "option", 0)` in C table order.
+    const OPTIONS: tcl_cmd_core::prefix::OptionTable<'static, &[u8]> =
+        tcl_cmd_core::prefix::OptionTable::abbreviating(
+            "option",
+            &[b"get", b"set", b"exists", b"unset"],
+        );
+    let option = obj_bytes(argv[2]);
+    OPTIONS
+        .index_of_cmd(&option)
+        .map(|index| OPTIONS.names()[index])
+        .map_err(|error| interp.report_cmd_error(error))
 }
 
 fn unknown_subcommand(interp: &mut Interp, sub: &[u8]) -> Code {
@@ -87,8 +111,8 @@ fn unknown_subcommand(interp: &mut Interp, sub: &[u8]) -> Code {
 }
 
 fn array_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
-    if argv.len() < 3 {
-        return interp.wrong_args(b"array subcommand arrayName ?arg ...?");
+    if argv.len() < 2 {
+        return interp.wrong_args(b"array subcommand ?arg ...?");
     }
     let word = obj_bytes(argv[1]);
     // Resolve the subcommand first — exact match, else a unique prefix — so
@@ -99,15 +123,28 @@ fn array_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         Some(index) => names[index],
         None => return unknown_subcommand(interp, &word),
     };
-    // C's `LocateArray` (tclVar.c:330-350) sits at the top of every `array`
-    // subcommand and fires the variable's `array` traces before the subcommand
-    // reads anything — `array names`, `array get`, `array set`, `array exists`
-    // and the rest each fire exactly one `<name> {} array` callback, while an
-    // ordinary `$arr(k)` read or `set arr(k)` write fires none. This is that
-    // one site (issue #1569), not a per-subcommand branch: the array command
-    // owns the hook, so the only per-subcommand fact it needs is where the
-    // array name is.
-    if let Some(name_obj) = array_name_index(sub).and_then(|i| argv.get(i)) {
+    let trace_target_index = array_trace_target_index(interp, argv, sub);
+    let mut for_variables = None;
+    let mut default_option = None;
+    if let Some(index) = trace_target_index {
+        // Every member validates its outer arity before `LocateArray`. Two
+        // content checks also precede it in C: `array for` validates its
+        // two-variable list and `array default` resolves its inner option.
+        // The selected default option's narrower arity is intentionally later.
+        match sub {
+            b"for" => match array_for_variables(interp, argv) {
+                Ok(variables) => for_variables = Some(variables),
+                Err(code) => return code,
+            },
+            b"default" => match array_default_option(interp, argv) {
+                Ok(option) => default_option = Some(option),
+                Err(code) => return code,
+            },
+            _ => {}
+        }
+        let Some(name_obj) = argv.get(index) else {
+            return interp.set_error(b"array subcommand has incomplete registry metadata");
+        };
         if let Some(code) = interp.fire_array_trace(&obj_bytes(*name_obj)) {
             return code;
         }
@@ -122,22 +159,15 @@ fn array_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
                 interp.set_result(v);
                 Code::Ok
             }
-            Err(e) => {
-                let (message, error_code) = e.into_parts();
-                match error_code {
-                    Some(code) => interp.error_with_code(message.as_bytes(), code.as_bytes()),
-                    None => interp.set_error(message.as_bytes()),
-                }
-            }
+            Err(e) => interp.report_cmd_error(e),
         };
     }
     // Per-runtime: `set` (per-element write traces), `default` (TIP 508), `for`
     // (Family-B iteration), and the unknown-subcommand message.
-    let name = obj_bytes(argv[2]);
     match sub {
-        b"set" => array_set(interp, argv, &name),
-        b"for" => array_for(interp, argv),
-        b"default" => array_default(interp, argv),
+        b"set" => array_set(interp, argv),
+        b"for" => array_for(interp, argv, for_variables),
+        b"default" => array_default(interp, argv, default_option),
         // Unreachable: every `SUBCOMMANDS` name is handled above or by the
         // shared core.
         other => unknown_subcommand(interp, other),
@@ -146,23 +176,21 @@ fn array_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
 
 /// `array default set|get|exists|unset arrayName ?value?` (TIP 508) — the array's
 /// default value for reads of missing elements.
-fn array_default(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
+fn array_default(
+    interp: &mut Interp,
+    argv: &[*mut TclObj],
+    prepared_option: Option<&'static [u8]>,
+) -> Code {
     // argv: array default <subcmd> arrayName ?value?
-    if argv.len() < 4 {
-        return interp.wrong_args(b"array default subcommand arrayName ?value?");
+    if !(4..=5).contains(&argv.len()) {
+        return interp.wrong_args(b"array default option arrayName ?value?");
     }
-    // TIP 508's own option table (`tclVar.c`), resolved with
-    // `Tcl_GetIndexFromObj(…, "option", 0)` in C *table* order — not
-    // alphabetical — so `e`/`ex` abbreviate `exists` and the empty word is
-    // `ambiguous option ""`.
-    const DEFAULT_OPTIONS: tcl_cmd_core::prefix::OptionTable<'static, &[u8]> =
-        tcl_cmd_core::prefix::OptionTable::abbreviating(
-            "option",
-            &[b"get", b"set", b"exists", b"unset"],
-        );
-    let sub = match DEFAULT_OPTIONS.index_of(&obj_bytes(argv[2])) {
-        Ok(i) => DEFAULT_OPTIONS.names()[i],
-        Err(m) => return interp.set_error(&m),
+    let sub = match prepared_option {
+        Some(option) => option,
+        None => match array_default_option(interp, argv) {
+            Ok(option) => option,
+            Err(code) => return code,
+        },
     };
     let name = obj_bytes(argv[3]);
     match sub {
@@ -234,16 +262,8 @@ fn array_default(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             interp.set_result_bytes(b"");
             Code::Ok
         }
-        // Unreachable: `DEFAULT_OPTIONS` has exactly the four arms above.
-        other => {
-            let mut m = b"bad option \"".to_vec();
-            m.extend_from_slice(other);
-            m.extend_from_slice(b"\": must be ");
-            m.extend_from_slice(&tcl_cmd_core::prefix::choice_list_bytes(
-                DEFAULT_OPTIONS.names(),
-            ));
-            interp.set_error(&m)
-        }
+        // Unreachable: `array_default_option` returns exactly these four.
+        _ => unreachable!("closed array default option table"),
     }
 }
 
@@ -252,20 +272,21 @@ fn array_default(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
 /// / `ArrayForLoopCallback`). A structural change to the array (an element added
 /// or removed) during iteration is an error, matching the invalidated hash
 /// search; changing an existing element's value is fine.
-fn array_for(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
+fn array_for(
+    interp: &mut Interp,
+    argv: &[*mut TclObj],
+    prepared_variables: Option<[Vec<u8>; 2]>,
+) -> Code {
     if argv.len() != 5 {
         return interp.wrong_args(b"array for {key value} arrayName script");
     }
-    let varlist = obj_bytes(argv[2]);
-    let vars = match crate::parse::split_list(&varlist) {
-        Ok(v) => v,
-        Err(e) => return interp.set_error(e.message()),
+    let [kvar, vvar] = match prepared_variables {
+        Some(variables) => variables,
+        None => match array_for_variables(interp, argv) {
+            Ok(variables) => variables,
+            Err(code) => return code,
+        },
     };
-    if vars.len() != 2 {
-        return interp.error_with_code(b"must have two variable names", b"TCL SYNTAX array for");
-    }
-    let kvar = vars[0].clone();
-    let vvar = vars[1].clone();
     let name = obj_bytes(argv[3]);
     if !interp.var_is_array(&name) {
         return not_array(interp, &name);
@@ -333,14 +354,15 @@ fn not_array(interp: &mut Interp, name: &[u8]) -> Code {
 }
 
 /// `array set arrayName {key value …}` — store each pair as an element.
-fn array_set(interp: &mut Interp, argv: &[*mut TclObj], name: &[u8]) -> Code {
+fn array_set(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     if argv.len() != 4 {
         return interp.wrong_args(b"array set arrayName list");
     }
+    let name = obj_bytes(argv[2]);
     // An array-element name (`foo(bar)`) can't be the target of `array set`.
-    if crate::frame::split_array_ref(name).1.is_some() {
+    if crate::frame::split_array_ref(&name).1.is_some() {
         let mut m = b"can't set \"".to_vec();
-        m.extend_from_slice(name);
+        m.extend_from_slice(&name);
         m.extend_from_slice(b"\": variable isn't array");
         return interp.set_error(&m);
     }
@@ -348,24 +370,27 @@ fn array_set(interp: &mut Interp, argv: &[*mut TclObj], name: &[u8]) -> Code {
     // value keeps its `Tcl_Obj` identity through the array — C shares objs by
     // reference, and TIP 280 keys a literal's source location on that identity
     // (so a `-body {…}` stored via `array set` still evaluates as `type source`).
+    let list = obj_bytes(argv[3]);
     let kvs = match crate::list::list_elements(argv[3]) {
         Ok(v) => v,
-        Err(e) => return interp.set_error(e.message()),
+        Err(e) => return interp.report_list_error(&list, e),
     };
     if kvs.len() % 2 != 0 {
-        return interp.set_error(b"list must have an even number of elements");
+        return interp.report_cmd_error(tcl_cmd_core::CmdError::argument_format(
+            "list must have an even number of elements",
+        ));
     }
     // `array set a {}` still materialises an empty array (and a scalar `a`
     // errors `variable isn't array`), so ensure the array up front — the loop
     // below never runs for an empty value list.
-    if let Err(e) = interp.ensure_array(name) {
-        return crate::builtins::var_error(interp, name, e);
+    if let Err(e) = interp.ensure_array(&name) {
+        return crate::builtins::var_error(interp, &name, e);
     }
     for pair in kvs.chunks_exact(2) {
         // `var_set_elem` retains the live value obj (no fresh allocation).
         let key = obj_bytes(pair[0]);
-        if let Err(e) = interp.var_set_elem(name, &key, pair[1]) {
-            return crate::builtins::var_error(interp, name, e);
+        if let Err(e) = interp.var_set_elem(&name, &key, pair[1]) {
+            return crate::builtins::var_error(interp, &name, e);
         }
     }
     interp.set_result_bytes(b"");

--- a/runtime/rust/src/cmd_binary.rs
+++ b/runtime/rust/src/cmd_binary.rs
@@ -255,7 +255,7 @@ fn binary_format(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             interp.set_result_byte_array(&out);
             Code::Ok
         }
-        Err(e) => interp.set_error(e.message().as_bytes()),
+        Err(e) => interp.report_cmd_error(e),
     }
 }
 
@@ -274,7 +274,7 @@ fn binary_scan(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     // The unpack grammar is shared; the variable assignment (Family-B) stays here.
     let values = match tcl_cmd_core::binary::scan(&data, &fmt) {
         Ok(v) => v,
-        Err(e) => return interp.set_error(e.message().as_bytes()),
+        Err(e) => return interp.report_cmd_error(e),
     };
     for (k, val) in values.iter().enumerate() {
         let Some(&var) = vars.get(k) else {

--- a/runtime/rust/src/cmd_chan.rs
+++ b/runtime/rust/src/cmd_chan.rs
@@ -35,7 +35,6 @@ use tcl_cmd_core::channel::{
     channel_output_error, config_list, config_value, encode_output_bytes, resolve_open_access_mode,
     set_config_value, ChannelConfig, OpenAccess, StandardChannelConfigs,
 };
-use tcl_cmd_core::CmdError;
 use tcl_platform::SystemEncoding;
 
 use crate::interp::{obj_bytes, Code, Interp};
@@ -340,7 +339,7 @@ fn open_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     let version = interp.runtime_version();
     let access = match resolve_open_access_mode(version, &mode_string) {
         Ok(access) => access,
-        Err(error) => return report_cmd_error(interp, error),
+        Err(error) => return interp.report_cmd_error(error),
     };
     let opened = interp.channels.borrow_mut().open(path_s, access, version);
     match opened {
@@ -575,7 +574,7 @@ pub(crate) fn puts_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         return interp.set_error(b"error writing to channel");
     }
     if let Some(error) = encoded.error {
-        return report_cmd_error(interp, channel_output_error(&name_for_error(&chan), error));
+        return interp.report_cmd_error(channel_output_error(&name_for_error(&chan), error));
     }
     interp.set_result_bytes(b"");
     Code::Ok
@@ -671,7 +670,7 @@ fn fconfigure_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
                     interp.set_result_bytes(config_value(option, &name, config).as_bytes());
                     Code::Ok
                 }
-                Err(error) => report_cmd_error(interp, error),
+                Err(error) => interp.report_cmd_error(error),
             }
         }
         pairs if pairs.len() % 2 == 0 => {
@@ -683,28 +682,20 @@ fn fconfigure_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
                     &option_word,
                 ) {
                     Ok(option) => option,
-                    Err(error) => return report_cmd_error(interp, error),
+                    Err(error) => return interp.report_cmd_error(error),
                 };
                 let value = obj_bytes(pair[1]);
                 let value = String::from_utf8_lossy(&value);
                 let configured = set_config_value(version, &mut config, option, &value);
                 let _ = interp.channels.borrow_mut().set_config(&id, config);
                 if let Err(error) = configured {
-                    return report_cmd_error(interp, error);
+                    return interp.report_cmd_error(error);
                 }
             }
             interp.set_result_bytes(b"");
             Code::Ok
         }
         _ => interp.wrong_args(b"fconfigure channelId ?-option value ...?"),
-    }
-}
-
-fn report_cmd_error(interp: &mut Interp, error: CmdError) -> Code {
-    let (message, code) = error.into_parts();
-    match code {
-        Some(code) => interp.error_with_code(message.as_bytes(), code.as_bytes()),
-        None => interp.set_error(message.as_bytes()),
     }
 }
 

--- a/runtime/rust/src/cmd_clock.rs
+++ b/runtime/rust/src/cmd_clock.rs
@@ -91,7 +91,7 @@ fn clock_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             interp.set_result(v);
             Code::Ok
         }
-        Err(e) => interp.set_error(e.message().as_bytes()),
+        Err(e) => interp.report_cmd_error(e),
     }
 }
 

--- a/runtime/rust/src/cmd_dict.rs
+++ b/runtime/rust/src/cmd_dict.rs
@@ -89,10 +89,14 @@ fn dict_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
                 // parser only through here, so without the re-wording every
                 // one of them reported the list noun (issue #1573).
                 Err(e) => {
-                    let msg = dict_worded(e.message());
+                    let (message, portable_code) = e.into_parts();
+                    let msg = dict_worded(&message);
                     match dict_parse_error_code(&msg) {
                         Some(code) => interp.error_with_code(msg.as_bytes(), code),
-                        None => interp.set_error(msg.as_bytes()),
+                        None => match portable_code {
+                            Some(code) => interp.error_with_code(msg.as_bytes(), code.as_bytes()),
+                            None => interp.set_error(msg.as_bytes()),
+                        },
                     }
                 }
             };

--- a/runtime/rust/src/cmd_info.rs
+++ b/runtime/rust/src/cmd_info.rs
@@ -377,7 +377,7 @@ fn info_level(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             interp.set_result(v);
             Code::Ok
         }
-        Err(e) => interp.set_error(e.message().as_bytes()),
+        Err(e) => interp.report_cmd_error(e),
     }
 }
 
@@ -472,7 +472,7 @@ fn info_body(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             interp.set_result(v);
             Code::Ok
         }
-        Err(e) => interp.set_error(e.message().as_bytes()),
+        Err(e) => interp.report_cmd_error(e),
     }
 }
 
@@ -485,7 +485,7 @@ fn info_args(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             interp.set_result(v);
             Code::Ok
         }
-        Err(e) => interp.set_error(e.message().as_bytes()),
+        Err(e) => interp.report_cmd_error(e),
     }
 }
 
@@ -500,7 +500,7 @@ fn info_default(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     // variable error verbatim (`can't set "a": variable is array`).
     let (val, has) = match tcl_cmd_core::info::default(interp, &argv[2], &argv[3]) {
         Ok(pair) => pair,
-        Err(e) => return interp.set_error(e.message().as_bytes()),
+        Err(e) => return interp.report_cmd_error(e),
     };
     if let Err(e) = interp.var_set(&var, val) {
         crate::interp::drop_fresh(val);

--- a/runtime/rust/src/cmd_list.rs
+++ b/runtime/rust/src/cmd_list.rs
@@ -39,7 +39,7 @@ fn adapt(interp: &mut Interp, result: Result<*mut TclObj, tcl_cmd_core::CmdError
             interp.set_result(v);
             Code::Ok
         }
-        Err(e) => interp.set_error(e.message().as_bytes()),
+        Err(e) => interp.report_cmd_error(e),
     }
 }
 
@@ -171,7 +171,7 @@ pub(crate) fn lappend(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     // stringified).
     let result = match tcl_cmd_core::var::lappend_value(interp, cur, values) {
         Ok(v) => v,
-        Err(e) => return interp.set_error(e.message().as_bytes()),
+        Err(e) => return interp.report_cmd_error(e),
     };
 
     // Always store back: rebinds the variable (a refcount-neutral re-set when
@@ -289,7 +289,7 @@ fn lassign(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
 // -- error helpers ---------------------------------------------------------
 
 fn bad_list(interp: &mut Interp, e: crate::parse::ListError) -> Code {
-    interp.set_error(e.message())
+    interp.error_with_code(e.message(), e.error_code())
 }
 
 // -- lrepeat / linsert / lreplace / lsearch / lsort ------------------------

--- a/runtime/rust/src/cmd_misc.rs
+++ b/runtime/rust/src/cmd_misc.rs
@@ -161,15 +161,7 @@ fn encoding_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
                         interp.set_result_bytes(b"");
                         Code::Ok
                     }
-                    Err(error) => {
-                        let (message, code) = error.into_parts();
-                        match code {
-                            Some(code) => {
-                                interp.error_with_code(message.as_bytes(), code.as_bytes())
-                            }
-                            None => interp.set_error(message.as_bytes()),
-                        }
-                    }
+                    Err(error) => interp.report_cmd_error(error),
                 }
             }
             _ => interp.wrong_args(b"encoding system ?encoding?"),

--- a/runtime/rust/src/cmd_string.rs
+++ b/runtime/rust/src/cmd_string.rs
@@ -156,7 +156,7 @@ fn string_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
                     interp.set_result(v);
                     Code::Ok
                 }
-                Err(e) => interp.set_error(e.message().as_bytes()),
+                Err(e) => interp.report_cmd_error(e),
             };
         }
     }

--- a/runtime/rust/src/cmd_switch.rs
+++ b/runtime/rust/src/cmd_switch.rs
@@ -49,7 +49,7 @@ fn switch_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     // the command name to the name-stripped slice the core expects).
     let opts = match core_switch::parse_options(interp, &argv[1..]) {
         Ok(o) => o,
-        Err(e) => return interp.set_error(e.message().as_bytes()),
+        Err(e) => return interp.report_cmd_error(e),
     };
     let value_idx = 1 + opts.value_index;
     let value = argv[value_idx];
@@ -114,7 +114,7 @@ fn switch_inline_form(
             interp.set_result_bytes(b"");
             return Code::Ok;
         }
-        Err(e) => return interp.set_error(e.message().as_bytes()),
+        Err(e) => return interp.report_cmd_error(e),
     };
     // Resolve a `-` fall-through to the next non-`-` body (guaranteed to exist).
     let mut b = matched;
@@ -193,7 +193,7 @@ fn switch_list_form(
             interp.set_result_bytes(b"");
             return Code::Ok;
         }
-        Err(e) => return interp.set_error(e.message().as_bytes()),
+        Err(e) => return interp.report_cmd_error(e),
     };
     let mut b = matched;
     while element_value(&list_str, &elems[b * 2 + 1]).as_slice() == b"-" {

--- a/runtime/rust/src/cmd_trace.rs
+++ b/runtime/rust/src/cmd_trace.rs
@@ -387,7 +387,7 @@ fn trace_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     let word = obj_bytes(argv[1]);
     let option = match core_trace::resolve_option(&String::from_utf8_lossy(&word), &options) {
         Ok(option) => option,
-        Err(e) => return interp.set_error(e.message().as_bytes()),
+        Err(e) => return interp.report_cmd_error(e),
     };
     match option.as_bytes() {
         // `trace add`/`remove` then dispatch on the type word (objv[2]).
@@ -409,7 +409,7 @@ fn trace_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
                 Ok(core_trace::TraceKind::Execution) => {
                     cmd_trace_add_remove(interp, argv, is_add, ops::EXEC_ANY)
                 }
-                Err(e) => interp.set_error(e.message().as_bytes()),
+                Err(e) => interp.report_cmd_error(e),
             }
         }
         b"info" => {
@@ -421,7 +421,7 @@ fn trace_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
                 Ok(core_trace::TraceKind::Variable) => trace_var_info(interp, argv),
                 Ok(core_trace::TraceKind::Command) => cmd_trace_info(interp, argv, ops::CMD_ANY),
                 Ok(core_trace::TraceKind::Execution) => cmd_trace_info(interp, argv, ops::EXEC_ANY),
-                Err(e) => interp.set_error(e.message().as_bytes()),
+                Err(e) => interp.report_cmd_error(e),
             }
         }
         // The deprecated 8.x forms; C rewrites them into `trace add|remove
@@ -613,7 +613,7 @@ fn cmd_trace_info(interp: &mut Interp, argv: &[*mut TclObj], category: u8) -> Co
 fn parse_ops(interp: &mut Interp, spec: &[u8]) -> Result<Vec<Vec<u8>>, Code> {
     match core_trace::parse_ops(spec, core_trace::TraceKind::Variable) {
         Ok(ops) => Ok(ops.iter().map(|o| o.as_bytes().to_vec()).collect()),
-        Err(e) => Err(interp.set_error(e.message().as_bytes())),
+        Err(e) => Err(interp.report_cmd_error(e)),
     }
 }
 
@@ -797,7 +797,7 @@ fn legacy_var_add_remove(interp: &mut Interp, argv: &[*mut TclObj], is_add: bool
     }
     let ops = match core_trace::parse_legacy_variable_ops(&obj_bytes(argv[3])) {
         Ok(ops) => ops.iter().map(|o| o.as_bytes().to_vec()).collect(),
-        Err(e) => return interp.set_error(e.message().as_bytes()),
+        Err(e) => return interp.report_cmd_error(e),
     };
     var_trace_apply(
         interp,

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -5186,6 +5186,25 @@ impl Interp {
         Code::Error
     }
 
+    /// Publish a portable command-layer error through this runtime's result
+    /// and exception-state ABI without losing a structured error code.
+    pub(crate) fn report_cmd_error(&mut self, error: tcl_cmd_core::CmdError) -> Code {
+        let (message, code) = error.into_parts();
+        match code {
+            Some(code) => self.error_with_code(message.as_bytes(), code.as_bytes()),
+            None => self.set_error(message.as_bytes()),
+        }
+    }
+
+    /// Publish a list parse failure using the shared list owner's message and
+    /// structured code.
+    pub(crate) fn report_list_error(&mut self, source: &[u8], error: parse::ListError) -> Code {
+        self.error_with_code(
+            &parse::list_error_message(source, error),
+            error.error_code(),
+        )
+    }
+
     /// The `interp bgerror` handler command prefix (empty ⇒ default).
     pub(crate) fn bgerror_handler(&self) -> Vec<u8> {
         self.bgerror.borrow().clone()
@@ -8752,17 +8771,8 @@ impl Interp {
                     Ok(prefix) if !prefix.is_empty() => EnsembleUnknown::Prefix(prefix),
                     Ok(_) => EnsembleUnknown::Reparse,
                     Err(e) => {
-                        let error_code: &[u8] = match e {
-                            crate::parse::ListError::UnmatchedBrace => b"TCL VALUE LIST BRACE",
-                            crate::parse::ListError::UnmatchedQuote => b"TCL VALUE LIST QUOTE",
-                            crate::parse::ListError::BraceFollowedByJunk
-                            | crate::parse::ListError::QuoteFollowedByJunk => {
-                                b"TCL VALUE LIST JUNK"
-                            }
-                            crate::parse::ListError::NotUtf8 => b"TCL VALUE LIST",
-                        };
                         let message = crate::parse::list_error_message(&res, e);
-                        let code = self.error_with_code(&message, error_code);
+                        let code = self.error_with_code(&message, e.error_code());
                         self.append_error_info_context(
                             b"while parsing result of ensemble unknown subcommand handler",
                         );

--- a/runtime/rust/src/parse.rs
+++ b/runtime/rust/src/parse.rs
@@ -699,6 +699,16 @@ impl From<tcl_syntax::list::ListError> for ListError {
 }
 
 impl ListError {
+    fn shared(self) -> Option<tcl_syntax::list::ListError> {
+        Some(match self {
+            ListError::UnmatchedBrace => tcl_syntax::list::ListError::UnmatchedBrace,
+            ListError::UnmatchedQuote => tcl_syntax::list::ListError::UnmatchedQuote,
+            ListError::BraceFollowedByJunk => tcl_syntax::list::ListError::BraceFollowedByJunk,
+            ListError::QuoteFollowedByJunk => tcl_syntax::list::ListError::QuoteFollowedByJunk,
+            ListError::NotUtf8 => return None,
+        })
+    }
+
     /// The Tcl error message for this failure — reusing the **shared**
     /// [`tcl_syntax::list::ListError`] strings (one source). The `…FollowedByJunk`
     /// variants are the message *prefix*; byte-exact text appends `"<frag>"
@@ -706,18 +716,17 @@ impl ListError {
     /// splitter (tracked follow-up).
     #[must_use]
     pub fn message(self) -> &'static [u8] {
-        match self {
-            ListError::UnmatchedBrace => tcl_syntax::list::ListError::UnmatchedBrace.message(),
-            ListError::UnmatchedQuote => tcl_syntax::list::ListError::UnmatchedQuote.message(),
-            ListError::BraceFollowedByJunk => {
-                tcl_syntax::list::ListError::BraceFollowedByJunk.message()
-            }
-            ListError::QuoteFollowedByJunk => {
-                tcl_syntax::list::ListError::QuoteFollowedByJunk.message()
-            }
-            ListError::NotUtf8 => "invalid list (not valid UTF-8)",
-        }
-        .as_bytes()
+        self.shared()
+            .map_or(b"invalid list (not valid UTF-8)", |error| {
+                error.message().as_bytes()
+            })
+    }
+
+    /// Tcl's structured `-errorcode` for this list failure.
+    #[must_use]
+    pub fn error_code(self) -> &'static [u8] {
+        self.shared()
+            .map_or(b"TCL VALUE LIST", |error| error.error_code().as_bytes())
     }
 }
 
@@ -744,13 +753,9 @@ pub fn split_list(src: &[u8]) -> Result<Vec<Vec<u8>>, ListError> {
 /// byte-identical re-implementation of that walk (issue #1429).
 #[must_use]
 pub fn list_error_message(src: &[u8], err: ListError) -> Vec<u8> {
-    let shared = match err {
-        ListError::UnmatchedBrace => tcl_syntax::list::ListError::UnmatchedBrace,
-        ListError::UnmatchedQuote => tcl_syntax::list::ListError::UnmatchedQuote,
-        ListError::BraceFollowedByJunk => tcl_syntax::list::ListError::BraceFollowedByJunk,
-        ListError::QuoteFollowedByJunk => tcl_syntax::list::ListError::QuoteFollowedByJunk,
+    let Some(shared) = err.shared() else {
         // Not a shared variant: the runtime's own internal-rep invariant.
-        ListError::NotUtf8 => return err.message().to_vec(),
+        return err.message().to_vec();
     };
     // A non-UTF-8 `src` cannot reach the fragment walk; fall back to the fixed
     // text rather than lose the error entirely.

--- a/runtime/rust/tests/array_trace_oracle.rs
+++ b/runtime/rust/tests/array_trace_oracle.rs
@@ -1,0 +1,207 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Standalone-runtime `array` trace conformance against the pinned Tcl 9.0.4
+//! interpreter and upstream `trace.test` definitions.
+
+use std::path::{Path, PathBuf};
+use std::rc::Rc;
+
+use tcl_dialect::TclVersion;
+use tcl_host_native::NativeHost;
+use tcl_platform::Host;
+use tcl_runtime::interp::{Code, Interp};
+use tcl_test_support::{
+    locate_source_tree, run_script_from_source_tree, upstream_test_definition, TclSourceTree,
+};
+
+fn repository_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+fn tcl_9_0_4() -> Option<TclSourceTree> {
+    let tree = locate_source_tree(&repository_root(), TclVersion::V9_0, None)
+        .expect("locate the pinned Tcl 9.0 source tree")?;
+    assert_eq!(tree.patchlevel, "9.0.4", "exact Tcl oracle pin");
+    Some(tree)
+}
+
+fn run_oracle(tree: &TclSourceTree, source: &str) -> Option<String> {
+    if !tree.root.join("unix/tclsh").is_file() {
+        eprintln!(
+            "skipping Tcl 9.0.4 oracle: {} has no built unix/tclsh",
+            tree.root.display()
+        );
+        return None;
+    }
+    Some(
+        run_script_from_source_tree(tree, TclVersion::V9_0, source.as_bytes())
+            .expect("run Tcl 9.0.4 oracle")
+            .strict_text()
+            .expect("Tcl 9.0.4 oracle succeeds"),
+    )
+}
+
+fn oracle_result(tree: &TclSourceTree, sheet: &str) -> Option<String> {
+    run_oracle(tree, &format!("{sheet}\nputs -nonewline [set ::out]\n"))
+}
+
+fn runtime_result(sheet: &str) -> String {
+    let mut interp = Interp::new();
+    interp.set_runtime_version(TclVersion::V9_0);
+    let code = interp.eval_str(sheet.as_bytes());
+    let result = String::from_utf8(interp.result_bytes()).expect("runtime result is UTF-8");
+    assert_eq!(code, Code::Ok, "runtime sheet failed: {result}\n{sheet}");
+    result
+}
+
+fn runtime_tcltest_result(tree: &TclSourceTree, sheet: &str) -> Option<String> {
+    let host = Rc::new(NativeHost::new());
+    host.env()
+        .set("TCL_LIBRARY", &tree.library_dir().to_string_lossy());
+    let mut interp = Interp::with_host(host);
+    interp.set_runtime_version(TclVersion::V9_0);
+    assert_eq!(interp.eval_str(b"info commands if"), Code::Ok);
+    if interp.result_bytes().is_empty() {
+        // The deliberate no-libtommath build omits expr-driven commands such
+        // as `if`; Tcl's init.tcl cannot execute in that representation tier.
+        return None;
+    }
+    assert_eq!(
+        interp.init_library(),
+        Code::Ok,
+        "real Tcl 9.0.4 init.tcl failed: {}",
+        String::from_utf8_lossy(&interp.result_bytes())
+    );
+    let code = interp.eval_str(sheet.as_bytes());
+    let result = String::from_utf8_lossy(&interp.result_bytes()).into_owned();
+    assert_eq!(code, Code::Ok, "real tcltest run failed: {result}");
+    Some(result)
+}
+
+#[test]
+fn upstream_trace_5_1_passes_through_real_tcltest_startup() {
+    let Some(tree) = tcl_9_0_4() else {
+        eprintln!("skipping: Tcl 9.0.4 source tree is not installed");
+        return;
+    };
+    let source = std::fs::read_to_string(tree.tests_dir().join("trace.test"))
+        .expect("read pinned upstream trace.test");
+    let callback = upstream_test_definition(&source, "proc traceArray2 {", "proc traceProc {")
+        .expect("extract upstream traceArray2 definition");
+    let definition = upstream_test_definition(&source, "test trace-5.1 {", "test trace-5.2 {")
+        .expect("extract upstream trace-5.1 definition");
+    let sheet = format!(
+        "package require tcltest\n\
+         namespace import -force ::tcltest::*\n\
+         {callback}\n\
+         {definition}\n\
+         set ::tcl_lsp_summary [list \
+             $::tcltest::numTests(Total) $::tcltest::numTests(Passed) \
+             $::tcltest::numTests(Skipped) $::tcltest::numTests(Failed)]\n\
+         ::tcltest::cleanupTests\n\
+         set ::tcl_lsp_summary"
+    );
+    let oracle = run_oracle(
+        &tree,
+        &format!("{sheet}\nputs -nonewline $::tcl_lsp_summary"),
+    );
+    let Some(runtime) = runtime_tcltest_result(&tree, &sheet) else {
+        eprintln!("skipping real tcltest startup: runtime has no numeric tower");
+        return;
+    };
+
+    const SUMMARY: &str = "1 1 0 0";
+    if let Some(oracle) = oracle {
+        assert!(
+            oracle.ends_with(SUMMARY),
+            "unexpected Tcl 9.0.4 result: {oracle:?}"
+        );
+    }
+    assert_eq!(
+        runtime, SUMMARY,
+        "unexpected standalone-runtime tcltest counters"
+    );
+}
+
+#[test]
+fn validation_precedes_array_traces_at_the_same_boundaries_as_tcl() {
+    let sheet = "set ::out {}\n\
+        proc A {n1 n2 op} { lappend ::log [list $n1 $n2 $op] }\n\
+        array set a {}\n\
+        trace add variable a array A\n\
+        proc probe {label script} {\n\
+        \x20   set ::log {}\n\
+        \x20   set code [catch {uplevel #0 $script} message]\n\
+        \x20   lappend ::out [list $label $code [llength $::log] $::log]\n\
+        }\n\
+        probe bare {array}\n\
+        probe member-only {array names}\n\
+        probe names-too-many {array names a -glob * extra}\n\
+        probe set-too-few {array set a}\n\
+        probe set-too-many {array set a {} extra}\n\
+        probe set-bad-list {array set a odd}\n\
+        probe for-too-few {array for {k v} a}\n\
+        probe for-bad-list {array for \\{ a {}}\n\
+        probe for-bad-count {array for k a {}}\n\
+        probe for-valid {array for {k v} a {}}\n\
+        probe default-too-few {array default get}\n\
+        probe default-too-many {array default get a x y}\n\
+        probe default-bad-option {array default bogus a}\n\
+        probe default-get-extra {array default get a x}\n\
+        probe default-set-missing {array default set a}\n\
+        probe default-prefix {array def ex a}\n\
+        probe unknown {array bogus a}\n\
+        set ::out";
+    let expected = "{bare 1 0 {}} {member-only 1 0 {}} {names-too-many 1 0 {}} \
+         {set-too-few 1 0 {}} {set-too-many 1 0 {}} \
+         {set-bad-list 1 1 {{a {} array}}} {for-too-few 1 0 {}} \
+         {for-bad-list 1 0 {}} {for-bad-count 1 0 {}} \
+         {for-valid 0 1 {{a {} array}}} {default-too-few 1 0 {}} \
+         {default-too-many 1 0 {}} {default-bad-option 1 0 {}} \
+         {default-get-extra 1 1 {{a {} array}}} \
+         {default-set-missing 1 1 {{a {} array}}} \
+         {default-prefix 0 1 {{a {} array}}} {unknown 1 0 {}}";
+
+    assert_eq!(runtime_result(sheet), expected);
+    if let Some(oracle) = tcl_9_0_4().and_then(|tree| oracle_result(&tree, sheet)) {
+        assert_eq!(oracle, expected);
+    }
+}
+
+#[test]
+fn validation_errors_preserve_tcl_9_structured_codes() {
+    let sheet = "set ::out {}\n\
+        proc probe {label script} {\n\
+        \x20   catch {uplevel #0 $script} message options\n\
+        \x20   lappend ::out [list $label [dict get $options -errorcode]]\n\
+        }\n\
+        array set a {}\n\
+        probe set-bad-list {array set a odd}\n\
+        probe for-bad-list {array for \\{ a {}}\n\
+        probe default-bad-option {array default bogus a}\n\
+        set ::out";
+    let expected = "{set-bad-list {TCL ARGUMENT FORMAT}} \
+         {for-bad-list {TCL VALUE LIST BRACE}} \
+         {default-bad-option {TCL LOOKUP INDEX option bogus}}";
+
+    assert_eq!(runtime_result(sheet), expected);
+    if let Some(oracle) = tcl_9_0_4().and_then(|tree| oracle_result(&tree, sheet)) {
+        assert_eq!(oracle, expected);
+    }
+}

--- a/rust/tcl-cmd-core/src/channel.rs
+++ b/rust/tcl-cmd-core/src/channel.rs
@@ -430,11 +430,10 @@ pub fn resolve_open_access_mode(version: TclVersion, access: &str) -> Result<Ope
     }
 
     let flags = tcl_syntax::list::split_list(access).map_err(|error| {
-        let message = error.full_message(access);
         if version >= TclVersion::V9_0 {
-            CmdError::with_error_code(message, "TCL OPENMODE INVALID")
+            CmdError::with_error_code(error.full_message(access), "TCL OPENMODE INVALID")
         } else {
-            CmdError::with_error_code(message, list_error_code(error))
+            CmdError::list(error, access)
         }
     })?;
     let mut direction = None;
@@ -487,15 +486,6 @@ fn open_mode_error(version: TclVersion, message: String) -> CmdError {
         CmdError::with_error_code(message, "TCL OPENMODE INVALID")
     } else {
         CmdError::new(message)
-    }
-}
-
-fn list_error_code(error: tcl_syntax::list::ListError) -> &'static str {
-    match error {
-        tcl_syntax::list::ListError::UnmatchedBrace => "TCL VALUE LIST BRACE",
-        tcl_syntax::list::ListError::UnmatchedQuote => "TCL VALUE LIST QUOTE",
-        tcl_syntax::list::ListError::BraceFollowedByJunk
-        | tcl_syntax::list::ListError::QuoteFollowedByJunk => "TCL VALUE LIST JUNK",
     }
 }
 

--- a/rust/tcl-cmd-core/src/error.rs
+++ b/rust/tcl-cmd-core/src/error.rs
@@ -93,6 +93,26 @@ impl CmdError {
     pub fn bad_choice(what: &str, got: &str, choices: &str) -> Self {
         Self::new(format!("bad {what} \"{got}\": must be {choices}"))
     }
+
+    /// A Tcl list syntax failure, preserving the list owner's message and
+    /// structured error code.
+    #[must_use]
+    pub fn list(error: tcl_syntax::list::ListError, source: &str) -> Self {
+        Self::with_error_code(error.full_message(source), error.error_code())
+    }
+
+    /// A failed `Tcl_GetIndexFromObj`-style lookup.
+    #[must_use]
+    pub fn lookup_index(message: impl Into<String>, what: &str, word: &str) -> Self {
+        let code = tcl_syntax::list::join_list(["TCL", "LOOKUP", "INDEX", what, word]);
+        Self::with_error_code(message, code)
+    }
+
+    /// A command argument whose shape is invalid after Tcl list parsing.
+    #[must_use]
+    pub fn argument_format(message: impl Into<String>) -> Self {
+        Self::with_error_code(message, "TCL ARGUMENT FORMAT")
+    }
 }
 
 impl core::fmt::Display for CmdError {
@@ -144,6 +164,24 @@ mod tests {
         assert_eq!(
             coded.into_parts(),
             ("constant".to_string(), Some("TCL UNSET CONST".to_string()))
+        );
+        assert_eq!(
+            CmdError::list(tcl_syntax::list::ListError::UnmatchedBrace, "{bad").into_parts(),
+            (
+                "unmatched open brace in list".to_string(),
+                Some("TCL VALUE LIST BRACE".to_string())
+            )
+        );
+        assert_eq!(
+            CmdError::lookup_index("bad option", "option", "two words").into_parts(),
+            (
+                "bad option".to_string(),
+                Some("TCL LOOKUP INDEX option {two words}".to_string())
+            )
+        );
+        assert_eq!(
+            CmdError::argument_format("bad shape").error_code(),
+            Some("TCL ARGUMENT FORMAT")
         );
     }
 }

--- a/rust/tcl-cmd-core/src/prefix.rs
+++ b/rust/tcl-cmd-core/src/prefix.rs
@@ -311,8 +311,22 @@ impl<'t, T: AsRef<[u8]>> OptionTable<'t, T> {
     /// # Errors
     /// The C-shaped message for an unmatched or ambiguous word.
     pub fn index_of_str(&self, word: &str) -> Result<usize, CmdError> {
-        self.index_of(word.as_bytes())
-            .map_err(|m| CmdError::new(String::from_utf8_lossy(&m).into_owned()))
+        self.index_of_cmd(word.as_bytes())
+    }
+
+    /// [`Self::index_of`] for byte-word [`CmdError`] consumers.
+    ///
+    /// # Errors
+    /// The C-shaped message and `TCL LOOKUP INDEX …` identity for an unmatched
+    /// or ambiguous word.
+    pub fn index_of_cmd(&self, word: &[u8]) -> Result<usize, CmdError> {
+        self.index_of(word).map_err(|message| {
+            CmdError::lookup_index(
+                String::from_utf8_lossy(&message).into_owned(),
+                self.what,
+                &String::from_utf8_lossy(word),
+            )
+        })
     }
 }
 
@@ -526,6 +540,7 @@ mod tests {
             e.message(),
             "bad operation \"w\": must be array, read, unset, or write"
         );
+        assert_eq!(e.error_code(), Some("TCL LOOKUP INDEX operation w"));
     }
 
     #[test]

--- a/rust/tcl-registry/src/resolved_invocation.rs
+++ b/rust/tcl-registry/src/resolved_invocation.rs
@@ -716,6 +716,47 @@ impl InvocationFacts {
     pub const fn world_state_effects(&self) -> &EffectFootprint {
         &self.effects
     }
+
+    /// Return the sole invocation argument carrying one of `roles` when the
+    /// resolved command or subcommand accepts the supplied outer arity.
+    ///
+    /// `argument_count` and the returned index both count words after the
+    /// command head, including a subcommand word when one was resolved. This
+    /// keeps runtime consumers on the registry's argument-offset and
+    /// resolver-first role contract instead of maintaining command-local
+    /// operand tables. Multiple requested roles on the same argument still
+    /// identify one operand; matching roles on different arguments are
+    /// ambiguous. An incomplete dynamic role resolution, invalid arity, or
+    /// missing or ambiguous role returns `None`.
+    #[must_use]
+    pub fn sole_argument_index_for_roles(
+        &self,
+        argument_count: usize,
+        roles: &[ArgRole],
+    ) -> Option<usize> {
+        let effective_count = argument_count.checked_sub(self.argument_offset)?;
+        let effective_count = u16::try_from(effective_count).ok()?;
+        if !self.arity.accepts(effective_count) || !self.arg_roles_complete {
+            return None;
+        }
+
+        let mut sole = None;
+        for &(index, role) in &self.arg_roles {
+            if !roles.contains(&role) {
+                continue;
+            }
+            let index = self.argument_offset + usize::from(index);
+            if index >= argument_count {
+                return None;
+            }
+            match sole {
+                None => sole = Some(index),
+                Some(previous) if previous == index => {}
+                Some(_) => return None,
+            }
+        }
+        sole
+    }
 }
 
 impl<'r, 'w> ResolvedInvocation<'r, 'w> {
@@ -1780,6 +1821,74 @@ mod tests {
 
         assert_eq!(facts.arg_roles, vec![(1, ArgRole::VarRead)]);
         assert!(facts.arg_roles_complete);
+    }
+
+    #[test]
+    fn sole_argument_role_index_uses_resolved_array_shape_and_dialect() {
+        let registry = CommandRegistry::build_default();
+        let variable_roles = [ArgRole::VarRead, ArgRole::VarWrite];
+
+        let exists = registry
+            .resolve_invocation(
+                "array",
+                &["exists", "items"],
+                Some(SurfaceQuery::core(Family::Tcl, "9.0")),
+            )
+            .expect("array exists resolves")
+            .facts();
+        assert_eq!(
+            exists.sole_argument_index_for_roles(2, &variable_roles),
+            Some(1)
+        );
+
+        let default = registry
+            .resolve_invocation(
+                "array",
+                &["def", "get", "items"],
+                Some(SurfaceQuery::core(Family::Tcl, "9.0")),
+            )
+            .expect("Tcl 9 array default prefix resolves")
+            .facts();
+        assert_eq!(default.subcommand.canonical_name(), Some("default"));
+        assert_eq!(
+            default.sole_argument_index_for_roles(3, &variable_roles),
+            Some(2)
+        );
+        assert_eq!(
+            default.sole_argument_index_for_roles(5, &variable_roles),
+            None,
+            "the member's outer arity is part of target resolution"
+        );
+
+        let legacy = registry
+            .resolve_invocation(
+                "array",
+                &["default", "get", "items"],
+                Some(SurfaceQuery::core(Family::Tcl, "8.6")),
+            )
+            .expect("the array command itself resolves")
+            .facts();
+        assert_eq!(legacy.subcommand.canonical_name(), None);
+        assert_eq!(
+            legacy.sole_argument_index_for_roles(3, &variable_roles),
+            None,
+            "a Tcl 9-only member has no target under Tcl 8.6"
+        );
+
+        let dict_with = registry
+            .resolve_invocation(
+                "dict",
+                &["with", "items", ""],
+                Some(SurfaceQuery::core(Family::Tcl, "9.0")),
+            )
+            .expect("dict with resolves")
+            .facts();
+        assert!(dict_with.arg_roles_complete);
+        assert_eq!(
+            dict_with.sole_argument_index_for_roles(3, &variable_roles),
+            Some(1),
+            "one multi-role argument is still the sole matching operand"
+        );
     }
 
     #[test]

--- a/rust/tcl-syntax/src/list.rs
+++ b/rust/tcl-syntax/src/list.rs
@@ -86,6 +86,18 @@ impl ListError {
         }
     }
 
+    /// Tcl's structured `-errorcode` for this list syntax failure.
+    #[must_use]
+    pub fn error_code(self) -> &'static str {
+        match self {
+            ListError::UnmatchedBrace => "TCL VALUE LIST BRACE",
+            ListError::UnmatchedQuote => "TCL VALUE LIST QUOTE",
+            ListError::BraceFollowedByJunk | ListError::QuoteFollowedByJunk => {
+                "TCL VALUE LIST JUNK"
+            }
+        }
+    }
+
     /// The complete Tcl error message for splitting `src` as a list. For the
     /// `…followed by "X" instead of space` cases this surfaces the offending
     /// fragment `X` directly after the closing delimiter (`tclUtil.c`); the other
@@ -904,6 +916,26 @@ mod tests {
         assert_eq!(split_list("\"unmatched"), Err(ListError::UnmatchedQuote));
         assert_eq!(split_list("{a}b"), Err(ListError::BraceFollowedByJunk));
         assert_eq!(split_list("\"a\"b"), Err(ListError::QuoteFollowedByJunk));
+    }
+
+    #[test]
+    fn list_errors_own_their_structured_codes() {
+        assert_eq!(
+            ListError::UnmatchedBrace.error_code(),
+            "TCL VALUE LIST BRACE"
+        );
+        assert_eq!(
+            ListError::UnmatchedQuote.error_code(),
+            "TCL VALUE LIST QUOTE"
+        );
+        assert_eq!(
+            ListError::BraceFollowedByJunk.error_code(),
+            "TCL VALUE LIST JUNK"
+        );
+        assert_eq!(
+            ListError::QuoteFollowedByJunk.error_code(),
+            "TCL VALUE LIST JUNK"
+        );
     }
 
     #[test]

--- a/rust/tcl-vm/src/cmd_array.rs
+++ b/rust/tcl-vm/src/cmd_array.rs
@@ -23,9 +23,10 @@
 //! VM's `array unset a` (no pattern), which used to iterate-and-unset elements
 //! (leaving an empty array) instead of removing the whole array.
 
-use tcl_registry::ArgRole;
+use tcl_registry::{ArgRole, InvocationWord, InvocationWords};
 use tcl_runtime_api::{ArrayTarget, Code, Completion, VarStore};
 
+use crate::command::{completion_from_cmd_error, completion_from_tcl_error};
 use crate::interp::{Vm, err, ok};
 use crate::value::Value;
 
@@ -64,7 +65,7 @@ fn cmd_array(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     // `for` is Tcl 9 (as is `default`, which this engine does not dispatch),
     // so under an earlier pin it must neither run nor claim the prefix `f`.
     let subs = crate::environment::release_subcommands(
-        vm.runtime_version().dialect_profile_name(),
+        vm.command_surface_profile().name,
         "array",
         ARRAY_SUBS,
     );
@@ -110,13 +111,7 @@ fn array_op_after_trace(
     if let Some(result) = tcl_cmd_core::array::dispatch_at(vm, sub, rest, target) {
         return match result {
             Ok(v) => ok(v),
-            Err(e) => {
-                let (message, error_code) = e.into_parts();
-                match error_code {
-                    Some(code) => crate::command::err_with_code(message, &code),
-                    None => err(message),
-                }
-            }
+            Err(e) => completion_from_cmd_error(e),
         };
     }
     // Per-runtime: `array set` (its per-element write traces must fail the
@@ -157,10 +152,12 @@ fn array_op_after_trace(
                 }
                 let items = match list.as_list() {
                     Ok(i) => i,
-                    Err(e) => return err(e.message),
+                    Err(e) => return completion_from_tcl_error(e),
                 };
                 if items.len() % 2 != 0 {
-                    return err("list must have an even number of elements");
+                    return completion_from_cmd_error(tcl_cmd_core::CmdError::argument_format(
+                        "list must have an even number of elements",
+                    ));
                 }
                 if items.is_empty() {
                     // `array set a {}` still materialises an empty array; onto an
@@ -206,39 +203,22 @@ fn array_op_after_trace(
 fn array_trace_target(vm: &Vm, sub: &str, rest: &[Value]) -> Option<String> {
     let profile = vm.command_surface_profile();
     let registry = crate::environment::store_for_profile(profile);
-    let words: Vec<String> = std::iter::once(sub.to_owned())
-        .chain(rest.iter().map(|value| value.to_str().to_string()))
+    let words: Vec<InvocationWord<'_>> = std::iter::once(InvocationWord::Literal(sub))
+        .chain(rest.iter().map(|_| InvocationWord::Dynamic))
         .collect();
-    let spellings: Vec<&str> = words.iter().map(String::as_str).collect();
-    let resolved = registry.resolve_invocation(
-        "array",
-        &spellings,
-        Some(crate::environment::surface_point(profile)),
-    )?;
+    let resolved = registry
+        .resolve_structured_invocation(
+            InvocationWords::structured(InvocationWord::Literal("array"), &words),
+            Some(crate::environment::surface_point(profile)),
+        )
+        .resolved()?;
     if resolved.subcommand.resolved()?.canonical_name != sub {
         return None;
     }
     let facts = resolved.facts();
-    let supplied = spellings.len().checked_sub(facts.argument_offset)?;
-    if !facts
-        .arity
-        .accepts(u16::try_from(supplied).unwrap_or(u16::MAX))
-        || !facts.arg_roles_complete
-    {
-        return None;
-    }
-    let mut targets: Vec<usize> = facts
-        .arg_roles
-        .iter()
-        .filter_map(|&(index, role)| {
-            matches!(role, ArgRole::VarRead | ArgRole::VarWrite)
-                .then_some(usize::from(index) + facts.argument_offset)
-        })
-        .collect();
-    targets.sort_unstable();
-    targets.dedup();
-    debug_assert!(targets.len() <= 1, "array member has one variable target");
-    let index = targets.into_iter().next()?.checked_sub(1)?;
+    let index = facts
+        .sole_argument_index_for_roles(words.len(), &[ArgRole::VarRead, ArgRole::VarWrite])?
+        .checked_sub(1)?;
     rest.get(index).map(|value| value.to_str().to_string())
 }
 
@@ -252,7 +232,7 @@ fn array_for(vm: &mut Vm, rest: &[Value], trace_target: Option<&str>) -> Complet
     };
     let vnames = match vars.as_list() {
         Ok(v) => v,
-        Err(e) => return err(e.message),
+        Err(e) => return completion_from_tcl_error(e),
     };
     let [kvar, vvar] = vnames.as_slice() else {
         return err("must have two variable names");

--- a/rust/tcl-vm/src/cmd_binary.rs
+++ b/rust/tcl-vm/src/cmd_binary.rs
@@ -248,7 +248,7 @@ fn binary_format(rest: &[Value]) -> Completion<Value> {
     let refs: Vec<&[u8]> = arg_bytes.iter().map(Vec::as_slice).collect();
     match tcl_cmd_core::binary::format(&fmt_bytes, &refs) {
         Ok(out) => ok(bytes_to_value(&out)),
-        Err(e) => err(e.message().to_string()),
+        Err(e) => crate::command::completion_from_cmd_error(e),
     }
 }
 
@@ -261,7 +261,7 @@ fn binary_scan(vm: &mut Vm, rest: &[Value]) -> Completion<Value> {
     // The unpack grammar is shared; the variable assignment stays here.
     let values = match tcl_cmd_core::binary::scan(&data, &fmt) {
         Ok(v) => v,
-        Err(e) => return err(e.message().to_string()),
+        Err(e) => return crate::command::completion_from_cmd_error(e),
     };
     for (k, val) in values.iter().enumerate() {
         let Some(var) = vars.get(k) else {

--- a/rust/tcl-vm/src/cmd_clock.rs
+++ b/rust/tcl-vm/src/cmd_clock.rs
@@ -71,6 +71,6 @@ fn cmd_clock(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     let offset = move |ts: i64| host.clock().local_offset_secs(ts);
     match core_clock::dispatch(vm, args, &now, &offset) {
         Ok(v) => ok(v),
-        Err(e) => err(e.into_message()),
+        Err(e) => crate::command::completion_from_cmd_error(e),
     }
 }

--- a/rust/tcl-vm/src/cmd_dict.rs
+++ b/rust/tcl-vm/src/cmd_dict.rs
@@ -321,6 +321,7 @@ fn dict_op(vm: &mut Vm, sub: &str, rest: &[Value], invoked: &str) -> Completion<
             // A *value-parse* failure is re-worded to C's dict spelling and
             // given its `TCL VALUE DICTIONARY …` code; anything else (wrong #
             // args, unknown key) passes through unchanged (issue #1573).
+            Err(e) if e.error_code().is_some() => crate::command::completion_from_cmd_error(e),
             Err(e) => crate::exec::dict_parse_err(&e.into_message()),
         };
     }

--- a/rust/tcl-vm/src/cmd_info.rs
+++ b/rust/tcl-vm/src/cmd_info.rs
@@ -137,7 +137,7 @@ fn cmd_info(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
             };
             match tcl_cmd_core::info::level(vm, number) {
                 Ok(v) => ok(v),
-                Err(e) => err(e.message()),
+                Err(e) => crate::command::completion_from_cmd_error(e),
             }
         }
         // commands/procs route through the shared namespace-aware core (over the
@@ -168,14 +168,14 @@ fn cmd_info(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
         "body" => match rest {
             [name] => match tcl_cmd_core::info::body(vm, name) {
                 Ok(v) => ok(v),
-                Err(e) => err(e.into_message()),
+                Err(e) => crate::command::completion_from_cmd_error(e),
             },
             _ => err("wrong # args: should be \"info body procname\""),
         },
         "args" => match rest {
             [name] => match tcl_cmd_core::info::args(vm, name) {
                 Ok(v) => ok(v),
-                Err(e) => err(e.into_message()),
+                Err(e) => crate::command::completion_from_cmd_error(e),
             },
             _ => err("wrong # args: should be \"info args procname\""),
         },
@@ -187,7 +187,7 @@ fn cmd_info(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
                     }
                     ok(Value::bool(has))
                 }
-                Err(e) => err(e.into_message()),
+                Err(e) => crate::command::completion_from_cmd_error(e),
             },
             _ => err("wrong # args: should be \"info default procname arg varname\""),
         },

--- a/rust/tcl-vm/src/cmd_list.rs
+++ b/rust/tcl-vm/src/cmd_list.rs
@@ -23,6 +23,7 @@ use std::rc::Rc;
 use tcl_cmd_core::list as list_core;
 use tcl_runtime_api::Completion;
 
+use crate::command::completion_from_cmd_error;
 use crate::interp::{Vm, err, err_wrong_args, ok};
 use crate::value::Value;
 
@@ -30,7 +31,7 @@ use crate::value::Value;
 fn adapt(result: Result<Value, tcl_cmd_core::CmdError>) -> Completion<Value> {
     match result {
         Ok(v) => ok(v),
-        Err(e) => err(e.into_message()),
+        Err(e) => completion_from_cmd_error(e),
     }
 }
 
@@ -188,7 +189,7 @@ fn cmd_ledit(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     };
     let result = match list_core::lreplace(vm, &cur, from, to, rest) {
         Ok(v) => v,
-        Err(e) => return err(e.into_message()),
+        Err(e) => return completion_from_cmd_error(e),
     };
     match vm.store_var_result(&n, result) {
         Ok(stored) => ok(stored),

--- a/rust/tcl-vm/src/cmd_string.rs
+++ b/rust/tcl-vm/src/cmd_string.rs
@@ -171,7 +171,7 @@ fn cmd_string(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     if let Some(result) = tcl_cmd_core::string::dispatch_canon(vm, canon, rest) {
         return match result {
             Ok(v) => ok(v),
-            Err(e) => err(e.into_message()),
+            Err(e) => crate::command::completion_from_cmd_error(e),
         };
     }
     match canon {

--- a/rust/tcl-vm/src/cmd_switch.rs
+++ b/rust/tcl-vm/src/cmd_switch.rs
@@ -45,7 +45,7 @@ fn cmd_switch(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     // Options + the `string` index are shared (the VM's argv is name-stripped).
     let opts = match core_switch::parse_options(vm, args) {
         Ok(o) => o,
-        Err(e) => return err(e.into_message()),
+        Err(e) => return crate::command::completion_from_cmd_error(e),
     };
     let value = args[opts.value_index].clone();
     let rest = &args[opts.value_index + 1..];
@@ -91,7 +91,7 @@ fn cmd_switch(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     let patterns: Vec<Value> = pairs.iter().map(|(p, _)| p.clone()).collect();
     let sel = match core_switch::select::<Vm, CrateEngine, Value>(vm, &opts, &value, &patterns) {
         Ok(s) => s,
-        Err(e) => return err(e.into_message()),
+        Err(e) => return crate::command::completion_from_cmd_error(e),
     };
     let Selection::Matched { index, writes } = sel else {
         return ok(Value::empty());

--- a/rust/tcl-vm/src/cmd_trace.rs
+++ b/rust/tcl-vm/src/cmd_trace.rs
@@ -81,7 +81,7 @@ fn cmd_trace(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     let options = visible_options(vm);
     let option = match core_trace::resolve_option(&sub.to_str(), &options) {
         Ok(o) => o,
-        Err(e) => return err(e.into_message()),
+        Err(e) => return crate::command::completion_from_cmd_error(e),
     };
     match option {
         "add" => trace_add_remove(vm, "add", rest, true),
@@ -119,7 +119,7 @@ fn trace_add_remove(vm: &mut Vm, sub: &str, rest: &[Value], add: bool) -> Comple
     let typeword = kindw.to_str();
     let kind = match core_trace::resolve_type(&typeword) {
         Ok(k) => k,
-        Err(e) => return err(e.into_message()),
+        Err(e) => return crate::command::completion_from_cmd_error(e),
     };
     let [name, ops, command] = args else {
         return err(format!(
@@ -129,7 +129,7 @@ fn trace_add_remove(vm: &mut Vm, sub: &str, rest: &[Value], add: bool) -> Comple
     // Validate the op list against the type's table (`bad operation …`).
     let ops: Vec<String> = match core_trace::parse_ops(ops.to_str().as_bytes(), kind) {
         Ok(o) => o.iter().map(|s| (*s).to_string()).collect(),
-        Err(e) => return err(e.into_message()),
+        Err(e) => return crate::command::completion_from_cmd_error(e),
     };
     match kind {
         core_trace::TraceKind::Variable => {
@@ -161,7 +161,7 @@ fn trace_info(vm: &mut Vm, rest: &[Value]) -> Completion<Value> {
     let typeword = kindw.to_str();
     let kind = match core_trace::resolve_type(&typeword) {
         Ok(k) => k,
-        Err(e) => return err(e.into_message()),
+        Err(e) => return crate::command::completion_from_cmd_error(e),
     };
     let [name] = args else {
         return err(format!(
@@ -228,7 +228,7 @@ fn legacy_variable(vm: &mut Vm, args: &[Value], add: bool) -> Completion<Value> 
     };
     let ops: Vec<String> = match core_trace::parse_legacy_variable_ops(ops.to_str().as_bytes()) {
         Ok(o) => o.iter().map(|s| (*s).to_string()).collect(),
-        Err(e) => return err(e.into_message()),
+        Err(e) => return crate::command::completion_from_cmd_error(e),
     };
     let command = command.to_str().to_string();
     if add {

--- a/rust/tcl-vm/src/command.rs
+++ b/rust/tcl-vm/src/command.rs
@@ -1766,13 +1766,7 @@ fn cmd_encoding(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
                     vm.set_system_encoding(encoding);
                     ok(Value::empty())
                 }
-                Err(error) => {
-                    let (message, code) = error.into_parts();
-                    match code {
-                        Some(code) => err_with_code(message, &code),
-                        None => err(message),
-                    }
-                }
+                Err(error) => completion_from_cmd_error(error),
             },
             _ => err_wrong_args("encoding system ?encoding?"),
         },

--- a/rust/tcl-vm/src/value.rs
+++ b/rust/tcl-vm/src/value.rs
@@ -395,7 +395,8 @@ impl Value {
             return Ok(items);
         }
         let s = self.to_str();
-        let elems = list::split_list(&s).map_err(|e| TclError::new(e.full_message(&s)))?;
+        let elems = list::split_list(&s)
+            .map_err(|e| TclError::with_error_code(e.full_message(&s), e.error_code()))?;
         let items: Rc<Vec<Value>> =
             Rc::new(elems.iter().map(|c| Value::string(c.as_ref())).collect());
         *self.0.intrep.borrow_mut() = IntRep::List(Rc::clone(&items));

--- a/rust/tcl-vm/tests/variable_trace_semantics_e2e.rs
+++ b/rust/tcl-vm/tests/variable_trace_semantics_e2e.rs
@@ -560,6 +560,24 @@ puts [list $em [dict get $eo -errorcode]]
 }
 
 #[test]
+fn array_content_validation_preserves_structured_error_codes() {
+    let script = r"
+array set a {}
+catch {array set a odd} setMessage setOptions
+catch {array for \{ a {}} forMessage forOptions
+puts [list $setMessage [dict get $setOptions -errorcode] \
+    $forMessage [dict get $forOptions -errorcode]]
+";
+    let expected = "{list must have an even number of elements} {TCL ARGUMENT FORMAT} \
+        {unmatched open brace in list} {TCL VALUE LIST BRACE}";
+
+    assert_eq!(vm_output(script), expected);
+    if let Some(oracle) = tclsh_output("TCL_LSP_TCLSH90", &["tclsh9.0"], script) {
+        assert_eq!(oracle, expected, "Tcl 9.0 array validation oracle");
+    }
+}
+
+#[test]
 fn read_and_write_trace_wrappers_publish_their_lookup_error_codes() {
     // Exact Tcl 9.0.4 transcript. Unlike the array operation, scalar
     // read/write wrapping replaces the callback's code with the variable


### PR DESCRIPTION
Closes #1945.

## Root cause

The standalone array adapter carried a second subcommand/operand table, so its target selection and validation order could drift from the dialect-selected registry facts. Portable command errors were also adapted independently at several runtime boundaries, flattening structured Tcl identities to `NONE`.

## Fix

- Add a registry-owned `InvocationFacts` query for the sole argument bearing a requested variable role, including outer arity and resolver completeness.
- Route both native and standalone array trace targeting through that owner and retain the original target object/cell.
- Validate Tcl 9 `array for` and `array default` content at the same pre-trace boundaries as Tcl 9.0.4.
- Centralise list, lookup-index, and argument-format error identities and the runtime adapters that publish them.
- Cover the exact validation matrix against Tcl 9.0.4 and run upstream `trace-5.1` through real `init.tcl`/`tcltest`.

## Verification

- `make rust-check`
- `make prep-pr` (30/30 smoke tests)
- `make test-spectcl-compat`
- standalone `array_trace_oracle` (3/3)
- native registry-resolved array trace and structured validation tests
- focused native and standalone Clippy with `-D warnings`

SpecTcl compatibility passed for evaluated 1.x/2.0 routes, golden 2.0 upgrades, real Tcl parsing, optimiser integration, and the shipped pack corpus.