### PR TITLE
ci: shard root Rust tests directly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,9 +194,17 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # The helper is covered by scripts/dev/test-already-green.sh and
-          # fails closed on every local Git, API, and schema error.
-          bash scripts/dev/already-green.sh
+          # Green-result reuse is only for a protected-branch merge push or a
+          # release tag. A pull request must not execute its checkout's helper
+          # to decide whether its own required tests run.
+          if [[ "$GITHUB_EVENT_NAME" == pull_request ]]; then
+            echo 'already_green=false' >> "$GITHUB_OUTPUT"
+            echo 'already_green=false (pull requests cannot reuse results)'
+          else
+            # The helper is covered by scripts/dev/test-already-green.sh and
+            # fails closed on every local Git, API, and schema error.
+            bash scripts/dev/already-green.sh
+          fi
 
       - name: Classify changed paths
         id: paths
@@ -395,8 +403,9 @@ jobs:
   # checks through the central `make rust-check` contract: root and standalone
   # crate formatting/Clippy plus generated-file drift gates. The test surface
   # runs
-  # concurrently in `rust-tests`, `rust-tests-heavy`, `lsp-e2e`, `cargo-deny`,
-  # `test-ext` and `python` — all on every PR and push.  See AGENTS.md for the
+  # concurrently in `rust-tests-shard` (with its `rust-tests` aggregate),
+  # `rust-tests-heavy`, `lsp-e2e`, `cargo-deny`, `test-ext` and `python` — all
+  # on every PR and push. See AGENTS.md for the
   # local gates (`make check-all`, plus the heavier suites) agents must run
   # before pushing / opening a PR.
   pr-gate:
@@ -862,16 +871,17 @@ jobs:
   # `cargo test --workspace --all-features --no-fail-fast`, Swatinem cache,
   # toolchain resolved from rust-toolchain.toml.
   #
-  # The Rust/WASM surface is split across SIX concurrent jobs so the CPU-bound
-  # suites don't serialise behind each other.  Wall-clock is the max of the
-  # six, not their sum.  The first four are required status checks on `rust`:
+  # The Rust/WASM surface is split across concurrent jobs so the CPU-bound
+  # suites don't serialise behind each other. The first five required status
+  # checks on `rust` are:
   #
-  #   rust-tests        workspace minus the VM-sim heavies and tcl-lsp-server,
-  #                     plus ALL workspace doctests (cheap; nextest can't run
-  #                     doctests, so they live here once rather than in each job)
+  #   rust-tests-shard   five direct hash-partitioned consumers of the workspace
+  #                     suite (minus VM-sim heavies and tcl-lsp-server)
+  #   rust-tests-doctest all workspace doctests, independently concurrent with
+  #                     the direct nextest consumers
   #   rust-tests-heavy  the VM-sim heavies (`tcl-irule-test`, `f5-cli`) plus
   #                     `tcl-fuzz`'s plumbing unit tests (excluded from
-  #                     rust-tests so wasmtime/cranelift stay out of the main
+  #                     rust-tests-shard so wasmtime/cranelift stay out of the main
   #                     partition's build graph; fuzz campaigns themselves are
   #                     manual-only, never CI).  Measured 2026-08-13: ~44 s
   #                     total.  Kept split for concurrency, not because it is
@@ -890,7 +900,7 @@ jobs:
   #                     404/timeout there must not be able to block a release.
   #                     Promote it (and to a required check) once it has proved
   #                     stable over a few weeks.  `tcl-compiler` is in
-  #                     `rust-tests`' workspace run too, so `wasm_real_link.rs`
+  #                     `rust-tests-shard`'s workspace run too, so `wasm_real_link.rs`
   #                     also executes there — without the toolchain, where it
   #                     skips loudly by naming what is missing.
   #   lsp-server-wasm   the real wasm-bindgen LSP server, driven through a
@@ -909,14 +919,21 @@ jobs:
   #                     Release — the same producer/attacher split
   #                     `build-server-matrix` uses.
   #
-  # nextest runs every test binary's tests in ONE global parallel pool, so the
-  # VM-sim suites overlap instead of running one binary at a time — a large
-  # wall-clock win over `cargo test`, which runs test binaries serially.
+  # nextest runs each hash shard in its own global parallel pool. Exact-head
+  # run 34283151340 measured four legs at 9m28–12m14 (hosted compile
+  # 3m24–3m56, nextest 4m41–5m42); shard 1 then added about 1m43 building
+  # doctests after nextest ended. Five direct consumers shorten the hash tail,
+  # while the independent doctest job removes that serial suffix. The aggregate
+  # proves that the exact selected nextest set is neither dropped nor duplicated.
   #
-  # `tcl-lsp-server` is excluded from rust-tests because lsp-e2e runs that crate
+  # `tcl-lsp-server` is excluded from rust-tests-shard because lsp-e2e runs that crate
   # in full.  The crate declares no [features], so dropping it from the
   # `--all-features` workspace run costs no coverage.
-  rust-tests:
+  rust-tests-shard:
+    name: rust-tests-shard (${{ matrix.shard }})
+    # Unaffected changes and already-green tags retain the aggregate status
+    # without allocating five test runners.
+    if: ${{ needs.channel.outputs.rust_tests_changed == 'true' && !(startsWith(github.ref, 'refs/tags/') && needs.channel.outputs.already_green == 'true') }}
     # Historically the longest pole (155s on the 16-core self-hosted box when
     # healthy — a 2026-08 regression to 16 min turned out to be two oversized
     # `tcl-compiler` per_item tests, since fixed; if this job blows past ~5
@@ -949,7 +966,26 @@ jobs:
     # explicit override, and runner-policy changes prove themselves on hosted
     # capacity.
     needs: [channel]
-    runs-on: ${{ ((github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]' || needs.channel.outputs.runner_policy_changed == 'true')) || needs.channel.outputs.rust_tests_runner == 'hosted') && 'ubuntu-26.04' || 'tank' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - shard: "1/5"
+            id: "1-5"
+            tank_capable: true
+          - shard: "2/5"
+            id: "2-5"
+            tank_capable: false
+          - shard: "3/5"
+            id: "3-5"
+            tank_capable: false
+          - shard: "4/5"
+            id: "4-5"
+            tank_capable: false
+          - shard: "5/5"
+            id: "5-5"
+            tank_capable: false
+    runs-on: ${{ matrix.tank_capable && needs.channel.outputs.rust_tests_runner == 'tank' && !(github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]' || needs.channel.outputs.runner_policy_changed == 'true')) && 'tank' || 'ubuntu-26.04' }}
     # The action starts the sccache server during setup, so the backend must be
     # configured at job scope rather than only on the later Cargo steps.
     # Self-hosted Tank has several runner registrations on one host. Their
@@ -965,19 +1001,21 @@ jobs:
       CARGO_HOME: /home/runner/.cargo
       RUSTUP_HOME: /home/runner/.rustup
       SCCACHE_GHA_ENABLED: "true"
+      RUNNER_MODE: ${{ matrix.tank_capable && needs.channel.outputs.rust_tests_runner == 'tank' && !(github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]' || needs.channel.outputs.runner_policy_changed == 'true')) && 'tank' || 'hosted' }}
     concurrency:
-      group: rust-tests-${{ ((github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]' || needs.channel.outputs.runner_policy_changed == 'true')) || needs.channel.outputs.rust_tests_runner == 'hosted') && format('hosted-{0}', github.run_id) || 'tank' }}
+      group: rust-tests-${{ matrix.tank_capable && needs.channel.outputs.rust_tests_runner == 'tank' && !(github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]' || needs.channel.outputs.runner_policy_changed == 'true')) && 'tank' || format('hosted-{0}-{1}', github.run_id, matrix.shard) }}
       queue: max
       cancel-in-progress: false
     steps:
-      # Keep this required job alive for unrelated changes; only the checkout
-      # runs when the channel says the root Rust test archive is unaffected.
+      # The channel job-level condition skips this matrix for unrelated
+      # changes and already-green tags; the stable rust-tests aggregate keeps
+      # the required status context in those no-op cases.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
 
       - name: Verify canonical Rust homes
-        if: needs.channel.outputs.rust_tests_changed == 'true'
+        if: needs.channel.outputs.rust_tests_changed == 'true' && (needs.channel.outputs.already_green != 'true' || matrix.shard == '1/5')
         shell: bash
         run: |
           set -euo pipefail
@@ -1000,7 +1038,7 @@ jobs:
       # The action installs the current stable and wires up the Swatinem cache
       # (keyed per job, so the concurrent cargo jobs don't race on save).
       - name: Set up Rust
-        if: needs.channel.outputs.rust_tests_changed == 'true'
+        if: needs.channel.outputs.rust_tests_changed == 'true' && (needs.channel.outputs.already_green != 'true' || matrix.shard == '1/5')
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           toolchain: stable
@@ -1018,7 +1056,7 @@ jobs:
       # that registrations with different absolute workspace paths share them.
       - name: Set up sccache
         id: sccache
-        if: needs.channel.outputs.rust_tests_changed == 'true'
+        if: needs.channel.outputs.rust_tests_changed == 'true' && (needs.channel.outputs.already_green != 'true' || matrix.shard == '1/5')
         continue-on-error: true
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
         with:
@@ -1030,7 +1068,7 @@ jobs:
       # Do not export the wrapper until both action setup and the installed
       # binary have succeeded; Cargo then falls back to rustc automatically.
       - name: Enable sccache when available
-        if: needs.channel.outputs.rust_tests_changed == 'true'
+        if: needs.channel.outputs.rust_tests_changed == 'true' && (needs.channel.outputs.already_green != 'true' || matrix.shard == '1/5')
         shell: bash
         env:
           SCCACHE_SETUP_OUTCOME: ${{ steps.sccache.outcome }}
@@ -1047,7 +1085,7 @@ jobs:
       # is safe to retain per runner registration.  Hosted overflow never
       # touches the root and keeps Cargo's ordinary ephemeral target.
       - name: Prepare persistent Tank Cargo target
-        if: needs.channel.outputs.rust_tests_changed == 'true' && needs.channel.outputs.rust_tests_runner == 'tank'
+        if: needs.channel.outputs.rust_tests_changed == 'true' && (needs.channel.outputs.already_green != 'true' || matrix.shard == '1/5') && env.RUNNER_MODE == 'tank'
         shell: bash
         run: |
           registration="${TCL_LSP_TANK_REGISTRATION_ID:-${RUNNER_NAME:-}}"
@@ -1055,7 +1093,7 @@ jobs:
           printf 'CARGO_TARGET_DIR=%s\n' "$target" >> "$GITHUB_ENV"
 
       - name: Install cargo-nextest
-        if: needs.channel.outputs.rust_tests_changed == 'true'
+        if: needs.channel.outputs.rust_tests_changed == 'true' && (needs.channel.outputs.already_green != 'true' || matrix.shard == '1/5')
         uses: taiki-e/install-action@e67fa11c4b9316fa714ddf0abed07a0c3143b95b # v2.87.4
         with:
           tool: nextest@0.9.143
@@ -1085,41 +1123,64 @@ jobs:
       # used with '--no-fail-fast'"), and the flag is meaningless anyway when
       # no tests are executed.
       - name: cargo nextest run (workspace minus VM-sim heavies and lsp-e2e)
-        if: needs.channel.outputs.rust_tests_changed == 'true' && needs.channel.outputs.docs_only != 'true' && !(startsWith(github.ref, 'refs/tags/') && needs.channel.outputs.already_green == 'true')
+        if: needs.channel.outputs.rust_tests_changed == 'true' && needs.channel.outputs.docs_only != 'true' && !(startsWith(github.ref, 'refs/tags/') && needs.channel.outputs.already_green == 'true') && (needs.channel.outputs.already_green != 'true' || matrix.shard == '1/5')
         env:
           ALREADY_GREEN: ${{ needs.channel.outputs.already_green }}
-          RUST_TESTS_RUNNER: ${{ needs.channel.outputs.rust_tests_runner }}
+          RUST_TESTS_RUNNER: ${{ env.RUNNER_MODE }}
+          SHARD: ${{ matrix.shard }}
         run: |
           extra="--no-fail-fast"
           if [ "$ALREADY_GREEN" = "true" ]; then
             echo "tree already green on its PR run — building test binaries (cache warmth) without re-running them"
-            extra="--no-run"
+            if [ "$RUST_TESTS_RUNNER" = tank ]; then
+              bash scripts/dev/persistent-cargo-target.sh with-lock "$CARGO_TARGET_DIR" cargo nextest run --no-run --workspace --exclude tcl-irule-test --exclude f5-cli --exclude tcl-lsp-server --exclude tcl-fuzz --all-features
+            else
+              cargo nextest run --no-run --workspace --exclude tcl-irule-test --exclude f5-cli --exclude tcl-lsp-server --exclude tcl-fuzz --all-features
+            fi
+            exit 0
           fi
           if [ "$RUST_TESTS_RUNNER" = tank ]; then
-            bash scripts/dev/persistent-cargo-target.sh with-lock "$CARGO_TARGET_DIR" cargo nextest run $extra --workspace --exclude tcl-irule-test --exclude f5-cli --exclude tcl-lsp-server --exclude tcl-fuzz --all-features
+            bash scripts/dev/persistent-cargo-target.sh with-lock "$CARGO_TARGET_DIR" cargo nextest run $extra --workspace --exclude tcl-irule-test --exclude f5-cli --exclude tcl-lsp-server --exclude tcl-fuzz --all-features --partition "hash:$SHARD"
           else
-            cargo nextest run $extra --workspace --exclude tcl-irule-test --exclude f5-cli --exclude tcl-lsp-server --exclude tcl-fuzz --all-features
+            cargo nextest run $extra --workspace --exclude tcl-irule-test --exclude f5-cli --exclude tcl-lsp-server --exclude tcl-fuzz --all-features --partition "hash:$SHARD"
           fi
 
-      # nextest does not run doctests; run them for the WHOLE workspace (incl.
-      # the crates excluded above — doctests are cheap) so the other jobs need
-      # not duplicate them.  Deps are already built, so this is compile + run.
-      - name: cargo test --doc
+      - name: Record selected shard listing
         if: needs.channel.outputs.rust_tests_changed == 'true' && needs.channel.outputs.docs_only != 'true' && needs.channel.outputs.already_green != 'true'
         env:
-          RUST_TESTS_RUNNER: ${{ needs.channel.outputs.rust_tests_runner }}
-        shell: bash
+          SHARD: ${{ matrix.shard }}
         run: |
-          if [ "$RUST_TESTS_RUNNER" = tank ]; then
-            bash scripts/dev/persistent-cargo-target.sh with-lock "$CARGO_TARGET_DIR" cargo test --workspace --all-features --doc --no-fail-fast
-          else
-            cargo test --workspace --all-features --doc --no-fail-fast
+          shard_file=$(printf '%s' "$SHARD" | tr '/' '-')
+          cargo nextest list --workspace --exclude tcl-irule-test --exclude f5-cli --exclude tcl-lsp-server --exclude tcl-fuzz --all-features --partition "hash:$SHARD" --message-format json > "$RUNNER_TEMP/rust-tests-$shard_file.json"
+          if [ "$SHARD" = "1/5" ]; then
+            cargo nextest list --workspace --exclude tcl-irule-test --exclude f5-cli --exclude tcl-lsp-server --exclude tcl-fuzz --all-features --message-format json > "$RUNNER_TEMP/rust-tests-all.json"
           fi
 
+      - name: Upload selected shard listing
+        if: always() && needs.channel.outputs.rust_tests_changed == 'true' && needs.channel.outputs.docs_only != 'true' && needs.channel.outputs.already_green != 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: rust-tests-listing-${{ matrix.id }}
+          path: ${{ runner.temp }}/rust-tests-${{ matrix.id }}.json
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 1
+          overwrite: true
+
+      - name: Upload authoritative all-tests listing
+        if: always() && matrix.shard == '1/5' && needs.channel.outputs.rust_tests_changed == 'true' && needs.channel.outputs.docs_only != 'true' && needs.channel.outputs.already_green != 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: rust-tests-listing-all
+          path: ${{ runner.temp }}/rust-tests-all.json
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 1
+          overwrite: true
       # Setup is intentionally skipped when the root Rust-test closure is
       # unaffected, so sccache is unavailable on those required no-op runs.
       - name: Report sccache statistics
-        if: always() && needs.channel.outputs.rust_tests_changed == 'true'
+        if: always() && needs.channel.outputs.rust_tests_changed == 'true' && (needs.channel.outputs.already_green != 'true' || matrix.shard == '1/5')
         shell: bash
         run: |
           if ! command -v sccache >/dev/null 2>&1; then
@@ -1143,7 +1204,7 @@ jobs:
       # Keep final target telemetry independent from test correctness.  This
       # runs after every Tank attempt, including failed Cargo commands.
       - name: Report final Tank Cargo target
-        if: always() && needs.channel.outputs.rust_tests_changed == 'true' && needs.channel.outputs.rust_tests_runner == 'tank'
+        if: always() && needs.channel.outputs.rust_tests_changed == 'true' && env.RUNNER_MODE == 'tank'
         continue-on-error: true
         shell: bash
         run: |
@@ -1152,6 +1213,97 @@ jobs:
           else
             echo '::warning::persistent Cargo target was not prepared; final telemetry unavailable'
           fi
+
+  # nextest does not run doctests. Keep the whole-workspace doctest command
+  # separate from the CPU-bound hash shards, so its build does not extend the
+  # slowest shard's wall time. This job is deliberately hosted: Tank capacity
+  # is reserved for shard 1, and doctests do not need its persistent target.
+  # It remains a step-gated job so the stable aggregate context is preserved
+  # for unrelated changes, docs-only changes, and already-green revisions.
+  rust-tests-doctest:
+    # Match the shard matrix's job-level no-op rules. The stable aggregate is
+    # the required context and accepts this skipped result only when the
+    # channel facts prove that no test command was required.
+    if: ${{ needs.channel.outputs.rust_tests_changed == 'true' && !(startsWith(github.ref, 'refs/tags/') && needs.channel.outputs.already_green == 'true') }}
+    needs: [channel]
+    runs-on: ubuntu-26.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+
+      - name: Set up Rust
+        if: needs.channel.outputs.rust_tests_changed == 'true' && needs.channel.outputs.docs_only != 'true' && needs.channel.outputs.already_green != 'true'
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+        with:
+          toolchain: stable
+          cache-key: rust-tests-doctest-v1
+          cache-targets: false
+
+      # The whole workspace includes crates intentionally omitted from the
+      # direct nextest selection. Doctests are a separate semantic surface,
+      # not a cache-warming duplicate of a nextest shard.
+      - name: cargo test --doc
+        if: needs.channel.outputs.rust_tests_changed == 'true' && needs.channel.outputs.docs_only != 'true' && needs.channel.outputs.already_green != 'true'
+        run: cargo test --workspace --all-features --doc --no-fail-fast
+
+  # Stable required status context. Every selected testcase must appear in
+  # exactly one of the five direct nextest listings, every shard must pass,
+  # and the independent whole-workspace doctest job must pass.
+  rust-tests:
+    if: ${{ always() }}
+    needs: [channel, rust-tests-shard, rust-tests-doctest]
+    runs-on: ubuntu-26.04
+    steps:
+      - name: Require all Rust test shards
+        env:
+          CHANNEL_RESULT: ${{ needs.channel.result }}
+          SHARDS_RESULT: ${{ needs.rust-tests-shard.result }}
+          DOCTEST_RESULT: ${{ needs.rust-tests-doctest.result }}
+          RUST_TESTS_CHANGED: ${{ needs.channel.outputs.rust_tests_changed }}
+          ALREADY_GREEN: ${{ needs.channel.outputs.already_green }}
+          IS_TAG: ${{ startsWith(github.ref, 'refs/tags/') }}
+        run: |
+          set -euo pipefail
+          echo "channel=$CHANNEL_RESULT shards=$SHARDS_RESULT doctests=$DOCTEST_RESULT rust_tests_changed=$RUST_TESTS_CHANGED already_green=$ALREADY_GREEN is_tag=$IS_TAG"
+          test "$CHANNEL_RESULT" = success
+          if [ "$SHARDS_RESULT" = success ] && [ "$DOCTEST_RESULT" = success ]; then
+            exit 0
+          fi
+          if [ "$SHARDS_RESULT" = skipped ] && [ "$DOCTEST_RESULT" = skipped ] && {
+            [ "$RUST_TESTS_CHANGED" != true ] ||
+            { [ "$IS_TAG" = true ] && [ "$ALREADY_GREEN" = true ]; };
+          }; then
+            echo 'Rust test shards and doctests were intentionally skipped by the channel decision'
+            exit 0
+          fi
+          echo '::error::Rust test shards or doctests did not complete successfully'
+          exit 1
+
+      - name: Check out verifier
+        if: needs.channel.result == 'success' && needs.channel.outputs.rust_tests_changed == 'true' && needs.channel.outputs.docs_only != 'true' && needs.channel.outputs.already_green != 'true'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+
+      - name: Download shard listings
+        if: needs.channel.result == 'success' && needs.channel.outputs.rust_tests_changed == 'true' && needs.channel.outputs.docs_only != 'true' && needs.channel.outputs.already_green != 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: rust-tests-listing-*
+          merge-multiple: true
+          path: ${{ runner.temp }}/rust-tests-listings
+
+      - name: Verify complete five-way selection
+        if: needs.channel.result == 'success' && needs.channel.outputs.rust_tests_changed == 'true' && needs.channel.outputs.docs_only != 'true' && needs.channel.outputs.already_green != 'true'
+        run: |
+          python3 scripts/dev/verify-nextest-partitions.py --partition-count 5 \
+            "$RUNNER_TEMP/rust-tests-listings/rust-tests-all.json" \
+            "$RUNNER_TEMP/rust-tests-listings/rust-tests-1-5.json" \
+            "$RUNNER_TEMP/rust-tests-listings/rust-tests-2-5.json" \
+            "$RUNNER_TEMP/rust-tests-listings/rust-tests-3-5.json" \
+            "$RUNNER_TEMP/rust-tests-listings/rust-tests-4-5.json" \
+            "$RUNNER_TEMP/rust-tests-listings/rust-tests-5-5.json"
 
   # Fail-closed SpecTcl compatibility on every PR that changes its TclVM,
   # compiler, registry, runtime, pack, or exact-reference-toolchain closure.
@@ -1177,11 +1329,11 @@ jobs:
         run: make test-spectcl-compat
 
   # The heavy VM-simulation suites, split out to run concurrently with
-  # `rust-tests` (see that job's header).  Doctests are covered there.
+  # `rust-tests-shard` (see that job's header). Doctests are covered there.
   rust-tests-heavy:
     # Deliberately hosted.  The self-hosted box has a single runner, so jobs
     # sent there execute serially; measured, moving this job as well pushed the
-    # critical path from 239s to 253s.  See `rust-tests` for the full reasoning.
+    # critical path from 239s to 253s. See `rust-tests-shard` for the full reasoning.
     needs: [channel]
     runs-on: ubuntu-26.04
     steps:
@@ -1194,7 +1346,7 @@ jobs:
         with:
           toolchain: stable
           # This job builds only the heavy crates + their deps, so it gets its
-          # own cache rather than racing rust-tests on save.
+          # own cache rather than racing rust-tests-shard on save.
           cache-key: rust-tests-heavy
 
       - name: Install cargo-nextest
@@ -1202,8 +1354,8 @@ jobs:
         with:
           tool: nextest@0.9.143
 
-      # Same skip/downgrade contract as rust-tests — see the channel job header.
-      # tcl-fuzz lives here, not in rust-tests: its wasmtime/cranelift
+      # Same skip/downgrade contract as rust-tests-shard — see the channel job header.
+      # tcl-fuzz lives here, not in rust-tests-shard: its wasmtime/cranelift
       # dependency chain (~40 crates, cranelift-codegen alone an 81 MB rlib)
       # would otherwise sit in the main partition's build graph.  Only the
       # fuzzer's own fast plumbing unit tests run — fuzz CAMPAIGNS are
@@ -1740,6 +1892,8 @@ jobs:
               "package": "tcl-lsp-server",
               "filter": "default",
               "partition": "all",
+              "partition_count": 3,
+              "shard_count": 3,
               "result": "success",
               "archive_sha256": archive_sha,
               "listings": {"all.json": all_sha, "1-3.json": first_sha, "2-3.json": second_sha, "3-3.json": third_sha},
@@ -1922,6 +2076,8 @@ jobs:
               "package": "tcl-lsp-server",
               "filter": "default",
               "partition": f"hash:{partition}",
+              "partition_count": 3,
+              "shard_count": 3,
               "result": result,
               "archive_sha256": archive_sha,
               "selected_listing_sha256": listing_sha,

--- a/Makefile
+++ b/Makefile
@@ -822,8 +822,8 @@ coverage-ext: compile $(NPM_STAMP) ensure-vscode-test-deps ## Run VS Code extens
 	@echo "VS Code extension coverage report: $(COV_DIR)/vscode/index.html"
 
 # --- Native (cargo xtask) check gates.  These need the Rust toolchain, so CI
-# runs them in the rust-tests job (rust-gate.yml / ci.yml).  `xtask-check` is
-# the CI aggregate.
+# runs them in the rust-tests-shard matrix and its stable rust-tests aggregate
+# (ci.yml). `xtask-check` is the CI aggregate.
 xtask-check: check-tcl-reference-toolchains check-spectcl-compat-paths check-runtime-rust-paths check-rust-tests-runner check-persistent-cargo-target check-rust-tests-paths check-lsp-e2e-paths check-lsp-e2e-partitions check-already-green check-monitoring-triggers check-smoke-targets check-wasm-cc-env check-homebrew-ci check-sign-and-upload check-release-dependency-graph check-vsix-web-assets-contract xtask-workflow-sync xtask-kcs-index-links xtask-diag-tables xtask-diag-emission-check xtask-gen-editor-catalogs xtask-gen-bundled-environments xtask-gen-editor-dialects xtask-gen-irule-test-data xtask-gen-zed-queries xtask-gen-tmlanguage-keywords xtask-gen-editor-settings xtask-gen-vscode-package xtask-gen-jetbrains-catalog xtask-gen-ai-diagnostics xtask-owner-resolution xtask-resolution-drift xtask-retired-api-gate xtask-pack-goldens xtask-number-drift xtask-segmentation-drift xtask-command-backing xtask-callback-inventory xtask-option-registry-drift xtask-sslictcl-data xtask-runtime-stdlib xtask-editor-extensions xtask-f5query-builtins-doc xtask-bigip-data-schema xtask-c-api-ownership ## Rust-side check gates (docs index coverage + generated-table/catalog drift) xtask-dialect-drift
 
 check-tcl-reference-toolchains: ## Verify pinned C Tcl patchlevels across shell setup and Rust oracle discovery
@@ -847,7 +847,7 @@ check-lsp-e2e-paths: ## Verify CI's native LSP e2e archive dependency closure an
 	@echo "==> Checking native LSP e2e archive path ownership"
 	@bash scripts/dev/test-lsp-e2e-paths.sh
 
-check-rust-tests-runner: ## Verify trusted rust-tests jobs serialize on the shared tank host
+check-rust-tests-runner: ## Verify trusted Rust shard 1 serializes on the shared Tank host
 	@echo "==> Checking self-hosted Rust test scheduling"
 	@sh scripts/dev/test-rust-tests-runner.sh
 
@@ -1048,8 +1048,9 @@ rust-check: check-rust-pr xtask-check ## Rust fmt + clippy + generated-file drif
 
 # The local pre-push gate: format + codegen + lint/typecheck + the smoke test
 # tier.  Deliberately NOT the full test suite — CI runs the deep suites
-# (rust-tests / rust-tests-heavy / lsp-e2e / test-ext / python) on every PR
-# and push.  `make test` remains available to reproduce CI locally.
+# (rust-tests-shard plus its rust-tests aggregate / rust-tests-heavy / lsp-e2e /
+# test-ext / python) on every PR and push. `make test` remains available to
+# reproduce CI locally.
 prep-pr: format codegen ## Fast local gate (format + codegen + lint + typecheck + smoke tier) — deep suites run in CI
 	@$(MAKE) -j $(NPROC) _prep-pr-checks _prep-pr-smoke-tier
 
@@ -1142,11 +1143,12 @@ fuzz: ## Run a tcl-fuzz differential campaign (manual-only; see the fuzz-finding
 # (rust/tcl-lsp-server/tests/*_e2e.rs).  Set SKIP_TEST_RUST=1 to skip.
 #
 # Prefers nextest when it is installed, the way `smoke` does, and for the same
-# reason CI's rust-tests job uses it: nextest runs every test binary's tests in
-# ONE global parallel pool, where plain `cargo test` runs the binaries serially.
+# reason each CI rust-tests-shard leg uses it: nextest runs every test binary's
+# tests in ONE global parallel pool, where plain `cargo test` runs the binaries
+# serially.
 # nextest cannot run doctests, so those follow in a second pass — the same split
-# the rust-tests job makes.  The `cargo test` fallback keeps the target working
-# on a machine without nextest.
+# the rust-tests-shard matrix makes. The `cargo test` fallback keeps the target
+# working on a machine without nextest.
 test-rust: ## Run Rust workspace tests + the native-server lsp_e2e suite (skip with SKIP_TEST_RUST=1)
 	@set -eu; \
 	if [ -n "$${SKIP_TEST_RUST:-}" ]; then \

--- a/docs/design/contracts/test-tiers-and-ci-gates.md
+++ b/docs/design/contracts/test-tiers-and-ci-gates.md
@@ -9,7 +9,7 @@ behind it.
 | Tier | Runs | What |
 |---|---|---|
 | **smoke** — `make smoke`, `make smoke-p P=<crate>` | locally after every compile; inside `make prep-pr` | the fail-closed smoke-named function/module and effective Cargo-target subset owned by `scripts/dev/smoke-targets.tsv`, one sanity check per crate, seconds warm. Reuses the dev-profile default-features build (never `--all-features`), so it never forces a recompile. |
-| **deep** — CI jobs `rust-tests`, `rust-tests-heavy`, `runtime-rust-tests`, `lsp-e2e`, `test-ext`, `test-ext-web`, `cargo-deny`, `python`, `spectcl-compat`, `web-frontends` | every PR and every push to `rust` | the full workspace suite (native `lsp_e2e` included), the VM-sim heavies, the standalone `runtime/rust` unit suite, the VS Code extension on desktop and in a browser host, supply-chain audit, Python lint/typecheck of `rust/bigip-report-gen/python`, and an `npm ci` of the two npm roots that are not `editors/vscode`. Skips only what demonstrably did not change (below). |
+| **deep** — CI jobs `rust-tests-shard` and `rust-tests-doctest` plus their stable `rust-tests` aggregate, `rust-tests-heavy`, `runtime-rust-tests`, `lsp-e2e`, `test-ext`, `test-ext-web`, `cargo-deny`, `python`, `spectcl-compat`, `web-frontends` | every PR and every push to `rust` | the full workspace suite (native `lsp_e2e` included), the VM-sim heavies, the standalone `runtime/rust` unit suite, the VS Code extension on desktop and in a browser host, supply-chain audit, Python lint/typecheck of `rust/bigip-report-gen/python`, and an `npm ci` of the two npm roots that are not `editors/vscode`. Skips only what demonstrably did not change (below). |
 | **exhaustive** — `make test-exhaustive`, `make fuzz`, `make tcltest-sweep[-check]` | only when a human invokes it by name | every `#[ignore]`d corpus sweep over `tmp/tcl*` and tcllib, differential-fuzz gates, privileged bpf/kernel tests, fuzz campaigns. **Never** wired into `prep-pr`, `test`, `check-all`, or CI. |
 
 The native `lsp-e2e` surface is produced once as a nextest 0.9.143 archive,
@@ -35,6 +35,26 @@ Validate that no-op path in Actions with a change outside both committed
 closures: the archive producer and all three partition jobs must succeed
 without building, uploading, downloading, or running the archive, and the
 required aggregate must still succeed after checking every upstream result.
+
+The root workspace suite is five direct `rust-tests-shard` matrix consumers,
+with hash partitions `1/5` through `5/5`; the stable `rust-tests` aggregate
+checks that `channel`, every required shard, and the concurrent
+`rust-tests-doctest` job succeeded (or that the shard matrix was skipped only
+under the exact no-op rules), and proves the uploaded listings are a disjoint,
+complete five-way selection. Shard 1 is the only Tank-capable leg and uses
+Tank only when the trusted runner decision selects it; shards 2–5 and doctests
+always run on hosted capacity. The shard matrix is job-skipped when
+`rust_tests_changed` is false or when a tag is already green; the aggregate
+accepts `skipped` only in those exact channel-declared cases and always fails
+if `channel` or doctests fail. The doctest job has the same job-level
+unchanged/exact-green skip as the shard matrix, while its test command remains
+step-gated for docs-only and already-green merge revisions.
+
+This shape follows exact-head run 34283151340: its four old shard legs took
+9m28, 10m25, 11m12, and 12m14, with hosted compilation taking 3m24–3m56 and
+nextest 4m41–5m42. Shard 1 finished nextest at about 22:08:20, then spent a
+further 1m43 building doctests. A fifth direct hash partition reduces the
+nextest tail and the concurrent doctest job removes that avoidable serial tail.
 
 ## Decision rules / contracts
 
@@ -169,9 +189,17 @@ CI skips only what demonstrably did not change. The rules live in
 - **Docs-only** changes skip the cargo test steps; `python`, `test-ext`, and
   `test-ext-web` run only when their input paths changed (`test-ext-web` on
   `ext_changed` or `lsp_wasm_changed`, since it consumes both).
-- The root `rust-tests` job keeps its required status for every change, but
-  step-skips Rust setup, sccache, nextest, the Tcl oracle, and doctests when
-  `rust_tests_changed` is false. The committed package closure in
+- The root `rust-tests-shard` matrix produces five direct hash-partitioned
+  legs when the Rust suite is required, while the concurrent hosted
+  `rust-tests-doctest` job runs `cargo test --workspace --all-features --doc
+  --no-fail-fast` exactly once. The stable `rust-tests` aggregate keeps the
+  required status context, executes no tests, and fails closed over every
+  shard plus doctests. The matrix job is skipped when `rust_tests_changed` is
+  false or a tag is already green; the aggregate accepts that skip only for
+  those exact channel cases. On an already-green non-tag merge push, the
+  matrix still allocates, but only shard 1 runs the cache-warming `--no-run`
+  path and shards 2–5 skip expensive setup and reporting; the doctest command
+  is also step-skipped. The committed package closure in
   `scripts/dev/rust-tests-package-paths.txt` and external-input closure in
   `scripts/dev/rust-tests-input-paths.txt` define that decision; `make
   check-rust-tests-paths` checks the manifests against locked Cargo metadata
@@ -182,10 +210,10 @@ CI skips only what demonstrably did not change. The rules live in
   because no sccache executable exists when setup is skipped. This audited
   closure overrides the broad docs-only shape check: an executable or
   test-consumed input under `docs/` or `.claude/` still runs the suite.
-  Validate an unaffected-path change in Actions by checking that the required
-  `rust-tests` job succeeds after checkout while its setup and test steps are
-  absent; a skipped job is not equivalent because it does not report the
-  required successful check.
+  Validate an unaffected-path change in Actions by checking that the
+  `rust-tests-shard` job is intentionally skipped and the `rust-tests`
+  aggregate succeeds after confirming the channel succeeded. A normal test
+  run or a non-green tag must not use this skipped path.
 - `runtime-rust-tests` runs the standalone `runtime/rust` unit suite
   (`make runtime-rust-test`) only when `runtime_rust_changed` is true — that
   crate plus the path-dependency closure its own lockfile resolves. It is its
@@ -210,18 +238,19 @@ CI skips only what demonstrably did not change. The rules live in
   or ambiguous PR association → run everything. `cargo-deny` is unconditional
   because its advisory database can change without a source-tree change.
 
-Trusted pull requests prefer the self-hosted `tank` runner for `rust-tests`.
-The `channel` job queries every nonterminal workflow state and routes to hosted
-capacity when another active `rust-tests` job already targets `tank`. The API
-snapshot is advisory: simultaneous channel jobs can both observe an idle lane,
-so the non-cancelling `rust-tests-tank` concurrency group remains the final
-one-physical-host safety guard. API errors, malformed data, and incomplete
-pagination fail safely to hosted capacity. Fork, Dependabot, and runner-policy
-pull requests independently force hosted placement. A manual dispatch remains
-an explicit `tank` or `hosted` override. Placement never changes the test
-filter, skips coverage, or carries forward a result.
+Trusted pull requests may place only shard 1 of `rust-tests-shard` on the
+self-hosted `tank` runner. The `channel` job queries every nonterminal workflow
+state and routes to hosted capacity when another active shard-1 job already
+targets `tank`; shards 2–5 are always hosted. The API snapshot is advisory:
+simultaneous channel jobs can both observe an idle lane, so the non-cancelling
+`rust-tests-tank` concurrency group remains the final one-physical-host safety
+guard. API errors, malformed data, and incomplete pagination fail safely to
+hosted capacity. Fork, Dependabot, and runner-policy pull requests
+independently force hosted placement. A manual dispatch remains an explicit
+`tank` or `hosted` override. Placement never changes the test filter, skips
+coverage, or carries forward a result.
 
-The Tank job uses canonical `/home/runner/.cargo` and `/home/runner/.rustup`
+The Tank-capable shard uses canonical `/home/runner/.cargo` and `/home/runner/.rustup`
 homes because each registration's default homes are rooted under its own
 checkout directory. These homes are shared mutable state: cancellation can
 interrupt Cargo or rustup writes, and any untrusted build script that reached
@@ -272,6 +301,8 @@ identity** (tree/SHA, never a label or commit message), and bounded in time.
   and exact Cargo fallback execution.
 - `.github/workflows/ci.yml` — the `channel` and `pr-gate` jobs.
 - `scripts/dev/lsp-e2e-path.sh` — the fail-closed archive/partition classifier.
+- `scripts/dev/verify-nextest-partitions.py` — configurable disjoint/completeness
+  proof for the five-way root suite and three-way archived LSP suite.
 
 ## Discoverability
 

--- a/scripts/dev/lsp-e2e-input-paths.txt
+++ b/scripts/dev/lsp-e2e-input-paths.txt
@@ -14,6 +14,7 @@ scripts/dev/lsp-e2e-input-paths.txt
 scripts/dev/lsp-e2e-package-paths.txt
 scripts/dev/test-lsp-e2e-partitions.sh
 scripts/dev/test-lsp-e2e-paths.sh
+scripts/dev/verify-nextest-partitions.py
 editors/vscode/testFixture/variableContexts.tcl
 samples/sslictcl/example.sslictcl
 specs

--- a/scripts/dev/rust-tests-input-paths.txt
+++ b/scripts/dev/rust-tests-input-paths.txt
@@ -31,6 +31,7 @@ scripts/dev/test-already-green.sh
 scripts/dev/test-rust-tests-paths.sh
 scripts/dev/test-rust-tests-runner.sh
 scripts/dev/test-persistent-cargo-target.sh
+scripts/dev/verify-nextest-partitions.py
 scripts/dev/tcl-reference-toolchains.sh
 scripts/dev/test-reference-tcl-toolchains.sh
 scripts/dev/wasm-cc-env.sh

--- a/scripts/dev/select-rust-tests-runner.sh
+++ b/scripts/dev/select-rust-tests-runner.sh
@@ -83,7 +83,7 @@ for run_id in $active_runs; do
                     and .status != "pending" and .status != "completed"))
         then error("malformed workflow-job response")
         else [.[].jobs[] | select(
-                .name == "rust-tests"
+                .name == "rust-tests-shard (1/5)"
                 and (.labels | index("tank"))
                 and .status != "completed"
             )] | length

--- a/scripts/dev/test-already-green.sh
+++ b/scripts/dev/test-already-green.sh
@@ -59,7 +59,9 @@ case "$(cat "$WORKFLOW")" in
         ;;
 esac
 
-require_text "the helper invocation" 'bash scripts/dev/already-green.sh'
+require_text "the pull-request exclusion" 'if [[ "$GITHUB_EVENT_NAME" == pull_request ]]; then'
+require_text "the forced pull-request result" "echo 'already_green=false' >> \"\$GITHUB_OUTPUT\""
+require_text "the helper invocation outside pull requests" 'bash scripts/dev/already-green.sh'
 require_helper_text "the 24-hour freshness bound" "date -u -d '24 hours ago'"
 require_helper_text "two-parent merge-head consistency" 'git rev-parse -q --verify HEAD^2'
 require_helper_text "squash-to-PR resolution" 'commits/$GITHUB_SHA/pulls'

--- a/scripts/dev/test-lsp-e2e-paths.sh
+++ b/scripts/dev/test-lsp-e2e-paths.sh
@@ -59,6 +59,7 @@ expect_relevant scripts/dev/lsp-e2e-input-paths.txt
 expect_relevant scripts/dev/lsp-e2e-package-paths.txt
 expect_relevant scripts/dev/test-lsp-e2e-paths.sh
 expect_relevant scripts/dev/test-lsp-e2e-partitions.sh
+expect_relevant scripts/dev/verify-nextest-partitions.py
 expect_relevant editors/vscode/testFixture/variableContexts.tcl
 expect_relevant samples/sslictcl/example.sslictcl
 expect_relevant specs/sdc_base.tclspec

--- a/scripts/dev/test-reference-tcl-toolchains.sh
+++ b/scripts/dev/test-reference-tcl-toolchains.sh
@@ -169,14 +169,14 @@ fi
 # on the same Make entry point as SpecTcl so neither lane can silently fall back
 # to an unpinned patchlevel.
 rust_tests_block="$(awk '
-    /^  rust-tests:/ { in_rust_tests = 1 }
-    in_rust_tests && /^  [A-Za-z0-9_-]+:/ && $1 != "rust-tests:" { exit }
+    /^  rust-tests-shard:/ { in_rust_tests = 1 }
+    in_rust_tests && /^  [A-Za-z0-9_-]+:/ && $1 != "rust-tests-shard:" { exit }
     in_rust_tests { print }
 ' "$REPO_ROOT/.github/workflows/ci.yml")"
 case "$rust_tests_block" in
     *'name: Install exact Tcl 9.0 reference interpreter'*'TCL_LSP_TCL_BIN_DIR: ${{ runner.temp }}/tcl-reference-bin'*'make ensure-tcl90-reference'*'. scripts/dev/tcl-reference-toolchains.sh'*'tcl_reference_resolve_tclsh 9.0'*'TCL_LSP_TCLSH90=%s\n'*'$GITHUB_ENV'*) ;;
     *)
-        echo "rust-tests must provision and export the exact Tcl 9.0 oracle through ensure-tcl90-reference" >&2
+        echo "rust-tests-shard must provision and export the exact Tcl 9.0 oracle through ensure-tcl90-reference" >&2
         exit 1
         ;;
 esac

--- a/scripts/dev/test-rust-tests-paths.sh
+++ b/scripts/dev/test-rust-tests-paths.sh
@@ -63,6 +63,7 @@ expect_relevant scripts/dev/test-already-green.sh
 expect_relevant scripts/dev/test-rust-tests-paths.sh
 expect_relevant scripts/dev/test-rust-tests-runner.sh
 expect_relevant scripts/dev/test-persistent-cargo-target.sh
+expect_relevant scripts/dev/verify-nextest-partitions.py
 expect_relevant rust/bigip-report-gen/templates/report.html.j2
 expect_relevant rust/tcl-vm-wasm/Cargo.toml
 expect_relevant rust/tcl-vm-wasm/Cargo.lock
@@ -255,16 +256,26 @@ grep -Fq '"$rust_tests_path" "$f"' "$WORKFLOW" \
 grep -Fq 'rust_tests_changed=true' "$WORKFLOW" \
     || fail "channel has no fail-closed Rust-test fallback"
 rust_job=$(awk '
-    /^  rust-tests:/ { in_job = 1 }
-    in_job && /^  [A-Za-z0-9_-]+:/ && $1 != "rust-tests:" { exit }
+    /^  rust-tests-shard:/ { in_job = 1 }
+    in_job && /^  [A-Za-z0-9_-]+:/ && $1 != "rust-tests-shard:" { exit }
     in_job { print }
 ' "$WORKFLOW")
-[ -n "$rust_job" ] || fail "ci.yml must define rust-tests"
+[ -n "$rust_job" ] || fail "ci.yml must define rust-tests-shard"
 printf '%s\n' "$rust_job" | grep -Fq "if: needs.channel.outputs.rust_tests_changed == 'true'" \
     || fail "rust-tests expensive steps are not path-gated"
 case "$rust_job" in
     *'if: always() && needs.channel.outputs.rust_tests_changed == '\''true'\'''*'sccache --show-stats'*) ;;
     *) fail "sccache statistics must be skipped when Rust setup is skipped" ;;
+esac
+doctest_job=$(awk '
+    /^  rust-tests-doctest:/ { in_job = 1 }
+    in_job && /^  [A-Za-z0-9_-]+:/ && $1 != "rust-tests-doctest:" { exit }
+    in_job { print }
+' "$WORKFLOW")
+[ -n "$doctest_job" ] || fail "ci.yml must define rust-tests-doctest"
+case "$doctest_job" in
+    *"if: \${{ needs.channel.outputs.rust_tests_changed == 'true' && !(startsWith(github.ref, 'refs/tags/') && needs.channel.outputs.already_green == 'true') }}"*'needs: [channel]'*'runs-on: ubuntu-26.04'*"if: needs.channel.outputs.rust_tests_changed == 'true' && needs.channel.outputs.docs_only != 'true' && needs.channel.outputs.already_green != 'true'"*'cargo test --workspace --all-features --doc --no-fail-fast'*) ;;
+    *) fail "doctests must be independently hosted and retain changed-path/exact-green step gates" ;;
 esac
 
 echo "root Rust test path and changed-file contracts passed"

--- a/scripts/dev/test-rust-tests-runner.sh
+++ b/scripts/dev/test-rust-tests-runner.sh
@@ -4,9 +4,10 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-# Contract test for the one-physical-host `tank` runner pool. Multiple runner
-# registrations must not turn into concurrent heavyweight workspace suites,
-# and bursts must not displace an older suite while it is waiting for the host.
+# Contract test for the direct five-way Rust test fan-out. The matrix keeps
+# shard 1 eligible for the one-physical-host Tank lane; shards 2–5 are always
+# hosted. The assertions below parse job and step structure, then exercise the
+# mocked selector API contract so comments or unrelated jobs cannot satisfy it.
 
 set -eu
 
@@ -15,21 +16,38 @@ REPO_ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/../.." && pwd)
 WORKFLOW=$REPO_ROOT/.github/workflows/ci.yml
 
 rust_tests_job=$(awk '
+    /^  rust-tests-shard:/ { in_job = 1 }
+    in_job && /^  [A-Za-z0-9_-]+:/ && $1 != "rust-tests-shard:" { exit }
+    in_job { print }
+' "$WORKFLOW")
+aggregate=$(awk '
     /^  rust-tests:/ { in_job = 1 }
     in_job && /^  [A-Za-z0-9_-]+:/ && $1 != "rust-tests:" { exit }
     in_job { print }
 ' "$WORKFLOW")
+doctest_job=$(awk '
+    /^  rust-tests-doctest:/ { in_job = 1 }
+    in_job && /^  [A-Za-z0-9_-]+:/ && $1 != "rust-tests-doctest:" { exit }
+    in_job { print }
+' "$WORKFLOW")
 
 if [ -z "$rust_tests_job" ]; then
-    echo "ci.yml must define the rust-tests job" >&2
+    echo "ci.yml must define the rust-tests-shard job" >&2
+    exit 1
+fi
+if [ -z "$aggregate" ]; then
+    echo "ci.yml must define the rust-tests aggregate job" >&2
+    exit 1
+fi
+if [ -z "$doctest_job" ]; then
+    echo "ci.yml must define the rust-tests-doctest job" >&2
     exit 1
 fi
 
-# Parse the workflow without PyYAML or another unprovisioned dependency.  This
+# Parse the workflow without PyYAML or another unprovisioned dependency. This
 # is a strict parser for the YAML subset used by the contract: mappings,
-# sequences, scalar values, and literal block scalars.  It records paths only
-# after walking indentation and list structure, so assertions cannot be
-# satisfied by a comment or an unrelated job/step with the same text.
+# sequences, scalar values, and block scalars. It records paths only after
+# walking indentation and list structure, so assertions are structural.
 awk '
 function fail(message) {
     print "ci.yml contract: " message > "/dev/stderr"
@@ -66,7 +84,7 @@ function put(path, value) {
     seen[path] = 1
     values[path] = value
 }
-function flush_block(    value) {
+function flush_block() {
     if (!block_active) return
     sub(/\n$/, "", block_value)
     put(block_path, block_value)
@@ -105,10 +123,7 @@ function contains(path, text, message) {
     while (substr(line, indent + 1, 1) == " ") indent++
     while (stack_count > 0 && stack_indent[stack_count] >= indent) stack_count--
     content = substr(line, indent + 1)
-    # YAML permits a flow sequence to continue on the line after its key
-    # (`needs:` in this workflow). It is a scalar for our purposes; consume it
-    # as the value of the pending mapping key rather than mistaking it for a
-    # malformed top-level line.
+    # A flow sequence may continue on the line after its key (`needs:`).
     if (content ~ /^\[/ && stack_count > 0) {
         path = stack_path[stack_count]
         need(!values_seen[path], "duplicate mapping key " path)
@@ -157,9 +172,6 @@ function contains(path, text, message) {
         block_path = path
         block_value = ""
     } else if (value ~ /^[>|][+-]?$/) {
-        # Preserve folded scalars line-for-line. The contract only searches
-        # literal shell blocks, but accepting both YAML block styles keeps an
-        # unrelated workflow field from making this structural parser brittle.
         block_active = 1
         block_indent = indent
         block_path = path
@@ -171,7 +183,13 @@ function contains(path, text, message) {
 END {
     if (failed) exit 1
     flush_block()
-    need(values_seen["jobs.rust-tests.runs-on"], "ci.yml must define jobs.rust-tests as a mapping")
+    shard_job = "jobs.rust-tests-shard"
+    aggregate_job = "jobs.rust-tests"
+    doctest_job = "jobs.rust-tests-doctest"
+    need(values[shard_job ".name"] == "rust-tests-shard (${{ matrix.shard }})", "Rust shards must have an explicit matrix job name")
+    need(values[shard_job ".if"] == "${{ needs.channel.outputs.rust_tests_changed == '\''true'\'' && !(startsWith(github.ref, '\''refs/tags/'\'') && needs.channel.outputs.already_green == '\''true'\'') }}", "unaffected changes and already-green tags must skip the shard matrix")
+    need(values_seen[shard_job ".runs-on"], "rust-tests-shard must define runs-on")
+    need(values_seen[aggregate_job ".needs"], "rust-tests aggregate must define needs")
     tank_jobs = 0
     for (path in values) {
         if (path ~ /^jobs\.[^.]+\.runs-on$/ && index(values[path], "tank") != 0) {
@@ -180,7 +198,7 @@ END {
             tank_job = parts[2]
         }
     }
-    need(tank_jobs == 1 && tank_job == "rust-tests", "rust-tests must remain the only job that can reach Tank")
+    need(tank_jobs == 1 && tank_job == "rust-tests-shard", "only rust-tests-shard may reach Tank")
     need(nodes["jobs.channel"], "ci.yml must define jobs.channel as a mapping")
     need(values["jobs.channel.outputs.runner_policy_changed"] == "${{ steps.paths.outputs.runner_policy_changed }}",
          "channel must publish runner_policy_changed from the paths step")
@@ -202,8 +220,8 @@ END {
     contains(runner_run, "elif [[ \"$EVENT_NAME\" == workflow_dispatch ]]", "manual dispatch must remain an explicit runner override")
     contains(runner_run, "runner=\"$DISPATCH_RUNNER\"", "manual dispatch must remain an explicit runner override")
     routing = "if [[ \"$EVENT_NAME\" == pull_request && (\"$PR_HEAD_REPOSITORY\" != \"$GITHUB_REPOSITORY\" || \"$PR_AUTHOR\" == '\''dependabot[bot]'\'' || \"$RUNNER_POLICY_CHANGED\" == true) ]]"
-    contains(runner_run, routing, "fork, Dependabot, policy-change, and manual-dispatch routing must stay outside the mutable selector")
-    contains(runner_run, "runner=hosted", "fork, Dependabot, policy-change, and manual-dispatch routing must stay outside the mutable selector")
+    contains(runner_run, routing, "trust routing must stay outside the mutable selector")
+    contains(runner_run, "runner=hosted", "trust routing must force hosted capacity")
 
     need(values["on.workflow_dispatch.inputs.rust_tests_runner.type"] == "choice", "manual dispatch must choose a Rust runner")
     need(values["on.workflow_dispatch.inputs.rust_tests_runner.options.0"] == "tank" &&
@@ -211,85 +229,85 @@ END {
          seq_count["on.workflow_dispatch.inputs.rust_tests_runner.options"] == 2,
          "manual dispatch must offer exactly tank and hosted Rust runner choices")
 
-    hosted = "(github.event_name == '\''pull_request'\'' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == '\''dependabot[bot]'\'' || needs.channel.outputs.runner_policy_changed == '\''true'\'')) || needs.channel.outputs.rust_tests_runner == '\''hosted'\''"
-    contains("jobs.rust-tests.runs-on", hosted, "runs-on must include all hosted guards")
-    contains("jobs.rust-tests.concurrency.group", hosted, "concurrency group must include all hosted guards")
-    contains("jobs.rust-tests.runs-on", "&& '\''ubuntu-26.04'\'' || '\''tank'\''", "rust-tests must retain the Tank fallback")
-    contains("jobs.rust-tests.concurrency.group", "format('\''hosted-{0}'\'', github.run_id) || '\''tank'\''", "hosted overflow must be unique while Tank remains one logical lane")
-    need(values["jobs.rust-tests.concurrency.queue"] == "max", "Tank concurrency must retain every pending suite")
-    need(values["jobs.rust-tests.concurrency.cancel-in-progress"] == "false", "a new Tank job must not cancel an already-running suite")
-    need(values["jobs.rust-tests.env.CARGO_HOME"] == "/home/runner/.cargo", "rust-tests must use the canonical Cargo home")
-    need(values["jobs.rust-tests.env.RUSTUP_HOME"] == "/home/runner/.rustup", "rust-tests must use the canonical rustup home")
-    need(!nodes["jobs.rust-tests.env.CARGO_TARGET_DIR"], "rust-tests must not share CARGO_TARGET_DIR")
-    need(!nodes["jobs.rust-tests.env.RUSTC_WRAPPER"], "sccache must not be correctness-critical at job scope")
-    need(values["jobs.rust-tests.env.SCCACHE_GHA_ENABLED"] == "true", "rust-tests must enable GHA sccache")
+    # Matrix and actual-mode facts must be explicit. In particular, job-level
+    # env is valid for steps but is not a valid source for runs-on/concurrency.
+    need(values[shard_job ".strategy.fail-fast"] == "false", "Rust shard matrix must disable fail-fast")
+    need(seq_count[shard_job ".strategy.matrix.include"] == 5, "Rust shard matrix must define five entries")
+    for (i = 0; i < 5; i++) {
+        need(values[shard_job ".strategy.matrix.include." i ".shard"] == (i + 1) "/5", "Rust shard matrix has incorrect shard names")
+        need(values[shard_job ".strategy.matrix.include." i ".id"] == (i + 1) "-5", "Rust shard matrix has incorrect artifact ids")
+        need(values[shard_job ".strategy.matrix.include." i ".tank_capable"] == (i == 0 ? "true" : "false"), "only shard 1 may be Tank-capable")
+    }
+    need(index(values[shard_job ".runs-on"], "matrix.tank_capable") != 0 && index(values[shard_job ".runs-on"], "needs.channel.outputs.rust_tests_runner") != 0 && index(values[shard_job ".runs-on"], "tank") != 0,
+         "runs-on must derive actual mode directly from matrix and channel")
+    need(index(values[shard_job ".runs-on"], "github.event_name == '\''pull_request'\''") != 0 && index(values[shard_job ".runs-on"], "github.event.pull_request.head.repo.full_name") != 0 && index(values[shard_job ".runs-on"], "runner_policy_changed") != 0,
+         "runs-on must retain direct fork, Dependabot, and policy trust guards")
+    need(index(values[shard_job ".concurrency.group"], "matrix.tank_capable") != 0 && index(values[shard_job ".concurrency.group"], "matrix.shard") != 0,
+         "concurrency must derive directly from matrix mode and shard")
+    need(index(values[shard_job ".concurrency.group"], "github.event_name == '\''pull_request'\''") != 0 && index(values[shard_job ".concurrency.group"], "runner_policy_changed") != 0,
+         "concurrency must retain direct trust guards")
+    need(index(values[shard_job ".env.RUNNER_MODE"], "matrix.tank_capable") != 0 && index(values[shard_job ".env.RUNNER_MODE"], "needs.channel.outputs.rust_tests_runner") != 0,
+         "job steps must receive the actual matrix runner mode")
+    need(index(values[shard_job ".runs-on"], "env.RUNNER_MODE") == 0, "runs-on must not use job-level env")
+    need(index(values[shard_job ".concurrency.group"], "env.RUNNER_MODE") == 0, "concurrency must not use job-level env")
+    need(values[shard_job ".concurrency.queue"] == "max" && values[shard_job ".concurrency.cancel-in-progress"] == "false", "Tank concurrency must retain every pending suite without cancellation")
+    need(values[shard_job ".env.CARGO_HOME"] == "/home/runner/.cargo" && values[shard_job ".env.RUSTUP_HOME"] == "/home/runner/.rustup", "Rust shards must use canonical Cargo and rustup homes")
+    need(!nodes[shard_job ".env.CARGO_TARGET_DIR"] && !nodes[shard_job ".env.RUSTC_WRAPPER"], "target and wrapper must not be correctness-critical at job scope")
+    need(values[shard_job ".env.SCCACHE_GHA_ENABLED"] == "true", "Rust shards must enable GHA sccache")
 
     changed = "needs.channel.outputs.rust_tests_changed == '\''true'\''"
-    preflight = step("jobs.rust-tests", "name", "Verify canonical Rust homes")
-    need(preflight >= 0 && values["jobs.rust-tests.steps." preflight ".if"] == changed,
-         "canonical-home preflight must skip with the unaffected root Rust archive")
-    contains("jobs.rust-tests.steps." preflight ".run", "test ! -L \"$root\"",
-             "canonical-home preflight must reject a symlinked root")
-    contains("jobs.rust-tests.steps." preflight ".run", "readlink -f \"$root\"",
-             "canonical-home preflight must resolve to the literal trusted root")
+    active = changed " && (needs.channel.outputs.already_green != '\''true'\'' || matrix.shard == '\''1/5'\'')"
+    preflight = step(shard_job, "name", "Verify canonical Rust homes")
+    need(preflight >= 0 && values[shard_job ".steps." preflight ".if"] == active, "canonical-home preflight must be path- and warm-path-gated")
+    contains(shard_job ".steps." preflight ".run", "test ! -L \"$root\"", "canonical-home preflight must reject a symlinked root")
+    contains(shard_job ".steps." preflight ".run", "readlink -f \"$root\"", "canonical-home preflight must resolve the trusted root")
 
-    setup = step("jobs.rust-tests", "name", "Set up Rust")
-    need(setup >= 0 && index(values["jobs.rust-tests.steps." setup ".uses"], "actions-rust-lang/setup-rust-toolchain@") == 1, "rust-tests must use setup-rust-toolchain")
-    need(values["jobs.rust-tests.steps." setup ".if"] == changed,
-         "Rust setup must skip with the unaffected root Rust archive")
-    need(values["jobs.rust-tests.steps." setup ".with.cache-key"] == "rust-tests-v2", "Rust cache key must reject old target-heavy archives")
-    need(values["jobs.rust-tests.steps." setup ".with.cache-targets"] == "false", "Rust target archives must remain disabled")
-    target_step = step("jobs.rust-tests", "name", "Prepare persistent Tank Cargo target")
-    need(target_step >= 0 && values["jobs.rust-tests.steps." target_step ".if"] == changed " && needs.channel.outputs.rust_tests_runner == '\''tank'\''",
-         "persistent Cargo target setup must be Tank-only")
-    contains("jobs.rust-tests.steps." target_step ".run", "persistent-cargo-target.sh prepare tank",
-             "Tank setup must use the persistent Cargo target helper")
-    contains("jobs.rust-tests.steps." target_step ".run", "TCL_LSP_TANK_REGISTRATION_ID",
-             "target identity must prefer the explicit registration id")
-    contains("jobs.rust-tests.steps." target_step ".run", "RUNNER_NAME",
-             "target identity must use only the stable runner-name fallback")
-    sccache = step("jobs.rust-tests", "name", "Set up sccache")
-    need(sccache >= 0 && index(values["jobs.rust-tests.steps." sccache ".uses"], "mozilla-actions/sccache-action@") == 1 && values["jobs.rust-tests.steps." sccache ".with.version"] == "v0.17.0", "rust-tests must retain the pinned sccache setup")
-    need(values["jobs.rust-tests.steps." sccache ".with.disable_annotations"] == "true",
-         "the resilient statistics step must own cache-degradation warnings")
-    need(values["jobs.rust-tests.steps." sccache ".id"] == "sccache" &&
-         values["jobs.rust-tests.steps." sccache ".if"] == changed &&
-         values["jobs.rust-tests.steps." sccache ".continue-on-error"] == "true",
-         "sccache setup must be observable, gated, and non-fatal")
-    enable = step("jobs.rust-tests", "name", "Enable sccache when available")
-    need(enable > sccache && values["jobs.rust-tests.steps." enable ".if"] == changed,
-         "the compiler wrapper must only be enabled after optional sccache setup")
-    need(values["jobs.rust-tests.steps." enable ".env.SCCACHE_SETUP_OUTCOME"] == "${{ steps.sccache.outcome }}",
-         "wrapper enablement must inspect the sccache setup outcome")
-    contains("jobs.rust-tests.steps." enable ".run", "RUSTC_WRAPPER=sccache",
-             "successful optional setup must enable the compiler cache")
-    contains("jobs.rust-tests.steps." enable ".run", "continuing with uncached compilation",
-             "failed optional setup must report the uncached fallback")
-    nextest = step("jobs.rust-tests", "name", "cargo nextest run (workspace minus VM-sim heavies and lsp-e2e)")
-    need(nextest >= 0, "rust-tests must retain the broad nextest step")
-    contains("jobs.rust-tests.steps." nextest ".run", "persistent-cargo-target.sh with-lock",
-             "Tank nextest must hold the persistent target lock")
-    doctest = step("jobs.rust-tests", "name", "cargo test --doc")
-    need(doctest >= 0, "rust-tests must retain the workspace doctest step")
-    contains("jobs.rust-tests.steps." doctest ".run", "persistent-cargo-target.sh with-lock",
-             "Tank doctests must hold the persistent target lock")
-    report = step("jobs.rust-tests", "name", "Report final Tank Cargo target")
-    need(report >= 0 && values["jobs.rust-tests.steps." report ".if"] == "always() && " changed " && needs.channel.outputs.rust_tests_runner == '\''tank'\''",
-         "final target telemetry must be Tank-only and always run")
-    need(values["jobs.rust-tests.steps." report ".continue-on-error"] == "true",
-         "final target telemetry must not change test correctness")
-    contains("jobs.rust-tests.steps." report ".run", "persistent-cargo-target.sh report",
-             "final target telemetry must report the retained target")
-    stats = step("jobs.rust-tests", "name", "Report sccache statistics")
-    need(stats > enable && values["jobs.rust-tests.steps." stats ".if"] == "always() && " changed,
-         "sccache reuse must be measured after every affected test attempt")
-    contains("jobs.rust-tests.steps." stats ".run", "sccache --show-stats",
-             "cross-registration sccache reuse must be observable")
-    contains("jobs.rust-tests.steps." stats ".run", "cache write errors",
-             "degraded cache writes must emit a workflow warning")
-    contains("jobs.rust-tests.steps." stats ".run", "exit 0",
-             "cache-statistics failures must not change test correctness")
-    for (path in nodes) if (path ~ /^jobs\.rust-tests\.env\./ && path ~ /SCCACHE_BASEDIRS$/) fail("do not claim cross-checkout Rust remapping without pinned-source support")
+    setup = step(shard_job, "name", "Set up Rust")
+    need(setup >= 0 && index(values[shard_job ".steps." setup ".uses"], "actions-rust-lang/setup-rust-toolchain@") == 1 && values[shard_job ".steps." setup ".if"] == active, "Rust setup must remain path- and warm-path-gated")
+    need(values[shard_job ".steps." setup ".with.cache-key"] == "rust-tests-v2" && values[shard_job ".steps." setup ".with.cache-targets"] == "false", "Rust target archives must remain disabled")
+    target_step = step(shard_job, "name", "Prepare persistent Tank Cargo target")
+    need(target_step >= 0 && values[shard_job ".steps." target_step ".if"] == active " && env.RUNNER_MODE == '\''tank'\''", "persistent target setup must use actual Tank mode")
+    contains(shard_job ".steps." target_step ".run", "persistent-cargo-target.sh prepare tank", "Tank setup must use the persistent target helper")
+    contains(shard_job ".steps." target_step ".run", "TCL_LSP_TANK_REGISTRATION_ID", "target identity must prefer explicit registration id")
+    contains(shard_job ".steps." target_step ".run", "RUNNER_NAME", "target identity must have a stable runner fallback")
+    sccache = step(shard_job, "name", "Set up sccache")
+    need(sccache >= 0 && index(values[shard_job ".steps." sccache ".uses"], "mozilla-actions/sccache-action@") == 1 && values[shard_job ".steps." sccache ".with.version"] == "v0.17.0" && values[shard_job ".steps." sccache ".with.disable_annotations"] == "true", "Rust shards must retain pinned resilient sccache setup")
+    need(values[shard_job ".steps." sccache ".id"] == "sccache" && values[shard_job ".steps." sccache ".if"] == active && values[shard_job ".steps." sccache ".continue-on-error"] == "true", "sccache setup must be observable, gated, and non-fatal")
+    enable = step(shard_job, "name", "Enable sccache when available")
+    need(enable > sccache && values[shard_job ".steps." enable ".if"] == active && values[shard_job ".steps." enable ".env.SCCACHE_SETUP_OUTCOME"] == "${{ steps.sccache.outcome }}", "wrapper enablement must follow optional setup")
+    contains(shard_job ".steps." enable ".run", "RUSTC_WRAPPER=sccache", "successful setup must enable compiler cache")
+    contains(shard_job ".steps." enable ".run", "continuing with uncached compilation", "failed setup must report uncached fallback")
+    nextest_setup = step(shard_job, "name", "Install cargo-nextest")
+    need(nextest_setup > enable && values[shard_job ".steps." nextest_setup ".if"] == active, "cargo-nextest setup must be warm-path-gated")
+
+    nextest = step(shard_job, "name", "cargo nextest run (workspace minus VM-sim heavies and lsp-e2e)")
+    need(nextest >= 0, "Rust shards must retain the broad nextest step")
+    contains(shard_job ".steps." nextest ".run", "if [ \"$RUST_TESTS_RUNNER\" = tank ]; then", "nextest must branch on the actual per-shard runner mode")
+    contains(shard_job ".steps." nextest ".run", "cargo nextest run $extra --workspace --exclude tcl-irule-test --exclude f5-cli --exclude tcl-lsp-server --exclude tcl-fuzz --all-features --partition \"hash:$SHARD\"", "nextest must retain the exact root workspace selection")
+    contains(shard_job ".steps." nextest ".run", "cargo nextest run --no-run --workspace --exclude tcl-irule-test --exclude f5-cli --exclude tcl-lsp-server --exclude tcl-fuzz --all-features", "already-green must warm the complete root workspace")
+    contains(shard_job ".steps." nextest ".run", "--partition \"hash:$SHARD\"", "nextest must use the five-way hash shard")
+    contains(shard_job ".steps." nextest ".run", "persistent-cargo-target.sh with-lock", "Tank nextest must hold the persistent target lock")
+    need(index(values[shard_job ".steps." nextest ".if"], "matrix.shard == '\''1/5'\''") != 0, "already-green warm compilation must be restricted to shard 1")
+    shard_upload = step(shard_job, "name", "Upload selected shard listing")
+    all_upload = step(shard_job, "name", "Upload authoritative all-tests listing")
+    need(shard_upload > nextest && values[shard_job ".steps." shard_upload ".with.overwrite"] == "true", "shard listing uploads must be replaceable on job reruns")
+    need(all_upload > shard_upload && values[shard_job ".steps." all_upload ".with.overwrite"] == "true", "authoritative listing uploads must be replaceable on job reruns")
+    doctest = step(doctest_job, "name", "cargo test --doc")
+    need(doctest >= 0, "doctests must run in their own job")
+    need(values[doctest_job ".if"] == values[shard_job ".if"], "doctests must retain the shard matrix unchanged/exact-green job skips")
+    need(values[doctest_job ".runs-on"] == "ubuntu-26.04", "doctests must run concurrently on hosted capacity")
+    need(values[doctest_job ".needs"] == "[channel]", "doctests must be independently concurrent with shards")
+    need(values[doctest_job ".steps." doctest ".if"] == changed " && needs.channel.outputs.docs_only != '\''true'\'' && needs.channel.outputs.already_green != '\''true'\''", "doctests must retain exact changed-path and exact-green skip semantics")
+    contains(doctest_job ".steps." doctest ".run", "cargo test --workspace --all-features --doc --no-fail-fast", "doctests must retain whole-workspace coverage")
+    report = step(shard_job, "name", "Report final Tank Cargo target")
+    need(report >= 0 && values[shard_job ".steps." report ".if"] == "always() && " changed " && env.RUNNER_MODE == '\''tank'\''" && values[shard_job ".steps." report ".continue-on-error"] == "true", "final target telemetry must be Tank-only, always-run, and non-fatal")
+    contains(shard_job ".steps." report ".run", "persistent-cargo-target.sh report", "final target telemetry must report the retained target")
+    stats = step(shard_job, "name", "Report sccache statistics")
+    need(stats > enable && values[shard_job ".steps." stats ".if"] == "always() && " active, "sccache reuse must be measured after every active attempt")
+    contains(shard_job ".steps." stats ".run", "sccache --show-stats", "sccache reuse must be observable")
+    contains(shard_job ".steps." stats ".run", "cache write errors", "degraded cache writes must emit a warning")
+    contains(shard_job ".steps." stats ".run", "exit 0", "cache-statistics failures must not change correctness")
+    for (path in nodes) if (path ~ /^jobs\.rust-tests-shard\.env\./ && path ~ /SCCACHE_BASEDIRS$/) fail("do not claim cross-checkout Rust remapping without pinned-source support")
 }
 ' "$WORKFLOW"
 
@@ -310,10 +328,10 @@ case "${SCENARIO:-idle}:$endpoint" in
     waiting:*'status=waiting'*) printf '%s\n' '[{"workflow_runs":[{"id":43,"status":"waiting"}]}]' ;;
     page2:*'status=pending'*) printf '%s\n' '[{"workflow_runs":[]},{"workflow_runs":[{"id":44,"status":"pending"}]}]' ;;
     *:*'status='*) printf '%s\n' '[{"workflow_runs":[]}]' ;;
-    occupied:*'/runs/41/jobs'*) printf '%s\n' '[{"jobs":[{"name":"rust-tests","status":"in_progress","labels":["tank"]}]}]' ;;
-    hosted:*'/runs/42/jobs'*) printf '%s\n' '[{"jobs":[{"name":"rust-tests","status":"in_progress","labels":["ubuntu-26.04"]}]}]' ;;
-    waiting:*'/runs/43/jobs'*) printf '%s\n' '[{"jobs":[{"name":"rust-tests","status":"waiting","labels":["tank"]}]}]' ;;
-    page2:*'/runs/44/jobs'*) printf '%s\n' '[{"jobs":[]},{"jobs":[{"name":"rust-tests","status":"pending","labels":["tank"]}]}]' ;;
+    occupied:*'/runs/41/jobs'*) printf '%s\n' '[{"jobs":[{"name":"rust-tests-shard (1/5)","status":"in_progress","labels":["tank"]}]}]' ;;
+    hosted:*'/runs/42/jobs'*) printf '%s\n' '[{"jobs":[{"name":"rust-tests-shard (1/5)","status":"in_progress","labels":["ubuntu-26.04"]}]}]' ;;
+    waiting:*'/runs/43/jobs'*) printf '%s\n' '[{"jobs":[{"name":"rust-tests-shard (1/5)","status":"waiting","labels":["tank"]}]}]' ;;
+    page2:*'/runs/44/jobs'*) printf '%s\n' '[{"jobs":[]},{"jobs":[{"name":"rust-tests-shard (1/5)","status":"pending","labels":["tank"]}]}]' ;;
     *) printf '%s\n' '[{"jobs":[]}]' ;;
 esac
 EOF
@@ -334,7 +352,7 @@ require_path_gate_count() {
     required=$2
     actual=$(printf '%s\n' "$rust_tests_job" | grep -Fxc "$expected" || true)
     if [ "$actual" -ne "$required" ]; then
-        echo "rust-tests expected $required gated steps, found $actual: $expected" >&2
+        echo "rust-tests-shard expected $required gated steps, found $actual: $expected" >&2
         exit 1
     fi
 }
@@ -349,34 +367,33 @@ expect_selection fail hosted
 
 case "$(cat "$selector")" in
     *'for status in in_progress queued requested waiting pending; do'*'--paginate --slurp'*) ;;
-    *)
-        echo "the load detector must cover and paginate every active workflow state" >&2
-        exit 1
-        ;;
+    *) echo "the load detector must cover and paginate every active workflow state" >&2; exit 1 ;;
 esac
 
 case "$(cat "$WORKFLOW")" in
     *'if [[ "$EVENT_NAME" == pull_request && ("$PR_HEAD_REPOSITORY" != "$GITHUB_REPOSITORY" || "$PR_AUTHOR" == '\''dependabot[bot]'\'' || "$RUNNER_POLICY_CHANGED" == true) ]]'*'runner=hosted'*'elif [[ "$EVENT_NAME" == workflow_dispatch ]]'*'runner="$DISPATCH_RUNNER"'*) ;;
-    *)
-        echo "fork, Dependabot, policy-change, and manual-dispatch routing must stay outside the mutable selector" >&2
-        exit 1
-        ;;
+    *) echo "fork, Dependabot, policy-change, and manual-dispatch routing must stay outside the mutable selector" >&2; exit 1 ;;
 esac
 
-# Keep the required job alive for unrelated changes, but do not provision
-# toolchains, caches, interpreters, or test binaries when its archive is not
-# in the changed-path closure. These are step-level gates deliberately: a
-# job-level skip would leave the required status absent.
-require_path_gate_count "        if: needs.channel.outputs.rust_tests_changed == 'true'" 5
+case "$aggregate" in
+    *'if: ${{ always() }}'*'needs: [channel, rust-tests-shard, rust-tests-doctest]'*'SHARDS_RESULT'*'DOCTEST_RESULT'*'RUST_TESTS_CHANGED'*'ALREADY_GREEN'*'IS_TAG'*'if [ "$SHARDS_RESULT" = success ] && [ "$DOCTEST_RESULT" = success ]'*'"$SHARDS_RESULT" = skipped'*'"$DOCTEST_RESULT" = skipped'*'"$RUST_TESTS_CHANGED" != true'*'"$IS_TAG" = true'*'"$ALREADY_GREEN" = true'*) ;;
+    *) echo "rust-tests aggregate must always run and fail closed over every shard plus doctests" >&2; exit 1 ;;
+esac
+case "$aggregate" in
+    *'verify-nextest-partitions.py --partition-count 5'*'rust-tests-all.json'*'rust-tests-5-5.json'*) ;;
+    *) echo "rust-tests aggregate must prove complete five-way selection" >&2; exit 1 ;;
+esac
+
+# Keep the stable aggregate alive for unrelated changes and already-green tags.
+# For an already-green merge push, the matrix remains allocated but only shard
+# 1 may warm the cache; shards 2–5 must skip every expensive setup/report step.
 require_path_gate_count "        if: needs.channel.outputs.rust_tests_changed == 'true' && needs.channel.outputs.docs_only != 'true' && needs.channel.outputs.already_green != 'true'" 2
-require_path_gate_count "        if: needs.channel.outputs.rust_tests_changed == 'true' && needs.channel.outputs.docs_only != 'true' && !(startsWith(github.ref, 'refs/tags/') && needs.channel.outputs.already_green == 'true')" 1
+require_path_gate_count "        if: needs.channel.outputs.rust_tests_changed == 'true' && (needs.channel.outputs.already_green != 'true' || matrix.shard == '1/5')" 5
+require_path_gate_count "        if: needs.channel.outputs.rust_tests_changed == 'true' && needs.channel.outputs.docs_only != 'true' && !(startsWith(github.ref, 'refs/tags/') && needs.channel.outputs.already_green == 'true') && (needs.channel.outputs.already_green != 'true' || matrix.shard == '1/5')" 1
 case "$(cat "$WORKFLOW")" in
     *'if [ "$rust_tests_changed" = "true" ]; then
               docs_only=false'*) ;;
-    *)
-        echo "root Rust closure must override the broad docs-only path shape" >&2
-        exit 1
-        ;;
+    *) echo "root Rust closure must override the broad docs-only path shape" >&2; exit 1 ;;
 esac
 
-echo "self-hosted Rust test scheduling contract passed"
+echo "direct five-way Rust test scheduling contract passed"

--- a/scripts/dev/verify-nextest-partitions.py
+++ b/scripts/dev/verify-nextest-partitions.py
@@ -17,7 +17,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-"""Verify that three nextest listings are a disjoint, complete partition.
+"""Verify that nextest listings are a disjoint, complete partition.
 
 The listing format deliberately contains tests which are present in the
 binary but excluded by the active profile, ignored-test mode, or a partition.
@@ -37,14 +37,17 @@ from typing import Any
 
 TestId = tuple[str, str]
 SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
-PARTITION_COUNT = 3
-PARTITIONS = tuple(
-    f"hash:{index}/{PARTITION_COUNT}" for index in range(1, PARTITION_COUNT + 1)
-)
-LISTING_NAMES = {
-    "all.json",
-    *(f"{index}-{PARTITION_COUNT}.json" for index in range(1, PARTITION_COUNT + 1)),
-}
+DEFAULT_PARTITION_COUNT = 3
+
+
+def _partitions(count: int) -> tuple[str, ...]:
+    if count < 1:
+        raise ValueError(f"partition count must be positive, got {count}")
+    return tuple(f"hash:{index}/{count}" for index in range(1, count + 1))
+
+
+def _listing_names(count: int) -> set[str]:
+    return {"all.json", *(f"{index}-{count}.json" for index in range(1, count + 1))}
 
 
 def _load(path: Path) -> Any:
@@ -110,12 +113,13 @@ def _authoritative_selected(path: Path) -> set[TestId]:
 
 
 def _verify_partition_sets(
-    all_tests: set[TestId], partitions: list[tuple[str, set[TestId]]]
+    all_tests: set[TestId], partitions: list[tuple[str, set[TestId]]], count: int
 ) -> None:
     names = [name for name, _ in partitions]
-    if tuple(names) != PARTITIONS:
+    expected = _partitions(count)
+    if tuple(names) != expected:
         raise ValueError(
-            f"expected exactly the partitions {', '.join(PARTITIONS)}; got {', '.join(names)}"
+            f"expected exactly the partitions {', '.join(expected)}; got {', '.join(names)}"
         )
     union: set[TestId] = set()
     for name, selected in partitions:
@@ -137,22 +141,27 @@ def _verify_partition_sets(
         raise ValueError("\n".join(details))
 
 
-def verify(all_path: Path, *partition_paths: Path) -> None:
+def verify(
+    all_path: Path,
+    *partition_paths: Path,
+    partition_count: int = DEFAULT_PARTITION_COUNT,
+) -> None:
     all_tests = _authoritative_selected(all_path)
-    if len(partition_paths) != PARTITION_COUNT:
+    if len(partition_paths) != partition_count:
         raise ValueError(
-            f"expected exactly {PARTITION_COUNT} partition listings, got {len(partition_paths)}"
+            f"expected exactly {partition_count} partition listings, got {len(partition_paths)}"
         )
     selected = [_selected(path) for path in partition_paths]
     _verify_partition_sets(
         all_tests,
         [
-            (f"hash:{index}/{PARTITION_COUNT}", tests)
+            (f"hash:{index}/{partition_count}", tests)
             for index, tests in enumerate(selected, 1)
         ],
+        partition_count,
     )
     counts = " ".join(
-        f"{index}/{PARTITION_COUNT}={len(tests)}"
+        f"{index}/{partition_count}={len(tests)}"
         for index, tests in enumerate(selected, 1)
     )
     print(f"nextest partition proof: all={len(all_tests)} {counts}")
@@ -228,24 +237,36 @@ def _require_listing_digest(
     _require_digest(listing, digest, f"listing {key}")
 
 
-def _require_exact_listing_keys(metadata: dict[str, Any], path: Path) -> None:
+def _require_exact_listing_keys(
+    metadata: dict[str, Any], path: Path, partition_count: int
+) -> None:
     listings = metadata.get("listings")
     if not isinstance(listings, dict):
         raise TypeError(f"{path}: metadata has no listings object")
     actual = set(listings)
-    if actual != LISTING_NAMES:
-        missing = sorted(LISTING_NAMES - actual)
-        extra = sorted(actual - LISTING_NAMES)
+    expected = _listing_names(partition_count)
+    if actual != expected:
+        missing = sorted(expected - actual)
+        extra = sorted(actual - expected)
         raise ValueError(
-            f"{path}: producer listings must be exactly {sorted(LISTING_NAMES)} "
+            f"{path}: producer listings must be exactly {sorted(expected)} "
             f"(missing={missing}, extra={extra})"
         )
 
 
 def _matching_metadata(
-    producer: dict[str, Any], consumer: dict[str, Any], path: Path, partition: str
+    producer: dict[str, Any],
+    consumer: dict[str, Any],
+    path: Path,
+    partition: str,
+    partition_count: int,
 ) -> None:
     _require_common(consumer, path)
+    for key in ("partition_count", "shard_count"):
+        if consumer.get(key) != partition_count:
+            raise ValueError(
+                f"{path}: {key} does not match partition count {partition_count}"
+            )
     for key in (
         "workspace_sha",
         "nextest_version",
@@ -263,7 +284,11 @@ def _matching_metadata(
         raise ValueError(f"{path}: consumer did not verify the downloaded archive")
 
 
-def verify_results(proof_dir: Path, *partition_dirs: Path) -> None:
+def verify_results(
+    proof_dir: Path,
+    *partition_dirs: Path,
+    partition_count: int = DEFAULT_PARTITION_COUNT,
+) -> None:
     """Verify the transferred proof and consumer result artifacts."""
     producer_meta_path = proof_dir / "producer-metadata.json"
     producer = _metadata(producer_meta_path)
@@ -274,12 +299,17 @@ def verify_results(proof_dir: Path, *partition_dirs: Path) -> None:
         or producer.get("result") != "success"
     ):
         raise ValueError(f"{producer_meta_path}: invalid producer metadata")
-    if len(partition_dirs) != PARTITION_COUNT:
+    for key in ("partition_count", "shard_count"):
+        if producer.get(key) != partition_count:
+            raise ValueError(
+                f"{producer_meta_path}: {key} does not match partition count {partition_count}"
+            )
+    if len(partition_dirs) != partition_count:
         raise ValueError(
-            f"expected exactly {PARTITION_COUNT} consumer result directories, "
+            f"expected exactly {partition_count} consumer result directories, "
             f"got {len(partition_dirs)}"
         )
-    _require_exact_listing_keys(producer, producer_meta_path)
+    _require_exact_listing_keys(producer, producer_meta_path, partition_count)
 
     archive_digest = _read_archive_digest(proof_dir / "archive.sha256")
     if archive_digest != producer["archive_sha256"]:
@@ -301,13 +331,13 @@ def verify_results(proof_dir: Path, *partition_dirs: Path) -> None:
 
     all_path = proof_dir / "all.json"
     producer_listing_paths = [
-        proof_dir / f"{index}-{PARTITION_COUNT}.json"
-        for index in range(1, PARTITION_COUNT + 1)
+        proof_dir / f"{index}-{partition_count}.json"
+        for index in range(1, partition_count + 1)
     ]
     listing_items = [
         (all_path, "all.json"),
         *[
-            (path, f"{index}-3.json")
+            (path, f"{index}-{partition_count}.json")
             for index, path in enumerate(producer_listing_paths, 1)
         ],
     ]
@@ -318,8 +348,10 @@ def verify_results(proof_dir: Path, *partition_dirs: Path) -> None:
     for index, directory in enumerate(partition_dirs, 1):
         metadata_path = directory / "result-metadata.json"
         metadata = _metadata(metadata_path)
-        partition = f"hash:{index}/{PARTITION_COUNT}"
-        _matching_metadata(producer, metadata, metadata_path, partition)
+        partition = f"hash:{index}/{partition_count}"
+        _matching_metadata(
+            producer, metadata, metadata_path, partition, partition_count
+        )
         listing = directory / "selected.json"
         consumer_data.append((partition, metadata, metadata_path, listing))
     for _, metadata, metadata_path, listing in consumer_data:
@@ -333,18 +365,26 @@ def verify_results(proof_dir: Path, *partition_dirs: Path) -> None:
     consumer_selected = [_selected(listing) for _, _, _, listing in consumer_data]
     _verify_partition_sets(
         all_tests,
-        [(partition, tests) for partition, tests in zip(PARTITIONS, producer_selected)],
+        [
+            (partition, tests)
+            for partition, tests in zip(_partitions(partition_count), producer_selected)
+        ],
+        partition_count,
     )
     _verify_partition_sets(
         all_tests,
-        [(partition, tests) for partition, tests in zip(PARTITIONS, consumer_selected)],
+        [
+            (partition, tests)
+            for partition, tests in zip(_partitions(partition_count), consumer_selected)
+        ],
+        partition_count,
     )
     if consumer_selected != producer_selected:
         raise ValueError(
             "consumer selected listings differ from producer partition listings"
         )
     counts = " ".join(
-        f"{index}/{PARTITION_COUNT}={len(tests)}"
+        f"{index}/{partition_count}={len(tests)}"
         for index, tests in enumerate(consumer_selected, 1)
     )
     print(f"transferred nextest proof: all={len(all_tests)} {counts}")
@@ -443,6 +483,7 @@ def self_test() -> None:
                     ("hash:1/3", set()),
                     ("hash:3/3", set()),
                 ],
+                3,
             )
         except ValueError as exc:
             assert "exactly the partitions" in str(exc)
@@ -463,6 +504,14 @@ def self_test() -> None:
             assert "authoritative listing selects no tests" in str(exc)
         else:
             raise AssertionError("empty authoritative selection passed verification")
+        verify(
+            Path("all"),
+            Path("first"),
+            Path("second"),
+            Path("empty"),
+            Path("empty"),
+            partition_count=4,
+        )
     finally:
         globals()["_load"] = original_load
     print(
@@ -506,6 +555,8 @@ def self_test() -> None:
             "package": "tcl-lsp-server",
             "filter": "default",
             "archive_sha256": archive_sha,
+            "partition_count": 3,
+            "shard_count": 3,
         }
         producer_metadata = dict(common)
         producer_metadata.update(
@@ -522,7 +573,9 @@ def self_test() -> None:
             json.dumps(producer_metadata), encoding="utf-8"
         )
         for directory, partition, fixture in zip(
-            partition_dirs, PARTITIONS, (first_fixture, second_fixture, third_fixture)
+            partition_dirs,
+            _partitions(DEFAULT_PARTITION_COUNT),
+            (first_fixture, second_fixture, third_fixture),
         ):
             listing = directory / "selected.json"
             listing.write_text(json.dumps(fixture), encoding="utf-8")
@@ -541,6 +594,20 @@ def self_test() -> None:
             )
         assert not (proof_dir / "lsp-e2e.tar.zst").exists()
         verify_results(proof_dir, *partition_dirs)
+        producer_metadata["partition_count"] = 4
+        (proof_dir / "producer-metadata.json").write_text(
+            json.dumps(producer_metadata), encoding="utf-8"
+        )
+        try:
+            verify_results(proof_dir, *partition_dirs)
+        except ValueError as exc:
+            assert "partition_count does not match" in str(exc)
+        else:
+            raise AssertionError("mismatched partition metadata passed verification")
+        producer_metadata["partition_count"] = 3
+        (proof_dir / "producer-metadata.json").write_text(
+            json.dumps(producer_metadata), encoding="utf-8"
+        )
         try:
             verify_results(proof_dir, *partition_dirs[:2])
         except ValueError as exc:
@@ -567,29 +634,41 @@ def main(argv: list[str]) -> int:
     if argv == ["--self-test"]:
         self_test()
         return 0
+    partition_count = DEFAULT_PARTITION_COUNT
+    if argv and argv[0] == "--partition-count":
+        try:
+            partition_count = int(argv[1])
+        except (IndexError, ValueError):
+            print("partition count must be an integer", file=sys.stderr)
+            return 2
+        if partition_count < 1:
+            print("partition count must be positive", file=sys.stderr)
+            return 2
+        argv = argv[2:]
     if argv and argv[0] == "--verify-results":
-        if len(argv) != PARTITION_COUNT + 2:
+        if len(argv) != partition_count + 2:
             print(
-                f"usage: {sys.argv[0]} --verify-results "
-                "PROOF_DIR FIRST_DIR SECOND_DIR THIRD_DIR",
+                f"usage: {sys.argv[0]} [--partition-count N] --verify-results PROOF_DIR DIR...",
                 file=sys.stderr,
             )
             return 2
         try:
-            verify_results(*(Path(arg) for arg in argv[1:]))
+            verify_results(
+                *(Path(arg) for arg in argv[1:]), partition_count=partition_count
+            )
         except (TypeError, ValueError) as exc:
             print(exc, file=sys.stderr)
             return 1
         return 0
-    if len(argv) != PARTITION_COUNT + 1:
+    if len(argv) != partition_count + 1:
         print(
-            f"usage: {sys.argv[0]} ALL.json 1-3.json 2-3.json 3-3.json",
+            f"usage: {sys.argv[0]} [--partition-count N] ALL.json 1-N.json ... N-N.json",
             file=sys.stderr,
         )
         print(f"       {sys.argv[0]} --self-test", file=sys.stderr)
         return 2
     try:
-        verify(*(Path(arg) for arg in argv))
+        verify(*(Path(arg) for arg in argv), partition_count=partition_count)
     except (TypeError, ValueError) as exc:
         print(exc, file=sys.stderr)
         return 1


### PR DESCRIPTION
Closes #1985.

## Summary

- replace the single broad root `rust-tests` execution with five direct nextest hash partitions
- keep shard 1 Tank-capable while shards 2–5 always use hosted Linux capacity
- run whole-workspace doctests once in a separate concurrent hosted job
- preserve the stable required `rust-tests` context through a fail-closed aggregate
- prove the five uploaded listings are disjoint and complete
- retain trust routing, changed-path filtering, exact-green behaviour, and the existing three-way LSP archive proof
- force pull requests to execute tests even if a checked-out helper is modified, and make listing uploads overwriteable for failed-job reruns

## Experimental basis

The selected suite contains roughly 19,500 tests across more than 300 binaries. The original four-way exact-head proof was green, selecting about 4,800–4,900 tests per shard, but the shard jobs took 9m28s, 10m25s, 11m12s, and 12m14s. Hosted compilation cost 3m24s–3m56s and shard execution cost 4m41s–5m42s; shard 1 then added a 1m43s doctest build. That version was not merged.

The alternative archive design was also rejected experimentally: production took 3m26s to compile plus 16.97s to archive, produced a 4.19 GB artifact, and would require about 16.7 GB of downloads across four consumers.

The revised five-way fan-out shortens the measured nextest tail, avoids archive transfer, lets four shards bypass the serial Tank lane, and removes the doctest suffix from the shard critical path. Exact-head timing from the revised run will be recorded before merge.

## Verification

- `make rust-check`
- `make prep-pr`
- focused runner/path/reference/LSP partition contracts
- configurable partition-verifier self-tests, including ignored/profile-filtered cases
- pull-request trust regression and failed-job artifact-rerun regression
- YAML parse and `git diff --check`
