### PR TITLE
perf(spectcl): parallelise independent corpus overlays

### DIFF
--- a/rust/tcl-spectcl/tests/spec_corpus.rs
+++ b/rust/tcl-spectcl/tests/spec_corpus.rs
@@ -118,6 +118,7 @@ use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::mpsc::RecvTimeoutError;
 use std::time::{Duration, Instant};
 
@@ -1259,6 +1260,60 @@ fn run_pack(pack: &ShippedPackFile, root: &Path, corpus: &[CorpusFile]) -> PackR
     run_pack_with_mode(pack, root, corpus, AnalysisMode::Shared)
 }
 
+/// Run independent overlays concurrently while preserving inventory order in
+/// the returned report. The default is capped at four workers; set to `1` for
+/// the serial control, or `2`/`4` to measure the bounded overlay sweep.
+fn pack_worker_count() -> usize {
+    let default = std::thread::available_parallelism().map_or(1, |count| count.get().min(4));
+    std::env::var("SPECTCL_CORPUS_PACK_THREADS")
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(default)
+        .clamp(1, 4)
+}
+
+fn run_packs(packs: &[ShippedPackFile], root: &Path, corpus: &[CorpusFile]) -> Vec<PackReport> {
+    let worker_count = pack_worker_count().min(packs.len());
+    if worker_count <= 1 {
+        return packs
+            .iter()
+            .map(|pack| run_pack(pack, root, corpus))
+            .collect();
+    }
+
+    let next = AtomicUsize::new(0);
+    let (tx, rx) = std::sync::mpsc::channel();
+    let mut reports: Vec<Option<PackReport>> = (0..packs.len()).map(|_| None).collect();
+    std::thread::scope(|scope| {
+        for _ in 0..worker_count {
+            let tx = tx.clone();
+            let next = &next;
+            std::thread::Builder::new()
+                .name("spectcl-corpus-pack".to_owned())
+                .stack_size(32 * 1024 * 1024)
+                .spawn_scoped(scope, move || {
+                    loop {
+                        let index = next.fetch_add(1, Ordering::Relaxed);
+                        let Some(pack) = packs.get(index) else {
+                            break;
+                        };
+                        tx.send((index, run_pack(pack, root, corpus)))
+                            .expect("collect pack report");
+                    }
+                })
+                .expect("spawn pack worker");
+        }
+        drop(tx);
+        for (index, report) in rx {
+            reports[index] = Some(report);
+        }
+    });
+    reports
+        .into_iter()
+        .map(|report| report.expect("every pack produced a report"))
+        .collect()
+}
+
 fn run_pack_with_mode(
     pack: &ShippedPackFile,
     root: &Path,
@@ -1532,10 +1587,7 @@ fn every_shipped_tclspec_loads_installs_and_analyses_against_corpus() {
                 packs.len()
             );
 
-            let reports: Vec<PackReport> = packs
-                .iter()
-                .map(|pack| run_pack(pack, &root, &corpus_files))
-                .collect();
+            let reports = run_packs(&packs, &root, &corpus_files);
 
             // This is the before/after proof for #1940. Keep it opt-in because
             // it runs the exact gate twice.


### PR DESCRIPTION
## Summary

- run the 24 independent shipped-pack corpus overlays through a bounded worker pool
- cap the default at four workers and keep a `SPECTCL_CORPUS_PACK_THREADS=1..4` control for reproducible comparisons
- reconstruct reports in inventory order so all existing coverage and deterministic diagnostics remain unchanged

## Experimental proof

Three alternating direct runs of the normal exact test, without the opt-in legacy comparator:

| Mode | Wall time | Maximum RSS |
| --- | --- | --- |
| Serial (`1`) | 15.25, 14.97, 14.77s | 205,236–206,016 KiB |
| Four workers (`4`) | 4.12, 4.05, 3.97s | 239,512–239,616 KiB |

That is about **73% less normal-path wall time** with a bounded ~16% RSS increase.

The stronger `SPECTCL_CORPUS_DIFF=1` equivalence path, which runs the gate and its legacy comparator, was also measured over five alternating runs:

| Mode | Wall time | Maximum RSS |
| --- | --- | --- |
| Serial (`1`) | 31.80, 32.35, 32.80, 36.26, 35.05s | 226,692–227,064 KiB |
| Four workers (`4`) | 21.59, 21.57, 22.89, 24.70, 24.19s | 260,736–262,676 KiB |

Every normal and differential run passed. Every differential run produced exactly 24 packs, 1,515 commands, 25 hook bodies, 4,088/4,088 VM calls, 864 diagnostics, and 961 optimisations. The focused five-test corpus suite passed.

The exact-head live Rust job also passed; its broad nextest step completed in 2m42s and the whole job in 3m32s, providing a whole-lane non-regression check. Those figures are not used as the controlled speedup claim because runner cache warmth differed from earlier runs.

## Gates

- `make rust-check`
- `make prep-pr`
- independent correctness/concurrency review: no ordering, deadlock, panic-propagation, or memory-bound findings

Progresses #1940. This removes the serial scheduling bottleneck; the issue remains open for its distinct cross-overlay invariant-work reuse goal.