### PR TITLE
fix(tclvm): centralise Tcl completion options and stack context

### DIFF
--- a/docs/design/compiler/wasm-codegen.md
+++ b/docs/design/compiler/wasm-codegen.md
@@ -295,6 +295,12 @@ entry as well. The runtime owns the `already_logged` protocol, so the innermost
 statement of a nest logs and the rest are no-ops, exactly as C dedups within one
 bytecode frame.
 
+A specialised instruction may need two unwind representations. Its
+`ErrorStackContext` carries the value-oriented TIP 348 inner context separately
+from the failing source command used by `errorInfo`; an inline `catch {error
+boom}` therefore records the same `"error boom"` source frame as the generic
+evaluator without giving up its specialised error-stack context.
+
 ### Binding a compiled body to its procedure
 
 A `proc` statement whose body became one of this module's functions lowers to

--- a/docs/design/contracts/shared-utility-contracts-rust.md
+++ b/docs/design/contracts/shared-utility-contracts-rust.md
@@ -50,7 +50,7 @@ entry point, or gate moves without this contract being updated.
 | sort numeric parsing | `rust/tcl-cmd-core/src/sort.rs` | `parse_wide`; `parse_real` | `NumberSyntax` per release | none |
 | command errors | `rust/tcl-cmd-core/src/error.rs` | `CmdError`; `wrong_args`; `bad_choice` | invariant | none |
 | channel output configuration / encoding | `rust/tcl-platform/src/lib.rs`; `rust/tcl-cmd-core/src/channel.rs`; `rust/tcl-registry/src/commands/tcl/fconfigure_.rs` | `SystemEncoding`; `Host::system_encoding`; `ChannelConfig`; `StandardChannelConfigs`; `OpenAccess`; `resolve_open_access_mode`; `ChannelDirection`; `ChannelEncoding`; `EncodingProfile`; `OutputTranslation`; `resolve_fconfigure_option`; `config_list`; `config_value`; `set_config_value`; `encode_output`; `encode_output_bytes`; `EncodedOutput`; `EILSEQ_ERROR_CODE` | system encoding per host locale and interpreter tree; option availability per dialect profile; open-access validation and profile/binary defaults per Tcl release; mutable direction-specific state per channel | none |
-| Tcl completion options / structured error stacks | `rust/tcl-runtime-api/src/completion_options.rs`; `rust/tcl-runtime-api/src/error_stack.rs` | `completion_options::plan`; `completion_options::ErrorOptions`; `completion_options::OptionValue`; `error_stack::ErrorStack`; `error_stack::validate_error_stack`; `error_stack::ErrorStackValueError` | standard option overlay follows completion code/level; TIP 348 `-errorstack` is available from Tcl 8.6 | none |
+| Tcl completion options / structured error stacks | `rust/tcl-runtime-api/src/completion_options.rs`; `rust/tcl-runtime-api/src/error_stack.rs` | `completion_options::plan`; `completion_options::ErrorOptions`; `completion_options::OptionValue`; `error_stack::ErrorStack`; `error_stack::validate_error_stack`; `error_stack::ErrorStackValueError` | standard option overlay follows completion code/level; TIP 348 `-errorstack` is available from Tcl 8.6; shifted contexts use the concrete runtime's frame count | none |
 | expression grammar / evaluation | `rust/tcl-syntax/src/expr/parser.rs`; `rust/tcl-syntax/src/expr/eval.rs`; `rust/tcl-registry/src/expr_surface.rs` | `parse_expr`; `eval`; `RuntimeExprSurface` | `RuntimeExprSurface` per release | none |
 | expr math functions and the `rand` generator | `rust/tcl-syntax/src/expr/mathfunc.rs`; `rust/tcl-syntax/src/expr/rand.rs` | `NumValue`; `dispatch`; `dispatch_with_backend_int_width`; `try_dispatch_with_backend_int_width`; `IntWidth`; `MathFuncError`; `MathFuncSince`; `spec`; `all`; `added_in`; `seed_from_wide`; `next_draw`; `seed_and_draw` | `MathFuncSince` per release for the function surface and `IntWidth` for `int()`'s width; the Park-Miller generator is release-invariant | none |
 | command / word segmentation | `rust/tcl-lexer/src/script.rs`; `rust/tcl-compiler/src/segmenter.rs`; `rust/tcl-compiler/src/parsing/syntax/build.rs`; `rust/tcl-compiler/src/parsing/syntax/segment.rs` | `group_commands`; `CommandSpan`; `WordSpan`; `WordKind`; `SegmentedCommand`; `segment_commands` | `LexerConfig` per document dialect | `xtask-segmentation-drift` |
@@ -124,7 +124,10 @@ entry point, or gate moves without this contract being updated.
 - `completion_options::plan` owns the standard Tcl return-options overlay.
   Engines supply their concrete values and live error metadata; the owner
   preserves carried custom and explicit return options, replaces `-code` and
-  `-level` with their settled values, and release-gates `-errorstack`.
+  `-level` with their settled values, and release-gates only the synthesis of
+  TIP 348 `-errorstack`. A carried option named `-errorstack` remains an
+  ordinary custom pair on Tcl 8.4/8.5 and must not be deleted or validated as
+  TIP 348 metadata there.
 - `error_stack::ErrorStack` owns TIP 348's flat tag/value shape, lazy reset,
   explicit-stack adoption, and procedure-boundary `CALL` rule. The native VM
   and portable runtime render their own value types but do not reproduce that

--- a/docs/design/contracts/shared-utility-contracts-rust.md
+++ b/docs/design/contracts/shared-utility-contracts-rust.md
@@ -50,6 +50,7 @@ entry point, or gate moves without this contract being updated.
 | sort numeric parsing | `rust/tcl-cmd-core/src/sort.rs` | `parse_wide`; `parse_real` | `NumberSyntax` per release | none |
 | command errors | `rust/tcl-cmd-core/src/error.rs` | `CmdError`; `wrong_args`; `bad_choice` | invariant | none |
 | channel output configuration / encoding | `rust/tcl-platform/src/lib.rs`; `rust/tcl-cmd-core/src/channel.rs`; `rust/tcl-registry/src/commands/tcl/fconfigure_.rs` | `SystemEncoding`; `Host::system_encoding`; `ChannelConfig`; `StandardChannelConfigs`; `OpenAccess`; `resolve_open_access_mode`; `ChannelDirection`; `ChannelEncoding`; `EncodingProfile`; `OutputTranslation`; `resolve_fconfigure_option`; `config_list`; `config_value`; `set_config_value`; `encode_output`; `encode_output_bytes`; `EncodedOutput`; `EILSEQ_ERROR_CODE` | system encoding per host locale and interpreter tree; option availability per dialect profile; open-access validation and profile/binary defaults per Tcl release; mutable direction-specific state per channel | none |
+| Tcl completion options / structured error stacks | `rust/tcl-runtime-api/src/completion_options.rs`; `rust/tcl-runtime-api/src/error_stack.rs` | `completion_options::plan`; `completion_options::ErrorOptions`; `completion_options::OptionValue`; `error_stack::ErrorStack`; `error_stack::validate_error_stack`; `error_stack::ErrorStackValueError` | standard option overlay follows completion code/level; TIP 348 `-errorstack` is available from Tcl 8.6 | none |
 | expression grammar / evaluation | `rust/tcl-syntax/src/expr/parser.rs`; `rust/tcl-syntax/src/expr/eval.rs`; `rust/tcl-registry/src/expr_surface.rs` | `parse_expr`; `eval`; `RuntimeExprSurface` | `RuntimeExprSurface` per release | none |
 | expr math functions and the `rand` generator | `rust/tcl-syntax/src/expr/mathfunc.rs`; `rust/tcl-syntax/src/expr/rand.rs` | `NumValue`; `dispatch`; `dispatch_with_backend_int_width`; `try_dispatch_with_backend_int_width`; `IntWidth`; `MathFuncError`; `MathFuncSince`; `spec`; `all`; `added_in`; `seed_from_wide`; `next_draw`; `seed_and_draw` | `MathFuncSince` per release for the function surface and `IntWidth` for `int()`'s width; the Park-Miller generator is release-invariant | none |
 | command / word segmentation | `rust/tcl-lexer/src/script.rs`; `rust/tcl-compiler/src/segmenter.rs`; `rust/tcl-compiler/src/parsing/syntax/build.rs`; `rust/tcl-compiler/src/parsing/syntax/segment.rs` | `group_commands`; `CommandSpan`; `WordSpan`; `WordKind`; `SegmentedCommand`; `segment_commands` | `LexerConfig` per document dialect | `xtask-segmentation-drift` |
@@ -59,7 +60,7 @@ entry point, or gate moves without this contract being updated.
 | iRules execution boundaries and placement | `rust/tcl-syntax/src/event_handler.rs`; `rust/tcl-registry/src/events.rs`; `rust/tcl-registry/src/registry.rs`; `rust/tcl-irules/src/when_block.rs`; `rust/tcl-irules/src/executable.rs` | `event_handlers`; `event_handlers_with_head_predicate`; `script_commands`; `top_level_when_handlers_with_registry_and_head_resolver`; `IrulesDeclarationArguments`; `IrulesExecutionContext`; `IrulesCommandPlacement`; `IrulesTopLevelDeclaration`; `IrulesTopLevelEffect`; `CommandRegistry::irules_command_placement`; `CommandRegistry::irules_event_declaration`; `CommandRegistry::irules_top_level_declaration`; `CommandRegistry::irules_top_level_declaration_shape`; `CommandRegistry::irules_top_level_effect`; `when_blocks`; `irules_executable_commands` | caller-supplied `LexerConfig`; offset-keyed resolved command identity; exact single-braced declaration body; declaration-only top level; known-event roots; call-reachable procedure bodies; stateful priority (`0..=1000`, default 500) | `xtask-gen-ai-diagnostics` |
 | text similarity | `rust/tcl-compiler/src/text.rs` | `edit_distance`; `rank_suggestions`; `rank_containment_suggestions` | invariant | none |
 | per-command knowledge | `rust/tcl-registry/src/spec.rs`; `rust/tcl-registry/src/hooks.rs`; `rust/tcl-registry/src/registry.rs` | `CommandSpec`; `SubCommand`; `CommandRegistry` | per release/dialect | `xtask-command-backing` |
-| dialect / release facts | `rust/tcl-dialect/src/profile.rs`; `rust/tcl-dialect/src/grammar.rs`; `rust/tcl-dialect/src/version.rs`; `rust/tcl-dialect/data/reference-toolchains.tsv` | `DialectProfile`; `LexerGrammar`; `TclVersion`; `TclVersion::patchlevel`; `TclVersion::reference_source_tag`; `find` | the resolved dialect/release axis plus exact pinned reference patchlevel/source tag | `xtask-editor-extensions` |
+| dialect / release facts | `rust/tcl-dialect/src/profile.rs`; `rust/tcl-dialect/src/grammar.rs`; `rust/tcl-dialect/src/version.rs`; `rust/tcl-dialect/data/reference-toolchains.tsv` | `DialectProfile`; `LexerGrammar`; `TclVersion`; `TclVersion::patchlevel`; `TclVersion::reference_source_tag`; `TclVersion::has_error_stack`; `find` | the resolved dialect/release axis plus exact pinned reference patchlevel/source tag | `xtask-editor-extensions` |
 | C Tcl conformance oracles | `rust/tcl-test-support/src/lib.rs` | `reference_patchlevel`; `reference_source_tag`; `locate_tclsh`; `available_tclshs`; `run_script`; `locate_source_tree`; `Tclsh`; `TclSourceTree`; `ScriptOutcome` | exact interpreter/source agreement and provenance for the selected release line | none |
 | interpreter platform bootstrap | `rust/tcl-platform/src/lib.rs` | `bootstrap::Values`; `bootstrap::Snapshot`; `bootstrap::snapshot`; `bootstrap::entries`; `bootstrap::HOST_ARRAYS`; `bootstrap::HOST_PATH_GLOBALS`; `bootstrap::safe_scrub_keys`; `bootstrap::SHARED_LIBRARY_EXTENSION` | key, selected-host snapshot, rebootstrap-clear, safe-scrub, and canonical Unix shared-library suffix invariant; runtime identity supplied per engine | none |
 | shared plain types | `rust/tcl-core-types/src/diag_code.rs` | `DiagCode` | invariant | `xtask-diag-tables` |
@@ -117,6 +118,18 @@ entry point, or gate moves without this contract being updated.
   each engine's `make_safe` consumes the derived scrub iterator. A fresh
   tree-walk `Interp`, its normal children, and bytecode-VM children all install
   the surface before any `init.tcl` work.
+
+### `tcl-runtime-api` — completion metadata
+
+- `completion_options::plan` owns the standard Tcl return-options overlay.
+  Engines supply their concrete values and live error metadata; the owner
+  preserves carried custom and explicit return options, replaces `-code` and
+  `-level` with their settled values, and release-gates `-errorstack`.
+- `error_stack::ErrorStack` owns TIP 348's flat tag/value shape, lazy reset,
+  explicit-stack adoption, and procedure-boundary `CALL` rule. The native VM
+  and portable runtime render their own value types but do not reproduce that
+  lifecycle. `TclVersion::has_error_stack` is the release fact: Tcl 8.6 and
+  later expose it; older and vendor profiles inherit their selected runtime.
 
 ### `tcl-syntax` — the parse grammars and value seam
 

--- a/docs/design/runtime/proc-call-and-stack-traces.md
+++ b/docs/design/runtime/proc-call-and-stack-traces.md
@@ -502,7 +502,9 @@ bottom-up as an error unwinds, from the same unwinding sites that build
 `reset_error_stack` (C's `iPtr->resetErrorStack`, set by `Tcl_ResetResult`)
 marks the start of a new episode: the *next* logged command rebuilds the stack,
 and the previous contents survive until then, so `info errorstack` after a
-`catch` still reports the error that was caught.
+`catch` still reports the error that was caught. An explicitly seeded error
+that suppresses a new inner log (for example, `return -level 0 -code error
+-errorinfo ...`) exposes that same retained stack in its completion options.
 
 `info errorstack ?interp?` accepts the interpreter argument but only reports the
 current interpreter.

--- a/docs/design/runtime/proc-call-and-stack-traces.md
+++ b/docs/design/runtime/proc-call-and-stack-traces.md
@@ -312,7 +312,10 @@ by `proc`, `apply`, and every TclOO method:
    `too many nested evaluations (infinite loop?)` rather than a stack overflow.
 3. push the frame (`push` for a normal call, `push_same_level` when the caller
    is redirecting the level) and record the invocation `words` for
-   `info level N`.
+   `info level N`. Those exact words are also TIP 348's procedure-boundary
+   `CALL`: `apply` supplies the public lambda invocation and TclOO supplies the
+   object command, method, and arguments, never an internal implementation
+   proc name.
 4. switch `current_ns` to the proc's defining namespace, pre-link any declared
    instance variables (the TclOO case), then bind positionals left to right —
    supplied argument, else default — with a trailing `args` soaking up the rest.

--- a/runtime/rust/src/builtins.rs
+++ b/runtime/rust/src/builtins.rs
@@ -29,6 +29,7 @@
 
 use crate::frame::{split_array_ref, VarError};
 use crate::interp::{obj_bytes, Code, Interp};
+use tcl_runtime_api::error_stack::{validate_error_stack, ErrorStackValueError};
 // The transient `1` of a tower `incr` is the only fresh object left to drop
 // by hand; every other path now stores through `store_var_result`.
 #[cfg(have_tommath)]
@@ -475,15 +476,18 @@ fn ret(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             return interp.error_with_code(&m, b"TCL RESULT ILLEGAL_ERRORCODE");
         }
     }
-    if let Some(es) = &errorstack {
-        match crate::parse::split_list(es) {
-            Err(_) => {
+    if let Some(es) = errorstack
+        .as_ref()
+        .filter(|_| interp.runtime_version().has_error_stack())
+    {
+        match validate_error_stack(crate::parse::split_list(es)) {
+            Err(ErrorStackValueError::NonList) => {
                 let mut m = b"bad -errorstack value: expected a list but got \"".to_vec();
                 m.extend_from_slice(es);
                 m.push(b'"');
                 return interp.error_with_code(&m, b"TCL RESULT NONLIST_ERRORSTACK");
             }
-            Ok(parts) if parts.len() % 2 != 0 => {
+            Err(ErrorStackValueError::OddSized) => {
                 let mut m = b"forbidden odd-sized list for -errorstack: \"".to_vec();
                 m.extend_from_slice(es);
                 m.push(b'"');

--- a/runtime/rust/src/builtins.rs
+++ b/runtime/rust/src/builtins.rs
@@ -374,9 +374,6 @@ fn parse_code(b: &[u8]) -> Option<Code> {
     }
 }
 
-/// `return ?-code code? ?-level n? ?-errorcode list? ?-errorinfo info?
-/// ?-options dict? ?result?` — complete with `-code` after unwinding `-level`
-/// proc/source boundaries (`Tcl_ReturnObjCmd`). A `-options` dict (as produced
 /// `exit ?returnCode?` — record the requested exit code and unwind uncatchably.
 ///
 /// The embedded runtime never terminates the host process (that would kill the
@@ -406,13 +403,25 @@ fn exit_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     Code::Error
 }
 
+/// `return ?-code code? ?-level n? ?-errorcode list? ?-errorinfo info?
+/// ?-options dict? ?result?` — complete with `-code` after unwinding `-level`
+/// proc/source boundaries (`Tcl_ReturnObjCmd`). A `-options` dict (as produced
 /// by `catch`) seeds the options; explicit flags override it.
 fn ret(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
+    fn set_carried(options: &mut Vec<(Vec<u8>, Vec<u8>)>, key: &[u8], value: &[u8]) {
+        if let Some((_, current)) = options.iter_mut().find(|(candidate, _)| candidate == key) {
+            *current = value.to_vec();
+        } else {
+            options.push((key.to_vec(), value.to_vec()));
+        }
+    }
+
     let mut code = Code::Ok;
     let mut level: usize = 1;
     let mut errorcode: Option<Vec<u8>> = None;
     let mut errorinfo: Option<Vec<u8>> = None;
     let mut errorstack: Option<Vec<u8>> = None;
+    let mut carried: Vec<(Vec<u8>, Vec<u8>)> = Vec::new();
 
     let mut i = 1;
     while i + 1 < argv.len() {
@@ -436,33 +445,52 @@ fn ret(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
                 Some(l) => level = l,
                 None => return interp.set_error(b"bad -level value"),
             },
-            b"-errorcode" => errorcode = Some(obj_bytes(argv[i + 1])),
-            b"-errorinfo" => errorinfo = Some(obj_bytes(argv[i + 1])),
-            b"-errorstack" => errorstack = Some(obj_bytes(argv[i + 1])),
+            b"-errorcode" => {
+                let value = obj_bytes(argv[i + 1]);
+                set_carried(&mut carried, &opt, &value);
+                errorcode = Some(value);
+            }
+            b"-errorinfo" => {
+                let value = obj_bytes(argv[i + 1]);
+                set_carried(&mut carried, &opt, &value);
+                errorinfo = Some(value);
+            }
+            b"-errorstack" => {
+                let value = obj_bytes(argv[i + 1]);
+                set_carried(&mut carried, &opt, &value);
+                errorstack = Some(value);
+            }
             b"-options" => {
-                // Seed code/level/errorcode/errorinfo from the options dict.
+                // Seed control and carried pairs from the options dict.
                 let opts = obj_bytes(argv[i + 1]);
-                if let Ok(d) = crate::parse::split_list(&opts) {
-                    let mut j = 0;
-                    while j + 1 < d.len() {
-                        match d[j].as_slice() {
-                            b"-code" => code = parse_code(&d[j + 1]).unwrap_or(code),
-                            b"-level" => {
-                                level = core::str::from_utf8(&d[j + 1])
-                                    .ok()
-                                    .and_then(|s| s.trim().parse().ok())
-                                    .unwrap_or(level);
-                            }
-                            b"-errorcode" => errorcode = Some(d[j + 1].clone()),
-                            b"-errorinfo" => errorinfo = Some(d[j + 1].clone()),
-                            b"-errorstack" => errorstack = Some(d[j + 1].clone()),
-                            _ => {}
+                let Ok(d) = crate::parse::split_list(&opts) else {
+                    return interp.set_error(b"bad -options value: expected a dictionary");
+                };
+                if d.len() % 2 != 0 {
+                    return interp.set_error(b"bad -options value: expected a dictionary");
+                }
+                let mut j = 0;
+                while j + 1 < d.len() {
+                    match d[j].as_slice() {
+                        b"-code" => code = parse_code(&d[j + 1]).unwrap_or(code),
+                        b"-level" => {
+                            level = core::str::from_utf8(&d[j + 1])
+                                .ok()
+                                .and_then(|s| s.trim().parse().ok())
+                                .unwrap_or(level);
                         }
-                        j += 2;
+                        b"-errorcode" => errorcode = Some(d[j + 1].clone()),
+                        b"-errorinfo" => errorinfo = Some(d[j + 1].clone()),
+                        b"-errorstack" => errorstack = Some(d[j + 1].clone()),
+                        _ => {}
                     }
+                    if !matches!(d[j].as_slice(), b"-code" | b"-level") {
+                        set_carried(&mut carried, &d[j], &d[j + 1]);
+                    }
+                    j += 2;
                 }
             }
-            _ => break, // not an option → the result word
+            _ => set_carried(&mut carried, &opt, &obj_bytes(argv[i + 1])),
         }
         i += 2;
     }
@@ -514,6 +542,7 @@ fn ret(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             errorstack.as_deref(),
         );
     }
+    interp.set_return_options(carried);
     if level == 0 {
         // No unwinding: complete with `code` right here.
         code

--- a/runtime/rust/src/cmd_error.rs
+++ b/runtime/rust/src/cmd_error.rs
@@ -769,6 +769,26 @@ mod tests {
         });
     }
 
+    #[test]
+    fn explicit_errorinfo_retains_the_prior_error_stack() {
+        leak_free(|i| {
+            assert_eq!(run(i, b"catch {error first} m o"), b"1");
+            let prior = run(i, b"dict get $o -errorstack");
+            assert!(!prior.is_empty());
+
+            assert_eq!(
+                run(
+                    i,
+                    b"catch {return -level 0 -code error -errorinfo I second} m o"
+                ),
+                b"1"
+            );
+            assert_eq!(run(i, b"dict get $o -errorstack"), prior);
+            assert_eq!(run(i, b"info errorstack"), prior);
+            i.eval_str(b"unset -nocomplain m o ::errorInfo ::errorCode");
+        });
+    }
+
     /// Pre-TIP runtimes still preserve `-errorstack` as an arbitrary custom
     /// return option; only synthesis and validation of its TIP 348 meaning are
     /// release-gated. Other custom pairs take the same shared path.

--- a/runtime/rust/src/cmd_error.rs
+++ b/runtime/rust/src/cmd_error.rs
@@ -125,18 +125,21 @@ pub(crate) fn completion_options(interp: &mut Interp, code: Code) -> *mut TclObj
         (code, 0)
     };
     let error = (eff_code == Code::Error).then(|| ErrorOptions {
-        error_code: Some(new_string(&interp.error_code())),
-        error_info: (level == 0).then(|| new_string(&interp.error_info())),
+        error_code: Some(interp.error_code()),
+        error_info: (level == 0).then(|| interp.error_info()),
         error_stack: (level == 0 && interp.runtime_version().has_error_stack())
-            .then(|| new_string(&interp.error_stack_value())),
+            .then(|| interp.error_stack_value()),
         error_line: (level == 0).then(|| i64::from(interp.error_line())),
-        during: (level == 0).then(|| interp.during_opts()).flatten(),
+        during: (level == 0)
+            .then(|| interp.during_opts().map(obj_bytes))
+            .flatten(),
     });
+    let carried = interp.pending_return_options();
     let planned = completion_options::plan(
         interp.runtime_version(),
         api_code(eff_code),
         i64::try_from(level).unwrap_or(i64::MAX),
-        &[],
+        &carried,
         error.as_ref(),
     );
     let pairs: Vec<(*mut TclObj, *mut TclObj)> = planned
@@ -144,7 +147,7 @@ pub(crate) fn completion_options(interp: &mut Interp, code: Code) -> *mut TclObj
         .map(|(key, value)| {
             let value = match value {
                 OptionValue::Integer(value) => new_string(value.to_string().as_bytes()),
-                OptionValue::Value(value) => value,
+                OptionValue::Value(value) => new_string(&value),
             };
             (new_string(&key), value)
         })
@@ -763,6 +766,26 @@ mod tests {
             run(i, b"catch {set x 5} m o");
             assert_eq!(run(i, b"dict get $o -code"), b"0");
             i.eval_str(b"unset m o x ::errorInfo ::errorCode");
+        });
+    }
+
+    /// Pre-TIP runtimes still preserve `-errorstack` as an arbitrary custom
+    /// return option; only synthesis and validation of its TIP 348 meaning are
+    /// release-gated. Other custom pairs take the same shared path.
+    #[test]
+    fn catch_preserves_custom_return_options_on_legacy_releases() {
+        use tcl_dialect::TclVersion;
+
+        leak_free(|i| {
+            for version in [TclVersion::V8_4, TclVersion::V8_5] {
+                i.set_runtime_version(version);
+                assert_eq!(run(i, b"catch {return -bar soom} m o"), b"2");
+                assert_eq!(run(i, b"set o"), b"-bar soom -code 0 -level 1");
+
+                assert_eq!(run(i, b"catch {return -errorstack odd} m o"), b"2");
+                assert_eq!(run(i, b"set o"), b"-errorstack odd -code 0 -level 1");
+            }
+            i.eval_str(b"unset -nocomplain m o");
         });
     }
 }

--- a/runtime/rust/src/cmd_error.rs
+++ b/runtime/rust/src/cmd_error.rs
@@ -35,6 +35,7 @@ use crate::dict;
 use crate::frame::VarError;
 use crate::interp::{drop_fresh, new_string, obj_bytes, Code, Interp};
 use crate::obj::{self, TclObj};
+use tcl_runtime_api::completion_options::{self, ErrorOptions, OptionValue};
 
 /// Register `catch`, `error`, `try`, and `throw`.
 pub fn install(interp: &mut Interp) {
@@ -123,33 +124,43 @@ pub(crate) fn completion_options(interp: &mut Interp, code: Code) -> *mut TclObj
     } else {
         (code, 0)
     };
-    let code_str = eff_code.as_int().to_string();
-    let level_str = level.to_string();
-    let mut pairs: Vec<(*mut TclObj, *mut TclObj)> = vec![
-        (new_string(b"-code"), new_string(code_str.as_bytes())),
-        (new_string(b"-level"), new_string(level_str.as_bytes())),
-    ];
-    if eff_code == Code::Error {
-        // `-errorcode` rides along with any error completion (incl. a pending
-        // `return -code error`). The accumulated trace + stack and the `-during`
-        // chain only exist once the error has actually been raised (level 0).
-        pairs.push((new_string(b"-errorcode"), new_string(&interp.error_code())));
-        if level == 0 {
-            pairs.push((new_string(b"-errorinfo"), new_string(&interp.error_info())));
-            // TIP 348: the error stack built as the error unwound.
-            pairs.push((
-                new_string(b"-errorstack"),
-                new_string(&interp.error_stack_value()),
-            ));
-            // TIP 329 exception chaining: when a `try` handler/`finally` threw
-            // over a prior exception, that prior exception's options ride along as
-            // `-during` (`During()` in `tclCmdMZ.c`). `new_dict_obj` retains it.
-            if let Some(during) = interp.during_opts() {
-                pairs.push((new_string(b"-during"), during));
-            }
-        }
-    }
+    let error = (eff_code == Code::Error).then(|| ErrorOptions {
+        error_code: Some(new_string(&interp.error_code())),
+        error_info: (level == 0).then(|| new_string(&interp.error_info())),
+        error_stack: (level == 0 && interp.runtime_version().has_error_stack())
+            .then(|| new_string(&interp.error_stack_value())),
+        error_line: (level == 0).then(|| i64::from(interp.error_line())),
+        during: (level == 0).then(|| interp.during_opts()).flatten(),
+    });
+    let planned = completion_options::plan(
+        interp.runtime_version(),
+        api_code(eff_code),
+        i64::try_from(level).unwrap_or(i64::MAX),
+        &[],
+        error.as_ref(),
+    );
+    let pairs: Vec<(*mut TclObj, *mut TclObj)> = planned
+        .into_iter()
+        .map(|(key, value)| {
+            let value = match value {
+                OptionValue::Integer(value) => new_string(value.to_string().as_bytes()),
+                OptionValue::Value(value) => value,
+            };
+            (new_string(&key), value)
+        })
+        .collect();
     dict::new_dict_obj(&pairs)
+}
+
+fn api_code(code: Code) -> tcl_runtime_api::Code {
+    match code {
+        Code::Ok => tcl_runtime_api::Code::Ok,
+        Code::Error => tcl_runtime_api::Code::Error,
+        Code::Return => tcl_runtime_api::Code::Return,
+        Code::Break => tcl_runtime_api::Code::Break,
+        Code::Continue => tcl_runtime_api::Code::Continue,
+        Code::Other(value) => tcl_runtime_api::Code::Other(value),
+    }
 }
 
 // -- error -----------------------------------------------------------------

--- a/runtime/rust/src/cmd_oo.rs
+++ b/runtime/rust/src/cmd_oo.rs
@@ -295,6 +295,50 @@ fn object_display(obj: &[u8]) -> Vec<u8> {
         .unwrap_or_else(|| obj.to_vec())
 }
 
+/// Exact command words whose dispatch entered a TclOO method body. Keeping
+/// this construction beside the OO dispatcher makes `info level 0` and TIP
+/// 348's `CALL` record agree for every proc-like consumer of [`CallMeta`].
+struct MethodInvocation {
+    external: bool,
+    level_words: Option<Vec<Vec<u8>>>,
+}
+
+impl MethodInvocation {
+    fn internal() -> Self {
+        Self {
+            external: false,
+            level_words: None,
+        }
+    }
+
+    fn with_words(external: bool, words: Vec<Vec<u8>>) -> Self {
+        Self {
+            external,
+            level_words: Some(words),
+        }
+    }
+}
+
+fn method_invocation(
+    obj: &[u8],
+    invoked: Option<&[u8]>,
+    method: &[u8],
+    args: &[*mut TclObj],
+    external: bool,
+) -> MethodInvocation {
+    let mut words = Vec::with_capacity(args.len() + 2);
+    words.push(if external {
+        invoked
+            .map(<[u8]>::to_vec)
+            .unwrap_or_else(|| object_display(obj))
+    } else {
+        b"my".to_vec()
+    });
+    words.push(method.to_vec());
+    words.extend(args.iter().map(|&arg| obj_bytes(arg)));
+    MethodInvocation::with_words(external, words)
+}
+
 /// The TclOO *execution* state (the per-flow stacks, not the shared class/object
 /// definitions): swapped in/out when a coroutine suspends/resumes so a method
 /// running inside a coroutine has its own `self`/`my`/`next` call chain and
@@ -851,13 +895,13 @@ fn oo_configure(interp: &mut Interp, obj: &[u8], args: &[*mut TclObj]) -> Code {
 /// ReadProperty).
 fn read_property(interp: &mut Interp, obj: &[u8], prop_hyph: &[u8]) -> Code {
     let mname = property_method_name(b"<ReadProp", prop_hyph);
-    let code = interp.oo_invoke(obj, &mname, &[], false);
+    let code = interp.oo_invoke(obj, &mname, &[], false, None);
     property_loopword_error(interp, code, b"getter", prop_hyph)
 }
 
 fn write_property(interp: &mut Interp, obj: &[u8], prop_hyph: &[u8], value: *mut TclObj) -> Code {
     let mname = property_method_name(b"<WriteProp", prop_hyph);
-    let code = interp.oo_invoke(obj, &mname, &[value], false);
+    let code = interp.oo_invoke(obj, &mname, &[value], false, None);
     property_loopword_error(interp, code, b"setter", prop_hyph)
 }
 
@@ -1255,7 +1299,7 @@ fn slot_m_unknown(interp: &mut Interp, obj: &[u8], args: &[*mut TclObj]) -> Code
     if !args.is_empty() && first.first() == Some(&b'-') {
         return interp.oo_unknown_method(obj, &first);
     }
-    interp.oo_invoke(obj, b"--default-operation", args, false)
+    interp.oo_invoke(obj, b"--default-operation", args, false, None)
 }
 
 fn err(interp: &mut Interp, msg: &[u8]) -> Code {
@@ -1548,7 +1592,7 @@ fn oo_copy_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     let mut usage = dst.clone();
     usage.extend_from_slice(b" <cloned>");
     interp.oo.borrow_mut().fwd_usage = Some(usage);
-    let code = interp.oo_invoke(&dst, b"<cloned>", &[src_obj], false);
+    let code = interp.oo_invoke(&dst, b"<cloned>", &[src_obj], false, None);
     interp.oo.borrow_mut().fwd_usage = None;
     unsafe { obj::decr_ref_count(src_obj) };
     if code == Code::Error {
@@ -2174,7 +2218,7 @@ fn slot_call(
     for &a in &argv {
         unsafe { obj::incr_ref_count(a) };
     }
-    let code = interp.oo_invoke(obj, method, &argv, false);
+    let code = interp.oo_invoke(obj, method, &argv, false, None);
     for &a in &argv {
         unsafe { obj::decr_ref_count(a) };
     }
@@ -2943,7 +2987,7 @@ fn my_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         return err(interp, b"my may only be called from inside a method");
     };
     let method = obj_bytes(argv[1]);
-    interp.oo_invoke(&object, &method, &argv[2..], false)
+    interp.oo_invoke(&object, &method, &argv[2..], false, None)
 }
 
 fn myclass_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
@@ -2985,7 +3029,7 @@ fn myclass_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         return err(interp, b"myclass may only be called from inside a method");
     };
     let method = obj_bytes(argv[1]);
-    interp.oo_invoke(&class, &method, &argv[2..], false)
+    interp.oo_invoke(&class, &method, &argv[2..], false, None)
 }
 
 fn next_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
@@ -3013,7 +3057,17 @@ fn next_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         if from_filter {
             interp.oo.borrow_mut().filter_handling = false;
         }
-        let code = interp.oo_run(&object, chain, index + 1, &target, &argv[1..], external);
+        let code = interp.oo_run(
+            &object,
+            chain,
+            index + 1,
+            &target,
+            &argv[1..],
+            MethodInvocation::with_words(
+                external,
+                argv.iter().map(|&word| obj_bytes(word)).collect(),
+            ),
+        );
         interp.oo.borrow_mut().filter_handling = saved_fh;
         code
     } else if target.is_empty() {
@@ -3079,7 +3133,17 @@ fn nextto_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     // Search forward (past the current step) for the class's implementation.
     for i in index + 1..chain.len() {
         if chain[i].provider == class && is_target(&chain[i]) {
-            return interp.oo_run(&object, chain, i, &target, &argv[2..], external);
+            return interp.oo_run(
+                &object,
+                chain,
+                i,
+                &target,
+                &argv[2..],
+                MethodInvocation::with_words(
+                    external,
+                    argv.iter().map(|&word| obj_bytes(word)).collect(),
+                ),
+            );
         }
     }
     // Not reachable ahead: distinguish "behind us" from "not in the chain".
@@ -4498,12 +4562,12 @@ impl Interp {
 
     /// Dispatch a command bound to the OO object/class FQN `fqn`.
     pub(crate) fn oo_dispatch(&mut self, fqn: &[u8], argv: &[*mut TclObj]) -> Code {
+        let invoked = obj_bytes(argv[0]);
         if self.oo.borrow().classes.contains_key(fqn) {
-            let cmd = obj_bytes(argv[0]);
             // The class instantiation built-ins honour the class's own
             // `export`/`unexport` for this external call.
             if let Some(sub) = argv.get(1).map(|&a| obj_bytes(a)) {
-                if let Some(code) = self.oo_class_factory(fqn, &cmd, &sub, &argv[2..], true) {
+                if let Some(code) = self.oo_class_factory(fqn, &invoked, &sub, &argv[2..], true) {
                     return code;
                 }
             }
@@ -4517,14 +4581,16 @@ impl Interp {
                 // `oo::define … self method`); dispatch it on the class object.
                 // An unknown method funnels through `oo_invoke` →
                 // `oo_unknown_method` for the C error text.
-                Some(other) => self.oo_invoke(fqn, other, &argv[2..], true),
+                Some(other) => self.oo_invoke(fqn, other, &argv[2..], true, Some(&invoked)),
                 // No method name: C forces the unknown handler (`FORCE_UNKNOWN`)
                 // with an empty method, so a *user* `unknown` runs with no args.
                 // With only the default handler, report the `wrong # args` usage
                 // naming the command as invoked (`argv[0]`, not the FQN).
-                None if self.has_user_unknown(fqn) => self.oo_invoke(fqn, b"unknown", &[], false),
+                None if self.has_user_unknown(fqn) => {
+                    self.oo_invoke(fqn, b"unknown", &[], false, None)
+                }
                 None => {
-                    let mut u = obj_bytes(argv[0]);
+                    let mut u = invoked;
                     u.extend_from_slice(b" method ?arg ...?");
                     wrong_args(self, &u)
                 }
@@ -4551,12 +4617,14 @@ impl Interp {
                     }
                     code
                 }
-                Some(method) => self.oo_invoke(fqn, &method, &argv[2..], true),
+                Some(method) => self.oo_invoke(fqn, &method, &argv[2..], true, Some(&invoked)),
                 // No method name: force a *user* `unknown` (C's `FORCE_UNKNOWN`)
                 // with empty args; else the `wrong # args` usage (as invoked).
-                None if self.has_user_unknown(fqn) => self.oo_invoke(fqn, b"unknown", &[], false),
+                None if self.has_user_unknown(fqn) => {
+                    self.oo_invoke(fqn, b"unknown", &[], false, None)
+                }
                 None => {
-                    let mut u = obj_bytes(argv[0]);
+                    let mut u = invoked;
                     u.extend_from_slice(b" method ?arg ...?");
                     wrong_args(self, &u)
                 }
@@ -4666,7 +4734,7 @@ impl Interp {
             })
             .collect();
         if !chain.is_empty() {
-            let code = self.oo_run(&fqn, chain, 0, b"", args, false);
+            let code = self.oo_run(&fqn, chain, 0, b"", args, MethodInvocation::internal());
             if code == Code::Error {
                 // A failed constructor tears the partially-built object down,
                 // running its destructor (C: the object is deleted, firing the
@@ -4704,6 +4772,7 @@ impl Interp {
         method: &[u8],
         args: &[*mut TclObj],
         external: bool,
+        invoked: Option<&[u8]>,
     ) -> Code {
         if !self.oo.borrow().objects.contains_key(obj) {
             return self.invalid_command(obj);
@@ -4807,7 +4876,8 @@ impl Interp {
                 if destroy_ok || objbuiltin_ok {
                     let filters = self.active_filters(obj, &providers);
                     if !filters.is_empty() {
-                        return self.oo_run(obj, filters, 0, method, args, external);
+                        let invocation = method_invocation(obj, invoked, method, args, external);
+                        return self.oo_run(obj, filters, 0, method, args, invocation);
                     }
                 }
             }
@@ -4873,7 +4943,7 @@ impl Interp {
                 }
                 // `unknown` is itself usually unexported, so dispatch it
                 // internally (it is the object's own fallback handler).
-                let code = self.oo_invoke(obj, b"unknown", &uargs, false);
+                let code = self.oo_invoke(obj, b"unknown", &uargs, false, None);
                 for a in uargs {
                     unsafe { obj::decr_ref_count(a) };
                 }
@@ -4896,10 +4966,12 @@ impl Interp {
             if !filters.is_empty() {
                 let mut chain: Vec<CallStep> = filters;
                 chain.append(&mut steps);
-                return self.oo_run(obj, chain, 0, method, args, external);
+                let invocation = method_invocation(obj, invoked, method, args, external);
+                return self.oo_run(obj, chain, 0, method, args, invocation);
             }
         }
-        self.oo_run(obj, steps, 0, method, args, external)
+        let invocation = method_invocation(obj, invoked, method, args, external);
+        self.oo_run(obj, steps, 0, method, args, invocation)
     }
 
     /// The unexported object built-in methods (`variable`/`varname`/`eval`),
@@ -5579,8 +5651,12 @@ impl Interp {
         index: usize,
         target: &[u8],
         args: &[*mut TclObj],
-        external: bool,
+        invocation: MethodInvocation,
     ) -> Code {
+        let MethodInvocation {
+            external,
+            level_words,
+        } = invocation;
         let prov = chain[index].provider.clone();
         let method = chain[index].method.clone();
         // Object-vs-class facet of this step (a class mixed into its own instance
@@ -5824,9 +5900,9 @@ impl Interp {
         // invocation (e.g. `oo::object create foo`), captured by the dispatcher,
         // rather than the synthetic `<constructor>` name (oo-2.1).
         let level_words = if method.is_empty() {
-            self.oo.borrow_mut().ctor_words.take()
+            self.oo.borrow_mut().ctor_words.take().or(level_words)
         } else {
-            None
+            level_words
         };
         // A filter step (its method differs from the invoked target) runs with
         // `filter_handling` set, so its own `my` calls — and everything they
@@ -5996,7 +6072,14 @@ impl Interp {
         // The destructor result is returned to the caller: explicit `obj
         // destroy` propagates it (C's `AfterNRDestructor`); implicit teardown
         // ignores it (routing to `bgerror`).
-        self.oo_run(obj, chain, 0, b"<destructor>", &[], false)
+        self.oo_run(
+            obj,
+            chain,
+            0,
+            b"<destructor>",
+            &[],
+            MethodInvocation::internal(),
+        )
     }
 
     fn oo_destroy_class(&mut self, class: &[u8]) {
@@ -7633,6 +7716,20 @@ mod tests {
             assert!(
                 contains(&ei, b"(in \"my eval\" script line 1)"),
                 "got {ei:?}"
+            );
+
+            // The shared proc runner uses the full external invocation for
+            // both `info level 0` and TIP 348's procedure-boundary `CALL`.
+            ok(i, b"oo::define cls method stack {arg} {error stacked}");
+            ok(i, b"catch {obj stack value} m o");
+            assert_eq!(
+                ok(i, b"lindex [dict get $o -errorstack] end"),
+                b"obj stack value"
+            );
+            ok(i, b"catch {::obj stack rooted} m o");
+            assert_eq!(
+                ok(i, b"lindex [dict get $o -errorstack] end"),
+                b"::obj stack rooted"
             );
         });
     }

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -464,7 +464,9 @@ pub(crate) struct CoroContext {
     script_stack: Vec<Vec<u8>>,
     return_code: Code,
     return_level: usize,
+    return_options: Vec<(Vec<u8>, Vec<u8>)>,
     exc: ExceptionState,
+    error_stack: ErrorStack<Vec<u8>>,
     error_line: u32,
     arg_lines: Vec<u32>,
     eval_depth: u32,
@@ -484,7 +486,9 @@ impl CoroContext {
             script_stack: Vec::new(),
             return_code: Code::Ok,
             return_level: 1,
+            return_options: Vec::new(),
             exc: ExceptionState::default(),
+            error_stack: ErrorStack::default(),
             error_line: 1,
             arg_lines: Vec::new(),
             eval_depth: 0,
@@ -813,6 +817,10 @@ pub struct InterpState {
     /// complete with once `-level` boundaries are unwound.
     return_code: Cell<Code>,
     return_level: Cell<usize>,
+    /// Non-control pairs carried by the current `return` completion. Byte
+    /// storage is sufficient at this portable boundary and preserves arbitrary
+    /// pre-TIP/custom option spellings for `catch`, `try`, and host adapters.
+    return_options: RefCell<Vec<(Vec<u8>, Vec<u8>)>>,
     /// Variable-trace registry (`trace add|remove|info variable`).
     pub(crate) traces: RefCell<crate::cmd_trace::TraceTable>,
     /// The error stack-trace accumulator (PC-4).
@@ -1279,6 +1287,7 @@ impl Interp {
             )),
             return_code: Cell::new(Code::Ok),
             return_level: Cell::new(1),
+            return_options: RefCell::new(Vec::new()),
             traces: RefCell::new(crate::cmd_trace::TraceTable::default()),
             exc: RefCell::new(ExceptionState::default()),
             error_line: Cell::new(1),
@@ -2778,6 +2787,16 @@ impl Interp {
     pub(crate) fn set_return_state(&mut self, level: usize, code: Code) {
         self.return_level.set(level);
         self.return_code.set(code);
+    }
+
+    /// Replace the arbitrary option pairs carried by the current `return`.
+    pub(crate) fn set_return_options(&self, options: Vec<(Vec<u8>, Vec<u8>)>) {
+        *self.return_options.borrow_mut() = options;
+    }
+
+    /// Snapshot the current `return`'s non-control option pairs.
+    pub(crate) fn pending_return_options(&self) -> Vec<(Vec<u8>, Vec<u8>)> {
+        self.return_options.borrow().clone()
     }
 
     /// The pending `return` `-code`/`-level` (the options a body that completed
@@ -5283,6 +5302,7 @@ impl Interp {
         std::mem::swap(&mut *self.script_stack.borrow_mut(), &mut ctx.script_stack);
         std::mem::swap(&mut *self.arg_lines.borrow_mut(), &mut ctx.arg_lines);
         std::mem::swap(&mut *self.exc.borrow_mut(), &mut ctx.exc);
+        std::mem::swap(&mut *self.error_stack.borrow_mut(), &mut ctx.error_stack);
         self.oo.borrow_mut().swap_exec(&mut ctx.oo);
         let ns = self.current_ns.replace(ctx.current_ns);
         ctx.current_ns = ns;
@@ -5292,6 +5312,10 @@ impl Interp {
         ctx.return_code = rc;
         let rl = self.return_level.replace(ctx.return_level);
         ctx.return_level = rl;
+        std::mem::swap(
+            &mut *self.return_options.borrow_mut(),
+            &mut ctx.return_options,
+        );
         let ed = self.eval_depth.replace(ctx.eval_depth);
         ctx.eval_depth = ed;
         let el = self.error_line.replace(ctx.error_line);
@@ -6594,6 +6618,12 @@ impl Interp {
         // native ABI. `argv` owns/borrows its objects independently, so dropping
         // the prior result here cannot invalidate an argument.
         self.set_result_bytes(b"");
+        // A parsed/direct command starts a new completion. Execution-trace
+        // callbacks run under SaveInterpState semantics and must not erase the
+        // option pairs returned by the command whose leave trace they observe.
+        if self.traces.borrow().exec_firing == 0 {
+            self.return_options.borrow_mut().clear();
+        }
         self.cmd_count.set(self.cmd_count.get() + 1);
         // Fast path: nothing is registered, so nothing can fire. Being inside a
         // trace callback is *not* a reason to skip: C's

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -42,6 +42,7 @@ use std::rc::{Rc, Weak};
 
 use tcl_core_types::RecursionLimit;
 use tcl_runtime_api::codegen_abi::NATIVE_PROC_STATUS_DECLINED;
+use tcl_runtime_api::error_stack::{validate_error_stack, ErrorStack};
 use tcl_runtime_api::guard::{
     GuardDomain, GuardDomains, GuardError, GuardIdentity, GuardManager, GuardToken,
 };
@@ -97,6 +98,17 @@ impl Code {
             4 => Code::Continue,
             other => Code::Other(other),
         }
+    }
+}
+
+fn shared_code(code: Code) -> tcl_runtime_api::Code {
+    match code {
+        Code::Ok => tcl_runtime_api::Code::Ok,
+        Code::Error => tcl_runtime_api::Code::Error,
+        Code::Return => tcl_runtime_api::Code::Return,
+        Code::Break => tcl_runtime_api::Code::Break,
+        Code::Continue => tcl_runtime_api::Code::Continue,
+        Code::Other(value) => tcl_runtime_api::Code::Other(value),
     }
 }
 
@@ -940,15 +952,12 @@ pub struct InterpState {
     /// error unwinds — `INNER <ctx>` for the innermost command, `CALL <info
     /// level 0>` per proc frame, `UP <delta>` per `uplevel` boundary. Rendered to
     /// a Tcl list on demand.
-    error_stack: RefCell<Vec<Vec<u8>>>,
-    /// C's `iPtr->resetErrorStack`: set when the result is reset (a new error
-    /// episode is starting), so the next command logged clears the stack and
-    /// records its inner context. Starts `true`.
-    reset_error_stack: Cell<bool>,
+    error_stack: RefCell<ErrorStack<Vec<u8>>>,
     /// The `try` exception-chaining link (TIP 329 `-during`): when a `try`
     /// handler or `finally` script throws, the options dict of the *prior*
     /// exception it superseded is stashed here so the next error-options build
-    /// ([`build_options`](crate::cmd_error)) splices it in as `-during`. Holds an
+    /// ([`completion_options`](crate::cmd_error::completion_options)) splices it
+    /// in as `-during`. Holds an
     /// owning reference (released when overwritten, cleared, or the interp drops).
     /// Cleared when an error is published/caught ([`publish_error`](Self::publish_error)),
     /// since the chain is then consumed.
@@ -1298,8 +1307,7 @@ impl Interp {
             ensemble_rewrite: RefCell::new(None),
             #[cfg(have_tommath)]
             rand_seed: Cell::new(None),
-            error_stack: RefCell::new(Vec::new()),
-            reset_error_stack: Cell::new(true),
+            error_stack: RefCell::new(ErrorStack::default()),
             during: Cell::new(None),
             result: Cell::new(result),
             cmd_arena: RefCell::new(CmdArena::default()),
@@ -5420,10 +5428,9 @@ impl Interp {
             code_explicit: errorcode.is_some(),
             already_logged,
         };
-        if let Some(es) = errorstack {
-            if let Ok(parts) = crate::parse::split_list(es) {
-                *self.error_stack.borrow_mut() = parts;
-                self.reset_error_stack.set(false);
+        if let Some(es) = errorstack.filter(|_| self.runtime_version().has_error_stack()) {
+            if let Ok(parts) = validate_error_stack(crate::parse::split_list(es)) {
+                let _ = self.error_stack.borrow_mut().adopt(parts);
             }
         }
     }
@@ -5828,31 +5835,30 @@ impl Interp {
     /// entries are added separately at proc-frame boundaries
     /// ([`error_stack_push_call`](Self::error_stack_push_call)).
     pub(crate) fn error_stack_log(&self, command: &[u8]) {
-        if self.reset_error_stack.get() {
-            self.reset_error_stack.set(false);
-            let mut es = self.error_stack.borrow_mut();
-            es.clear();
-            es.push(b"INNER".to_vec());
-            es.push(command.to_vec());
+        if !self.runtime_version().has_error_stack() {
+            return;
         }
+        let mut es = self.error_stack.borrow_mut();
+        let _ = es.begin_inner(b"INNER".to_vec(), command.to_vec());
         let (top, active) = {
             let f = self.frames.borrow();
             (f.top_level(), f.current_level())
         };
         if top > active {
-            let mut es = self.error_stack.borrow_mut();
-            es.push(b"UP".to_vec());
-            es.push((top - active).to_string().into_bytes());
+            let _ = es.push_pair(b"UP".to_vec(), (top - active).to_string().into_bytes());
         }
     }
 
     /// Append a TIP 348 `CALL <info level 0>` entry — the invocation words of a
     /// proc/lambda/method frame that an error is unwinding out of. The words are
     /// joined into a single Tcl-list element (so `g 1212` renders as `{g 1212}`).
-    pub(crate) fn error_stack_push_call(&self, words: &[Vec<u8>]) {
-        if self.reset_error_stack.get() {
-            // No inner context recorded yet (the error started at this boundary);
-            // nothing to chain a CALL onto until a command is logged.
+    pub(crate) fn error_stack_push_call(
+        &self,
+        body_code: Code,
+        settled_code: Code,
+        words: &[Vec<u8>],
+    ) {
+        if !self.runtime_version().has_error_stack() {
             return;
         }
         let mut value = Vec::new();
@@ -5862,9 +5868,12 @@ impl Interp {
             }
             crate::list::append_list_element(&mut value, w, i == 0);
         }
-        let mut es = self.error_stack.borrow_mut();
-        es.push(b"CALL".to_vec());
-        es.push(value);
+        let _ = self.error_stack.borrow_mut().push_proc_call(
+            shared_code(body_code),
+            shared_code(settled_code),
+            b"CALL".to_vec(),
+            value,
+        );
     }
 
     /// Render the TIP 348 error stack as a Tcl list (`info errorstack` / the
@@ -5872,7 +5881,7 @@ impl Interp {
     pub(crate) fn error_stack_value(&self) -> Vec<u8> {
         let es = self.error_stack.borrow();
         let mut buf = Vec::new();
-        for (i, e) in es.iter().enumerate() {
+        for (i, e) in es.entries().iter().enumerate() {
             if i > 0 {
                 buf.push(b' ');
             }
@@ -5881,12 +5890,17 @@ impl Interp {
         buf
     }
 
+    /// The innermost error command's 1-based source line.
+    pub(crate) fn error_line(&self) -> u32 {
+        self.error_line.get()
+    }
+
     /// Mark the start of a new error episode (C's `iPtr->resetErrorStack = 1`,
     /// set by `Tcl_ResetResult`): the *next* logged command rebuilds the stack.
     /// The current contents are kept until then (so `info errorstack` after a
     /// `catch` still reports the last error).
     pub(crate) fn mark_error_stack_reset(&self) {
-        self.reset_error_stack.set(true);
+        self.error_stack.borrow_mut().mark_reset();
     }
 
     /// Publish the accumulated trace to the `::errorInfo`/`::errorCode` globals
@@ -5937,7 +5951,8 @@ impl Interp {
         }
     }
 
-    /// The pending `-during` chain link (borrowed), for `build_options` to splice
+    /// The pending `-during` chain link (borrowed), for
+    /// [`completion_options`](crate::cmd_error::completion_options) to splice
     /// into an error's options dict. `None` when no chaining is active.
     pub(crate) fn during_opts(&self) -> Option<*mut TclObj> {
         let d = self.during.take();
@@ -8430,7 +8445,7 @@ impl Interp {
                 self.make_proc_error(meta.err);
                 // TIP 348: record this proc/lambda/method frame as a `CALL` entry.
                 if let Some(words) = call_words {
-                    self.error_stack_push_call(&words);
+                    self.error_stack_push_call(code, settled, &words);
                 }
             } else {
                 // `return -code error`: no procedure frame, but the *caller* still

--- a/rust/tcl-bytecode/src/lib.rs
+++ b/rust/tcl-bytecode/src/lib.rs
@@ -1128,8 +1128,13 @@ pub enum Operand {
 /// reconstructed from source text after lowering.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ErrorStackContext {
-    /// Build `{head <runtime-result>}` for a specialised error command.
-    CommandResult { head: String },
+    /// Build `{head <runtime-result>}` for TIP 348 while using the failing
+    /// command itself, rather than its containing lowered instruction, for
+    /// `errorInfo`.
+    CommandResult {
+        head: String,
+        error_info_command: String,
+    },
 }
 
 // Instruction

--- a/rust/tcl-bytecode/src/lib.rs
+++ b/rust/tcl-bytecode/src/lib.rs
@@ -1124,6 +1124,14 @@ pub enum Operand {
     Label(String),
 }
 
+/// Runtime ingredients for a TIP 348 `INNER` context that cannot be
+/// reconstructed from source text after lowering.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ErrorStackContext {
+    /// Build `{head <runtime-result>}` for a specialised error command.
+    CommandResult { head: String },
+}
+
 // Instruction
 
 /// Whether an instruction begins an executable source command.
@@ -1185,6 +1193,8 @@ pub struct Instruction {
     pub source_line: u32,
     /// Original command text for `errorInfo`.
     pub source_cmd_text: String,
+    /// Runtime-only recipe for structured error-stack logging.
+    pub error_stack_context: Option<ErrorStackContext>,
     /// Canonical unrooted constructed namespace in which
     /// [`Self::source_cmd_text`] resolves when this instruction is an
     /// executable command boundary. Empty denotes the global namespace.
@@ -1260,6 +1270,7 @@ impl Instruction {
             no_fold: false,
             source_line: 0,
             source_cmd_text: String::new(),
+            error_stack_context: None,
             source_command_namespace: String::new(),
             source_command_boundary: SourceCommandBoundary::None,
             source_span: None,

--- a/rust/tcl-compiler/src/codegen/control_flow.rs
+++ b/rust/tcl-compiler/src/codegen/control_flow.rs
@@ -995,7 +995,7 @@ impl CodegenCtx<'_> {
         // invoke arm, as do guard failures.
         match self.inline_cmd_subst_hook(body_cmd, body_args) {
             Some(InlineCodegenHookId::Return) => self.emit_catch_return(body_args),
-            Some(InlineCodegenHookId::Error) => self.emit_catch_error(body_args),
+            Some(InlineCodegenHookId::Error) => self.emit_catch_error(body_cmd, body, body_args),
             Some(InlineCodegenHookId::Break) => {
                 self.emit(Op::BREAK, vec![]);
             }
@@ -1112,7 +1112,12 @@ impl CodegenCtx<'_> {
     }
 
     /// Compile `error msg ?info? ?code?` inside a catch body.
-    pub fn emit_catch_error(&mut self, args: &[(String, bool)]) {
+    pub fn emit_catch_error(
+        &mut self,
+        command: &str,
+        source_command: &str,
+        args: &[(String, bool)],
+    ) {
         if let Some(first) = args.first() {
             self.emit_cmd_subst_arg(&first.0, first.1);
         } else {
@@ -1124,7 +1129,8 @@ impl CodegenCtx<'_> {
             vec![Operand::Imm(1), Operand::Imm(0)], // code=error, level=0
         );
         self.instructions[throw].error_stack_context = Some(ErrorStackContext::CommandResult {
-            head: "error".to_owned(),
+            head: command.to_owned(),
+            error_info_command: source_command.trim().to_owned(),
         });
     }
 
@@ -1528,6 +1534,7 @@ impl CodegenCtx<'_> {
                 &args.iter().map(String::as_str).collect::<Vec<_>>(),
             ) == Some(InlineCodegenHookId::Error)
         {
+            let error_info_command = self.source_text(stmt.span());
             if let Some(arg) = args.first() {
                 self.emit_value(arg, false);
             } else {
@@ -1537,6 +1544,7 @@ impl CodegenCtx<'_> {
             let throw = self.emit(Op::RETURN_IMM, vec![Operand::Imm(1), Operand::Imm(0)]);
             self.instructions[throw].error_stack_context = Some(ErrorStackContext::CommandResult {
                 head: command.clone(),
+                error_info_command,
             });
             self.cmd_index += 1;
             return;
@@ -1882,7 +1890,7 @@ mod tests {
     fn catch_error_emits_return_imm() {
         let registry = CommandRegistry::build_default();
         let mut ctx = CodegenCtx::new(true, &[], &registry);
-        ctx.emit_catch_error(&[("oops".into(), false)]);
+        ctx.emit_catch_error("error", "error oops", &[("oops".into(), false)]);
         let ops: Vec<Op> = ctx.instructions.iter().map(|i| i.op).collect();
         assert!(ops.contains(&Op::RETURN_IMM));
     }

--- a/rust/tcl-compiler/src/codegen/control_flow.rs
+++ b/rust/tcl-compiler/src/codegen/control_flow.rs
@@ -21,6 +21,7 @@
 //! Extends [`CodegenCtx`] with methods for emitting `beginCatch4`/`endCatch`
 //! bytecodes for `catch` and `try` commands.
 
+use tcl_bytecode::ErrorStackContext;
 use tcl_registry::hooks::{InlineCodegenHookId, LoweringHookId};
 use tcl_registry::{CommandRegistry, Traits, TryClauseKind, TryCompletionSelector};
 
@@ -1118,10 +1119,13 @@ impl CodegenCtx<'_> {
             self.push_lit("");
         }
         self.push_lit(""); // options
-        self.emit(
+        let throw = self.emit(
             Op::RETURN_IMM,
             vec![Operand::Imm(1), Operand::Imm(0)], // code=error, level=0
         );
+        self.instructions[throw].error_stack_context = Some(ErrorStackContext::CommandResult {
+            head: "error".to_owned(),
+        });
     }
 
     // -- inline try/on error compilation --
@@ -1530,7 +1534,10 @@ impl CodegenCtx<'_> {
                 self.push_lit("");
             }
             self.push_lit("");
-            self.emit(Op::RETURN_IMM, vec![Operand::Imm(1), Operand::Imm(0)]);
+            let throw = self.emit(Op::RETURN_IMM, vec![Operand::Imm(1), Operand::Imm(0)]);
+            self.instructions[throw].error_stack_context = Some(ErrorStackContext::CommandResult {
+                head: command.clone(),
+            });
             self.cmd_index += 1;
             return;
         }

--- a/rust/tcl-dialect/src/version.rs
+++ b/rust/tcl-dialect/src/version.rs
@@ -455,6 +455,16 @@ impl TclVersion {
         !matches!(self, Self::V8_4)
     }
 
+    /// Whether this release exposes TIP 348 structured error stacks.
+    ///
+    /// Tcl 8.6 introduced both `info errorstack` and the `-errorstack` return
+    /// option. Keeping the release boundary here lets every runtime and
+    /// completion adapter consume the same dialect fact.
+    #[must_use]
+    pub fn has_error_stack(self) -> bool {
+        matches!(self, Self::V8_6 | Self::V9_0 | Self::V9_1)
+    }
+
     /// Does this release **definitely** satisfy any of `requirements` — the
     /// answer `package vsatisfies [package provide Tcl] REQ ?REQ …?` gives on
     /// every build of the release line?
@@ -1393,5 +1403,14 @@ mod tests {
             TclVersion::V9_0.string_character_model(),
             StringCharacterModel::UnicodeScalars
         );
+    }
+
+    #[test]
+    fn structured_error_stacks_begin_at_tcl_eight_six() {
+        assert!(!TclVersion::V8_4.has_error_stack());
+        assert!(!TclVersion::V8_5.has_error_stack());
+        assert!(TclVersion::V8_6.has_error_stack());
+        assert!(TclVersion::V9_0.has_error_stack());
+        assert!(TclVersion::V9_1.has_error_stack());
     }
 }

--- a/rust/tcl-runtime-api/src/completion_options.rs
+++ b/rust/tcl-runtime-api/src/completion_options.rs
@@ -50,8 +50,9 @@ pub type CarriedOption<V> = (Vec<u8>, V);
 /// Carried options are retained, including custom keys and explicit error
 /// metadata. `-code` and `-level` are always replaced by the settled values;
 /// live level-zero error metadata replaces its carried counterpart. A missing
-/// `-errorcode` is filled for every error. TIP 348 is gated by the selected
-/// Tcl release at this shared seam.
+/// `-errorcode` is filled for every error. Synthesis of TIP 348 metadata is
+/// gated by the selected Tcl release; a carried pre-TIP option with the same
+/// spelling remains an ordinary custom pair.
 #[must_use]
 pub fn plan<V: Clone>(
     version: TclVersion,
@@ -62,11 +63,7 @@ pub fn plan<V: Clone>(
 ) -> Vec<(Vec<u8>, OptionValue<V>)> {
     let mut rows: Vec<(Vec<u8>, OptionValue<V>)> = carried
         .iter()
-        .filter(|(key, _)| {
-            key.as_slice() != b"-code"
-                && key.as_slice() != b"-level"
-                && (version.has_error_stack() || key.as_slice() != b"-errorstack")
-        })
+        .filter(|(key, _)| key.as_slice() != b"-code" && key.as_slice() != b"-level")
         .map(|(key, value)| (key.clone(), OptionValue::Value(value.clone())))
         .collect();
 
@@ -141,7 +138,7 @@ mod tests {
     }
 
     #[test]
-    fn tip_348_is_release_gated_and_explicit_values_are_preserved() {
+    fn tip_348_synthesis_is_gated_but_pre_tip_custom_spelling_is_preserved() {
         let carried = vec![
             (b"-errorstack".to_vec(), "explicit"),
             (b"-errorinfo".to_vec(), "INFO"),
@@ -151,7 +148,7 @@ mod tests {
             ..ErrorOptions::default()
         };
         let old = plan(TclVersion::V8_5, Code::Error, 1, &carried, Some(&error));
-        assert!(!keys(&old).contains(&b"-errorstack".as_slice()));
+        assert!(keys(&old).contains(&b"-errorstack".as_slice()));
         let modern = plan(TclVersion::V9_0, Code::Error, 1, &carried, Some(&error));
         assert!(keys(&modern).contains(&b"-errorstack".as_slice()));
         assert!(keys(&modern).contains(&b"-errorinfo".as_slice()));

--- a/rust/tcl-runtime-api/src/completion_options.rs
+++ b/rust/tcl-runtime-api/src/completion_options.rs
@@ -1,0 +1,159 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Standard Tcl return-option planning shared by runtime engines.
+//!
+//! The plan decides which standard keys a completion exposes and how live
+//! error metadata overrides a carried `return -options` dictionary. Concrete
+//! runtimes remain responsible only for constructing their Tcl object type.
+
+use tcl_dialect::TclVersion;
+
+use crate::Code;
+
+/// A planned option value which an engine materialises in its Tcl value model.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OptionValue<V> {
+    /// A standard integer value (`-code`, `-level`, or `-errorline`).
+    Integer(i64),
+    /// An already-materialised runtime value.
+    Value(V),
+}
+
+/// Live metadata for an error completion.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ErrorOptions<V> {
+    /// The resolved Tcl error-code list. Every error supplies one.
+    pub error_code: Option<V>,
+    /// The accumulated `errorInfo`, once the error is active at level zero.
+    pub error_info: Option<V>,
+    /// The accumulated TIP 348 stack, once active and available in the release.
+    pub error_stack: Option<V>,
+    /// The source line of the innermost error frame.
+    pub error_line: Option<i64>,
+    /// The prior completion superseded by a `try` handler or `finally` error.
+    pub during: Option<V>,
+}
+
+/// One carried return-option pair.
+pub type CarriedOption<V> = (Vec<u8>, V);
+
+/// Plan the complete return-options dictionary for one completion.
+///
+/// Carried options are retained, including custom keys and explicit error
+/// metadata. `-code` and `-level` are always replaced by the settled values;
+/// live level-zero error metadata replaces its carried counterpart. A missing
+/// `-errorcode` is filled for every error. TIP 348 is gated by the selected
+/// Tcl release at this shared seam.
+#[must_use]
+pub fn plan<V: Clone>(
+    version: TclVersion,
+    code: Code,
+    level: i64,
+    carried: &[CarriedOption<V>],
+    error: Option<&ErrorOptions<V>>,
+) -> Vec<(Vec<u8>, OptionValue<V>)> {
+    let mut rows: Vec<(Vec<u8>, OptionValue<V>)> = carried
+        .iter()
+        .filter(|(key, _)| {
+            key.as_slice() != b"-code"
+                && key.as_slice() != b"-level"
+                && (version.has_error_stack() || key.as_slice() != b"-errorstack")
+        })
+        .map(|(key, value)| (key.clone(), OptionValue::Value(value.clone())))
+        .collect();
+
+    rows.push((b"-code".to_vec(), OptionValue::Integer(code.as_int())));
+    rows.push((b"-level".to_vec(), OptionValue::Integer(level)));
+
+    if code != Code::Error {
+        return rows;
+    }
+    let Some(error) = error else {
+        return rows;
+    };
+    if version.has_error_stack()
+        && let Some(value) = &error.error_stack
+    {
+        set_or_append(&mut rows, b"-errorstack", OptionValue::Value(value.clone()));
+    }
+    if let Some(value) = &error.error_code {
+        set_or_append(&mut rows, b"-errorcode", OptionValue::Value(value.clone()));
+    }
+    if let Some(value) = &error.error_info {
+        set_or_append(&mut rows, b"-errorinfo", OptionValue::Value(value.clone()));
+    }
+    if let Some(line) = error.error_line {
+        set_or_append(&mut rows, b"-errorline", OptionValue::Integer(line));
+    }
+    if let Some(value) = &error.during {
+        set_or_append(&mut rows, b"-during", OptionValue::Value(value.clone()));
+    }
+    rows
+}
+
+fn set_or_append<V>(rows: &mut Vec<(Vec<u8>, OptionValue<V>)>, key: &[u8], value: OptionValue<V>) {
+    if let Some((_, current)) = rows.iter_mut().find(|(candidate, _)| candidate == key) {
+        *current = value;
+    } else {
+        rows.push((key.to_vec(), value));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn keys<'a>(rows: &'a [(Vec<u8>, OptionValue<&'a str>)]) -> Vec<&'a [u8]> {
+        rows.iter().map(|(key, _)| key.as_slice()).collect()
+    }
+
+    #[test]
+    fn errors_receive_standard_metadata_and_keep_custom_options() {
+        let carried = vec![(b"-foo".to_vec(), "bar")];
+        let error = ErrorOptions {
+            error_code: Some("NONE"),
+            error_info: Some("boom"),
+            error_stack: Some("INNER boom"),
+            error_line: Some(3),
+            during: None,
+        };
+        let rows = plan(TclVersion::V9_0, Code::Error, 0, &carried, Some(&error));
+        assert_eq!(
+            keys(&rows),
+            [
+                b"-foo".as_slice(),
+                b"-code",
+                b"-level",
+                b"-errorstack",
+                b"-errorcode",
+                b"-errorinfo",
+                b"-errorline"
+            ]
+        );
+    }
+
+    #[test]
+    fn tip_348_is_release_gated_and_explicit_values_are_preserved() {
+        let carried = vec![
+            (b"-errorstack".to_vec(), "explicit"),
+            (b"-errorinfo".to_vec(), "INFO"),
+        ];
+        let error = ErrorOptions {
+            error_code: Some("NONE"),
+            ..ErrorOptions::default()
+        };
+        let old = plan(TclVersion::V8_5, Code::Error, 1, &carried, Some(&error));
+        assert!(!keys(&old).contains(&b"-errorstack".as_slice()));
+        let modern = plan(TclVersion::V9_0, Code::Error, 1, &carried, Some(&error));
+        assert!(keys(&modern).contains(&b"-errorstack".as_slice()));
+        assert!(keys(&modern).contains(&b"-errorinfo".as_slice()));
+    }
+}

--- a/rust/tcl-runtime-api/src/error_stack.rs
+++ b/rust/tcl-runtime-api/src/error_stack.rs
@@ -157,11 +157,12 @@ impl<T> ErrorStack<T> {
 }
 
 impl<T: Clone> ErrorStack<T> {
-    /// Snapshot the active stack, or a carried explicit stack before logging.
+    /// Snapshot the active stack, an explicit carried stack, or the retained
+    /// prior stack when a reset episode supplies no new inner context.
     #[must_use]
     pub fn snapshot_or(&self, carried: Option<Vec<T>>) -> Vec<T> {
         if self.reset {
-            carried.unwrap_or_default()
+            carried.unwrap_or_else(|| self.entries.clone())
         } else {
             self.entries.clone()
         }
@@ -184,6 +185,22 @@ mod tests {
         assert_eq!(stack.entries(), &["INNER", "first", "CALL", "p"]);
         assert!(stack.begin_inner("INNER", "second"));
         assert_eq!(stack.entries(), &["INNER", "second"]);
+    }
+
+    #[test]
+    fn reset_snapshot_retains_prior_entries_until_a_new_inner_context() {
+        let mut stack = ErrorStack::default();
+        assert!(stack.begin_inner("INNER", "first"));
+        stack.mark_reset();
+
+        assert_eq!(stack.snapshot_or(None), ["INNER", "first"]);
+        assert_eq!(
+            stack.snapshot_or(Some(vec!["INNER", "explicit"])),
+            ["INNER", "explicit"]
+        );
+
+        assert!(stack.begin_inner("INNER", "second"));
+        assert_eq!(stack.snapshot_or(None), ["INNER", "second"]);
     }
 
     #[test]

--- a/rust/tcl-runtime-api/src/error_stack.rs
+++ b/rust/tcl-runtime-api/src/error_stack.rs
@@ -1,0 +1,191 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! TIP 348 structured error-stack representation and lifecycle.
+//!
+//! Runtime engines use different Tcl value representations, but the stack's
+//! lazy-reset and tag/value-pair invariants are identical. This owner keeps
+//! those rules below both engines; adapters only construct concrete values.
+
+use crate::Code;
+
+/// A rejected explicit `-errorstack` value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ErrorStackValueError {
+    /// The value could not be decoded as a Tcl list.
+    NonList,
+    /// A flat tag/value list must contain an even number of elements.
+    OddSized,
+}
+
+/// Validate a decoded explicit `-errorstack` value.
+pub fn validate_error_stack<T, E>(
+    parts: Result<Vec<T>, E>,
+) -> Result<Vec<T>, ErrorStackValueError> {
+    let parts = parts.map_err(|_| ErrorStackValueError::NonList)?;
+    if !parts.len().is_multiple_of(2) {
+        return Err(ErrorStackValueError::OddSized);
+    }
+    Ok(parts)
+}
+
+/// Interpreter-local TIP 348 stack over one engine's concrete Tcl value type.
+#[derive(Debug, Clone)]
+pub struct ErrorStack<T> {
+    entries: Vec<T>,
+    reset: bool,
+}
+
+impl<T> Default for ErrorStack<T> {
+    fn default() -> Self {
+        Self {
+            entries: Vec::new(),
+            reset: true,
+        }
+    }
+}
+
+impl<T> ErrorStack<T> {
+    /// Whether the next inner-context log starts a new episode.
+    #[must_use]
+    pub const fn is_reset(&self) -> bool {
+        self.reset
+    }
+
+    /// Keep the last entries introspectable but make the next inner log replace them.
+    pub const fn mark_reset(&mut self) {
+        self.reset = true;
+    }
+
+    /// Adopt an already-decoded, validated explicit stack.
+    pub fn adopt(&mut self, entries: Vec<T>) -> Result<(), ErrorStackValueError> {
+        if !entries.len().is_multiple_of(2) {
+            return Err(ErrorStackValueError::OddSized);
+        }
+        self.entries = entries;
+        self.reset = false;
+        Ok(())
+    }
+
+    /// Start the next error episode with one `INNER context` pair.
+    pub fn begin_inner(&mut self, tag: T, context: T) -> bool {
+        if !self.reset {
+            return false;
+        }
+        self.entries.clear();
+        self.entries.push(tag);
+        self.entries.push(context);
+        self.reset = false;
+        true
+    }
+
+    /// Discard the active episode and immediately start another `INNER` pair.
+    pub fn restart_inner(&mut self, tag: T, context: T) {
+        self.reset = true;
+        let _ = self.begin_inner(tag, context);
+    }
+
+    /// Extend an active episode with another tag/value pair.
+    pub fn push_pair(&mut self, tag: T, value: T) -> bool {
+        if self.reset {
+            return false;
+        }
+        self.entries.push(tag);
+        self.entries.push(value);
+        true
+    }
+
+    /// Append a procedure `CALL` only when an error unwound through its body.
+    ///
+    /// A positive-level `return -code error` reaches its settling procedure as
+    /// [`Code::Return`] and creates the error there, so that procedure is not a
+    /// frame the error unwound through. Outer procedures see [`Code::Error`]
+    /// and append normally.
+    pub fn push_proc_call(
+        &mut self,
+        body_code: Code,
+        settled_code: Code,
+        tag: T,
+        invocation: T,
+    ) -> bool {
+        if settled_code != Code::Error || body_code == Code::Return {
+            return false;
+        }
+        self.push_pair(tag, invocation)
+    }
+
+    /// Borrow the flat tag/value entries for engine-specific Tcl-list encoding.
+    #[must_use]
+    pub fn entries(&self) -> &[T] {
+        &self.entries
+    }
+
+    /// Borrow the active episode, or `None` while waiting for the next error.
+    #[must_use]
+    pub fn active_entries(&self) -> Option<&[T]> {
+        (!self.reset).then_some(&self.entries)
+    }
+}
+
+impl<T: Clone> ErrorStack<T> {
+    /// Snapshot the active stack, or a carried explicit stack before logging.
+    #[must_use]
+    pub fn snapshot_or(&self, carried: Option<Vec<T>>) -> Vec<T> {
+        if self.reset {
+            carried.unwrap_or_default()
+        } else {
+            self.entries.clone()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lifecycle_is_lazy_and_pair_shaped() {
+        let mut stack = ErrorStack::default();
+        assert!(stack.begin_inner("INNER", "first"));
+        assert!(!stack.begin_inner("INNER", "ignored"));
+        assert!(stack.push_pair("CALL", "p"));
+        assert_eq!(stack.entries(), &["INNER", "first", "CALL", "p"]);
+
+        stack.mark_reset();
+        assert_eq!(stack.entries(), &["INNER", "first", "CALL", "p"]);
+        assert!(stack.begin_inner("INNER", "second"));
+        assert_eq!(stack.entries(), &["INNER", "second"]);
+    }
+
+    #[test]
+    fn validation_is_shared() {
+        assert_eq!(
+            validate_error_stack::<u8, _>(Err(())),
+            Err(ErrorStackValueError::NonList)
+        );
+        assert_eq!(
+            validate_error_stack::<_, ()>(Ok(vec![1])),
+            Err(ErrorStackValueError::OddSized)
+        );
+        assert_eq!(
+            validate_error_stack::<_, ()>(Ok(vec![1, 2])),
+            Ok(vec![1, 2])
+        );
+    }
+
+    #[test]
+    fn return_boundary_suppresses_only_the_error_creating_proc() {
+        let mut stack = ErrorStack::default();
+        stack.adopt(Vec::<&str>::new()).unwrap();
+        assert!(!stack.push_proc_call(Code::Return, Code::Error, "CALL", "inner"));
+        assert!(stack.push_proc_call(Code::Error, Code::Error, "CALL", "outer"));
+        assert_eq!(stack.entries(), &["CALL", "outer"]);
+    }
+}

--- a/rust/tcl-runtime-api/src/error_stack.rs
+++ b/rust/tcl-runtime-api/src/error_stack.rs
@@ -41,6 +41,7 @@ pub fn validate_error_stack<T, E>(
 pub struct ErrorStack<T> {
     entries: Vec<T>,
     reset: bool,
+    shifted_contexts: Vec<(usize, usize)>,
 }
 
 impl<T> Default for ErrorStack<T> {
@@ -48,6 +49,7 @@ impl<T> Default for ErrorStack<T> {
         Self {
             entries: Vec::new(),
             reset: true,
+            shifted_contexts: Vec::new(),
         }
     }
 }
@@ -121,6 +123,26 @@ impl<T> ErrorStack<T> {
         self.push_pair(tag, invocation)
     }
 
+    /// Enter an `uplevel`-style redirect, identified by the concrete runtime's
+    /// target frame count and the logical level delta recorded by TIP 348.
+    pub fn enter_shifted_context(&mut self, frame_count: usize, delta: usize) {
+        self.shifted_contexts.push((frame_count, delta));
+    }
+
+    /// Leave the innermost `uplevel`-style redirect.
+    pub fn leave_shifted_context(&mut self) {
+        let _ = self.shifted_contexts.pop();
+    }
+
+    /// The innermost active shift whose target is the command being logged.
+    #[must_use]
+    pub fn shifted_context_delta(&self, frame_count: usize) -> Option<usize> {
+        self.shifted_contexts
+            .iter()
+            .rev()
+            .find_map(|(target, delta)| (*target == frame_count).then_some(*delta))
+    }
+
     /// Borrow the flat tag/value entries for engine-specific Tcl-list encoding.
     #[must_use]
     pub fn entries(&self) -> &[T] {
@@ -187,5 +209,16 @@ mod tests {
         assert!(!stack.push_proc_call(Code::Return, Code::Error, "CALL", "inner"));
         assert!(stack.push_proc_call(Code::Error, Code::Error, "CALL", "outer"));
         assert_eq!(stack.entries(), &["CALL", "outer"]);
+    }
+
+    #[test]
+    fn shifted_context_uses_the_innermost_matching_target() {
+        let mut stack = ErrorStack::<&str>::default();
+        stack.enter_shifted_context(2, 1);
+        stack.enter_shifted_context(2, 3);
+        assert_eq!(stack.shifted_context_delta(2), Some(3));
+        assert_eq!(stack.shifted_context_delta(1), None);
+        stack.leave_shifted_context();
+        assert_eq!(stack.shifted_context_delta(2), Some(1));
     }
 }

--- a/rust/tcl-runtime-api/src/lib.rs
+++ b/rust/tcl-runtime-api/src/lib.rs
@@ -41,6 +41,12 @@ pub use tcl_core_types::{
     Code, CommandId, Completion, FrameId, GLOBAL_FRAME, NsId, ROOT_NS, VarId,
 };
 
+/// Standard Tcl return-option construction policy.
+pub mod completion_options;
+
+/// Shared TIP 348 structured error-stack state and validation.
+pub mod error_stack;
+
 /// An owned, byte-preserving script completion for host and embedding
 /// boundaries.
 ///

--- a/rust/tcl-vm/src/cmd_coro.rs
+++ b/rust/tcl-vm/src/cmd_coro.rs
@@ -221,7 +221,7 @@ fn cmd_coroutine(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     let is_apply = matches!(&*args[1].to_str(), "apply" | "::apply");
     let mut temp_proc = None;
     let words: Vec<Value> = if args.len() >= 3 && is_apply {
-        match crate::command::build_lambda_proc(vm, &args[2]) {
+        match crate::command::build_lambda_proc(vm, &args[2], args[1..].to_vec()) {
             Ok(lambda_name) => {
                 let mut w = Vec::with_capacity(args.len() - 2);
                 w.push(Value::string(lambda_name.as_str()));

--- a/rust/tcl-vm/src/cmd_info.rs
+++ b/rust/tcl-vm/src/cmd_info.rs
@@ -263,6 +263,23 @@ fn cmd_info(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
             [] => ok(crate::cmd_coro::current_coroutine(vm)),
             _ => err("wrong # args: should be \"info coroutine\""),
         },
+        // TIP 348 (Tcl 8.6+). Availability is already filtered through the
+        // registry-derived release subcommand set above; the state lives on
+        // the selected interpreter, so child access uses the ordinary arena.
+        "errorstack" => {
+            let id = match rest {
+                [] => None,
+                [path] => match vm.resolve_interp_path(&path.to_str()) {
+                    Ok(id) => Some(id),
+                    Err(error) => return error,
+                },
+                _ => return err("wrong # args: should be \"info errorstack ?interp?\""),
+            };
+            match id {
+                Some(id) => ok(vm.in_interp(id, |target| target.error_stack_value())),
+                None => ok(vm.error_stack_value()),
+            }
+        }
         // Reached by a word that matched nothing, prefixed several entries, or
         // resolved to a subcommand this engine does not implement.
         other => err(
@@ -341,6 +358,18 @@ mod tests {
             missing.result.to_str().as_ref(),
             "can't read \"tcl_patchLevel\": no such variable"
         );
+    }
+
+    #[test]
+    fn errorstack_surface_follows_the_selected_runtime_release() {
+        let mut vm = Vm::new();
+        vm.set_runtime_version(TclVersion::V8_5);
+        assert!(!info(&mut vm, "errorstack").code.is_ok());
+
+        vm.set_runtime_version(TclVersion::V8_6);
+        let result = info(&mut vm, "errorstack");
+        assert!(result.code.is_ok());
+        assert!(result.result.as_list().expect("TIP 348 list").is_empty());
     }
 
     #[test]

--- a/rust/tcl-vm/src/cmd_oo.rs
+++ b/rust/tcl-vm/src/cmd_oo.rs
@@ -917,10 +917,12 @@ fn factory(
         return make_class(vm, &name, body, class_key);
     }
 
-    let (obj_key, obj_ns, ctor_args, ctor_usage) = if anon {
+    let (obj_key, obj_ns, ctor_args, ctor_usage, ctor_identity) = if anon {
         // An anonymous object's command *is* its instance namespace (`oo::ObjN`).
         let n = fresh_obj_name(vm);
-        (n.clone(), n, args, format!("{class_invoked} new"))
+        let mut identity = vec![Value::string(class_invoked), Value::string("new")];
+        identity.extend_from_slice(args);
+        (n.clone(), n, args, format!("{class_invoked} new"), identity)
     } else {
         let Some((name, rest)) = args.split_first() else {
             return err(format!(
@@ -934,11 +936,18 @@ fn factory(
         }
         // A named object's instance namespace is still a fresh `oo::ObjN`,
         // decoupled from its command name (C's `oo::Obj` counter).
+        let mut identity = vec![
+            Value::string(class_invoked),
+            Value::string("create"),
+            Value::string(name.as_ref()),
+        ];
+        identity.extend_from_slice(rest);
         (
             vm.qualify_name(&name),
             fresh_obj_name(vm),
             rest,
             format!("{class_invoked} create {name}"),
+            identity,
         )
     };
     if vm.lookup_command(&obj_key).is_some() {
@@ -947,7 +956,15 @@ fn factory(
             display(&obj_key)
         ));
     }
-    oo_new(vm, class_key, &obj_key, &obj_ns, ctor_args, &ctor_usage)
+    oo_new(
+        vm,
+        class_key,
+        &obj_key,
+        &obj_ns,
+        ctor_args,
+        &ctor_usage,
+        ctor_identity,
+    )
 }
 
 /// A fresh `oo::ObjN` name (canonical) for an anonymous object.
@@ -967,6 +984,7 @@ fn oo_new(
     obj_ns: &str,
     ctor_args: &[Value],
     ctor_usage: &str,
+    ctor_identity: Vec<Value>,
 ) -> Completion<Value> {
     let id = vm.oo.counter;
     vm.oo.counter += 1;
@@ -1017,6 +1035,7 @@ fn oo_new(
             false,
             display(obj_key),
             ctor_usage.to_string(),
+            ctor_identity,
         );
         if !res.code.is_ok() && res.code != Code::Return {
             // Tear the half-built object down and re-raise.
@@ -1231,6 +1250,11 @@ fn oo_invoke(
         return unknown_method(vm, obj_key, method, external);
     }
     let usage = format!("{invoked} {method}");
+    let mut call_identity = vec![
+        Value::string(if external { invoked } else { "my" }),
+        Value::string(method),
+    ];
+    call_identity.extend_from_slice(args);
     run_step(
         vm,
         obj_key,
@@ -1241,6 +1265,7 @@ fn oo_invoke(
         external,
         invoked.to_string(),
         usage,
+        call_identity,
     )
 }
 
@@ -1289,6 +1314,7 @@ fn run_step(
     external: bool,
     invoked: String,
     usage_prefix: String,
+    call_identity: Vec<Value>,
 ) -> Completion<Value> {
     if let Err(c) = vm.enter_oo_dispatch() {
         return c;
@@ -1303,6 +1329,7 @@ fn run_step(
         external,
         invoked,
         usage_prefix,
+        call_identity,
     );
     vm.exit_oo_dispatch();
     result
@@ -1319,6 +1346,7 @@ fn run_step_inner(
     external: bool,
     invoked: String,
     usage_prefix: String,
+    call_identity: Vec<Value>,
 ) -> Completion<Value> {
     let step = chain[index].clone();
     // Resolve the method body for this step.
@@ -1412,6 +1440,7 @@ fn run_step_inner(
         body,
         body_src: m.body_src.clone(),
         usage_name: Some(usage_prefix.clone()),
+        call_identity: Some(call_identity),
     };
     // Refresh through the shared proc owner, then persist the replacement on
     // its defining facet.  Recompiling on every method call after a profile
@@ -1610,6 +1639,8 @@ pub(crate) fn cmd_next(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
         };
         return err(format!("no next {kind} implementation"));
     }
+    let mut call_identity = vec![Value::string("next")];
+    call_identity.extend_from_slice(args);
     run_step(
         vm,
         &obj,
@@ -1620,6 +1651,7 @@ pub(crate) fn cmd_next(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
         external,
         invoked,
         usage,
+        call_identity,
     )
 }
 
@@ -1646,8 +1678,19 @@ pub(crate) fn cmd_nextto(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
         .enumerate()
         .position(|(i, s)| i > index && !s.is_object && s.provider == target)
     {
+        let mut call_identity = vec![Value::string("nextto")];
+        call_identity.extend_from_slice(args);
         return run_step(
-            vm, &obj, &chain, pos, method, rest, external, invoked, usage,
+            vm,
+            &obj,
+            &chain,
+            pos,
+            method,
+            rest,
+            external,
+            invoked,
+            usage,
+            call_identity,
         );
     }
     err(format!(
@@ -1706,6 +1749,7 @@ fn oo_destroy(vm: &mut Vm, obj_key: &str) -> Completion<Value> {
             .collect();
         if !chain.is_empty() {
             let d = display(obj_key);
+            let call_identity = vec![Value::string(d.as_str()), Value::string("destroy")];
             let res = run_step(
                 vm,
                 obj_key,
@@ -1716,6 +1760,7 @@ fn oo_destroy(vm: &mut Vm, obj_key: &str) -> Completion<Value> {
                 false,
                 d.clone(),
                 d,
+                call_identity,
             );
             if !res.code.is_ok() && res.code != Code::Return {
                 result = res;

--- a/rust/tcl-vm/src/cmd_try.rs
+++ b/rust/tcl-vm/src/cmd_try.rs
@@ -352,7 +352,7 @@ pub(crate) fn advance_try(vm: &mut Vm, state: TryState, c: Completion<Value>) ->
     match phase {
         TryPhase::Body => advance_after_body(vm, &plan, c),
         TryPhase::Handler { body_opts } => advance_after_handler(vm, &plan, &body_opts, c),
-        TryPhase::Finally { outcome } => advance_after_finally(outcome, c),
+        TryPhase::Finally { outcome } => advance_after_finally(vm, outcome, c),
     }
 }
 
@@ -372,7 +372,7 @@ fn advance_after_body(vm: &mut Vm, plan: &Rc<TryPlan>, body_comp: Completion<Val
     };
     // The body's options dict (bound to a handler's optionsVar and reused as the
     // `-during` chain link if a handler/finally throws over the body's exception).
-    let body_opts = completion_options(&body_comp);
+    let body_opts = vm.completion_options_snapshot(&body_comp);
     let matched = plan.handlers.iter().position(|h| {
         if h.is_trap {
             body_comp.code == Code::Error && errorcode_prefix_match(&h.pattern, &errorcode)
@@ -421,7 +421,7 @@ fn advance_after_body(vm: &mut Vm, plan: &Rc<TryPlan>, body_comp: Completion<Val
         // A failed var bind also chains to the body (C's `handlerFailed`).
         Err(mut e) => {
             if e.code == Code::Error {
-                e.options = add_during(&completion_options(&e), &body_opts);
+                e.options = add_during(&vm.completion_options_snapshot(&e), &body_opts);
             }
             finish_body_or_handler(vm, plan, e)
         }
@@ -439,7 +439,7 @@ fn advance_after_handler(
 ) -> TryOutcome {
     let mut outcome = handler_comp;
     if outcome.code == Code::Error {
-        outcome.options = add_during(&completion_options(&outcome), body_opts);
+        outcome.options = add_during(&vm.completion_options_snapshot(&outcome), body_opts);
     }
     finish_body_or_handler(vm, plan, outcome)
 }
@@ -450,11 +450,17 @@ fn advance_after_handler(
 fn finish_body_or_handler(
     vm: &mut Vm,
     plan: &Rc<TryPlan>,
-    outcome: Completion<Value>,
+    mut outcome: Completion<Value>,
 ) -> TryOutcome {
+    if outcome.code == Code::Error {
+        outcome.options = vm.completion_options_snapshot(&outcome);
+    }
     let Some(fin) = plan.finally.clone() else {
         return TryOutcome::Deliver(outcome);
     };
+    if outcome.code == Code::Error {
+        let _ = vm.take_error_info();
+    }
     // Compiled lazily here rather than in `cmd_try` up front: a `finally`
     // never runs before this point, matching the old synchronous ordering (a
     // body/handler compile error is reported before `finally`'s own grammar
@@ -464,11 +470,11 @@ fn finish_body_or_handler(
         // A `finally` parse error is `finally`'s own exception overriding the
         // prior outcome, same as a runtime error in `finally` would (chains
         // `-during` to what `finally` superseded).
-        Err(e) => return advance_after_finally(outcome, err(e.message)),
+        Err(e) => return advance_after_finally(vm, outcome, err(e.message)),
     };
     let Some(script) = prepared.prefix else {
         let completion = prepared.fatal_tail.map_or_else(|| ok(Value::empty()), err);
-        return advance_after_finally(outcome, completion);
+        return advance_after_finally(vm, outcome, completion);
     };
     TryOutcome::Push(TryReq {
         script,
@@ -482,14 +488,19 @@ fn finish_body_or_handler(
 
 /// `finally` just completed as `fc`: only its own non-`Ok` completion
 /// overrides — chaining `-during` to the prior outcome's options if it threw.
-fn advance_after_finally(outcome: Completion<Value>, fc: Completion<Value>) -> TryOutcome {
+fn advance_after_finally(
+    vm: &mut Vm,
+    outcome: Completion<Value>,
+    fc: Completion<Value>,
+) -> TryOutcome {
     if fc.code == Code::Ok {
+        vm.restore_completion_error_state(&outcome);
         return TryOutcome::Deliver(outcome);
     }
     let mut fc = fc;
     if fc.code == Code::Error {
         let prior_opts = completion_options(&outcome);
-        fc.options = add_during(&completion_options(&fc), &prior_opts);
+        fc.options = add_during(&vm.completion_options_snapshot(&fc), &prior_opts);
     }
     TryOutcome::Deliver(fc)
 }

--- a/rust/tcl-vm/src/command.rs
+++ b/rust/tcl-vm/src/command.rs
@@ -26,6 +26,8 @@
 use std::rc::Rc;
 
 use tcl_cmd_core::CmdError;
+use tcl_runtime_api::completion_options::{self as shared_options, ErrorOptions, OptionValue};
+use tcl_runtime_api::error_stack::{ErrorStackValueError, validate_error_stack};
 use tcl_runtime_api::{Code, Completion};
 use tcl_syntax::formal_params::{has_trailing_args, parse_formal_parameters};
 
@@ -1542,7 +1544,7 @@ pub(crate) fn opt_get(options: &Value, key: &str) -> Option<Value> {
 /// Shared with the `returnStk` opcode (C `INST_RETURN_STK` →
 /// `Tcl_SetReturnOptions`), which behaves exactly like
 /// `return -options $opts $result`.
-pub(crate) fn cmd_return(_vm: &mut Vm, args: &[Value]) -> Completion<Value> {
+pub(crate) fn cmd_return(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     // Apply one option pair, from a direct argument or an expanded `-options`
     // dict. `-code`/`-level` drive the completion; every other key (`-errorcode`,
     // `-errorinfo`, or a user option like `-foo`) is preserved in the options
@@ -1603,6 +1605,40 @@ pub(crate) fn cmd_return(_vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     }
     let extra_refs: Vec<(&str, Value)> =
         extra.iter().map(|(k, v)| (k.as_str(), v.clone())).collect();
+    if vm.supports_error_stack()
+        && let Some((_, stack)) = extra.iter().find(|(key, _)| key == "-errorstack")
+    {
+        let parts = match validate_error_stack(stack.as_list().map(|parts| parts.as_ref().clone()))
+        {
+            Ok(parts) => parts,
+            Err(ErrorStackValueError::NonList) => {
+                return err_with_code(
+                    format!(
+                        "bad -errorstack value: expected a list but got \"{}\"",
+                        stack.to_str()
+                    ),
+                    "TCL RESULT NONLIST_ERRORSTACK",
+                );
+            }
+            Err(ErrorStackValueError::OddSized) => {
+                return err_with_code(
+                    format!(
+                        "forbidden odd-sized list for -errorstack: \"{}\"",
+                        stack.to_str()
+                    ),
+                    "TCL RESULT ODDSIZEDLIST_ERRORSTACK",
+                );
+            }
+        };
+        if ret_code == Code::Error {
+            vm.seed_error_stack_parts(parts);
+        }
+    }
+    if ret_code == Code::Error
+        && let Some((_, info)) = extra.iter().find(|(key, _)| key == "-errorinfo")
+    {
+        vm.seed_error_info(info.to_str().to_string());
+    }
     let options = options_dict(ret_code, level, &extra_refs);
     // `-level 0` makes the requested `-code` take effect *immediately* (the
     // completion IS that code, including `ok` — `return -level 0 -code N` is how
@@ -1873,6 +1909,90 @@ fn cmd_catch(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
 }
 
 impl Vm {
+    /// Snapshot a completion through the shared standard-options planner.
+    /// `catch`, compiled catch ranges, and `try` all use this adapter, so live
+    /// error metadata and carried return options cannot drift between them.
+    pub(crate) fn completion_options_snapshot(&self, comp: &Completion<Value>) -> Value {
+        let carried = comp.options.as_list().map_or_else(
+            |_| Vec::new(),
+            |items| {
+                items
+                    .as_slice()
+                    .as_chunks::<2>()
+                    .0
+                    .iter()
+                    .map(|pair| (pair[0].to_str().as_bytes().to_vec(), pair[1].clone()))
+                    .collect()
+            },
+        );
+        let (code, level) = if comp.code == Code::Return {
+            let code = opt_get(&comp.options, "-code")
+                .and_then(|value| value.as_int().ok())
+                .and_then(|value| i32::try_from(value).ok())
+                .map_or(Code::Ok, Code::from_int);
+            let level = opt_get(&comp.options, "-level")
+                .and_then(|value| value.as_int().ok())
+                .unwrap_or(1);
+            (code, level)
+        } else {
+            (comp.code, 0)
+        };
+        let active_error = code == Code::Error && comp.code == Code::Error && level == 0;
+        let error = (code == Code::Error).then(|| ErrorOptions {
+            error_code: Some(resolved_error_code(comp)),
+            error_info: active_error.then(|| {
+                self.error_info_value().map_or_else(
+                    || opt_get(&comp.options, "-errorinfo").unwrap_or_else(|| comp.result.clone()),
+                    Value::string,
+                )
+            }),
+            error_stack: active_error
+                .then(|| self.error_stack_for_completion(opt_get(&comp.options, "-errorstack"))),
+            error_line: active_error.then(|| i64::from(self.error_line())),
+            during: None,
+        });
+        let rows = shared_options::plan(
+            self.runtime_version(),
+            code,
+            level,
+            &carried,
+            error.as_ref(),
+        );
+        Value::list(
+            rows.into_iter()
+                .flat_map(|(key, value)| {
+                    let value = match value {
+                        OptionValue::Integer(value) => Value::int(value),
+                        OptionValue::Value(value) => value,
+                    };
+                    [Value::string(String::from_utf8_lossy(&key)), value]
+                })
+                .collect(),
+        )
+    }
+
+    /// Restore a frozen error completion after a successful `finally` body so
+    /// subsequent procedure unwinding extends the original stack.
+    pub(crate) fn restore_completion_error_state(&mut self, comp: &Completion<Value>) {
+        if comp.code != Code::Error {
+            return;
+        }
+        let info = opt_get(&comp.options, "-errorinfo")
+            .unwrap_or_else(|| comp.result.clone())
+            .to_str()
+            .to_string();
+        self.seed_error_info(info);
+        if let Some(stack) = opt_get(&comp.options, "-errorstack") {
+            self.seed_error_stack(&stack);
+        }
+        if let Some(line) = opt_get(&comp.options, "-errorline")
+            .and_then(|value| value.as_int().ok())
+            .and_then(|value| u32::try_from(value).ok())
+        {
+            self.set_error_line(line);
+        }
+    }
+
     /// The `catch` epilogue, shared by the explicit-stack catch frame
     /// ([`crate::exec`]'s `unwind`) and the `invoke_command` / parse-error
     /// fallbacks: from the body's completion `comp`, bind the result and options
@@ -1893,33 +2013,27 @@ impl Vm {
         if self.exit_pending() {
             return comp;
         }
-        let error_meta = if comp.code == Code::Error {
-            let einfo = self.take_error_info().unwrap_or_else(|| {
-                opt_get(&comp.options, "-errorinfo").map_or_else(
-                    || comp.result.to_str().to_string(),
-                    |v| v.to_str().to_string(),
-                )
-            });
-            Some((einfo, resolved_error_code(&comp), self.error_line()))
-        } else {
-            let _ = self.take_error_info();
-            None
-        };
+        let opts = self.completion_options_snapshot(&comp);
+        let error_meta = (comp.code == Code::Error).then(|| {
+            let einfo = opt_get(&opts, "-errorinfo").map_or_else(
+                || comp.result.to_str().to_string(),
+                |value| value.to_str().to_string(),
+            );
+            let ecode = opt_get(&opts, "-errorcode").unwrap_or_else(|| resolved_error_code(&comp));
+            (einfo, ecode)
+        });
+        let _ = self.take_error_info();
         if let Some(r) = resvar
             && let Err(e) = self.set_var(&r.to_str(), comp.result.clone())
         {
             return e;
         }
-        if let Some(o) = optvar {
-            let opts = match &error_meta {
-                Some((einfo, ecode, eline)) => catch_error_options(&comp, ecode, einfo, *eline),
-                None => completion_options(&comp),
-            };
-            if let Err(e) = self.set_var(&o.to_str(), opts) {
-                return e;
-            }
+        if let Some(o) = optvar
+            && let Err(e) = self.set_var(&o.to_str(), opts)
+        {
+            return e;
         }
-        if let Some((einfo, ecode, _)) = &error_meta {
+        if let Some((einfo, ecode)) = &error_meta {
             self.publish_error(einfo, ecode);
         }
         ok(Value::int(comp.code.as_int()))
@@ -1933,14 +2047,13 @@ impl Vm {
     /// `PUSH_RESULT`/`PUSH_RETURN_CODE`/`PUSH_RETURN_OPTS`.
     pub(crate) fn digest_catch_options(&mut self, comp: &Completion<Value>) -> Value {
         if comp.code == Code::Error {
-            let einfo = self.take_error_info().unwrap_or_else(|| {
-                opt_get(&comp.options, "-errorinfo").map_or_else(
-                    || comp.result.to_str().to_string(),
-                    |v| v.to_str().to_string(),
-                )
-            });
-            let ecode = resolved_error_code(comp);
-            let opts = catch_error_options(comp, &ecode, &einfo, self.error_line());
+            let opts = self.completion_options_snapshot(comp);
+            let einfo = opt_get(&opts, "-errorinfo").map_or_else(
+                || comp.result.to_str().to_string(),
+                |value| value.to_str().to_string(),
+            );
+            let ecode = opt_get(&opts, "-errorcode").unwrap_or_else(|| resolved_error_code(comp));
+            let _ = self.take_error_info();
             self.publish_error(&einfo, &ecode);
             opts
         } else {
@@ -1948,42 +2061,6 @@ impl Vm {
             completion_options(comp)
         }
     }
-}
-
-/// The options dict `catch` binds for an error completion. C always attaches
-/// `-errorcode`, `-errorinfo`, and `-errorline` to an error's options — even a
-/// bare builtin error such as `catch {llength} m opts` — so
-/// `dict get $opts -errorcode` never fails. The resolved code
-/// and trace already fold in any values a user `error`/`throw`/`return` carried;
-/// any *other* carried option (a custom `-foo`) is preserved verbatim.
-fn catch_error_options(comp: &Completion<Value>, ecode: &Value, einfo: &str, eline: u32) -> Value {
-    let mut items = vec![
-        Value::string("-code"),
-        Value::int(comp.code.as_int()),
-        Value::string("-level"),
-        Value::int(0),
-        Value::string("-errorcode"),
-        ecode.clone(),
-        Value::string("-errorinfo"),
-        Value::string(einfo),
-        Value::string("-errorline"),
-        Value::int(i64::from(eline)),
-    ];
-    if let Ok(carried) = comp.options.as_list() {
-        let mut i = 0;
-        while i + 1 < carried.len() {
-            let k = carried[i].to_str();
-            if !matches!(
-                &*k,
-                "-code" | "-level" | "-errorcode" | "-errorinfo" | "-errorline"
-            ) {
-                items.push(carried[i].clone());
-                items.push(carried[i + 1].clone());
-            }
-            i += 2;
-        }
-    }
-    Value::list(items)
 }
 
 /// `unset ?-nocomplain? ?--? name ...` — remove variables / array elements.

--- a/rust/tcl-vm/src/command.rs
+++ b/rust/tcl-vm/src/command.rs
@@ -92,6 +92,10 @@ pub struct ProcDef {
     /// message reads `wrong # args: should be "apply lambdaExpr …"` rather than
     /// leaking the internal temp proc name (apply-4.*).
     pub usage_name: Option<String>,
+    /// Exact invocation words for proc-like adapters whose registered command
+    /// is an implementation detail (`apply` lambdas and `TclOO` method bodies).
+    /// Ordinary procs derive them from the dispatched head and arguments.
+    pub(crate) call_identity: Option<Vec<Value>>,
 }
 
 /// A registered command.
@@ -386,7 +390,11 @@ fn fresh_apply_name() -> String {
 /// activation stack* (a `yield` inside it is then yieldable — the generic
 /// `apply` path evaluates the body through a host-stack re-entry, which a
 /// `yield` cannot cross).
-pub(crate) fn build_lambda_proc(vm: &mut Vm, lambda: &Value) -> Result<String, Completion<Value>> {
+pub(crate) fn build_lambda_proc(
+    vm: &mut Vm,
+    lambda: &Value,
+    call_identity: Vec<Value>,
+) -> Result<String, Completion<Value>> {
     let parts = match lambda.as_list() {
         Ok(p) => p,
         Err(c) => return Err(err(c.message)),
@@ -439,6 +447,7 @@ pub(crate) fn build_lambda_proc(vm: &mut Vm, lambda: &Value) -> Result<String, C
         body: body_asm,
         body_src: body,
         usage_name: Some("apply lambdaExpr".to_string()),
+        call_identity: Some(call_identity),
     });
     Ok(name)
 }
@@ -460,7 +469,10 @@ fn cmd_apply(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     let Some((lambda, call_args)) = args.split_first() else {
         return err("wrong # args: should be \"apply lambdaExpr ?arg ...?\"");
     };
-    let name = match build_lambda_proc(vm, lambda) {
+    let mut call_identity = Vec::with_capacity(args.len() + 1);
+    call_identity.push(Value::string(vm.invoked_name().unwrap_or("apply")));
+    call_identity.extend_from_slice(args);
+    let name = match build_lambda_proc(vm, lambda, call_identity) {
         Ok(n) => n,
         Err(c) => return c,
     };
@@ -1335,6 +1347,7 @@ fn cmd_proc(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
         body,
         body_src: body_text.clone(),
         usage_name: None,
+        call_identity: None,
     });
     ok(Value::empty())
 }

--- a/rust/tcl-vm/src/embed.rs
+++ b/rust/tcl-vm/src/embed.rs
@@ -145,6 +145,7 @@ impl Vm {
             body: compiled,
             body_src: Value::string(body),
             usage_name: None,
+            call_identity: None,
         });
         Ok(())
     }

--- a/rust/tcl-vm/src/exec.rs
+++ b/rust/tcl-vm/src/exec.rs
@@ -1635,16 +1635,18 @@ impl Vm {
                     .get(frame.pc.saturating_sub(1))
                     .map(|instruction| {
                         let context = match instruction.error_stack_context.as_ref() {
-                            Some(ErrorStackContext::CommandResult { head }) => {
+                            Some(ErrorStackContext::CommandResult { head, .. }) => {
                                 Value::list(vec![Value::string(head.as_str()), c.result.clone()])
                             }
                             None => Value::string(instruction.source_cmd_text.as_str()),
                         };
-                        (
-                            instruction.source_cmd_text.clone(),
-                            instruction.source_line,
-                            context,
-                        )
+                        let text = match instruction.error_stack_context.as_ref() {
+                            Some(ErrorStackContext::CommandResult {
+                                error_info_command, ..
+                            }) => error_info_command.clone(),
+                            None => instruction.source_cmd_text.clone(),
+                        };
+                        (text, instruction.source_line, context)
                     })
             })
         {
@@ -1725,7 +1727,7 @@ impl Vm {
         for r in covering {
             let body_line = self.error_line().saturating_sub(r.line_base).max(1);
             self.append_body_frame_line(&r.label, body_line);
-            self.log_command_info(&r.cmd_text, "", r.cmd_line);
+            self.log_command_info_only(&r.cmd_text, "", r.cmd_line);
         }
     }
 
@@ -2131,9 +2133,12 @@ impl Vm {
         if self.recursion_depth() >= self.recursion_limit() {
             return Err(err("too many nested evaluations (infinite loop?)"));
         }
-        let mut call_argv = Vec::with_capacity(argv.len() + 1);
-        call_argv.push(invoked.clone());
-        call_argv.extend(argv.iter().cloned());
+        let call_argv = proc.call_identity.clone().unwrap_or_else(|| {
+            let mut words = Vec::with_capacity(argv.len() + 1);
+            words.push(invoked.clone());
+            words.extend(argv.iter().cloned());
+            words
+        });
         self.push_call_frame(Some(proc.name.clone()), call_argv);
 
         let mut i = 0;

--- a/rust/tcl-vm/src/exec.rs
+++ b/rust/tcl-vm/src/exec.rs
@@ -29,7 +29,9 @@
 use std::collections::HashMap;
 use std::rc::Rc;
 
-use tcl_bytecode::{ErrorRegion, FunctionAsm, INDEX_END, Instruction, ModuleAsm, Op, Operand};
+use tcl_bytecode::{
+    ErrorRegion, ErrorStackContext, FunctionAsm, INDEX_END, Instruction, ModuleAsm, Op, Operand,
+};
 use tcl_runtime_api::{Code, Completion, ScriptCompileTarget};
 use tcl_syntax::expr::{BinOp, UnaryOp};
 use tcl_syntax::value::string_char_len;
@@ -531,7 +533,12 @@ enum Tick {
     /// The current frame finished — unwind with this completion.
     Return(Completion<Value>),
     /// Call a proc — push a new activation + call-frame.
-    Call { proc: Rc<ProcDef>, argv: Vec<Value> },
+    Call {
+        proc: Rc<ProcDef>,
+        /// The command spelling before namespace resolution.
+        invoked: Value,
+        argv: Vec<Value>,
+    },
     /// Run a compiled script on the explicit stack — push a *transparent* script
     /// activation ([`Frame::new_script`]). Used by `EVAL_STK` (and the
     /// `eval`/`uplevel`/`apply` builtins routed through it) so a `yield` inside
@@ -1386,7 +1393,11 @@ impl Vm {
             }
             match tick {
                 Tick::Continue => {}
-                Tick::Call { proc, argv } => match self.enter_proc(&proc, &argv) {
+                Tick::Call {
+                    proc,
+                    invoked,
+                    argv,
+                } => match self.enter_proc(&proc, &invoked, &argv) {
                     Ok(()) => self.push_proc_frame(acts, &proc),
                     Err(c) => {
                         // A traced dispatch that failed at proc entry (arity)
@@ -1616,6 +1627,30 @@ impl Vm {
         acts: &mut Vec<Frame>,
         c: Completion<Value>,
     ) -> Option<Completion<Value>> {
+        if c.code == Code::Error
+            && let Some((text, line, context)) = acts.last().and_then(|frame| {
+                frame
+                    .asm
+                    .instructions
+                    .get(frame.pc.saturating_sub(1))
+                    .map(|instruction| {
+                        let context = match instruction.error_stack_context.as_ref() {
+                            Some(ErrorStackContext::CommandResult { head }) => {
+                                Value::list(vec![Value::string(head.as_str()), c.result.clone()])
+                            }
+                            None => Value::string(instruction.source_cmd_text.as_str()),
+                        };
+                        (
+                            instruction.source_cmd_text.clone(),
+                            instruction.source_line,
+                            context,
+                        )
+                    })
+            })
+        {
+            let message = c.result.to_str().to_string();
+            self.log_command_info_with_context(&text, context, &message, line);
+        }
         let c = match self
             .absorb_catch_range(acts.last_mut().expect("activation stack is non-empty"), c)
         {
@@ -1961,6 +1996,8 @@ impl Vm {
     /// return), and on error log the caller's `invoked from
     /// within "…"` frame. Mutates `c` in place. Split out of [`Vm::unwind`].
     fn unwind_proc_frame(&mut self, act: &Frame, acts: &[Frame], c: &mut Completion<Value>) {
+        let body_code = c.code;
+        let call_words = self.frame_argv(self.current_level()).unwrap_or_default();
         // C's `InterpProcNR2` proc epilogue (`tclProc.c:1864`): a proc body that
         // reaches its boundary with a bare `break`/`continue` — i.e. a
         // `break`/`continue` or `return -level 0 -code break` that produced
@@ -2033,8 +2070,15 @@ impl Vm {
                     .map_or(Code::Ok, Code::from_int);
                 c.options = crate::command::with_return_level(&c.options, 0);
                 c.code = code;
+                if code == Code::Error {
+                    // A carried `-errorinfo` suppresses the `return` command's
+                    // own frame, but the call site that receives the settled
+                    // error must still be appended.
+                    self.clear_error_logged();
+                }
             }
         }
+        self.error_stack_push_proc_call(body_code, c.code, &call_words);
         if c.code == Code::Error
             && let Some((cmd, line)) = acts.last().and_then(|parent| {
                 parent
@@ -2076,15 +2120,19 @@ impl Vm {
     }
 
     /// Push a call-frame and bind `argv` to the proc's parameters.
-    fn enter_proc(&mut self, proc: &ProcDef, argv: &[Value]) -> Result<(), Completion<Value>> {
+    fn enter_proc(
+        &mut self,
+        proc: &ProcDef,
+        invoked: &Value,
+        argv: &[Value],
+    ) -> Result<(), Completion<Value>> {
         // Recursion bound (catchable, not a host stack overflow). Checked before
         // the frame push, matching C's `interp recursionlimit`.
         if self.recursion_depth() >= self.recursion_limit() {
             return Err(err("too many nested evaluations (infinite loop?)"));
         }
-        let simple = crate::interp::key_holder_and_tail_unrooted(&proc.name).1;
         let mut call_argv = Vec::with_capacity(argv.len() + 1);
-        call_argv.push(Value::string(simple));
+        call_argv.push(invoked.clone());
         call_argv.extend(argv.iter().cloned());
         self.push_call_frame(Some(proc.name.clone()), call_argv);
 
@@ -3958,7 +4006,12 @@ impl Vm {
                         let cmd_text = instr.source_cmd_text.clone();
                         let msg = c.result.to_str().to_string();
                         let line = instr.source_line;
-                        self.log_command_info(&cmd_text, &msg, line);
+                        self.log_command_info_with_context(
+                            &cmd_text,
+                            Value::list(words),
+                            &msg,
+                            line,
+                        );
                         return Tick::Return(c);
                     }
                 }
@@ -4008,7 +4061,12 @@ impl Vm {
                         let cmd_text = instr.source_cmd_text.clone();
                         let msg = c.result.to_str().to_string();
                         let line = instr.source_line;
-                        self.log_command_info(&cmd_text, &msg, line);
+                        self.log_command_info_with_context(
+                            &cmd_text,
+                            Value::list(words),
+                            &msg,
+                            line,
+                        );
                         return Tick::Return(c);
                     }
                 }
@@ -4046,7 +4104,12 @@ impl Vm {
                     Err(c) => {
                         let cmd_text = instr.source_cmd_text.clone();
                         let msg = c.result.to_str().to_string();
-                        self.log_command_info(&cmd_text, &msg, instr.source_line);
+                        self.log_command_info_with_context(
+                            &cmd_text,
+                            Value::list(rewritten),
+                            &msg,
+                            instr.source_line,
+                        );
                         return Tick::Return(c);
                     }
                 }
@@ -5129,6 +5192,7 @@ impl Vm {
                 .map_err(crate::command::completion_from_tcl_error)?;
                 Ok(Some(Tick::Call {
                     proc: p,
+                    invoked: words[0].clone(),
                     argv: words[1..].to_vec(),
                 }))
             }
@@ -5514,7 +5578,7 @@ impl Vm {
                     Ok(proc) => proc,
                     Err(error) => return crate::command::completion_from_tcl_error(error),
                 };
-                match self.enter_proc(&p, argv) {
+                match self.enter_proc(&p, &Value::string(name), argv) {
                     Ok(()) => self.run_activation(Frame::new(p.body.clone(), true)),
                     Err(c) => c,
                 }
@@ -5566,7 +5630,8 @@ impl Vm {
         link_vars: &[(String, String)],
         frame: crate::cmd_oo::OoFrame,
     ) -> Completion<Value> {
-        if let Err(c) = self.enter_proc(proc, argv) {
+        let simple = crate::interp::key_holder_and_tail_unrooted(&proc.name).1;
+        if let Err(c) = self.enter_proc(proc, &Value::string(simple), argv) {
             return c;
         }
         for (local, storage) in link_vars {
@@ -5644,7 +5709,11 @@ impl Vm {
                 Some(c)
             }
             Some(parent) => match self.dispatch_words(parent, words) {
-                Ok(Some(Tick::Call { proc, argv })) => match self.enter_proc(&proc, &argv) {
+                Ok(Some(Tick::Call {
+                    proc,
+                    invoked,
+                    argv,
+                })) => match self.enter_proc(&proc, &invoked, &argv) {
                     Ok(()) => {
                         let mut fr = Frame::new(proc.body.clone(), true);
                         if let Some(ctx) = self.pending_exec_leave.take() {

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -10628,8 +10628,8 @@ impl Vm {
         Value::list(self.error_stack.entries().to_vec())
     }
 
-    /// Prefer the live stack, while retaining an explicit carried stack before
-    /// the first runtime log.
+    /// Prefer the live stack. Before the first runtime log, an explicit carried
+    /// stack wins; otherwise the lazily retained prior stack remains visible.
     pub(crate) fn error_stack_for_completion(&self, carried: Option<Value>) -> Value {
         let carried =
             carried.and_then(|value| value.as_list().ok().map(|items| items.as_ref().clone()));

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -1372,6 +1372,7 @@ pub(crate) struct ParkedFlow {
     recursion_depth: usize,
     error_info: Option<String>,
     error_logged: bool,
+    error_stack: ErrorStack<Value>,
     error_line: u32,
     invoked_name: Option<String>,
     script_stack: Vec<String>,
@@ -2089,7 +2090,6 @@ impl InterpState {
             limits: LimitSet::default(),
             commands_run: 0,
             limit_tick: 0,
-            // Keep an unseeded VM deterministic; tests seed explicitly.
             rand_seed: 1,
             oo: crate::cmd_oo::OoState::default(),
             coro: crate::cmd_coro::CoroSystem::default(),
@@ -8695,7 +8695,15 @@ impl Vm {
         let saved_ns = self.ns_stack.split_off(ns_cut);
         let saved_ns_ids = self.ns_id_stack.split_off(ns_cut);
         let saved_depth = self.recursion_depth;
+        if up_delta != 0 {
+            let target_frame_count = self.frames.len();
+            self.error_stack
+                .enter_shifted_context(target_frame_count, up_delta);
+        }
         let result = self.eval_source(src);
+        if up_delta != 0 {
+            self.error_stack.leave_shifted_context();
+        }
         // Destroy any activation the script left in place through the ordinary
         // lifecycle, then re-attach the frames set aside above.
         self.drain_call_frames_to(target + 1);
@@ -8705,14 +8713,10 @@ impl Vm {
         self.ns_id_stack.truncate(ns_cut);
         self.ns_id_stack.extend(saved_ns_ids);
         self.recursion_depth = saved_depth;
-        let completion = match result {
+        match result {
             Ok(c) => c,
             Err(e) => err(e.message),
-        };
-        if completion.code == Code::Error && up_delta != 0 {
-            self.error_stack_push_up(up_delta);
         }
-        completion
     }
 
     /// Exchange the live per-flow execution context with `p` — the coroutine
@@ -8745,6 +8749,7 @@ impl Vm {
         std::mem::swap(&mut self.recursion_depth, &mut p.recursion_depth);
         std::mem::swap(&mut self.error_info, &mut p.error_info);
         std::mem::swap(&mut self.error_logged, &mut p.error_logged);
+        std::mem::swap(&mut self.error_stack, &mut p.error_stack);
         std::mem::swap(&mut self.error_line, &mut p.error_line);
         std::mem::swap(&mut self.invoked_name, &mut p.invoked_name);
         std::mem::swap(&mut self.script_stack, &mut p.script_stack);
@@ -10397,6 +10402,16 @@ impl Vm {
             return;
         }
         self.error_stack_log_value(context);
+        self.log_command_info_only(cmd_text, msg, line);
+    }
+
+    /// ErrorInfo-only half of command logging. Compiler error regions call this
+    /// while reconstructing synthetic body frames; those are not additional
+    /// Tcl command logs and therefore must not duplicate TIP 348 `UP` entries.
+    pub(crate) fn log_command_info_only(&mut self, cmd_text: &str, msg: &str, line: u32) {
+        if self.error_logged {
+            return;
+        }
         // The innermost logged command's line drives the enclosing `(procedure …
         // line N)` / `("while" body line N)` frames (C's `iPtr->errorLine`).
         if line != 0 {
@@ -10572,6 +10587,12 @@ impl Vm {
         let _ = self
             .error_stack
             .begin_inner(Value::string("INNER"), context);
+        if let Some(delta) = self.error_stack.shifted_context_delta(self.frames.len()) {
+            let delta = i64::try_from(delta).unwrap_or(i64::MAX);
+            let _ = self
+                .error_stack
+                .push_pair(Value::string("UP"), Value::int(delta));
+        }
     }
 
     /// Replace the current episode when a non-error trace completion is
@@ -10602,17 +10623,6 @@ impl Vm {
         );
     }
 
-    /// Append an `UP <delta>` entry at an `uplevel` boundary.
-    pub(crate) fn error_stack_push_up(&mut self, delta: usize) {
-        if !self.supports_error_stack() {
-            return;
-        }
-        let delta = i64::try_from(delta).unwrap_or(i64::MAX);
-        let _ = self
-            .error_stack
-            .push_pair(Value::string("UP"), Value::int(delta));
-    }
-
     /// Return the last TIP 348 stack as a Tcl list value.
     pub(crate) fn error_stack_value(&self) -> Value {
         Value::list(self.error_stack.entries().to_vec())
@@ -10632,7 +10642,7 @@ impl Vm {
         self.error_stack.mark_reset();
         self.error_info = None;
         self.error_logged = false;
-        self.error_line = 0;
+        self.error_line = 1;
     }
 
     /// Take the accumulated `errorInfo` trace (if any) and reset it for the next

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -36,6 +36,7 @@ use tcl_dialect::{PackagePrefer, model::SurfaceQuery};
 use tcl_bytecode::{FunctionAsm, ModuleAsm, ProcedureProvenance};
 use tcl_core_types::RecursionLimit;
 use tcl_platform::Host;
+use tcl_runtime_api::error_stack::{ErrorStack, validate_error_stack};
 use tcl_runtime_api::guard::{
     GuardDomain, GuardDomains, GuardError, GuardIdentity, GuardManager, GuardToken,
 };
@@ -1188,6 +1189,9 @@ pub struct InterpState {
     /// real frame boundary (a nested `eval`/`[subst]`, a proc/control body) so
     /// the enclosing command logs its own `invoked from within` frame.
     error_logged: bool,
+    /// TIP 348's interpreter-local structured error stack. Its lazy reset
+    /// keeps the last caught stack introspectable until a new error is logged.
+    error_stack: ErrorStack<Value>,
     /// The 1-based source line of the innermost command logged into the current
     /// `errorInfo` trace (C's `iPtr->errorLine`) — the line the `(procedure …
     /// line N)` / `("while" body line N)` frames report.
@@ -2061,6 +2065,7 @@ impl InterpState {
             eval_cache_plain: HashMap::new(),
             error_info: None,
             error_logged: false,
+            error_stack: ErrorStack::default(),
             error_line: 1,
             invoked_name: None,
             invoked_sidecar: None,
@@ -4385,10 +4390,20 @@ impl Vm {
         if !self.interp_alive(id) {
             return err("could not find interpreter");
         }
-        self.in_interp(id, |vm| match vm.eval_source(script) {
-            Ok(c) => c,
-            Err(e) => err(e.message),
-        })
+        let completion = self.in_interp(id, |vm| {
+            let mut completion = match vm.eval_source(script) {
+                Ok(c) => c,
+                Err(e) => err(e.message),
+            };
+            if completion.code == Code::Error {
+                completion.options = vm.completion_options_snapshot(&completion);
+            }
+            completion
+        });
+        if completion.code == Code::Error {
+            self.restore_completion_error_state(&completion);
+        }
+        completion
     }
 
     /// Evaluate assembled alias-target words (`target prefix… args…`) as one
@@ -8044,8 +8059,14 @@ impl Vm {
                     Err(error) => Some(crate::command::completion_from_tcl_error(error)),
                 };
                 if let Some(mut failure) = failed {
+                    let was_error = failure.code == Code::Error;
                     match op {
                         "write" | "read" | "array" => {
+                            if !was_error {
+                                self.error_stack_restart_with_inner(Value::string(
+                                    command.as_str(),
+                                ));
+                            }
                             // C's `TclCallVarTraces` logs a `(write|read trace
                             // on "name")` frame, then clears ERR_ALREADY_LOGGED
                             // so the command that triggered the trace logs its
@@ -8662,6 +8683,7 @@ impl Vm {
         if target >= self.frames.len() {
             return err(format!("bad level \"{target}\""));
         }
+        let up_delta = self.frames.len() - 1 - target;
         let saved = self.frames.split_off(target + 1);
         // The namespace name/id stacks are kept aligned 1:1 with the call-frame
         // stack (every proc call and `namespace eval` pushes one of each), so the
@@ -8683,10 +8705,14 @@ impl Vm {
         self.ns_id_stack.truncate(ns_cut);
         self.ns_id_stack.extend(saved_ns_ids);
         self.recursion_depth = saved_depth;
-        match result {
+        let completion = match result {
             Ok(c) => c,
             Err(e) => err(e.message),
+        };
+        if completion.code == Code::Error && up_delta != 0 {
+            self.error_stack_push_up(up_delta);
         }
+        completion
     }
 
     /// Exchange the live per-flow execution context with `p` — the coroutine
@@ -10354,9 +10380,23 @@ impl Vm {
     /// (`error_logged`) is not re-logged. Command text over 150 bytes is
     /// truncated with `...`, as in C.
     pub(crate) fn log_command_info(&mut self, cmd_text: &str, msg: &str, line: u32) {
+        self.log_command_info_with_context(cmd_text, Value::string(cmd_text), msg, line);
+    }
+
+    /// Value-preserving form of [`Self::log_command_info`]. `cmd_text` remains
+    /// the source spelling for `errorInfo`; `context` is the post-substitution
+    /// operation stored in TIP 348's first `INNER` entry.
+    pub(crate) fn log_command_info_with_context(
+        &mut self,
+        cmd_text: &str,
+        context: Value,
+        msg: &str,
+        line: u32,
+    ) {
         if self.error_logged {
             return;
         }
+        self.error_stack_log_value(context);
         // The innermost logged command's line drives the enclosing `(procedure …
         // line N)` / `("while" body line N)` frames (C's `iPtr->errorLine`).
         if line != 0 {
@@ -10500,10 +10540,106 @@ impl Vm {
         self.error_logged = true;
     }
 
+    /// Borrow the accumulated `errorInfo` without consuming the error episode.
+    pub(crate) fn error_info_value(&self) -> Option<&str> {
+        self.error_info.as_deref()
+    }
+
+    /// Whether the selected Tcl release exposes TIP 348 error stacks.
+    pub(crate) fn supports_error_stack(&self) -> bool {
+        self.runtime_version().has_error_stack()
+    }
+
+    /// Adopt an explicit, already-validated `return -errorstack` list.
+    pub(crate) fn seed_error_stack_parts(&mut self, parts: Vec<Value>) {
+        let _ = self.error_stack.adopt(parts);
+    }
+
+    /// Adopt an explicit stack stored in a completion options dictionary.
+    pub(crate) fn seed_error_stack(&mut self, stack: &Value) {
+        let Ok(parts) = validate_error_stack(stack.as_list().map(|items| items.as_ref().clone()))
+        else {
+            return;
+        };
+        self.seed_error_stack_parts(parts);
+    }
+
+    /// Add the innermost command context for a new Tcl 8.6+ error episode.
+    pub(crate) fn error_stack_log_value(&mut self, context: Value) {
+        if !self.supports_error_stack() {
+            return;
+        }
+        let _ = self
+            .error_stack
+            .begin_inner(Value::string("INNER"), context);
+    }
+
+    /// Replace the current episode when a non-error trace completion is
+    /// transformed into a new error by the variable subsystem.
+    pub(crate) fn error_stack_restart_with_inner(&mut self, context: Value) {
+        if !self.supports_error_stack() {
+            return;
+        }
+        self.error_stack
+            .restart_inner(Value::string("INNER"), context);
+    }
+
+    /// Append the invocation of a procedure that an error unwound through.
+    pub(crate) fn error_stack_push_proc_call(
+        &mut self,
+        body_code: Code,
+        settled_code: Code,
+        words: &[Value],
+    ) {
+        if !self.supports_error_stack() {
+            return;
+        }
+        let _ = self.error_stack.push_proc_call(
+            body_code,
+            settled_code,
+            Value::string("CALL"),
+            Value::list(words.to_vec()),
+        );
+    }
+
+    /// Append an `UP <delta>` entry at an `uplevel` boundary.
+    pub(crate) fn error_stack_push_up(&mut self, delta: usize) {
+        if !self.supports_error_stack() {
+            return;
+        }
+        let delta = i64::try_from(delta).unwrap_or(i64::MAX);
+        let _ = self
+            .error_stack
+            .push_pair(Value::string("UP"), Value::int(delta));
+    }
+
+    /// Return the last TIP 348 stack as a Tcl list value.
+    pub(crate) fn error_stack_value(&self) -> Value {
+        Value::list(self.error_stack.entries().to_vec())
+    }
+
+    /// Prefer the live stack, while retaining an explicit carried stack before
+    /// the first runtime log.
+    pub(crate) fn error_stack_for_completion(&self, carried: Option<Value>) -> Value {
+        let carried =
+            carried.and_then(|value| value.as_list().ok().map(|items| items.as_ref().clone()));
+        Value::list(self.error_stack.snapshot_or(carried))
+    }
+
+    /// Reset transient metadata for a distinct nested evaluation. The error
+    /// stack itself resets lazily so `info errorstack` retains the last value.
+    fn reset_error_state_for_eval(&mut self) {
+        self.error_stack.mark_reset();
+        self.error_info = None;
+        self.error_logged = false;
+        self.error_line = 0;
+    }
+
     /// Take the accumulated `errorInfo` trace (if any) and reset it for the next
     /// error — used when `catch` reports an error.
     pub(crate) fn take_error_info(&mut self) -> Option<String> {
         self.error_logged = false;
+        self.error_stack.mark_reset();
         self.error_info.take()
     }
 
@@ -10764,6 +10900,7 @@ impl Vm {
     /// (the runtime-`eval` / command-substitution path) in the *current* frame.
     pub fn eval_source(&mut self, src: &str) -> Result<Completion<Value>, TclError> {
         self.claim_number_grammar();
+        self.reset_error_state_for_eval();
         let module = self.compile_cached(src)?;
         let comp = self.run_current_module(&module);
         // Crossing back out of a nested script is a frame boundary: clear
@@ -10792,6 +10929,7 @@ impl Vm {
         src: &str,
         namespace: &str,
     ) -> Result<CompiledUnit, TclError> {
+        self.reset_error_state_for_eval();
         let module = self.compile_cached_in_namespace(src, namespace)?;
         self.validate_module_profile(&module)?;
         Self::validate_module_namespace(&module, namespace)?;

--- a/rust/tcl-vm/tests/builtins_e2e.rs
+++ b/rust/tcl-vm/tests/builtins_e2e.rs
@@ -2445,6 +2445,21 @@ fn explicit_return_errorinfo_reports_line_one() {
     );
 }
 
+/// Tcl retains the prior TIP 348 stack when an explicit `-errorinfo` suppresses
+/// logging a new inner command during a lazily reset error episode.
+#[test]
+fn explicit_return_errorinfo_retains_the_prior_error_stack() {
+    out_eq(
+        "catch {error first} m o\n\
+         set prior [dict get $o -errorstack]\n\
+         catch {return -level 0 -code error -errorinfo I second} m o\n\
+         puts [list [expr {$prior ne {}}] \
+                    [expr {[dict get $o -errorstack] eq $prior}] \
+                    [expr {[info errorstack] eq $prior}]]\n",
+        "1 1 1\n",
+    );
+}
+
 #[test]
 fn error_stack_call_preserves_qualified_invocation() {
     out_eq(

--- a/rust/tcl-vm/tests/builtins_e2e.rs
+++ b/rust/tcl-vm/tests/builtins_e2e.rs
@@ -2401,6 +2401,50 @@ fn catch_reports_structured_error_stack() {
     );
 }
 
+/// A specialised catch body still logs the failing command, not the enclosing
+/// catch instruction. Its `errorInfo` must be byte-identical to the dynamic
+/// body that reaches the generic evaluator.
+#[test]
+fn inline_and_generic_catch_bodies_report_the_same_errorinfo() {
+    out_eq(
+        "proc inline {} {catch {error boom} m o; dict get $o -errorinfo}\n\
+         proc generic {} {set body {error boom}; catch $body m o; dict get $o -errorinfo}\n\
+         set inlineInfo [inline]\n\
+         set genericInfo [generic]\n\
+         puts [list [expr {$inlineInfo eq $genericInfo}] \
+                    [string match {*while executing*\\\"error boom\\\"*} $inlineInfo]]\n",
+        "1 1\n",
+    );
+}
+
+/// Proc-like adapters carry the exact invocation words into the one procedure
+/// boundary that emits TIP 348 `CALL` entries.
+#[test]
+fn lambda_and_method_error_stacks_preserve_invocation_identity() {
+    out_eq(
+        "catch {apply {{} {error APPLY}}} m o\n\
+         puts [lindex [dict get $o -errorstack] end]\n\
+         oo::class create C {method fail {arg} {error METHOD}}\n\
+         C create named\n\
+         catch {named fail value} m o\n\
+         puts [lindex [dict get $o -errorstack] end]\n\
+         catch {::named fail rooted} m o\n\
+         puts [lindex [dict get $o -errorstack] end]\n",
+        "apply {{} {error APPLY}}\nnamed fail value\n::named fail rooted\n",
+    );
+}
+
+/// An explicit errorInfo starts a real line-one error episode even though the
+/// command itself is already logged.
+#[test]
+fn explicit_return_errorinfo_reports_line_one() {
+    out_eq(
+        "catch {return -level 0 -code error -errorinfo EXPLICIT boom} m o\n\
+         puts [list [dict get $o -errorline] [dict get $o -errorinfo]]\n",
+        "1 EXPLICIT\n",
+    );
+}
+
 #[test]
 fn error_stack_call_preserves_qualified_invocation() {
     out_eq(

--- a/rust/tcl-vm/tests/builtins_e2e.rs
+++ b/rust/tcl-vm/tests/builtins_e2e.rs
@@ -2384,3 +2384,91 @@ fn dict_inline_return_body_falls_back_cleanly() {
         "7|\n",
     );
 }
+
+/// TIP 348 metadata is accumulated once at the shared command-unwind seam and
+/// exposed identically by catch and `info errorstack`.
+#[test]
+fn catch_reports_structured_error_stack() {
+    out_eq(
+        "catch {error boom} m o\n\
+         puts [list $m [dict get $o -errorstack] [info errorstack]]\n\
+         proc f {x} {g $x$x}\n\
+         proc g {x} {error G:$x}\n\
+         catch {f 12} m o\n\
+         puts [list $m [dict get $o -errorstack] [info errorstack]]\n",
+        "boom {INNER {error boom}} {INNER {error boom}}\n\
+         G:1212 {INNER {error G:1212} CALL {g 1212} CALL {f 12}} {INNER {error G:1212} CALL {g 1212} CALL {f 12}}\n",
+    );
+}
+
+#[test]
+fn error_stack_call_preserves_qualified_invocation() {
+    out_eq(
+        "namespace eval n {proc p {x} {error E:$x}}\n\
+         catch {::n::p z} m o\n\
+         puts [dict get $o -errorstack]\n",
+        "INNER {error E:z} CALL {::n::p z}\n",
+    );
+}
+
+/// Trace callback failures retain the callback's stack; a control completion
+/// converted to an error begins a distinct trace episode.
+#[test]
+fn variable_trace_errors_retain_error_stack() {
+    out_eq(
+        "proc boom {n1 n2 op} {error TRACE}\n\
+         trace add variable x write boom\n\
+         catch {set x 1} m o\n\
+         puts [list $m [dict get $o -errorstack]]\n\
+         trace remove variable x write boom\n\
+         unset -nocomplain x\n\
+         proc storeStk {n1 n2 op} {return -code break}\n\
+         trace add variable x write storeStk\n\
+         catch {set x 1} m o\n\
+         puts [list $m [dict get $o -errorstack]]\n",
+        "{can't set \"x\": TRACE} {INNER {error TRACE} CALL {boom x {} write}}\n\
+         {can't set \"x\": } {INNER storeStk}\n",
+    );
+}
+
+/// A valid explicit stack survives both immediate and pending return options.
+#[test]
+fn explicit_return_error_stack_is_preserved() {
+    out_eq(
+        "catch {return -level 0 -code error -errorstack {INNER custom} explicit} m o\n\
+         puts [list $m [dict get $o -errorstack] [info errorstack]]\n\
+         catch {return -code error -errorstack {CALL a CALL b} pending} m o\n\
+         puts [list $m [dict get $o -code] [dict get $o -level] \
+                    [dict get $o -errorstack] [info errorstack]]\n",
+        "explicit {INNER custom} {INNER custom}\n\
+         pending 1 1 {CALL a CALL b} {CALL a CALL b}\n",
+    );
+}
+
+#[test]
+fn explicit_return_error_stack_obeys_proc_boundaries() {
+    out_eq(
+        "proc direct {} {return -code error -errorstack {} boom}\n\
+         catch {direct} m o\n\
+         puts [dict get $o -errorstack]\n\
+         proc inner {} {return -code error -errorstack {INNER custom} boom}\n\
+         proc outer {} {inner}\n\
+         catch {outer} m o\n\
+         puts [dict get $o -errorstack]\n\
+         proc metadata {} {return -code error -errorcode CUSTOM -errorinfo EXPLICIT boom}\n\
+         catch {metadata} m o\n\
+         puts [list [dict get $o -errorcode] \
+                    [string match {EXPLICIT*} [dict get $o -errorinfo]]]\n",
+        "\nINNER custom CALL outer\nCUSTOM 1\n",
+    );
+}
+
+/// `try` consumes the same rich completion snapshot as catch.
+#[test]
+fn try_handler_receives_error_metadata() {
+    out_eq(
+        "set t try\n\
+         puts [$t {error boom} on error {m o} {list [dict exists $o -errorinfo] [dict get $o -errorstack]}]\n",
+        "1 {INNER {error boom}}\n",
+    );
+}

--- a/rust/tcl-vm/tests/tcltest_load.rs
+++ b/rust/tcl-vm/tests/tcltest_load.rs
@@ -355,3 +355,23 @@ fn upstream_dict_info_definitions_pass_after_real_startup() {
         "missing parseable upstream dict-10 summary: {output:?}"
     );
 }
+
+/// Tcl 9.0.4's array-search mutation tests require `try` to bind the body's
+/// complete error options, including `-errorinfo`.
+#[test]
+fn upstream_var_search_mutation_handlers_receive_errorinfo() {
+    let Some((ok, error, output)) = run_upstream_definitions(
+        "var.test",
+        "test var-23.10 {",
+        "test var-23.12 {",
+        "tcltest-var-search-mutation",
+    ) else {
+        eprintln!("skipping: no Tcl 9.0.4 source tree available");
+        return;
+    };
+    assert!(ok, "focused upstream var.test failed: {error}\n{output}");
+    assert!(
+        output.contains("Total\t2\tPassed\t2\tSkipped\t0\tFailed\t0"),
+        "missing parseable upstream var-23.10/23.11 summary: {output:?}"
+    );
+}

--- a/rust/tcl-vm/tests/tcltest_load.rs
+++ b/rust/tcl-vm/tests/tcltest_load.rs
@@ -375,3 +375,60 @@ fn upstream_var_search_mutation_handlers_receive_errorinfo() {
         "missing parseable upstream var-23.10/23.11 summary: {output:?}"
     );
 }
+
+/// Tcl 9.0.4's canonical shifted-context cases prove that `UP 1` is stamped
+/// where the inner command errors, even when that error is caught before the
+/// surrounding `uplevel` invocation returns.
+#[test]
+fn upstream_error_shifted_context_definitions_pass_after_real_startup() {
+    let Some((ok, error, output)) = run_upstream_definitions(
+        "error.test",
+        "test error-4.6 {",
+        "test error-5.1 {",
+        "tcltest-error-shifted-context",
+    ) else {
+        eprintln!("skipping: no Tcl 9.0.4 source tree available");
+        return;
+    };
+    assert!(ok, "focused upstream error.test failed: {error}\n{output}");
+    assert!(
+        output.contains("Total\t3\tPassed\t3\tSkipped\t0\tFailed\t0"),
+        "missing parseable upstream error-4.6/4.7/4.8 summary: {output:?}"
+    );
+}
+
+#[test]
+fn upstream_error_stack_reset_preserves_shifted_context() {
+    let Some((ok, error, output)) = run_upstream_definitions(
+        "error.test",
+        "test error-6.10 {",
+        "test error-7.1 {",
+        "tcltest-error-stack-reset",
+    ) else {
+        eprintln!("skipping: no Tcl 9.0.4 source tree available");
+        return;
+    };
+    assert!(ok, "focused upstream error.test failed: {error}\n{output}");
+    assert!(
+        output.contains("Total\t1\tPassed\t1\tSkipped\t0\tFailed\t0"),
+        "missing parseable upstream error-6.10 summary: {output:?}"
+    );
+}
+
+#[test]
+fn upstream_invalid_error_stack_preserves_shifted_context() {
+    let Some((ok, error, output)) = run_upstream_definitions(
+        "result.test",
+        "test result-6.4 {",
+        "# cleanup",
+        "tcltest-result-error-stack",
+    ) else {
+        eprintln!("skipping: no Tcl 9.0.4 source tree available");
+        return;
+    };
+    assert!(ok, "focused upstream result.test failed: {error}\n{output}");
+    assert!(
+        output.contains("Total\t2\tPassed\t2\tSkipped\t0\tFailed\t0"),
+        "missing parseable upstream result-6.4/6.5 summary: {output:?}"
+    );
+}


### PR DESCRIPTION
## Summary

- centralise structured completion-option and TIP 348 error-stack lifecycle semantics in tcl-runtime-api
- make synthesized option availability dialect-aware through tcl-dialect while preserving arbitrary carried options in Tcl 8.4 and 8.5
- preserve errorInfo, errorCode, errorline, errorstack, shifted contexts, and public invocation identity across compiled catch/try, procedures, apply, coroutines, and TclOO
- keep compiler specialisation on typed registry hooks and carry the distinct error-stack command context through bytecode
- retain the prior Tcl 9 error stack during lazy reset when an explicit errorInfo suppresses a new inner log

## Verification

- make rust-check
- make prep-pr — 30/30 smoke tests
- make test-spectcl-compat — 20 loader, 3 golden including SpecTcl 1.x to 2.0, real Tcl pack, 4 source, and 5 corpus tests
- Tcl 9.0.4 init.tcl/tcltest slices: error-4.6/4.7/4.8/6.10, result-6.4/6.5, var-23.10/23.11
- native builtins 114/114 and coroutines 53/53; standalone completion/error and TclOO focused suites
- direct Tcl 9.0.4 oracle for retained errorstack/errorline/errorInfo parity

Closes #1750
Closes #1929