### PR TITLE
docs: scrub the root docs, editor READMEs, samples, scripts, and skills

### DIFF
--- a/.claude/skills/bytecode-compare/SKILL.md
+++ b/.claude/skills/bytecode-compare/SKILL.md
@@ -50,7 +50,7 @@ python3 .claude/skills/bytecode-compare/bytecode_compare.py [-v VERSION] <subcom
 
 | Subcommand | Arguments | What it does |
 |---|---|---|
-| `all` | | Compare all 72 fixtures, show summary table |
+| `all` | | Compare all 72 fixtures: the summary table, then a detailed diff per mismatch |
 | `diff` | `<snippet>` | Detailed instruction-by-instruction diff for one snippet (e.g. `while-simple`) |
 | `summary` | | One-line per snippet: match/mismatch with instruction counts |
 | `instructions` | `<snippet>` | Side-by-side normalised instruction listing |

--- a/.claude/skills/compiler-explorer/SKILL.md
+++ b/.claude/skills/compiler-explorer/SKILL.md
@@ -45,7 +45,7 @@ covering `set x 1` in a 7-byte document reports `off 0-7`. Slices are therefore
 
 | View | What it shows | Why it helps |
 |---|---|---|
-| `slices` | Every IR statement's range as offsets **and `[line:col]`**, plus the literal `repr(source[start:end])` the range covers | A one-byte range overshoot reads as an extra delimiter in the slice (`'return {}}'` vs `'return {}'`). This is how issue #527 was found. |
+| `slices` | Every IR statement's range as offsets **and `[line:col]`**, plus the literal `repr(source[start:end])` the range covers | A one-byte range overshoot reads as an extra delimiter in the slice (`'return {}}'` vs `'return {}'`). |
 | `tokens` | The CST's **leaf** nodes: kind, absolute offsets, and the source slice each covers | A mis-placed `endOffset` shows up directly. |
 | `cst` | The parse tree as an indented tree with offsets and tags | Brace-matching and delimiter questions. |
 | `lowlevel` | `tokens` + `cst` + `slices` back to back | One-shot low-level overview for a quick triage. |
@@ -63,10 +63,12 @@ no renderer for it; it exists only in the `--json` contract.
 Any other `<view>` is forwarded to `tcl explore --show <view> --text --no-colour`.
 The full catalogue (`VIEW_META` in `rust/tcl-explorer/src/views.rs`):
 
-`cst`, `segments`, `structuralIndex`, `sourceMap`, `ir`, `cfg`, `ssa`, `loops`,
-`types`, `intervals`, `bounds`, `dataflow`, `interproc`, `rendered`, `opt`,
-`optimiserPasses`, `gvn`, `shimmer`, `taint`, `irules`, `eventOrder`, `callouts`,
-`asm`, `asmOpt`, `wasm`, `wasmOpt`.
+`cst`, `segments`, `structuralIndex`, `sourceMap`, `ir`, `cfg`, `ssa`,
+`dominators`, `sccp`, `liveness`, `semantic`, `worldSsa`, `loops`, `types`,
+`intervals`, `bounds`, `dataflow`, `interproc`, `unitScope`, `rendered`, `opt`,
+`optimiserPasses`, `gvn`, `shimmer`, `taint`, `taintFacts`, `irules`,
+`connectionScope`, `eventOrder`, `callouts`, `asm`, `asmOpt`, `wasm`,
+`wasmOpt`, `semanticOptimisations`.
 
 `interproc` additionally reports each procedure's **param constants** — the
 caller-uniform-literal SCCP seed it was analysed under. That line is the first
@@ -76,9 +78,10 @@ not have: its presence names the literal every visible caller passed, and its
 `eval $script`) withdrew the seed. See
 `docs/design/compiler/interprocedural-call-site-seeding.md`.
 
-Four of those have **no text renderer** and are reachable only via `--json`:
-`cst` (rendered locally instead), `segments`, `asmOpt`, `wasmOpt`. Asking for one
-prints `compiler explorer: no matching views`.
+Five of those have **no text renderer** and are reachable only via `--json`:
+`cst` (rendered locally instead), `segments`, `asmOpt`, `wasmOpt`, and
+`semanticOptimisations`. Asking for one prints
+`compiler explorer: no matching views`.
 
 > [!WARNING]
 > `--show` matches view names by **substring**, not exact name. `--show all` does
@@ -92,7 +95,7 @@ There is no `--opt` lens. The optimised paths are their own views (`opt`,
 ## Examples
 
 ```bash
-# Issue #527 reproducer — the slice exposes the overshoot instantly
+# A closing-delimiter check — the slice exposes an overshoot instantly
 python .claude/skills/compiler-explorer/explore.py slices --source 'if {1} {return {}}'
 #   IRIf       off 0-18  [1:1-1:19]  slice='if {1} {return {}}'
 #   IRReturn   off 8-17  [1:9-1:18]  slice='return {}'      <- correct

--- a/.claude/skills/fuzz-findings/SKILL.md
+++ b/.claude/skills/fuzz-findings/SKILL.md
@@ -12,8 +12,8 @@ allowed-tools: Bash, Read, Write, Edit
 # Fuzz Findings Management
 
 The differential fuzzer lives in `rust/tcl-fuzz`. It generates Tcl programs
-and runs each through a pair of **engines** (issue #1313), recording every
-divergence to a findings registry. Three engines are available:
+and runs each through a pair of **engines**, recording every divergence to a
+findings registry. Three engines are available:
 
 | Engine | What it is | Binary |
 |---|---|---|
@@ -22,14 +22,13 @@ divergence to a findings registry. Three engines are available:
 | `runtime-rust` | `runtime/rust`'s tree-walking interpreter | `runtime/rust`'s `run_script` dev-tool example (`cargo build --release --example run_script` under `runtime/rust`; needs `TCL_TOMMATH_DIR` pointed at a libtommath source tree for `expr`/math to work — see "Building the `runtime-rust` engine" below) |
 
 `run --reference E1 --subject E2` pairs any two of these (default: `tclsh`
-reference, `tclvm` subject — the original, still-default pair). Findings are
+reference, `tclvm` subject). Findings are
 keyed by their generating **seed** (so they replay exactly) and stored as a
 JSON record (see `rust/tcl-fuzz/src/findings.rs`) plus the raw `.tcl` script
 under the findings directory (default `fuzz-findings/`, override with
 `--findings DIR`). A non-default pair is namespaced under
 `<findings>/<subject>-vs-<reference>/` so two pairs never collide on the same
-seed; the default pair keeps using `<findings>/` directly (no migration for
-existing registries).
+seed; the default pair uses `<findings>/` directly.
 
 There is no separate "fixed/unfixed" state: the registry de-duplicates by seed
 and categorises by the divergence kind. A finding is "fixed" when its seed no
@@ -47,8 +46,10 @@ cargo run -q -p tcl-fuzz -- <command> [args...]
 
 Global flags: `--findings DIR` (registry location), `--timeout-ms MS`
 (per-script timeout), `--tclvm PATH` / `--tclsh PATH` / `--runtime-rust PATH`
-(engine binaries; sensible defaults are auto-located beside `tcl-fuzz` or on
-`PATH`).
+(engine binaries; defaults are auto-located beside `tcl-fuzz` or on `PATH`),
+and the two generator dials `--malformed-expr-permille` /
+`--word-shape-permille`. Both dials are global rather than `run`-only because
+`replay` has to generate a seed exactly as the recording campaign did.
 
 ## Commands
 
@@ -59,14 +60,15 @@ Global flags: `--findings DIR` (registry location), `--timeout-ms MS`
 | `replay` | `SEED [--reference E] [--subject E] [--tcl-version X.Y]` | Regenerate seed S, restoring its persisted release automatically. An explicit release selects that exact registry |
 | `wasm-check` | `--iterations N [--seed S] [--verbose]` | WASM-runnability arm: compile each program to the eval-fallback WASM module and flag codegen panics / instantiation failures / traps |
 | `wasm-diff` | `--iterations N [--seed S] [--verbose]` | WASM value-differential arm: compare compiled-WASM control flow (hosted by `tcl-vm`) against direct `tcl-vm`, isolating control-flow miscompiles |
+| `characterise` | `--iterations N [--seed S] [--verbose] [--compare-error-text]` | Three-way campaign classifying `tcl-vm` and `runtime/rust` against C Tcl 9; agreement between the two Rust backends alone is never correctness |
+| `bpf-diff` | `--iterations N [--seed S] [--verbose]` | eBPF arm: compare a generated BPF-Tcl socket filter's dialect contract against the real lowering, eBPF emitter, and userspace eBPF VM |
+| `linked-wasm-diff` | `--iterations N [--seed S] [--verbose]` | Link a compiled user module against `runtime/rust`'s WASM module and compare against C Tcl 9 |
 
 ## Match the reference `tclsh`'s version, or read every finding twice
 
 **A divergence is evidence of a bug only when both engines speak the same
-version of Tcl.** Issue #1328 was filed as two `runtime/rust` bugs from a
-200-iteration campaign against `tclsh8.6`. Re-run against `tclsh9.0.4`, **all
-eight** of that campaign's findings disappear — every one was a deliberate
-8.6-vs-9.0 language change, not a defect:
+version of Tcl.** A campaign against `tclsh8.6` with a 9.0-era subject reports
+deliberate language changes as findings. The usual culprits:
 
 | Cause | Seeds | What differs |
 |---|---|---|
@@ -74,9 +76,9 @@ eight** of that campaign's findings disappear — every one was a deliberate
 | TIP 521 `isfinite()`/`isinf()`/`isnan()` (9.0+) | 90119 | 8.6: `invalid command name "tcl::mathfunc::isfinite"` |
 | Namespace-scope global fallback for relative variable names, removed in 9.0 (TIP 278) | 90022, 90188 | see the [KCS note](../../../docs/kcs/kcs-qa-why-does-a-namespace-variable-behave-differently-on-tcl-8-and-9.md) |
 
-Every campaign now prints both engines' releases before it starts and warns
-when they differ, and every finding records `reference_version`,
-`subject_version` and `version_skew`. Check those before triaging.
+Every campaign prints both engines' releases before it starts and warns when
+they differ; every finding records `reference_version`, `subject_version` and
+`version_skew`. Check those before triaging.
 
 To run version-matched against an older reference, pin the whole pair:
 
@@ -89,10 +91,10 @@ cargo run -q -p tcl-fuzz -- \
 
 `runtime-rust` and `tclvm` receive the same `--tcl-version` argument. A fixed
 release engine such as C `tclsh` is selected by its binary instead, then its
-reported release is verified; no engine may silently ignore a pair pin. The old
-`--subject-tcl-version` spelling remains an alias, but now has pair-wide
-semantics. Pinned findings live below `tclX.Y/` and replay restores that line;
-the same seed at 8.6 and 9.0 is deliberately two separate records.
+reported release is verified; no engine may silently ignore a pair pin.
+`--subject-tcl-version` is an alias with the same pair-wide semantics. Pinned
+findings live below `tclX.Y/` and replay restores that line; the same seed at
+8.6 and 9.0 is deliberately two separate records.
 
 `--compare-error-text` (on `run`) additionally flags an `ErrorTextMismatch`
 finding when both engines error but their stderr text differs — off by

--- a/.claude/skills/jetbrains-plugin-compat/SKILL.md
+++ b/.claude/skills/jetbrains-plugin-compat/SKILL.md
@@ -17,7 +17,7 @@ allowed-tools: Bash, Read, Edit, Grep, Glob, WebFetch
 # JetBrains plugin compatibility
 
 The plugin under `editors/jetbrains` is compiled **once** against the
-`sinceBuild` floor (IntelliJ IDEA Ultimate 2024.1) and must load in **every**
+`sinceBuild` floor (IntelliJ IDEA Ultimate 2025.3, build `253`) and must load in **every**
 IDE from that floor to the newest release, with an open `untilBuild`. Nothing
 recompiles per IDE — the *same* bytecode is linked against whatever platform
 the user is running. So a plugin breaks when the platform API it was linked
@@ -33,9 +33,7 @@ There are two verification surfaces. Keep both green:
    wide matrix of released IDEs after every upload and shows the verdicts on
    `…/edit/versions/{stable,eap}`. Read them over the REST API with
    `marketplace_verify.sh`. This is the only surface that covers IDE builds
-   **newer than anything in our local `ides` list** — which is exactly how the
-   `LspServer.sendRequestSync$default` breakage first surfaced (a 2.1.x build
-   flagged CRITICAL on 2026.1/2026.2 that no local target covered).
+   **newer than anything in our local `ides` list**.
 
 Helper scripts live next to this file:
 
@@ -113,8 +111,9 @@ make verify-editor-jetbrains          # -> ./gradlew verifyPlugin
 ```
 
 Targets live in `editors/jetbrains/build.gradle.kts` under
-`pluginVerification.ides`. Keep the `sinceBuild` floor **and** the newest
-verified stable major in that list. **A >=2026.1 target is load-bearing**:
+`pluginVerification.ides` (IDEA Ultimate at the floor and at the newest stable
+major, plus CLion at that major). Keep the `sinceBuild` floor **and** the
+newest verified stable major in that list. **A >=2026.1 target is load-bearing**:
 2026.1 is where the `LspServer*` API was superseded and `sendRequestSync` moved
 to the `LspClient` super-interface — without it the local verifier cannot catch
 the whole `$default` / moved-API class of failure. First run downloads each
@@ -134,7 +133,7 @@ the failing build — no IDE download needed:
 
 ```bash
 S=.claude/skills/jetbrains-plugin-compat/inspect_sdk.sh
-$S 241.14494.240 com.intellij.platform.lsp.api.LspServer          # what we compiled against
+$S 2025.3        com.intellij.platform.lsp.api.LspServer          # what we compiled against
 $S 262.8665.176  com.intellij.platform.lsp.api.LspServer   -c     # the failing build (-c = show bytecode)
 $S 262.8665.176  com.intellij.platform.lsp.api.LspClient          # the suspected new home
 $S --list                                                          # list available `lsp` module versions
@@ -143,7 +142,7 @@ $S 262.8665.176  some.other.Class  platform-impl                  # a different 
 
 For the `sendRequestSync` case this shows, unambiguously:
 
-- **241** — `LspServer` declares `sendRequestSync(int, Function1)` **and** the
+- **2025.3** — `LspServer` declares `sendRequestSync(int, Function1)` **and** the
   synthetic `sendRequestSync$default(LspServer, int, Function1, int, Object)`.
 - **262** — `LspServer extends LspClient` and declares **neither**; both moved
   to `LspClient`. `LspServer.sendRequestSync(int, Function1)` still *resolves*
@@ -178,10 +177,11 @@ val result = server.sendRequestSync(LspServer.DEFAULT_REQUEST_TIMEOUT_MS) { lsp4
 }
 ```
 
-Both call sites are `TclLspActionBase.runCommand` and
-`CompilerExplorerToolWindowFactory.runCompile`. Each carries a comment pointing
-back here — **do not "simplify" them back to the no-timeout form**, that
-reintroduces the `$default` bridge.
+Every `sendRequestSync` call site passes the timeout explicitly
+(`TclLspActionBase`, `CompilerExplorerToolWindowFactory` ×2,
+`SpecStudioToolWindowFactory`, `packs/TclLspPackAssociations`) and carries a
+comment pointing back here — **do not "simplify" them back to the no-timeout
+form**, that reintroduces the `$default` bridge.
 
 ## Fix catalogue for other breakage
 

--- a/.claude/skills/lsp-client/SKILL.md
+++ b/.claude/skills/lsp-client/SKILL.md
@@ -46,10 +46,9 @@ subcommand. All line/col arguments are **0-based**.
 `definition`, `references`, `diagnostics`, `code-actions`, `context`, `all`,
 `completion`, and `code-lens` wait for the background workspace scan
 (`--scan-timeout`, default 30 s) before proceeding; otherwise cross-file
-results race the scan (#1094). A new cross-file check must call
-`client.wait_for_workspace_scan()` *before* `didOpen` — its docstring says
-why. `--also-open FILE` (repeatable) opens companion files after that wait
-and before `<file>` (#1111):
+results race the scan. A new cross-file check must call
+`client.wait_for_workspace_scan()` *before* `didOpen`. `--also-open FILE`
+(repeatable) opens companion files after that wait and before `<file>`:
 
 ```bash
 python3 .claude/skills/lsp-client/lsp_client.py --also-open lib.tcl definition consumer.tcl 3 10

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -228,7 +228,7 @@ on that Environment — report it, do not work around it. The laptop targets
 only when a CI job itself failed (keyless `az login` for vsce; `OVSX_PAT`;
 `JETBRAINS_TOKEN`, first-ever upload is manual in the web UI).
 
-Sublime needs no step: Package Control resolves the `TclLsp.sublime-package`
+Sublime needs no step: Package Control resolves the `LSP-Tcl.sublime-package`
 asset on the release (`make publish-verify` checks it is there; registering
 the channel entry is a one-time PR the user raises —
 `editors/sublime-text/SUBMITTING.md`). Neovim and Helix are one-time

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,13 +1,13 @@
 # AGENTS.md — development guide for AI agents
 
 tcl-lsp is a Tcl language server and toolchain: a native Rust workspace under
-`rust/` (~45 crates; `[workspace] members` in `Cargo.toml` is the list) that
-builds four binaries — `tcl-lsp-server`, `tcl`, `f5-query`, `tcl-mcp` — plus
+`rust/` (`[workspace] members` in `Cargo.toml` is the list) that builds the
+released binaries — `tcl-lsp-server`, `tcl`, `f5-query`, `tcl-mcp` — plus
 editor integrations under `editors/` (VS Code, Zed, JetBrains, Neovim, Emacs,
 Helix, Sublime) and the WASM runtime the compiler targets under
 `runtime/rust/`. It covers Tcl 8.4–9.1, F5 iRules/iApps, and the EDA dialects.
-Python is retired on this branch. `rust` is the only active branch;
-`legacy-py` is a locked archive — never branch, merge, or tag from it.
+`rust` is the only active branch; `legacy-py` is a locked archive — never
+branch, merge, or tag from it.
 
 Orientation: the crate map and dependency direction in
 [project-layout.md](docs/design/contracts/project-layout.md); the compiler
@@ -27,8 +27,7 @@ make prep-pr        # format + codegen + lint/typecheck + smoke tier
 
 - `rust-check` is the minimum for Rust-only changes; `prep-pr` is the gate
   before every `git push`. Fix failures, never skip them; commit the
-  formatting `prep-pr` applies and re-run. Every "pr-gate bounced on a
-  trivial lint" on this repo was a push that skipped this.
+  formatting `prep-pr` applies and re-run.
 - **CI carries the deep suites.** Rebase on `rust`, run `prep-pr`, open the
   PR, subscribe to its activity, fix forward. Do not block on the full suite
   locally. To reproduce a deep-tier failure: `make test` (workspace,
@@ -146,8 +145,8 @@ an interpreter-fallback path, or an explicit not-required classification.
 on an unclassified command; a real gap goes on `KNOWN_UNBACKED` in
 `rust/xtask/src/command_backing.rs` until it gains a handler. The
 `wasm_stdlib` feature embeds Tcl scripts and the Tcl-level `tcltest` package
-in the runtime VFS; it is not a port of the C `test*` commands, and
-package-driven extension bundling is future state only. Pipeline:
+in the runtime VFS; it is not a port of the C `test*` commands and does not
+bundle package-driven extensions. Pipeline:
 [wasm-codegen.md](docs/design/compiler/wasm-codegen.md); extensions:
 [wasm-extensions.md](docs/design/compiler/wasm-extensions.md).
 
@@ -163,8 +162,8 @@ trust it rather than re-deriving.
 
 ### Lexer, lowering, LSP
 
-- A stray `}` or `]` is `TokenType::ESC`; check `tok.kind`, not just
-  `tok.text` — a `}` typed `STR` is structural.
+- A stray `}` or `]` is `TokenType::Esc`; check `tok.kind`, not just
+  `tok.text` — a `}` typed `Str` is structural.
   [lexing-segmentation.md](docs/design/compiler/lexing-segmentation.md).
 - A lowering hook that cannot safely specialise a construct falls through to
   the generic call IR: the compiler only inlines what it can prove is safe,
@@ -215,7 +214,7 @@ glossary, and screenshot updates in the same PR
 
 ## Long-running lanes
 
-A lane keeps a tracking document under `docs/design/lanes/`, commits at every
-compiling milestone as `wip(<lane>):` with explicitly staged paths, never
-pushes (the orchestrator does), and never deletes `.git/index.lock`.
-Protocol: [lanes/README.md](docs/design/lanes/README.md).
+A lane keeps a tracking document under `docs/design/lanes/`, commits each
+coherent, compiling state as `wip(<lane>):` with explicitly staged paths,
+never pushes (the orchestrator does), and waits rather than deleting
+`.git/index.lock`. Rules: [lanes/README.md](docs/design/lanes/README.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,19 +2,11 @@
 
 ## Upstream first
 
-This project is licensed under the AGPL-3.0-or-later. If you fix a bug, add a
-feature, or improve performance, please submit your changes as a pull request to
-this repository rather than maintaining a private fork.
-
-The AGPL already requires that derivative works are published under the same
-license, so upstreaming your changes costs nothing extra and benefits everyone:
-you get ongoing maintenance from the project, and the community gets your
-improvements. Private forks that diverge over time become a burden for both
-parties.
-
-If your change is specific to an internal environment and genuinely cannot be
-generalised, please open an issue describing the need so we can discuss how to
-accommodate it in a way that works upstream.
+Submit fixes and features as pull requests rather than maintaining a private
+fork: the AGPL-3.0-or-later already requires derivative works to be published
+under the same licence, so upstreaming costs nothing extra and spares both
+sides a diverging fork. If a change is specific to an internal environment and
+cannot be generalised, open an issue describing the need.
 
 ## AI Use
 
@@ -27,9 +19,8 @@ to come up with scenarios for the AI to generate tests to. AI still has a tenden
 to cheat, generating bad code and bad tests if left to its own devices. Much like
 AI, we tend to take shortcuts ourselves.
 
-You MUST be honest about AI contributions including models used. It would be nice
-to include prompts used so people can see what you did. Yes, I know I'm aware that
-I didn't think about that from the start and include mine.
+You MUST be honest about AI contributions, including the models used;
+including the prompts is welcome.
 
 Models used so far: Claude Opus 4.6, Gemini 3.1 Pro, GPT-5.3-Codex.
 
@@ -48,7 +39,7 @@ Models used so far: Claude Opus 4.6, Gemini 3.1 Pro, GPT-5.3-Codex.
   convey the point. No banner comments (`// -----`, `// --- Text ---`) and no
   standalone separator lines; a plain `// Text` line instead.
 - TypeScript style is enforced with ESLint and Prettier. Run `make lint-ts`.
-- Python style (the remaining `f5report` / skills / Sublime code) is enforced with Ruff. Run `make lint-py` and `make format-py`.
+- Python style (`f5report`, the repo skills and scripts, the Sublime plugin) is enforced with Ruff. Run `make lint-py` and `make format-py`.
 - Use UK spelling in internal names and comments (for example `normalise`, `optimiser`, `analyse`).
 - Keep names explicit; avoid ambiguous one-letter variables outside tiny local loops.
   - Function parameters and return-position variables can be single letters when the type is explicit, the use is local to the function, and the letter means the same thing everywhere in the codebase.
@@ -56,9 +47,7 @@ Models used so far: Claude Opus 4.6, Gemini 3.1 Pro, GPT-5.3-Codex.
   - If a single letter would mean two different things (e.g. `d` for both diagnostics and dominator candidates), use a two-letter identifier for the less common meaning. Each file that uses short names must declare them in a comment block near its imports.
 - Domain abbreviations are acceptable when established and clear (`cfg`, `ssa`, `uri`).
 - Prefer ASCII punctuation in comments/docs for consistency.
-- Prefer `match/case` for enum/token dispatch with 3+ branches; use `if` for simple guards.
-- Prefer `x & 1` over `x % 2` for odd/even checks on integers, and use
-  truthiness (`if x & 1:` rather than `if x & 1 == 1:`).
+- Prefer `match` for enum/token dispatch with 3+ arms; use `if` for simple guards.
 - Put the project copyright/license header on our own original source files
   only: the full AGPL-3.0 notice with `Copyright (C) <year> James Deucker
   (bitwisecook)`, placed after any shebang or coding/`-*-` magic first line.
@@ -83,26 +72,12 @@ the same helper, extract it into an appropriate shared module.
   If it already exists elsewhere, extract it into a shared location rather than
   copying it.
 
-### Command parsing protocol
+### Command and word boundaries
 
-Several modules walk Tcl token streams using a shared accumulation pattern.
-The three-list contract is:
-
-| Variable | Type | Meaning |
-|---|---|---|
-| `argv` | `list[Token]` | First token of each whitespace-separated word |
-| `argv_texts` | `list[str]` | Concatenated text of each word (may span multiple tokens) |
-| `all_tokens` | `list[Token]` | Every token in the command span |
-
-`argv[0]` / `argv_texts[0]` is the command name. `argv[1:]` / `argv_texts[1:]`
-are arguments. The accumulator flushes on `TokenType.EOL`. When a token follows
-`SEP` or `EOL`, it starts a new word; otherwise it is concatenated onto the
-current word.
-
-If you need this pattern, check whether an existing loop
-(`compiler_checks._CompilerCheckRunner._process_text`, the analyser's main
-loop, or the semantic-token emitter) already covers your use case before adding
-another copy.
+Command and word ranges come from the red-green CST through the shared
+segmenter; never re-derive them in a consumer — `cargo xtask
+segmentation-drift` (in `make rust-check`) fails on a private re-implementation.
+See [lexing-segmentation.md](docs/design/compiler/lexing-segmentation.md).
 
 
 ## Documentation style
@@ -202,9 +177,9 @@ Source -> Lexer (rust/tcl-lexer/src/lexer.rs)
       -> Diagnostics / codegen (rust/tcl-compiler/src/codegen/)
 ```
 
-Individual classes and functions with domain-specific names (e.g. `IRBarrier`,
-`LatticeValue`, `_sccp`) must include a one-sentence explanation of the concept,
-not just the implementation.
+Types and functions with domain-specific names (e.g. `LatticeValue`, `sccp`)
+must include a one-sentence explanation of the concept, not just the
+implementation.
 
 ## Swallowed errors must still be logged
 
@@ -230,7 +205,7 @@ let cfg = match load_config(path) {
 };
 ```
 
-In the remaining Python (`f5report`, the Claude skills, the Sublime plugin), a
+In Python (`f5report`, the repo skills, the Sublime plugin), a
 bare `except Exception:` must carry a `log.debug(..., exc_info=True)`:
 
 ```python
@@ -241,28 +216,23 @@ except Exception:
 
 ## Command metadata belongs on `CommandSpec`
 
-When code needs to classify commands (e.g. "is this a diagram-worthy action?",
-"does this always mutate state?", "can this be translated to XC?"), the metadata
-must live as a field on `CommandSpec` in `rust/tcl-registry/src/spec.rs`.
+When code needs to classify commands ("is this a diagram-worthy action?",
+"does this always mutate state?", "can this be translated to XC?"), the
+metadata lives on the command's `CommandSpec` in `rust/tcl-registry` — a
+`Traits` flag in `traits.rs`, or a descriptor field in `spec.rs` when a flag
+cannot express it. Never keep `HashSet`/`match` literals of command names in a
+consumer crate.
 
-**Do not** create hardcoded `HashSet`/`match` literals of command names in
-consumer crates. This scatters knowledge about commands across the codebase and
-makes it easy for new commands to be missed.
+1. **Add the flag or field** (`traits.rs` / `spec.rs`).
+2. **Add a query** to `CommandRegistry` in `registry.rs` — a single-command
+   predicate such as `is_diagram_action(name)`, and a bulk query where a
+   consumer needs one.
+3. **Set it** on each relevant spec under `commands/` (`tcl/`, `irules/`,
+   `iapps/`, …).
+4. **Use the registry** in the consumer.
 
-The pattern to follow:
-
-1. **Add a field** to `CommandSpec` (default `false` / `None`).
-2. **Add query methods** to `CommandRegistry` in
-   `rust/tcl-registry/src/registry.rs` — a single-command predicate (e.g.
-   `is_diagram_action(name)`) and a bulk query where consumers need one.
-3. **Set the flag** on each relevant command spec under
-   `rust/tcl-registry/src/commands/` (`tcl/`, `irules/`, `iapps/`, …).
-4. **Use the registry** in the consumer crate instead of a local set.
-
-Existing examples of this pattern: `pure`, `commits_response`,
-`http_namespace`, `diagram_action`, `drops_connection`, `always_mutating`,
-`output_only`, `http_setter_by_arity`, `mutator_subcommands`,
-`xc_translatable`.
+The registry rule and its descriptor families are in
+[AGENTS.md](AGENTS.md#the-registry-is-the-source-of-truth).
 
 ## Body identification and command argument roles
 
@@ -282,7 +252,7 @@ general delegation call.
 - Remove dead code promptly. Do not leave stub functions, no-op registrations
   in dispatch tables, or unused helpers.
 - If a function is planned but not yet implemented, mark it with
-  `# TODO(author): description` and do not register it in dispatch tables.
+  `// TODO(author): description` and do not register it in dispatch tables.
 - Docstrings must match implementation. If a method's behaviour changes, update
   the docstring in the same commit.
 
@@ -295,15 +265,14 @@ instances through constructors over importing module globals where practical.
 
 ## Source of truth
 
-The product is a Cargo workspace — see [`AGENTS.md`](AGENTS.md) "Repository
-layout" for the crate roles, and `[workspace] members` in the top-level
-`Cargo.toml` for the authoritative list. The language server, both CLIs, and the
-MCP server are all cargo bins; there is no Python in the shipped server.
+The product is a Cargo workspace — crate roles in
+[project-layout.md](docs/design/contracts/project-layout.md), the authoritative
+list in `[workspace] members` of the top-level `Cargo.toml`. The language
+server, both CLIs, and the MCP server are cargo bins.
 
-Python remains only in `rust/bigip-report-gen/python` (the `f5report` package
-backed by the native `_engine`), the Claude skills under `.claude/skills/`, and
-the Sublime Text plugin. `make lint-py` / `make typecheck-py` cover exactly that
-set (`git ls-files '*.py'`).
+Python is limited to `rust/bigip-report-gen/python` (the `f5report` package
+over the native `_engine`), a few repo skills and scripts, and the Sublime Text
+plugin; `make lint-py` / `make typecheck-py` cover `git ls-files '*.py'`.
 
 - `make package-vsix` stages the VSIX into an isolated packaging directory under
   `build/`, bundling one native `tcl-lsp-server` binary per platform.

--- a/INSTALL-cli.md
+++ b/INSTALL-cli.md
@@ -1,26 +1,26 @@
 # CLI installation
 
-The `tcl` and `f5` CLIs are self-contained native binaries. No Python,
-no runtime, no interpreter — download one file per tool and run it.
+The `tcl` and `f5` CLIs are self-contained native binaries: download one
+file per tool and run it.
 
 ## Install
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/bitwisecook/tcl-lsp/rust/scripts/install/install.sh \
-  | TCL_LSP_VERSION=v2.1.19 sh
+curl -fsSL https://github.com/bitwisecook/tcl-lsp/releases/latest/download/install.sh | sh
 ```
 
 Works on macOS and glibc-based Linux (x86_64, arm64, and riscv64 on Linux).
 The x86_64 and arm64 binaries require glibc 2.28 or newer; RISC-V requires
 glibc 2.35 or newer. Alpine and other non-glibc systems build the native CLIs
-from source. Re-run the same line to update.
+from source. Re-run the same line to update; set `TCL_LSP_VERSION=vX.Y.Z` to
+pin a release.
 
 To inspect first, or run unattended:
 
 ```sh
-curl -fsSLo install.sh https://raw.githubusercontent.com/bitwisecook/tcl-lsp/rust/scripts/install/install.sh
+curl -fsSLo install.sh https://github.com/bitwisecook/tcl-lsp/releases/latest/download/install.sh
 less install.sh
-TCL_LSP_VERSION=v2.1.19 TCL_LSP_ASSUME_YES=1 sh install.sh
+TCL_LSP_ASSUME_YES=1 sh install.sh
 ```
 
 The installer picks the binary for your platform, verifies it against the
@@ -32,22 +32,14 @@ Bobbit is project-only because it discovers the project-root `.mcp.json`.
 Claude Code skills are offered separately. Run `sh install.sh --help` for the full env-var list
 (`TCL_LSP_ONLY`, `TCL_LSP_NO_MCP`, `TCL_LSP_NO_SKILLS`, `TCL_LSP_NO_PATH`, …).
 
-### Migrating from the main-branch Python installer
+### Upgrading from a 1.x install
 
-Migration is automatic, even when you decline an equivalent native component.
-The installer removes positively identified Python zipapps (`tcl`, `f5`, the
-two retired compiler-explorer launchers, and `tcl-lsp-mcp-server.pyz`), including
-installs with a suffix or in a custom directory recorded in your shell startup
-file. It also removes Python `argcomplete` scripts and stale Claude Code or
-Codex MCP registrations. The old Claude prompt and skill bundle is moved out of
-active discovery and backed up under `~/.claude/.tcl-lsp-python-backup-*` before
-the native bundle is installed.
-
-Shared system packages such as Python, Tcl, `curl`, `unzip`, `sshpass`, or
-Wireshark are not removed, because the installer did not own them. Existing
-`.tcl-lsp-bak-*` recovery directories are also preserved. Set
-`TCL_LSP_NO_LEGACY_CLEANUP=1` only if you deliberately need to keep the retired
-installation active.
+The installer removes a 1.x Python install it positively identifies — the
+`tcl` / `f5` zipapps, `tcl-lsp-mcp-server.pyz`, `argcomplete` scripts, and
+stale Claude Code or Codex MCP registrations — and backs up the old Claude
+bundle under `~/.claude/.tcl-lsp-python-backup-*`. Shared packages (Python,
+Tcl, `curl`, …) are left alone. Set `TCL_LSP_NO_LEGACY_CLEANUP=1` to keep the
+old install.
 
 ## Manual install
 
@@ -101,8 +93,7 @@ has the Helix and Neovim configurations.
 ## Verify downloads
 
 ```sh
-tag="v2.1.19"
-curl -fLO "https://github.com/bitwisecook/tcl-lsp/releases/download/$tag/SHA256SUMS"
+curl -fLO https://github.com/bitwisecook/tcl-lsp/releases/latest/download/SHA256SUMS
 sha256sum --ignore-missing -c SHA256SUMS \
     || shasum -a 256 --ignore-missing -c SHA256SUMS
 ```
@@ -119,6 +110,8 @@ rm -f "${ZDOTDIR:-$HOME}/.zsh/completions/_tcl"
 rm -f "${ZDOTDIR:-$HOME}/.zsh/completions/_f5"
 rm -f ~/.config/fish/completions/tcl.fish ~/.config/fish/completions/f5.fish
 rm -rf ~/.claude/skills/irule-* ~/.claude/skills/tcl-* ~/.claude/skills/tk-*
+rm -rf ~/.claude/skills/ai-help ~/.claude/skills/bigip-cleanup ~/.claude/skills/explain-flow
+rm -rf ~/.claude/skills/f5-query ~/.claude/skills/spec-author
 claude mcp remove tcl-lsp 2>/dev/null || true
 ```
 

--- a/INSTALL-editors.md
+++ b/INSTALL-editors.md
@@ -3,21 +3,16 @@
 Install the editor-specific artefact from
 [GitHub Releases](https://github.com/bitwisecook/tcl-lsp/releases/latest).
 
-**No editor needs Python.** The server is a self-contained native
-`tcl-lsp-server` binary. The VS Code `.vsix` and the JetBrains `.zip`
+The server is a self-contained native `tcl-lsp-server` binary. The VS Code
+`.vsix` and the JetBrains `.zip`
 each bundle one binary per platform (macOS/Linux/Windows on x64 and
 arm64, plus Linux riscv64) and run the one matching your machine. The
 Sublime Text package and the Zed extension download the matching binary
 on first use.
 
-The Linux native binaries target glibc: x86_64 and arm64 require 2.28 or
-newer, while RISC-V requires 2.35 or newer. This covers the maintained GNU
-distribution families in the release matrix; Alpine does not run these native
-binaries. The separately published WASI server is independent of the host libc
-and is documented below for editors that can launch a WebAssembly runtime.
-
-On an architecture none of those seven covers, the same server is also
-published as a WebAssembly module — see
+The Linux binaries need glibc 2.28+ (x86_64, arm64) or 2.35+ (riscv64).
+Alpine and other non-glibc systems, and any architecture outside those seven,
+can run the WebAssembly build instead — see
 [No prebuilt binary for your platform?](#no-prebuilt-binary-for-your-platform)
 
 The standalone editors (Neovim, Emacs, Helix, and any other LSP-capable
@@ -143,7 +138,7 @@ file-types = ["tcl", "tk", "itcl", "tm", "tclspec", "irul", "irule", "iapp", "ia
 language-servers = ["tcl-lsp"]
 ```
 
-**Neovim** (`~/.config/nvim/server/tcl_lsp.lua`):
+**Neovim** (`~/.config/nvim/lsp/tcl_lsp.lua`):
 
 ```lua
 return {
@@ -186,11 +181,10 @@ every platform in one file, so it works regardless of your OS/architecture):
 code --install-extension ~/Downloads/tcl-lsp-vscode-<v>-universal.vsix
 ```
 
-Configure under **Settings > Extensions > Tcl**. No Python interpreter
-is needed — the extension ships a native `tcl-lsp-server` binary for
-your platform and launches it automatically. There is no Python backend:
-to run against a local build, point `tclLsp.rustServerPath` at a
-`tcl-lsp-server` binary or `tclLsp.serverPath` at a checkout.
+Configure under **Settings > Extensions > Tcl**. The extension ships a
+native `tcl-lsp-server` binary for your platform and launches it
+automatically; to run a local build instead, point `tclLsp.rustServerPath`
+at a `tcl-lsp-server` binary or `tclLsp.serverPath` at a checkout.
 
 The `-universal` package works on **any** architecture, including ones with no
 prebuilt binary: it also carries the WebAssembly server, and falls back to it
@@ -234,7 +228,7 @@ What differs from the desktop:
   stayed clean.
 - **Cross-file analysis is limited on a virtual workspace.** The browser server
   has no filesystem, so the extension reads the workspace itself and hands the
-  files to the server. That transfer currently only carries files on the `file:`
+  files to the server. That transfer only carries files on the `file:`
   scheme, and github.dev / vscode.dev serve a repository on a virtual one
   (`vscode-vfs:`) — so on those hosts each open file is analysed in full, while
   results that depend on *un-opened* files (a definition in a sibling, the
@@ -262,31 +256,6 @@ cd editors/vscode && npm run test:web      # headless smoke test over testFixtur
 which downloads a VS Code web build and a Playwright Chromium. On a machine
 that already has Playwright's browsers elsewhere, point at them with
 `PLAYWRIGHT_BROWSERS_PATH=/path/to/browsers` instead of downloading again.
-
-### VS Code-compatible editors
-
-The `-universal` package works in editors that cannot use the Microsoft
-Marketplace (Cursor, Windsurf, VSCodium, Eclipse Theia, code-server /
-Coder, Gitpod, GitHub Codespaces Theia builds) — it bundles every
-platform's binary in one file, so there's no need to pick the right one
-by hand. Download it from the GitHub release and sideload through the
-editor's Extensions UI, or via the CLI:
-
-```sh
-cursor   --install-extension ~/Downloads/tcl-lsp-vscode-<v>-universal.vsix
-codium   --install-extension ~/Downloads/tcl-lsp-vscode-<v>-universal.vsix
-code-server --install-extension ~/Downloads/tcl-lsp-vscode-<v>-universal.vsix
-```
-
-(Windsurf, Theia, and Gitpod all surface the same drag-and-drop or
-"Install from VSIX" entry in their Extensions panel.)
-
-The extension is also published to **Open VSX**
-(<https://open-vsx.org/extension/bitwisecook/tcl-lsp>), the marketplace
-that code-server, openvscode-server, Gitpod, and Theia point at by
-default. Where one of those is configured with the Open VSX registry,
-install `tcl-lsp` from its built-in Extensions panel directly instead
-of sideloading a `.vsix`.
 
 ## Sublime Text
 
@@ -330,7 +299,7 @@ Language Server**.
 Install the server binary at `~/bin/tcl-lsp-server` (see
 [The server binary](#the-server-binary)).
 
-`~/.config/nvim/server/tcl_lsp.lua`:
+`~/.config/nvim/lsp/tcl_lsp.lua`:
 
 ```lua
 return {
@@ -416,9 +385,13 @@ and install with the editor's own CLI.
 | **Eclipse Theia** | Extensions side panel > **Install from VSIX…** |
 
 Settings UI, keybindings, and the compiler-explorer / Tk preview
-panels behave the same as in VS Code itself. The bundled native
-`tcl-lsp-server` binary is used automatically; no Python interpreter
-is involved.
+panels behave the same as in VS Code itself; the bundled native
+`tcl-lsp-server` binary is used automatically.
+
+The extension is also published to **Open VSX**
+(<https://open-vsx.org/extension/bitwisecook/tcl-lsp>), the registry
+code-server, openvscode-server, Gitpod, and Theia point at by default —
+install `tcl-lsp` from their Extensions panel instead of sideloading.
 
 ## Other LSP-capable editors
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,9 +1,7 @@
 # Installation
 
-The installation guide has been split into two documents:
-
 - **[INSTALL-editors.md](INSTALL-editors.md)** — VS Code, Neovim, Zed,
-  Emacs, Helix, Sublime Text, JetBrains (macOS, Linux, Windows).
-- **[INSTALL-cli.md](INSTALL-cli.md)** — the `tcl` and `f5` command-line
-  tools, including a one-line `curl | sh` installer for macOS, Debian/
-  Ubuntu, RHEL/CentOS, Fedora, Arch, and Alpine.
+  Emacs, Helix, Sublime Text, JetBrains (macOS, Linux, Windows), plus
+  VS Code-compatible and generic LSP editors.
+- **[INSTALL-cli.md](INSTALL-cli.md)** — the `tcl`, `f5`, and `tcl-mcp`
+  command-line tools and their one-line `curl | sh` installer.

--- a/README-f5.md
+++ b/README-f5.md
@@ -15,7 +15,7 @@ iRules and iApps files too; this document covers what is F5-only.
 - [BIG-IP configuration support](#big-ip-configuration-support)
 - [The `f5` CLI](#the-f5-cli)
 - [`f5 query` — the query DSL](#f5-query--the-query-dsl)
-- [Scripting the query engine from Python (`f5q`)](#scripting-the-query-engine-from-python-f5q)
+- [Scripting the query engine from Python](#scripting-the-query-engine-from-python)
 - [BIG-IP report generator](#big-ip-report-generator)
 - [Secret handling](#secret-handling)
 - [APL (iApp Presentation Language)](#apl-iapp-presentation-language)
@@ -27,7 +27,7 @@ iRules and iApps files too; this document covers what is F5-only.
 
 ## Dialects and file types
 
-Four of the sixteen dialect profiles are F5:
+Four dialect profiles are F5:
 
 | Dialect | Covers | Detected from |
 |---|---|---|
@@ -61,8 +61,8 @@ and warning when a support milestone is within one year or has passed.
 
 The report's **Security** tab runs a small, offline set of high-confidence
 checks — factory/default `root`/`admin` credentials (verified against the
-stored password hash with no platform `crypt(3)` call, so the native, wasm,
-and any future backend agree), default/weak SNMP communities, disabled or
+stored password hash with no platform `crypt(3)` call, so the native and
+wasm backends agree), default/weak SNMP communities, disabled or
 weak password-policy enforcement, plaintext secrets, unprotected private-key
 material, and non-administrative shell access — and lists each as a
 stable-id, severity-ranked finding with remediation guidance. Detection never
@@ -92,8 +92,8 @@ the `tcl` CLI. Verbs:
 | `query` | The jq-shaped query/transform DSL over a config — see below |
 | `cleanup` | Emit a `tmsh delete` script for every unreferenced object |
 | `grep` | Walk the reference graph around an object, name, regex, or CIDR |
+| `explain` | Resolve one virtual or pool: profile chain, iRules, persistence, SNAT, pool, members |
 | `irule` | iRules-specific analysis (events, commands, references) |
-| `report` | Generate the standalone HTML BIG-IP report |
 | `extract` / `convert` | Read UCS/SCF archives, including passphrase-protected ones |
 
 Install it with the [one-line installer](INSTALL-cli.md), or build it from
@@ -159,18 +159,18 @@ f5 irule event-order samples/irules/policy.irule
 f5 irule event-info HTTP_REQUEST --json
 ```
 
-`f5` is a separate CLI from `tcl`.  The full verb list (today):
+The full verb list:
 
 | Group | Verbs |
 | --- | --- |
 | Acquisition | `fetch`, `extract` (UCS → SCF) |
-| Analysis | `stats`, `graph`, `explain`, `diff`, `grep`, `cleanup`, `validate` |
-| Transformation | `rename`, `redact`, `unredact`, `encrypt-secrets`, `decrypt-secrets`, `pcap-remap`, `split`, `merge`, `convert`, `tmsh` |
+| Analysis | `query`, `stats`, `graph`, `explain`, `explain-flow`, `diff`, `grep`, `cleanup`, `validate` |
+| Transformation | `rename`, `redact`, `unredact`, `encrypt-secrets`, `decrypt-secrets`, `pcap-remap`, `enrich-pcapng`, `enrich-wireshark`, `split`, `merge`, `convert`, `tmsh` |
 | Round-trip | `pull`, `push` |
-| iRules | `irule event-order`, `irule event-info`, `irule lint`, `irule trace`, `irule extract` |
-| Misc | `completion` |
+| iRules | `irule event-order`, `irule event-info`, `irule lint`, `irule trace`, `irule extract`, `irule format`, `irule minify`, `irule context` |
+| Misc | `registry-dump`, `completion` |
 
-Highlights of the newer verbs:
+Verb notes:
 
 - **`f5 fetch`** — pull SCF/UCS from a live BIG-IP via iControl REST or
   SSH (system `ssh`/`scp`).  Credentials resolve from CLI flags, env
@@ -268,12 +268,6 @@ Highlights of the newer verbs:
 - [Design — `f5 query` plugin contract](docs/design/f5-query-renderer-contract.md)
   — formal contracts, registration lifecycle, error mapping.
 
-**Install the `f5` CLI** — the released artefact is the native
-`f5-query` binary; no Python required.
-See [INSTALL-cli.md](INSTALL-cli.md) for the one-line `curl | sh`
-installer, manual install steps for macOS/Debian/Ubuntu/RHEL/CentOS/
-Fedora, shell completion setup, and source-build instructions.
-
 In VS Code, run the command palette entry **Tcl: Generate BIG-IP
 Cleanup Script** while a `bigip.conf` is open; the script and its JSON
 metadata report open side-by-side.  See
@@ -305,7 +299,7 @@ Worked how-tos, each a KCS note:
 | Read a passphrase-protected UCS | [read encrypted UCS archives](docs/kcs/kcs-howto-read-encrypted-ucs-archives.md) |
 | Pick between `query`, `grep`, and `rename` | [query vs grep vs rename](docs/kcs/kcs-qa-query-vs-grep-vs-rename.md) |
 
-## Scripting the query engine from Python (`f5q`)
+## Scripting the query engine from Python
 
 The query engine is also importable. The package is `f5report` under
 `rust/bigip-report-gen/python`, backed by the native `_engine` extension, so
@@ -344,7 +338,7 @@ build with `make report-wasm`.
 Passwords, keys, and other secret material in a config are treated as secrets
 throughout: findings never quote a password, hash, or salt, and the report's
 credential checks verify against the stored hash without calling the platform
-`crypt(3)`, so the native, WASM, and any future backend agree. See
+`crypt(3)`, so the native and WASM backends agree. See
 [kcs-feature-f5-secret-crypto.md](docs/kcs/features/kcs-feature-f5-secret-crypto.md).
 
 ## APL (iApp Presentation Language)
@@ -387,10 +381,10 @@ with recursive resolution and circular-include protection.
 
 ## tmsh commands
 
-The `f5-iapps` dialect includes 30+ `tmsh::` namespace commands
+The `f5-iapps` dialect includes the `tmsh::` namespace commands
 (`tmsh::create`, `tmsh::modify`, `tmsh::get_config`, `tmsh::get_field_value`,
-etc.) and 4 `script::` commands (`script::run`, `script::init`, etc.) with
-hover documentation and arity validation.
+…) and the `script::` commands (`script::run`, `script::init`, …) with hover
+documentation and arity validation.
 
 ## iRules-to-XC migration
 
@@ -433,7 +427,7 @@ behaviour in a standard `tclsh`.
 exit [::orch::done]
 ```
 
-The `generate-test` CLI command and `generate_irule_test` MCP tool analyse an
+The `generate-test` Claude Code skill and the `generate_irule_test` MCP tool analyse an
 iRule's control-flow graph to produce test cases automatically.  For iRules
 with CMP-sensitive patterns (`static::` writes in hot events, `table` shared
 state), multi-TMM scenarios using fakeCMP distribution are included.
@@ -522,6 +516,7 @@ triggering example and the fix.
 | `/migrate` | Convert nginx/Apache/HAProxy config to an iRule |
 | `/diagram` | Generate a Mermaid flowchart of the iRule's logic flow |
 | `/xc` | Translate the iRule to F5 Distributed Cloud configuration |
+| `/test` | Generate an Event Orchestrator test script for the iRule |
 
 ```
 User:   @irule /create rate limiter that allows 100 requests per minute per client IP

--- a/README.md
+++ b/README.md
@@ -58,27 +58,26 @@ Grab the artefact for your editor from
 [Releases](https://github.com/bitwisecook/tcl-lsp/releases/latest), or install
 the VS Code extension from the
 [Marketplace](https://marketplace.visualstudio.com/items?itemName=bitwisecook.tcl-lsp).
-Nothing needs Python — the server is a self-contained native binary.
+The server is a self-contained native binary.
 
-While the Rust rewrite is on the pre-release channel, install it from the
-`rust` branch and pin the current pre-release:
+The `tcl`, `f5`, and `tcl-mcp` command-line tools have a one-line installer
+([INSTALL-cli.md](INSTALL-cli.md)):
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/bitwisecook/tcl-lsp/rust/scripts/install/install.sh \
-  | TCL_LSP_VERSION=v2.1.19 sh
+curl -fsSL https://github.com/bitwisecook/tcl-lsp/releases/latest/download/install.sh | sh
 ```
 
 ### All editors
 
 | Editor | Type | Setup | Unique extras |
 |--------|------|-------|---------------|
-| [VS Code](editors/vscode/) | Full extension (.vsix) | Install `.vsix` from Releases | Compiler explorer panel, Tk preview, `@irule`/`@tcl`/`@tk` Copilot chat, 25+ commands |
-| [Neovim](editors/neovim/) | Config snippet (Lua) | Copy `tcl_lsp.lua` to `~/.config/nvim/server/` | Zero-plugin on 0.11+; also supports nvim-lspconfig |
+| [VS Code](editors/vscode/) | Full extension (.vsix) | Install from the Marketplace or a `.vsix` from Releases | Compiler explorer panel, Tk preview, `@irule`/`@tcl`/`@tk` Copilot chat, command-palette tooling |
+| [Neovim](editors/neovim/) | Config snippet (Lua) | Copy `tcl_lsp.lua` to `~/.config/nvim/lsp/` | Zero-plugin on 0.11+; also supports nvim-lspconfig |
 | [Zed](editors/zed/) | LSP extension (TOML + Rust) | Install from Zed extension registry | Downloads the matching native server for macOS, Linux, or Windows |
 | [Emacs](editors/emacs/) | Config snippet (Elisp) | Add to `init.el` for eglot or lsp-mode | Works with built-in eglot (Emacs 29+) |
 | [Helix](editors/helix/) | Config snippet (TOML) | Add to `~/.config/helix/languages.toml` | Minimal pure-TOML setup |
 | [Sublime Text](editors/sublime-text/) | LSP helper package (.sublime-package) | Install LSP and LSP-Tcl from Package Control | Uses Sublime's built-in Tcl syntax and snippets; downloads the matching native server |
-| [JetBrains](editors/jetbrains/) | Full plugin (.zip) | Settings > Plugins > Install from Disk | Compiler explorer tool window, settings UI panel, dynamic file-type registration for pack-claimed extensions, IntelliJ IDEA 2025.3+ |
+| [JetBrains](editors/jetbrains/) | Full plugin (.zip) | Settings > Plugins > Install from Disk | Compiler explorer tool window, settings UI panel, dynamic file-type registration for pack-claimed extensions, IntelliJ IDEA Ultimate 2025.3+ |
 
 All editors connect to the native Rust binary `tcl-lsp-server` over stdio
 (build it with `make rust-server`, or `cargo build -p tcl-lsp-server`).
@@ -118,10 +117,6 @@ optimisations, for the same file.
 Files named `tclpkg.tcl` are analysed as `tcl pkg` package manifests:
 their directives resolve against the manifest command set instead of
 drawing unknown-command warnings.
-
-Full per-editor instructions, including every VS Code-compatible and generic
-LSP editor, live in **[INSTALL-editors.md](INSTALL-editors.md)**. For the `tcl`
-and `f5` command-line tools, see **[INSTALL-cli.md](INSTALL-cli.md)**.
 
 ### VS Code
 
@@ -167,7 +162,7 @@ limited on a virtual workspace (see
 
 ### Neovim
 
-Copy [`tcl_lsp.lua`](editors/neovim/) to `~/.config/nvim/server/` and enable it
+Copy [`tcl_lsp.lua`](editors/neovim/) to `~/.config/nvim/lsp/` and enable it
 (`vim.lsp.enable('tcl_lsp')`) — no plugin needed on Neovim 0.11+. Point `cmd`
 at your `tcl-lsp-server` binary.
 
@@ -198,8 +193,8 @@ on first use.
 
 **Settings > Plugins > gear > Install Plugin from Disk…**, select
 `tcl-lsp-jetbrains-<version>.zip`, restart. The plugin bundles the native
-server for every platform. Requires IDEA Ultimate 2024.1+ (free editions from
-2025.3).
+server for every platform. Requires IntelliJ IDEA Ultimate 2025.3+ (or
+another paid JetBrains IDE).
 
 ## The seven you will use most
 
@@ -410,8 +405,8 @@ proc ::set {a b} { ... }         ;# W113: 'set' is a genuine core built-in
 
 #### What the analyser checks
 
-Seven families of finding, each code with its own page explaining why the check
-exists, a triggering example, and the fix:
+Each code has its own page explaining why the check exists, a triggering
+example, and the fix:
 
 | Family | Covers |
 |---|---|
@@ -422,6 +417,7 @@ exists, a triggering example, and the fix:
 | **T** | [Taint analysis](docs/kcs/codes/README.md) — untrusted data reaching dangerous sinks, option positions, regex patterns, and network addresses |
 | **O** | [Optimiser](docs/kcs/features/kcs-feature-optimiser.md) suggestions — constant folding, propagation, dead code, LICM, strength reduction, and repeated stable calls whose [dispatch is provably unobserved](docs/design/compiler/dispatch-stability-proof.md) |
 | **IRULE** | iRules-only checks — see [README-f5.md](README-f5.md#irules-diagnostic-codes) |
+| **IAPP**, **BIGIP**, **SSLIC** | iApp cross-file checks, BIG-IP configuration objects, and `.sslictcl` declarations |
 
 Full tables: [diagnostic codes](docs/generated/diagnostic_codes.md) ·
 [optimiser codes](docs/generated/optimisation_codes.md) ·
@@ -431,8 +427,8 @@ Full tables: [diagnostic codes](docs/generated/diagnostic_codes.md) ·
 
 Variables, procs, keywords, and strings are classified using SSA-informed type
 information, giving richer highlighting than a TextMate grammar alone.  The
-server provides 44 token types beyond the standard LSP set, including
-sub-token highlighting inside strings.  Tokens are cached per top-level chunk
+server adds its own token types to the standard LSP set, including sub-token
+highlighting inside strings.  Tokens are cached per top-level chunk
 so only dirty regions are recomputed after an edit, and the server supports
 `textDocument/semanticTokens/full/delta` for bandwidth-efficient incremental
 updates.
@@ -465,8 +461,8 @@ domain-specific token types:
 | **Binary format** | `binarySpec`, `binaryCount`, `binaryFlag` | `binary scan $data su3 x y z` — `s`, `u`, and `3` each highlighted |
 | **Clock format** | `clockPercent`, `clockSpec`, `clockModifier` | `clock format $t -format "%Y-%m-%d"` — `%`, `Y`, `m`, `d` each highlighted |
 | **Escape sequences** | `escape` | `puts "line1\nline2\t${var}"` — `\n`, `\t` highlighted inside strings |
-| **Options** | `decorator`, `optionValue`, `enumMember` | `file delete -force f` and `$chart Xaxis -name x -type value` — switches and their values get their own colours |
-| **BIG-IP config** | `object`, `ipAddress`, `port`, `partition`, `pool`, `monitor`, `profile`, `vlan`, `fqdn`, `routeDomain`, `encrypted`, `interface` | BIG-IP `.conf` files get object-aware highlighting |
+| **Options** | `decorator`, `property`, `enumMember` | `file delete -force f` and `$chart Xaxis -name x -type value` — switches and their values get their own colours |
+| **BIG-IP config** | `object`, `ipAddress`, `port`, `partition`, `pool`, `monitor`, `profile`, `vlan`, `fqdn`, `routeDomain`, `encrypted`, `bigipInterface` | BIG-IP `.conf` files get object-aware highlighting |
 
 Command options are highlighted precisely for commands the registry knows,
 including object methods on a tracked handle — the standard `TclOO` / Tk
@@ -747,10 +743,9 @@ is refused with a reason rather than quietly renaming the command instead.
 
 ### 7. Formatting
 
-Full-document and range formatting with 25 configurable options.  Defaults
-follow the F5 iRules Style Guide.  Supports full-document
-(`textDocument/formatting`) and range (`textDocument/rangeFormatting`)
-requests.
+Full-document (`textDocument/formatting`) and range
+(`textDocument/rangeFormatting`) formatting.  Defaults follow the F5 iRules
+Style Guide; every option is configurable.
 
 ```tcl
 # Before:
@@ -905,32 +900,31 @@ these same notes.
 
 ### Every supported dialect
 
-Eighteen dialect profiles, each gating which commands exist, which are
-deprecated, and which options and subcommands are valid. The list below
-mirrors the profile catalog (`DialectProfile`) in `rust/tcl-dialect`, the
-single source of truth — its `display_name` is the second column.
+Each dialect profile gates which commands exist, which are deprecated, and
+which options and subcommands are valid. The list mirrors the profile
+catalogue (`DialectProfile::all`) in `rust/tcl-dialect`.
 
-| Dialect | Language / tooling it models |
+| Dialect | What it models |
 |---|---|
-| `tcl8.4` | Tcl 8.4 |
-| `tcl8.5` | Tcl 8.5 |
-| `tcl8.6` | Tcl 8.6 (the default) |
-| `tcl9.0` | Tcl 9.0 |
-| `tcl9.1` | Tcl 9.1 |
-| `expect` | Expect |
+| `tcl8.4` | Tcl 8.4 core commands |
+| `tcl8.5` | Tcl 8.5 (adds `{*}`, `lassign`, `dict`, …) |
+| `tcl8.6` | Tcl 8.6 (adds `try`/`finally`, `tailcall`, coroutines) — **the default** |
+| `tcl9.0` | Tcl 9.0 (adds `lpop`, zipfs, updated `encoding`) |
+| `tcl9.1` | Tcl 9.1 (superset of 9.0; adds the `unicode` and `timer` ensembles and `subst`'s positive `-backslashes`/`-commands`/`-variables` options) |
+| `expect` | Expect: `spawn`, `expect`, `send`, `interact` and related commands |
 | `bpf` | BPF-Tcl, the eBPF packet-matching dialect |
-| `spectcl` | SpecTcl command packs (`.tclspec`) |
-| `sslictcl` | SslicTcl TLS declarations (`.sslictcl`) |
-| `f5-irules` | F5 iRules (embedded Tcl 8.4.6) — see [README-f5.md](README-f5.md) |
+| `spectcl` | SpecTcl command packs (`.tclspec`): the declarations that teach the registry a private library |
+| `sslictcl` | SslicTcl TLS declarations (`.sslictcl`): certificates, endpoints, trust programs, and assurance policy, read and never evaluated |
+| `f5-irules` | F5 iRules (embedded Tcl 8.4.6): HTTP/SSL/DNS/LB namespaces, event-validity checks, taint analysis, `static::` scoping — see [README-f5.md](README-f5.md) |
 | `f5-iapps` | F5 iApps — iApp templates and implementation scripts |
 | `f5-bigip` | F5 BIG-IP `bigip.conf` / `.scf` objects |
-| `f5-tmsh` | F5 tmsh scripts |
-| `cadence-eda-tcl` | Cadence EDA Tcl |
-| `intel-quartus-eda-tcl` | Intel Quartus EDA Tcl |
-| `mentor-eda-tcl` | Mentor EDA Tcl (ModelSim/Questa) |
-| `microchip-libero-eda-tcl` | Microchip Libero EDA Tcl |
-| `synopsys-eda-tcl` | Synopsys EDA Tcl (incl. the SDC constraint base) |
-| `xilinx-eda-tcl` | Xilinx EDA Tcl (AMD/Xilinx Vivado) |
+| `f5-tmsh` | F5 tmsh scripts: the `tmsh::` surface on a Tcl 8.5 base |
+| `cadence-eda-tcl` | Cadence EDA (Genus, Innovus, Tempus, Xcelium) |
+| `intel-quartus-eda-tcl` | Intel Quartus Prime |
+| `mentor-eda-tcl` | Mentor/Siemens EDA (ModelSim, Questa, Calibre) |
+| `microchip-libero-eda-tcl` | Microchip Libero SoC |
+| `synopsys-eda-tcl` | Synopsys EDA (Design Compiler, PrimeTime, ICC2, Formality), including the SDC constraint base |
+| `xilinx-eda-tcl` | AMD/Xilinx EDA (Vivado, Vitis) |
 
 Pick one per file with a `# tcl-dialect:` comment, per project in
 configuration, or let detection choose — see
@@ -968,16 +962,13 @@ the vocabulary, the open/closed block rule, and the value domains are in
 
 ### Every package in the registry
 
-Commands from these 69 packages are modelled with hover docs,
-completion, arity checking, argument roles, and side-effect classification.
-They activate when their `package require` appears (or ambiently, when a
-dialect ships them):
-
-`argparse`, `base32::core`, `base64`, `bibtex`, `cksum`, `cmdline`, `comm`, `control`, `cookiejar`, `crc16`, `crc32`, `csv`, `debug`, `defer`, `dns`, `f5-irules-cmds`, `fileutil`, `generator`, `hook`, `html`, `http`, `inifile`, `ip`, `Itcl`, `json`, `lambda`, `logger`, `math`, `math::constants`, `math::statistics`, `md4`, `md5`, `md5crypt`, `mime`, `msgcat`, `namespacex`, `ooutil`, `opt`, `otp`, `platform`, `platform::shell`, `processman`, `rc4`, `report`, `safe`, `sha1`, `sha2`, `smtp`, `snit`, `soundex`, `stooop`, `stringprep`, `struct::list`, `struct::queue`, `struct::set`, `struct::stack`, `sum`, `tcl::chan::halfpipe`, `tcl::idna`, `tcltest`, `textutil`, `ticklecharts`, `tie`, `Tk`, `unicode`, `uri`, `uuid`, `websocket`, `yaml`
-
-That includes Tk in full, Itcl, and the whole `tcltest` surface with
-per-version availability (`test -errorCode` only from tcltest 2.5, `bytestring`
-gone under Tcl 9.0). Most of the rest is tcllib — see
+Every package the registry knows — Tk in full, Itcl, the whole `tcltest`
+surface with per-version availability (`test -errorCode` only from tcltest
+2.5, `bytestring` gone under Tcl 9.0), and most of tcllib — has its commands
+modelled with hover docs, completion, arity checking, argument roles, and
+side-effect classification. They activate when their `package require`
+appears (or ambiently, when a dialect ships them). `tcl registry-dump` lists
+them; see
 [tcllib package coverage](docs/kcs/features/kcs-feature-tcllib-package-coverage.md)
 for the module-by-module state, and
 [kcs-howto-add-command-registry-package.md](docs/kcs/kcs-howto-add-command-registry-package.md)
@@ -995,11 +986,7 @@ comes with one shell and not another is then floored — and excused from
 ### Dialect profiles
 
 Switch between Tcl 8.4/8.5/8.6/9.0/9.1, F5 iRules, F5 iApps, F5 tmsh, and EDA
-tooling profiles.  Tk, tcllib, and stdlib commands activate automatically when their
-`package require` appears — including the full `tcltest` surface (`test`,
-`configure`, and the convenience commands) with per-version awareness, so
-`test -errorCode` is offered only for tcltest 2.5+ and `bytestring` disappears
-under Tcl 9.0. F5 iRules metadata follows BIG-IP command/event
+tooling profiles. F5 iRules metadata follows BIG-IP command/event
 source data, including profile aliases used by newer namespaces and events,
 shared TLS helper profiles such as `PERSIST`, and protocol namespace layer
 metadata that stays aligned with the enabling profile stack. The configured
@@ -1038,11 +1025,6 @@ newer than the `::tcl::` namespace's own 8.5 baseline:
 # With dialect = tcl8.6:
 ::tcl::mathop::lt 1 2              ;# W002: disabled in active dialect (available in: tcl9.0, tcl9.1)
 ```
-
-The server ships a registry of command signatures, argument roles, and
-validation rules keyed by dialect.  Switching the dialect profile changes
-which commands are known, which are deprecated, and which event/layer
-constraints apply.
 
 Version-aware diagnostics reach every gateable level of a call, not just
 the command: a subcommand, a second-level operation of a two-level
@@ -1098,41 +1080,6 @@ The dialect is selected automatically using the following priority chain
 Per-file hints (directive, shebang, extension) always take priority over
 the global setting, so different files in the same workspace can target
 different Tcl versions without manual switching.
-
-| Dialect | Description |
-|---------|-------------|
-| `tcl8.4` | Tcl 8.4 core commands |
-| `tcl8.5` | Tcl 8.5 core commands (adds `{*}`, `lassign`, `dict`, etc.) |
-| `tcl8.6` | Tcl 8.6 core commands (adds `try`/`finally`, `tailcall`, coroutines) -- **default** |
-| `tcl9.0` | Tcl 9.0 core commands (adds `lpop`, zipfs, updated `encoding`) |
-| `tcl9.1` | Tcl 9.1 core commands (superset of 9.0; adds the `unicode` and `timer` ensembles and `subst`'s positive `-backslashes`/`-commands`/`-variables` options) |
-| `f5-irules` | F5 BIG-IP iRules: HTTP/SSL/DNS/LB namespaces, event-validity checks, taint analysis, `static::` scoping rules |
-| `f5-iapps` | F5 iApps template commands |
-| `f5-bigip` | F5 BIG-IP configuration (`bigip.conf` / `.scf`) commands |
-| `f5-tmsh` | F5 tmsh scripts: the `tmsh::` command surface on a Tcl 8.5 base |
-| `synopsys-eda-tcl` | Synopsys EDA commands (Design Compiler, PrimeTime, ICC2, Formality) |
-| `cadence-eda-tcl` | Cadence EDA commands (Genus, Innovus, Tempus, Xcelium) |
-| `xilinx-eda-tcl` | Xilinx/AMD EDA commands (Vivado, Vitis) |
-| `intel-quartus-eda-tcl` | Intel Quartus Prime commands |
-| `mentor-eda-tcl` | Mentor/Siemens EDA commands (ModelSim, Questa, Calibre) |
-| `microchip-libero-eda-tcl` | Microchip Libero SoC EDA commands |
-| `expect` | Expect: `spawn`, `expect`, `send`, `interact` and related commands for automating interactive programs |
-| `bpf` | BPF-Tcl: the eBPF packet-matching dialect |
-| `spectcl` | SpecTcl command packs (`.tclspec`): the declarations that teach the registry a private library |
-| `sslictcl` | SslicTcl TLS declarations (`.sslictcl`): the certificates, endpoints, trust programs, and assurance policy of a deployment, read and never evaluated |
-
-**Tk**, **tcllib**, and **Tcl stdlib** commands are automatically recognised
-when the corresponding `package require` appears in the file.  No manual
-toggle is needed — the registry activates the relevant command definitions
-per-document.  The tcllib coverage spans the cryptography/hash
-(`md4`, `ripemd`, `crc*`, `aes`/`blowfish`/`des`, …), encoding (`base32`,
-`ascii85`, `uuencode`, `yencode`), maths (`math`, `math::fuzzy`,
-`math::roman`), data/utility (`inifile`, `units`, `counter`, `tie`,
-`lambda`), web/protocol/client (`asn`, `ncgi`, `imap4`, `ldap`, `ftp`,
-`pop3`, `irc`, `rest`, `SASL`, `websocket`, …), format (`png`, `jpeg`,
-`tiff`, `gpx`, `mapproj`, `nmea`), and ensemble (`generator`, `debug`,
-`hook`) package families — see
-[the tcllib coverage note](docs/kcs/features/kcs-feature-tcllib-package-coverage.md).
 
 ### Dialect command stubs
 
@@ -1222,8 +1169,8 @@ document: **[README-f5.md](README-f5.md)**.
 
 It covers the `f5-irules`, `f5-iapps`, `f5-bigip`, and `f5-tmsh` dialects; the
 BIG-IP configuration model and iRule extraction; the `f5` CLI (`query`,
-`cleanup`, `grep`, `irule`, `report`); the jq-shaped
-[query DSL](docs/references/f5_query/dsl.md) and its Python (`f5q`) bindings;
+`cleanup`, `grep`, `explain`, `irule`, …); the jq-shaped
+[query DSL](docs/references/f5_query/dsl.md) and its Python bindings (`f5report`);
 the standalone HTML report generator; iRules-to-XC translation; and the iRule
 Event Orchestrator test framework with fakeCMP multi-TMM simulation.
 
@@ -1267,8 +1214,7 @@ statement, CFG block, or bytecode instruction — rather than raw text, so
 byte offsets, source ranges, sequence indices, and tree-connector glyphs
 that merely shift when the optimiser adds or removes a node are ignored.
 A single rewrite then shows as a single localised change instead of every
-following line being flagged.  The `tcl-explorer` CLI and TUI render the
-same offset-free diff via `--opt diff`.
+following line being flagged.
 
 ```
 ┌─────────────────────────────────────────────────┐
@@ -1305,22 +1251,22 @@ tcl explore script.tcl
 # Focus on optimiser rewrites only
 tcl explore script.tcl --show opt
 
-# Inline source with optimised output
-tcl explore --source 'set a 1; set b [expr {$a + 2}]' --show-optimised-source
+# Inline source, optimiser view only
+tcl explore --source 'set a 1; set b [expr {$a + 2}]' --show opt
 
 # Show only IR and CFG
 tcl explore script.tcl --show ir,cfg
 
 # iRules dialect with flow analysis
-tcl explore irule.tcl --dialect bigip --show irules
+tcl explore irule.tcl --dialect f5-irules --show irules
 
 # Serve the embedded web GUI
 tcl explore --serve
 ```
 
-Available views: `ir`, `cfg`, `ssa`, `interproc`, `types`, `opt`, `gvn`,
-`shimmer`, `taint`, `irules`, `callouts`, `asm`, `wasm`.  Groups: `all`,
-`compiler`, `optimiser`.
+Views include `ir`, `cfg`, `ssa`, `interproc`, `types`, `opt`, `gvn`,
+`shimmer`, `taint`, `irules`, `callouts`, `asm`, and `wasm`; `--show` matches
+view names by substring, and `--json` emits every view.
 
 ### Compiler explorer (web GUI)
 
@@ -1531,10 +1477,9 @@ Copilot: generates Tk code with grid layout, button callbacks, and display label
 
 ### Claude Code skills
 
-Twenty purpose-built skills for Claude Code (CLI) that combine LSP static
-analysis with AI reasoning.  The skills are native — each calls the
-`tcl-mcp` MCP server's tools, iterates on diagnostics, and produces clean
-output.
+Purpose-built skills for Claude Code that combine LSP static analysis with
+AI reasoning; each calls the `tcl-mcp` MCP server's tools, iterates on
+diagnostics, and produces clean output.
 
 | Skill | Description |
 |-------|-------------|
@@ -1552,13 +1497,19 @@ output.
 | `irule-migrate` | Convert nginx/Apache/HAProxy config to an iRule |
 | `irule-diagram` | Generate a Mermaid flowchart from compiler IR |
 | `irule-xc` | Translate to F5 XC with Terraform and JSON output |
+| `irule-dataflow` | Def-use chains, memory aliases, and a data-flow diagram from the SSA |
+| `bigip-cleanup` | Generate a `tmsh delete` script for objects no virtual server references |
+| `f5-query` | Turn a question about a BIG-IP config into an `f5 query` and run it |
+| `explain-flow` | Narrate a captured session (pcap) against a BIG-IP config |
 | `tcl-create` | Generate Tcl code from a description, validate until clean |
 | `tcl-explain` | Explain Tcl code with analysis context |
 | `tcl-fix` | Iteratively fix all Tcl diagnostics |
 | `tcl-validate` | Categorised Tcl validation report |
 | `tcl-optimise` | Apply Tcl optimiser suggestions |
+| `tcl-refactor` | Extract/inline variables, if-chain to switch, switch to dict, brace expr |
 | `tk-create` | Generate Tk GUI code with proper widget hierarchy |
 | `spec-author` | Build command specs for a private Tcl library from compiler-inferred evidence |
+| `ai-help` | Show which features and AI tools are available where |
 
 ```sh
 # Example: fix all issues in an iRule
@@ -1577,10 +1528,10 @@ A Model Context Protocol server that exposes tcl-lsp analysis to any
 MCP-compatible client (Claude Code, Claude Desktop, Codex, custom agents).
 
 The server is the **native Rust `tcl-mcp`** binary — a single self-contained
-executable that calls the Rust analysis crates directly (no Python, no PyO3).
-It hosts the full tool surface (46 tools: analysis, LSP features, refactors,
-diagnostics, docstrings, iRule/BIG-IP tools, XC translation, Tk layout, test
-generation, …). Build it with `make rust-mcp`.
+executable that calls the Rust analysis crates directly. It hosts the full
+tool surface — analysis, LSP features, refactors, diagnostics, docstrings,
+iRule/BIG-IP tools, XC translation, Tk layout, test generation, SpecTcl
+authoring — and `make rust-mcp` builds it.
 
 **Install / register.** The installer fetches the prebuilt native binary for
 your platform from the GitHub release (`tcl-mcp-<triple>`), verifies its
@@ -1607,6 +1558,8 @@ with `make rust-mcp && claude mcp add tcl-lsp -- "$(pwd)/target/release/tcl-mcp"
 | Tool | Description |
 |------|-------------|
 | `analyze` | Full analysis: diagnostics, symbols, events, and metadata |
+| `detect_dialect` | Detect the Tcl dialect from source (and optional filename) |
+| `help` | Search the KCS feature knowledge base |
 | `validate` | Categorised validation report |
 | `review` | Security-focused diagnostic report |
 | `find-legacy` | Detect legacy patterns eligible for modernisation |
@@ -1617,22 +1570,42 @@ with `make rust-mcp && claude mcp add tcl-lsp -- "$(pwd)/target/release/tcl-mcp"
 | `find_references` | Find all references to a symbol |
 | `symbols` | Document symbol hierarchy |
 | `code_actions` | Quick fixes for a source range |
+| `refactor` | List the refactorings available at a selection |
+| `extract_variable` | Extract a selected expression into a `set` binding |
+| `inline_variable` | Inline a single-use variable |
+| `if_to_switch` | Convert an if/elseif chain on one variable to `switch` |
+| `switch_to_dict` | Convert a `switch` whose arms set one variable to a dict lookup |
+| `brace_expr` | Brace an unbraced `expr` argument |
+| `extract_datagroup` | Extract an if/switch over literals into an iRules data-group lookup |
+| `suggest_datagroup_extractions` | Scan for if/switch patterns extractable to data-groups |
 | `format_source` | Format Tcl/iRules source code |
 | `rename` | Rename a symbol throughout the document |
+| `generate_docstring` | Generate a docstring stub for a named proc |
+| `read_proc_docs` | Structured docs for every proc: params, docstring, inferred traits |
+| `update_docstrings` | Insert docstring stubs above every undocumented proc |
+| `unminify_error` | Translate a minified error back to original names and lines |
 | `event_info` | iRules event metadata and valid commands |
 | `command_info` | Command metadata and valid events |
 | `event_order` | Events in canonical firing order |
 | `call_graph` | Build proc call graph with roots and leaves |
 | `symbol_graph` | Build scope/definition/reference graph |
 | `dataflow_graph` | Build taint and side-effect graph |
+| `def_use_chains` | SSA def-use chains and memory-SSA aliases |
+| `memory_aliases` | Memory-SSA alias sets (`upvar`/`global`/`variable`) with reasons |
 | `diagram` | Extract control-flow diagram data from IR |
+| `compile_wasm` | Compile source to a WebAssembly module |
 | `xc_translate` | Translate iRule to XC configuration |
+| `irule_with_context` | Bundle each iRule in a BIG-IP config with the objects it references |
+| `explain_flow` | Narrate a captured session (pcap) against a BIG-IP config |
 | `tk_layout` | Extract Tk widget tree as JSON |
 | `generate_irule_test` | Generate iRule test script with CFG paths and multi-TMM detection |
 | `irule_cfg_paths` | Extract CFG control-flow paths for test planning |
 | `fakecmp_which_tmm` | Look up which TMM a connection tuple maps to |
 | `fakecmp_suggest_sources` | Find client addr/port combos that hit each TMM |
 | `set_dialect` | Set active Tcl dialect for the session |
+| `spectcl_check` | Validate a SpecTcl pack in the deterministic sandbox |
+| `spectcl_expand` | Expand a SpecTcl pack to its canonical straight-line form |
+| `spec_import` | Derive command version ranges from local release snapshots |
 
 ```json
 // Claude Desktop — claude_desktop_config.json (native binary)
@@ -1673,10 +1646,15 @@ A single verb-based CLI that aggregates common local workflows:
 - `highlight` — emit syntax-highlighted source (`ansi` or `html`)
 - `diff` — compare two sources across AST/IR/CFG compiler representations
 - `explore` — run compiler-explorer views (`ir`, `cfg`, `ssa`, `opt`, `asm`, `wasm`, ...)
+- `minify` / `unminify-error` — minify source, and map a minified error back to original names
+- `minimize` — reduce a diagnostic to a minimal reproducer for a bug report
+- `registry-dump` — dump the command registry as JSON
 - `help` — search bundled KCS feature docs from the SQLite help index
-- `pkg` — package management: `init`, `add`, `remove`, `install`, `list`, `tree`, `verify`, `info`, `search`, `update`, `sync`, `outdated`, `why`, `vendor`, `run`
+- `completion` — print a bash / fish / zsh completion script
+- `pkg` — package management: `init`, `discover`, `add`, `remove`, `install`, `list`, `tree`, `verify`, `info`, `search`, `update`, `sync`, `outdated`, `why`, `vendor`, `run`, `freeze`, `policy`, `hooks`, `audit`, `trust`, `build`
 - `venv` — virtual environments: `create`, `delete`, `info`, `activate`, `deactivate`, `list`, `update`, `run`
-- `spec` — author SpecTcl (`.tclspec`) command packs: `import` derives `introduced_version`/`retired_version` ranges for a package's commands from several labelled release snapshots
+- `docker` — generate Dockerfiles and install recipes for Tcl projects
+- `spec` — author SpecTcl (`.tclspec`) command packs: `import` derives `introduced_version`/`retired_version` ranges from several labelled release snapshots, `export` renders a pack's canonical expansion, `upgrade` rewrites a 1.x pack to the current vocabulary
 
 ```sh
 # Optimise everything under src/ into one output script
@@ -1731,7 +1709,7 @@ tcl dis script.tcl
 tcl compwasm script.tcl -o out.wasm --wat-output out.wat
 
 # Emit ANSI-highlighted output (or --format html)
-tcl highlight script.tcl --force-colour
+tcl highlight script.tcl --colour
 
 # Diff two iRules using compiler structure layers
 tcl diff old.irule new.irule --show ast,ir,cfg
@@ -1767,17 +1745,9 @@ tcl lint rules/ --dialect f5-irules
 iRules-specific verbs (`event-order`, `event-info`) live on the separate
 `f5` CLI under the `irule` verb group — see the F5 BIG-IP CLI section.
 
-For source builds, run `make kcs-db` first so the `tcl help` command can query
-the bundled KCS SQLite database.
-
-**Install the `tcl` CLI** — the released artefact is the native `tcl`
-binary; no Python required.
-See [INSTALL-cli.md](INSTALL-cli.md) for the one-line `curl | sh`
-installer, manual install steps for macOS/Debian/Ubuntu/RHEL/CentOS/
-Fedora, source builds, and shell completion (`bash`, `zsh`, `fish`)
-that covers every verb, dialect, optimiser profile, and source-path
-glob — the same indexed-source extension set the server walks, from the
-one catalogue, rather than a list of its own.
+**Install** — [INSTALL-cli.md](INSTALL-cli.md) covers the one-line installer,
+manual install, source builds, and shell completion (`bash`, `zsh`, `fish`)
+for every verb, dialect, optimiser profile, and source-path glob.
 
 ![Unified Tcl verb CLI](docs/screenshots/30-tcl-verb-cli.png)
 
@@ -1843,9 +1813,6 @@ require json    1.3.5
 require http    2.9.8
 dev-require tcltest 2.5.5
 ```
-
-The LSP server auto-detects `tclpkg.tcl` projects and venv `lib/` directories,
-and offers an "Install via tclpkg" quick-fix on missing-package diagnostics.
 
 See [docs/kcs/features/kcs-feature-tcl-pkg.md](docs/kcs/features/kcs-feature-tcl-pkg.md) for the
 full architecture and contracts.
@@ -1989,8 +1956,8 @@ In a project with an "entry" file that runs the `package require`s and then
 Every code has its own page — what it means, why the check exists, a
 triggering example, and the fix:
 
-- [Diagnostic codes](docs/generated/diagnostic_codes.md) — the E, W, S, T, and
-  IRULE families
+- [Diagnostic codes](docs/generated/diagnostic_codes.md) — every family except
+  the optimiser's
 - [Optimiser codes](docs/generated/optimisation_codes.md) — the O family
 - [Per-code KCS pages](docs/kcs/codes/README.md) — one note per code
 
@@ -2013,7 +1980,7 @@ file for editor-independent configuration.
 - **Formatter options** —
   [kcs-feature-formatting.md](docs/kcs/features/kcs-feature-formatting.md)
 
-In VS Code, **Tcl: Export Settings** writes your current configuration out as
+In VS Code, **Tcl: Export Settings to Config File** writes your current configuration out as
 an INI file you can commit alongside the project.
 
 ## Screenshots
@@ -2040,11 +2007,10 @@ an INI file you can commit alongside the project.
 
 ## Building and contributing
 
-- A Rust toolchain (current stable) via [rustup](https://rustup.rs/).  The
-  workspace tracks the floating `stable` channel; current stable is 1.98.1,
-  released 2026-09-03.
-- Node.js 24+ with npm (pinned to v12 via `packageManager`; run `corepack enable npm`)
-- VS Code 1.93+
+- A Rust toolchain via [rustup](https://rustup.rs/); the workspace tracks the
+  floating `stable` channel.
+- Node.js 24+ with npm (pinned via `packageManager`; run `corepack enable npm`)
+- VS Code 1.95+
 
 On macOS, run `make ensure-rust-deps` before the Rust/WASM gates. Stock Apple
 clang has no WebAssembly backend, so this installs and selects the pinned
@@ -2062,13 +2028,10 @@ before pushing, how to add a diagnostic or a formatter option, the repository
 layout, and the code-style rules — see **[AGENTS.md](AGENTS.md)** and
 **[CONTRIBUTING.md](CONTRIBUTING.md)**.
 
-The local smoke gate prefers `cargo nextest` when it is installed. If nextest
-is unavailable, `make smoke` and `make smoke-p P=<crate>` use the checked-in
-manifest at `scripts/dev/smoke-targets.tsv` through `cargo xtask smoke-targets`
-instead. The fallback selects the same smoke sources without changing Cargo's
-workspace feature resolution. Run `cargo xtask smoke-targets check` to inspect
-or validate the ownership manifest; see the [smoke fallback troubleshooting
-note](docs/kcs/kcs-issue-smoke-fallback-does-not-match-nextest.md) if it fails.
+`make smoke` and `make smoke-p P=<crate>` prefer `cargo nextest`; without it
+they fall back to the manifest at `scripts/dev/smoke-targets.tsv` via
+`cargo xtask smoke-targets` (`cargo xtask smoke-targets check` validates it —
+see the [smoke fallback note](docs/kcs/kcs-issue-smoke-fallback-does-not-match-nextest.md)).
 
 Tcl VM conformance work uses the shared C Tcl oracle harness. See
 **[How to run the C tcltest suite through the bytecode VM](docs/kcs/kcs-howto-run-tcltest-bundles.md)**;

--- a/ai/claude/skills/_prompts/explain_flow_system.md
+++ b/ai/claude/skills/_prompts/explain_flow_system.md
@@ -7,47 +7,73 @@ Shared reference for the BIG-IP `explain_flow` analyser, loaded by the
 `f5_cli::explain_flow_value`); keep this file in sync with the shape that
 function returns — it is the contract the LLM consumes.
 
-## The compact MCP shape
+## The report shape
 
-Fixed top-level keys:
+The MCP tool and `f5 explain-flow --json` return the same value. Fixed
+top-level keys, all always present:
 
 ```jsonc
 {
-  "pcap": "/path/to/flow.pcap",
-  "matched": 1,                    // # sessions that matched a VS
-  "sessions_total": 3,             // total sessions, incl. unmatched
-  "tshark": true,
-  "keylog": "...",                 // present if used
-  "tshark_filter": "...",          // present if used
-  "gtm_wide_ips_in_config": [...], // GLOBAL inventory, not per-session
+  "pcap_path": "/path/to/flow.pcap",
+  "flow_count": 6,                 // one-directional flows walked
+  "session_count": 3,              // sessions, incl. unmatched
+  "matched_count": 1,              // # sessions that matched a VS
+  "used_tshark": true,
+  "keylog_path": "",               // "" when unused
+  "tshark_filter": "",             // "" when unused
   "sessions": [ /* one entry per session, see below */ ]
 }
 ```
 
-Each session is the high-signal subset; empty fields are omitted:
+Each session carries every key; an unset field is `""`, `[]`, `false`, or
+`null` rather than being omitted:
 
 ```jsonc
 {
-  "summary": "1.2.3.4:11111 → /partition/vs_app | SNI=api.example.com | GET /v1/health → 200 | pool→ 10.0.0.10:8080 | snat→ 10.0.0.5:22222",
+  "session": {
+    // Front is client↔VIP, back is TMM↔pool member (null when unpaired).
+    // Each side is { "client": <flow>, "server": <flow>|null }; a flow
+    // carries src/dst ip+port, proto, packets, bytes, the TCP flag counters
+    // (tcp_syn, tcp_rst, tcp_rst_after_bytes, …), the TLS observations
+    // (tls_sni, tls_version, tls_alpn, tls_alert_desc, tls_cert_subject, …),
+    // the HTTP observations (http_method, http_host, http_uri, http_path,
+    // http_query, http_response_code, http_response_headers, …),
+    // "f5_reset_causes", and the F5-trailer peer tuple (peer_remote_ip, …).
+    "front": { "client": { "src_ip": "1.2.3.4", "src_port": 11111,
+                           "dst_ip": "5.6.7.8", "dst_port": 443,
+                           "proto": "tcp", "tls_sni": "api.example.com",
+                           "http_method": "GET", "http_uri": "/v1/health" },
+               "server": null },
+    "back": null
+  },
   "matched_vs": "/partition/vs_app",
-  "flow": { "client": "1.2.3.4:11111", "vip": "5.6.7.8:443",
-            "pool_member": "10.0.0.10:8080", "snat": "10.0.0.5:22222",
-            "proto": "tcp" },
-  "captured_request": { "method": "GET", "host": "api.example.com",
-                         "uri": "/v1/health", "tls_sni": "api.example.com",
-                         "tls_version": "TLS1.3", "tls_cipher": "..." },
-  "captured_response": { "status": "200" },
-  "profiles": ["tcp (lab_tcp)", "client_ssl (lab_clientssl_valid)", "http (lab_http)"],
+  "partition": "partition",
+  "profile_chain": ["tcp (lab_tcp)", "client_ssl (lab_clientssl_valid)",
+                    "http (lab_http)"],
+  "pool_selected": "10.0.0.10:8080",   // observed on the back side
+  "snat_observed": "10.0.0.5:22222",   // observed, "" when not SNATted
+  "event_sequence": ["rule_sni::CLIENTSSL_CLIENTHELLO",
+                     "rule_route::HTTP_REQUEST"],   // "<rule>::<EVENT>"
+  "event_blocks": [
+    { "rule": "rule_sni", "event": "CLIENTSSL_CLIENTHELLO",
+      "body": "if { [SSL::extensions exists -type 0] } { ... }\n... (truncated)" }
+  ],
+  "event_annotations": [
+    { "rule": "rule_route", "event": "HTTP_REQUEST",
+      "annotations": [ { "line": "if { [HTTP::host] equals \"api.example.com\" }",
+                         "command": "HTTP::host",
+                         "value": "api.example.com" } ] }
+  ],
   "ltm_policies": ["/partition/lab_policy_rewrite"],
   "policy_decisions": [
     { "policy": "/partition/lab_policy_rewrite", "strategy": "first-match",
-      "fired": [
-        { "rule": "api_route", "ordinal": 1,
-          "matched_on": [
-            { "field": "http-host.host", "operator": "equals",
-              "expected": ["api.example.com"], "actual": "api.example.com" },
-            { "field": "http-uri.path", "operator": "starts-with",
-              "expected": ["/v1/"], "actual": "/v1/health" }
+      "rules": [
+        { "rule": "api_route", "ordinal": 1, "matched": true, "fired": true,
+          "conditions": [
+            { "operand": "http-host", "selector": "host", "operator": "equals",
+              "expected": ["api.example.com"], "actual": "api.example.com",
+              "matched": true, "name": "", "negate": false,
+              "event": "request", "note": "" }
           ],
           "actions": [
             { "target": "forward", "verb": "select",
@@ -55,54 +81,49 @@ Each session is the high-signal subset; empty fields are omitted:
           ] }
       ] }
   ],
-  "events_fired": ["RULE_INIT", "CLIENT_ACCEPTED", "CLIENTSSL_CLIENTHELLO",
-                    "HTTP_REQUEST", "LB_SELECTED", "SERVER_CONNECTED"],
-  "irule_decisions": [
-    { "event": "CLIENTSSL_CLIENTHELLO", "command": "SSL::extensions",
-      "value": "sni=api.example.com, alpn=h2" },
-    { "event": "HTTP_REQUEST", "command": "HTTP::host",
-      "value": "api.example.com" }
-  ],
-  "irule_bodies": [
-    { "rule": "rule_sni", "event": "CLIENTSSL_CLIENTHELLO",
-      "body": "if { [SSL::extensions exists -type 0] } { ... }\n... (truncated)" }
-  ],
-  "termination": "graceful FIN teardown (no RST)",
-  "simulated": { "pool": "/partition/lab_pool_api",
-                 "decisions": [ { "category": "lb", "action": "pool_select",
-                                   "value": "/partition/lab_pool_api" } ] }
+  "apm_profile": "",
+  "gtm_wide_ips": ["/Common/app.example.com"],  // the config's wide IPs
+  "explain_text": "…",           // `f5 explain virtual` text for matched_vs
+  "reset_analysis": "graceful FIN teardown (no RST)",
+  "simulated_pool": "/partition/lab_pool_api",   // "" unless simulate=true
+  "simulated_node": "10.0.0.10:8080",
+  "simulated_response_committed": false,
+  "simulated_logs": [],
+  "simulated_decisions": [ { "category": "lb", "action": "pool_select",
+                             "value": "/partition/lab_pool_api" } ],
+  "simulation_error": ""
 }
 ```
 
 ## Narrating a session
 
-1. Quote `summary` — the one-line gist.
-2. `captured_request` + `captured_response`: what the client sent and what
-   came back, or how far the connection got.
-3. `profiles`: which BIG-IP code paths ran (TCP-only, TLS-decrypt,
+1. Open with the 5-tuple and `matched_vs` — the one-line gist.
+2. `session.front` / `session.back`: what the client sent and what came back,
+   or how far the connection got (HTTP and TLS fields, byte and packet
+   counts).
+3. `profile_chain`: which BIG-IP code paths ran (TCP-only, TLS-decrypt,
    HTTP-aware); order is attach order.
-4. `events_fired` + `irule_decisions`: which branches were taken and what
-   they read — each decision is "in event X the iRule looked at command Y
+4. `event_sequence` + `event_annotations`: which branches were taken and what
+   they read — each annotation is "in event X the iRule looked at command Y
    and saw Z", which explains a `[HTTP::host] equals` branch or an SNI route.
-5. `policy_decisions`: which LTM policy rule fired and what it did; only
-   fired rules appear, with the conditions that matched (`matched_on`,
-   expected beside actual) and the actions. An empty `fired` means the
-   policy ran and nothing matched; a rule with zero conditions always
-   matches, so a "default" rule shows in `fired` under first-match /
-   all-match whenever no earlier rule won. `best-match` is reported as
-   `best-match-approx` ("most conditions wins"; F5's operand-specificity
-   weighting is not reproduced). The full per-condition trace, including
-   non-matched and unevaluable conditions, is only in the verbose shape.
-6. `irule_bodies`: consult only when you need to quote Tcl; already
+5. `policy_decisions`: which LTM policy rule fired and what it did. Every
+   rule is listed with `matched` / `fired` and its full per-condition trace
+   (`expected` beside `actual`, plus `note` for a condition that could not be
+   evaluated) — narrate the fired ones and reach for the rest only to explain
+   why nothing matched. A rule with zero conditions always matches, so a
+   "default" rule fires under first-match / all-match whenever no earlier
+   rule won. `best-match` is reported as `best-match-approx` ("most
+   conditions wins"; F5's operand-specificity weighting is not reproduced).
+6. `event_blocks`: consult only when you need to quote Tcl; already
    truncated — do not ask for `max_event_body_lines > 20` without cause.
-7. `flow.pool_member` + `flow.snat` are observed. If `simulated.pool` differs,
-   say so: the capture usually pre-dates the rule edit or another rule
-   overrode the choice.
-8. `termination` explains why the session ended; an RST with an F5 reset
-   cause (e.g. `POOL_DOWN`) is definitive.
-9. `simulated`, when present, is the truth source (the iRule run under
-   c-tcl with the captured state); on `simulated.error` fall back to the
-   static analysis.
+7. `pool_selected` + `snat_observed` are observed. If `simulated_pool`
+   differs, say so: the capture usually pre-dates the rule edit or another
+   rule overrode the choice.
+8. `reset_analysis` explains why the session ended; an RST with an F5 reset
+   cause (e.g. `POOL_DOWN`, in the flow's `f5_reset_causes`) is definitive.
+9. The `simulated_*` fields, when `simulate=true`, are the truth source (the
+   iRule run under c-tcl with the captured state); on a non-empty
+   `simulation_error` fall back to the static analysis.
 
 ## Limitations
 
@@ -110,17 +131,17 @@ Each session is the high-signal subset; empty fields are omitted:
   peer-tuples that pair `:np` front/back sides come only from the built-in
   walker, so a filtered run loses front/back pairing. Drop the filter for
   proxied traffic.
-- `simulated` needs `tclsh` on PATH and one orchestrator subprocess per
+- `simulate` needs `tclsh` on PATH and one orchestrator subprocess per
   matched session; avoid on captures with hundreds of sessions unless
   `tshark_filter` is set.
 - Static event ordering comes from attached profiles and observed L7
   features; it does not honour `event disable` or conditional
-  `when ... { return }` — consult `simulated` for runtime truth.
+  `when ... { return }` — consult the `simulated_*` fields for runtime truth.
 - Path-through-iRule analysis is static unless `simulate=true`: it surfaces
   the relevant `when` bodies, it does not follow branches on payload bytes.
-- GTM probe results and APM session state are not retained;
-  `gtm_wide_ips_in_config` is a report-level global inventory, not
-  per-session.
+- GTM probe results and APM session state are not retained; `gtm_wide_ips`
+  is the config's wide-IP inventory repeated on each session, not a
+  per-session resolution.
 - LTM policy evaluation covers operands `http-host`, `http-uri`
   (host/path/query), `http-method`, `http-header` (named), `ssl-extension
   server-name`, `tcp address`, and actions `forward select`, `http-reply
@@ -128,9 +149,9 @@ Each session is the high-signal subset; empty fields are omitted:
   Other operands (cookie, geoip, ssl-cert, rate-limit) parse but evaluate
   as no-match with a `note`.
 
-## When to use the verbose `report_to_dict` shape
+## Keeping the answer small
 
-Only when the user wants every packet's full 5-tuple and flags, is piping to
-a tool that expects the full per-flow dicts, or explicitly asks for the raw
-JSON. Otherwise the compact shape is the answer — it carries the
-operator-relevant fields at the smallest token cost.
+The report is complete, not pruned: a large capture returns a session per
+5-tuple with every flow field on each. Narrow with `tshark_filter` and lower
+`max_event_body_lines` rather than quoting the JSON back at the user; quote
+only the fields the question turns on.

--- a/ai/claude/skills/explain-flow/SKILL.md
+++ b/ai/claude/skills/explain-flow/SKILL.md
@@ -21,12 +21,10 @@ allowed-tools: mcp__tcl-lsp__explain_flow, Bash, Read
 
 ## Steps
 
-1. Read `../_prompts/explain_flow_system.md`: the compact JSON shape, how
-   to narrate each field, the limitations, and when the verbose report is
-   warranted.
-2. Call `mcp__tcl-lsp__explain_flow` — preferred, it returns the pruned
-   high-signal shape — with `pcap_path`, `config_paths` (array) or
-   `config_text`, and as needed `use_tshark`, `keylog_path` (NSS keylog for
+1. Read `../_prompts/explain_flow_system.md`: the JSON shape, how to
+   narrate each field, and the limitations.
+2. Call `mcp__tcl-lsp__explain_flow` — preferred — with `pcap_path`,
+   `config_paths` (array) or `config_text`, and as needed `use_tshark`, `keylog_path` (NSS keylog for
    HTTPS), `tshark_filter` (e.g. `"host 10.0.0.5 and port 443"`),
    `max_event_body_lines`, `simulate`.
 3. Narrate each session per the guide.
@@ -39,7 +37,7 @@ allowed-tools: mcp__tcl-lsp__explain_flow, Bash, Read
 - CLI fallback only when the MCP tool is unreachable, and then the **text**
   report: `f5-query explain-flow capture.pcap bigip.conf`
   (`--max-event-lines 8`, `--no-event-bodies`, `--tshark-filter '…'`).
-  `--json` is the full report — for piping to another tool, never for your
-  own reasoning.
+  `--json` is the same value the MCP tool returns — for piping to another
+  tool, never for your own reasoning.
 
 $ARGUMENTS

--- a/ai/claude/skills/f5-query/SKILL.md
+++ b/ai/claude/skills/f5-query/SKILL.md
@@ -11,8 +11,9 @@ the file(s) they name.
 
 ## Workflow
 
-1. **Input.** `.conf` and `.scf` load directly; `.ucs` needs
-   `f5 ucs-extract` first. No file named → ask.
+1. **Input.** `.conf`, `.scf`, and `.ucs` all load directly (a UCS is
+   decrypted in memory; `f5 extract` converts one to SCF when the user wants
+   the text). No file named → ask.
 2. **Translate** from the recipes below; grammar in
    `docs/references/f5_query/dsl.md` (`f5 query --help-dsl`), every builtin
    in `docs/references/f5_query/builtins.md` (`f5 query --help-builtins
@@ -37,13 +38,12 @@ one loaded source (below); reads and writes both route to it.
 | Divergence from jq | f5 query |
 |---|---|
 | function args | `,` separated, not `;` |
-| stream concat `,` | absent — use `[ ... ]` lists or `;` statements |
-| `test()` | `match()` is boolean; capture groups via `sub` / `gsub` |
+| stream concat `,` | supported, including inside `[ ... ]`; a comma in a function argument or object entry stays a structural separator, so parenthesise a comma value there |
+| regex | `match()` and `test()` are both boolean; capture groups via `sub` / `gsub` |
 | truthiness | empty string / list / stream / PathRef and numeric 0 are also falsey |
 | object literals | `{name, dest: .destination}` (bareword key = `key: .key`; stream fields broadcast one row per item) |
 | `expr as $x \| body` | supported — streams iterate, plain lists bind whole |
-| string interpolation | not in v1 — concat with `+` (scalars auto-coerce) |
-| `,` inside `[...]` | not in v1 — parse error names the comma |
+| string interpolation | `"\(…)"` is not interpolated — concat with `+` (scalars auto-coerce) |
 
 ## Multi-config queries
 
@@ -60,9 +60,15 @@ route back; it refuses when two sources define the same `(kind, full-path)`.
 | list virtuals from ltm.conf with gtm.conf loaded | `$ltm.ltm.virtual[].name` |
 | every LTM pool a GTM pool references | `--merge .gtm.pool[] \| refs(.)` |
 | rename a pool in tier1 only | `$tier1.ltm.pool["/Common/old"].name = "/Common/new"` |
-| every object across both tiers | `--merge .ltm[][].name` |
+| every virtual and pool across both tiers | `--merge .ltm.virtual[]."full-path", .ltm.pool[]."full-path"` |
 
 ## Network probes and cert audit
+
+The engine projects objects for the `ltm`, `gtm` and `security` modules
+only; `net`, `sys`, `cm` and `apm` parse but expose no kinds, so
+`.sys["file-ssl-cert"][]` and `.cm.cert[]` raise `no entry`. Until they are
+projected, feed a cert in from a builtin instead — `cert_load(path)`,
+`x509_parse(pem)`, `ucs_cert(...)`, or a live `tls_handshake` / `url_get`.
 
 Live checks need `--enable-probes`. Every cert-emitting builtin returns the
 same dict (`subject`, `issuer`, `serial`, `fingerprint_sha256`, `sans`,
@@ -102,7 +108,7 @@ retry unverified so the audit still gets body and peer cert, and report
 | any iRule referencing the missing pool /Common/X | `any(.ltm.rule[].refs.pools[] \| (. == "/Common/X"))` |
 | each pool's member count | `.ltm.pool[] \| .name + ": " + count(.members)` |
 | persistence profiles inheriting from cookie | `.ltm.persistence[] \| select(."defaults-from" == "/Common/cookie") \| .name` |
-| data-groups whose body contains 'foo' | `.ltm["data-group"][] \| select(contains(.records, "foo")) \| .name` |
+| data-groups whose body contains 'foo' | `.ltm["data-group"][] \| select(any(.records[] \| contains(., "foo"))) \| .name` |
 | every kind of object | `[.[]] \| count` |
 | unreferenced pools | use `f5 cleanup` |
 
@@ -125,7 +131,8 @@ source format and reads strict UTF-8), `--write`, `--in-place`,
 
 1. `map(body)` is many-to-many and flattens like the pipe;
    `map(select(...) | .field)` is the filter+transform idiom.
-2. No `,` inside `[ ... ]` — one pipeline expression per bracket.
+2. A comma inside a function argument list or an object entry separates
+   arguments, not streams — parenthesise a comma expression there.
 3. `--in-place --format tmsh` is refused; use `--write` for tmsh.
 4. Field-edit strings are SCF-encoded on write; newlines and braces raise an
    `EditError`.
@@ -134,10 +141,10 @@ source format and reads strict UTF-8), `--write`, `--in-place`,
 
 ## Defer to
 
-`f5 cleanup` (orphans, reverse-topological), `f5 lint` (BIG-IP rule
-findings), `f5 grep` (transitive reference graph), `f5 diff`
-(round-trip-aware whole-config diff), `f5 trace` / `f5 explain` (ad-hoc Tcl
-analysis).
+`f5 cleanup` (orphans, reverse-topological), `f5 irule lint` (iRule-only
+lint rules), `f5 grep` (transitive reference graph), `f5 diff`
+(round-trip-aware whole-config diff), `f5 irule trace` (static event-flow
+trace), `f5 explain` (the resolved plan for one virtual or pool).
 
 ## Etiquette
 

--- a/editors/emacs/README.md
+++ b/editors/emacs/README.md
@@ -86,7 +86,7 @@ Pass settings via eglot workspace configuration:
 
 ```elisp
 (setq-default eglot-workspace-configuration
-              '(:tclLsp (:dialect "tcl8.6"   ;; tcl8.4 | tcl8.5 | tcl8.6 | tcl9.0 | tcl9.1 | f5-irules | f5-iapps | f5-tmsh | f5-bigip | bpf | expect | spectcl | cadence-eda-tcl | intel-quartus-eda-tcl | mentor-eda-tcl | microchip-libero-eda-tcl | synopsys-eda-tcl | xilinx-eda-tcl
+              '(:tclLsp (:dialect "tcl8.6"   ;; tcl8.4 | tcl8.5 | tcl8.6 | tcl9.0 | tcl9.1 | f5-irules | f5-iapps | f5-tmsh | f5-bigip | bpf | expect | spectcl | sslictcl | cadence-eda-tcl | intel-quartus-eda-tcl | mentor-eda-tcl | microchip-libero-eda-tcl | synopsys-eda-tcl | xilinx-eda-tcl
                          :formatting (:indentSize 4 :maxLineLength 120))))
 ```
 
@@ -126,21 +126,18 @@ spec-correct reference client driven through the same edits
 (`rust/tcl-lsp-server/tests/e2e/semantic_tokens_reference_client.rs`) — so
 this is purely how eglot paints them.
 
-The accumulation was reproduced against real Tcl code and measured
-under several fixes (see `scripts/eglot_test/prove_fix.el`): the
-**client-side painter advice below collapses a 7-deep face stack to a
-single correct face**, whereas a purely server-side capability tweak
-made **no difference** — confirming the bug lives entirely in eglot's
-painter. The same accumulation reproduces with rust-analyzer and clangd,
-so it is not tcl-lsp-specific.
+The client-side painter advice below is the only fix that works: it
+collapses the stacked faces to the single correct one. A server-side
+capability tweak makes no difference, and the same accumulation
+reproduces with rust-analyzer and clangd, so the bug is not
+tcl-lsp-specific. `scripts/eglot_test/prove_fix.el` reproduces and
+measures it.
 
-The server does its part to *shrink* that stale window: it implements
-proper `semanticTokens/full/delta`, so a keystroke transmits only the
-changed tokens (a few bytes) instead of the whole document — the same
-incremental behaviour rust-analyzer uses. That reduces how often eglot
-is caught mid-refresh, but the definitive fix is still the painter
-advice below. Lowering `eglot-send-changes-idle-time` also helps, by
-keeping the round-trip short.
+The server shrinks the stale window by implementing
+`semanticTokens/full/delta`, so a keystroke transmits only the changed
+tokens rather than the whole document. Lowering
+`eglot-send-changes-idle-time` helps for the same reason. Neither is a
+substitute for the advice.
 
 **Workarounds (pick one):**
 

--- a/editors/helix/README.md
+++ b/editors/helix/README.md
@@ -13,14 +13,11 @@ it with `make rust-server`.
 See [The server binary](../../INSTALL-editors.md#the-server-binary) in the
 installation guide for the per-platform asset names.
 
-## Upstream integration (after merge)
+## Configuration
 
-Once tcl-lsp is added to
+tcl-lsp is not yet in
 [`helix-editor/helix`](https://github.com/helix-editor/helix)'s default
-`languages.toml`, Helix users only need `tcl-lsp-server` on their PATH — no
-per-user `languages.toml` edit is required.
-
-## Configuration (until upstream merges)
+`languages.toml`, so add the blocks below to your own.
 
 ```toml
 # The released binary, or a local build from `make rust-server`.
@@ -196,7 +193,7 @@ Pass workspace settings via the `config` key:
 ```toml
 [language-server.tcl-lsp.config.tclLsp]
 # Valid dialects: tcl8.4, tcl8.5, tcl8.6, tcl9.0, tcl9.1, f5-irules, f5-iapps,
-# f5-tmsh, f5-bigip, bpf, expect, spectcl, cadence-eda-tcl,
+# f5-tmsh, f5-bigip, bpf, expect, spectcl, sslictcl, cadence-eda-tcl,
 # intel-quartus-eda-tcl, mentor-eda-tcl, microchip-libero-eda-tcl,
 # synopsys-eda-tcl, xilinx-eda-tcl
 dialect = "tcl8.6"

--- a/editors/jetbrains/README.md
+++ b/editors/jetbrains/README.md
@@ -48,7 +48,7 @@ Everything the IDE's LSP client asks for is supported:
   reveals the matching source. The CFG, WASM and optimiser-diff panes stay in
   the tool window, since their edges and connectors are drawn rather than
   written.
-- **Dialect support**: Tcl 8.4–9.0, F5 iRules, F5 iApps, EDA Tools
+- **Dialect support**: Tcl 8.4–9.1, F5 iRules, F5 iApps, EDA Tools
 - **Pack-declared file extensions** registered as the packs that claim them
   load and unload (see below)
 
@@ -138,11 +138,11 @@ make build-editor-jetbrains
 **Settings → Tools → Tcl Language Server**
 
 - **Server path**: Path to a `tcl-lsp-server` binary (dev mode; leave empty for the bundled server)
-- **Dialect**: Tcl 8.4–9.0, F5 iRules, F5 iApps, EDA Tools
+- **Dialect**: Tcl 8.4–9.1, F5 iRules, F5 iApps, EDA Tools
 - **Feature toggles**: Enable/disable individual LSP features
 - **Formatting**: 20+ style settings (indent, braces, line length, etc.)
-- **Diagnostics**: Toggle individual diagnostic codes (E001–W309)
-- **Optimiser**: Toggle optimisation suggestions (O100–O130)
+- **Diagnostics**: Toggle any individual diagnostic code
+- **Optimiser**: Toggle any individual optimisation suggestion
 
 ## Development
 

--- a/editors/neovim/README.md
+++ b/editors/neovim/README.md
@@ -16,20 +16,9 @@ See the [Installation Guide](../../INSTALL-editors.md) for full details.
 Point `cmd` at the binary — either its name (`tcl-lsp-server`) if it is on
 your PATH, or an absolute path to it.
 
-## Via nvim-lspconfig (recommended once merged upstream)
-
-Once the tcl-lsp config is merged into
-[`neovim/nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig), the
-setup is a one-liner:
-
-```lua
-require('lspconfig').tcl_lsp.setup({})
-```
-
-The config expects the `tcl-lsp-server` binary to be on your PATH.
-Download it from the
-[latest release](https://github.com/bitwisecook/tcl-lsp/releases/latest)
-and drop it somewhere on PATH.
+tcl-lsp is not yet in
+[`neovim/nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig)'s
+built-in server list, so configure it with one of the forms below.
 
 ## Neovim 0.11+ (native LSP)
 
@@ -134,9 +123,9 @@ Settings are sent under the `tclLsp` namespace. Key options:
 | `formatting.braceStyle` | string | `k_and_r` | `k_and_r` |
 | `formatting.maxLineLength` | integer | `120` | Maximum line length |
 
-The eighteen dialect profiles `dialect` accepts: `tcl8.4`, `tcl8.5`,
-`tcl8.6`, `tcl9.0`, `tcl9.1`, `f5-irules`, `f5-iapps`, `f5-tmsh`,
-`f5-bigip`, `bpf`, `expect`, `spectcl`, `cadence-eda-tcl`,
+The dialect profiles `dialect` accepts: `tcl8.4`, `tcl8.5`, `tcl8.6`,
+`tcl9.0`, `tcl9.1`, `f5-irules`, `f5-iapps`, `f5-tmsh`, `f5-bigip`, `bpf`,
+`expect`, `spectcl`, `sslictcl`, `cadence-eda-tcl`,
 `intel-quartus-eda-tcl`, `mentor-eda-tcl`, `microchip-libero-eda-tcl`,
 `synopsys-eda-tcl`, `xilinx-eda-tcl`.
 

--- a/editors/sublime-text/SUBMITTING.md
+++ b/editors/sublime-text/SUBMITTING.md
@@ -44,10 +44,6 @@ order:
 }
 ```
 
-The first release eligible for this entry is v2.2.2. v2.2.1 carries the
-previous `TclLsp.sublime-package` shape and remains useful only as the tested
-baseline.
-
 ## Pre-submission checks
 
 1. Confirm the stable GitHub release carries `LSP-Tcl.sublime-package`.

--- a/editors/zed/README.md
+++ b/editors/zed/README.md
@@ -1,8 +1,7 @@
 # Tcl LSP for Zed
 
-Language-server support for Tcl, iRules, iApps, Expect, TMSH, and supported
-EDA Tcl dialects, powered by
-[tcl-lsp](https://github.com/bitwisecook/tcl-lsp).
+Language-server support for Tcl, iRules, iApps, APL, TMSH, and Expect,
+powered by [tcl-lsp](https://github.com/bitwisecook/tcl-lsp).
 
 ## Features
 
@@ -26,9 +25,11 @@ Zed's command palette and select this directory.
 ## File and dialect tracking
 
 The `languages/*/config.toml` suffix lists are generated from tcl-lsp's Rust
-dialect catalog by `cargo xtask gen-editor-extensions`. The repository drift
-gate prevents the extension from falling behind when a dialect or suffix is
-added.
+dialect catalogue by `cargo xtask gen-editor-extensions`; a drift gate in
+`make xtask-check` fails when a dialect or suffix is added without
+regenerating. The APL and BIG-IP tree-sitter grammars live in this repository
+under `grammars/` and are fetched by commit — bump the `rev` in
+`extension.toml` whenever either changes.
 
 The server detects the dialect from the file name and content. To force one,
 add a Zed setting such as:

--- a/experiments/corpus/MANIFEST.md
+++ b/experiments/corpus/MANIFEST.md
@@ -37,8 +37,9 @@ oometa,ooutil}` (session-provided tcllib tree).
 
 ### `vendor/tcl-oo-tests/` — Tcl core `oo` test suites
 
-`oo.test`, `ooNext2.test`, `ooUtil.test` from the Tcl **8.6.16** and
-**9.0.3** source trees (`tests/`), copied and prefixed with the version.
+`oo.test`, `ooNext2.test`, `ooUtil.test` from the Tcl **8.6.18** and
+**9.0.4** source trees under `tmp/` (`tests/`), copied and prefixed with the
+version.
 Real TclOO exercised by the interpreter's own conformance tests.
 
 ### `repo-fixtures/` — this repo's analyser OO fixtures

--- a/experiments/mro_eval/RESULTS.md
+++ b/experiments/mro_eval/RESULTS.md
@@ -349,13 +349,6 @@ classes — resolves correctly *in isolation*. See the granularity caveat.
   therefore already gets this resolving power today, via the type lattice
   + workspace class index. This experiment did not find a case where the
   lattice adds to it.
-- **Cross-file inheritance is under-linked.** A class declared with a bare
-  `superclass Device` inside an importing file does not link to
-  `::SpiceGenTcl::Device` in the merged MRO (the hierarchy builder
-  normalises only via `::name`), producing the 6 false W308s. Fixing it
-  would need namespace-aware superclass normalisation in the shipping
-  `class_hierarchy` builder — out of scope for this measurement-only
-  experiment, and noted as a prerequisite for *any* cross-file W308.
 - **Labeled sample bias.** Precision/recall are measured on the sites the
   resolver could reach at all; 81 % of sites are `EXTERN`/`DYNAMIC` and are
   excluded from the "knowable" denominators by construction. The headline
@@ -424,11 +417,10 @@ Concretely, staged by evidence:
    `all_classes` already deliver the 18.7 % that *is* resolvable. Keep
    using them; the experiment validates that design.
 3. **Do not source W308 from this resolver.** Against the real emitter it
-   is a net *loss*: +2 W307 false positives removed, but **6 new W308 false
-   positives** introduced and **0 true findings**, because cross-file
-   inheritance through bare `superclass` names is under-linked. Cross-file
-   W308 needs namespace-aware superclass normalisation *first*, and even
-   then this corpus offers no true positives to gain.
+   is a net *loss*: +2 W307 false positives removed, but **3 new W308 false
+   positives** introduced and **0 true findings**. The remaining three are
+   the `{*}[info class definition …]` dynamic-method idiom; this corpus
+   offers no true positives to gain either way.
 4. **The ⊤-rate lever is *container element-typing*, not parameter flow —
    and it is expensive. Decision: not productionized.** The follow-up
    experiment (above) refutes the parameter-typing hypothesis (0.9 % of ⊤;
@@ -452,5 +444,6 @@ Concretely, staged by evidence:
 hypothesis ("the lattice beats the heuristic") is **not supported** — the
 lattice's local evidence is absent at 99.8 % of sites, and the value is
 entirely in the already-shipping MRO/CHA half plus cross-file indexing.
-The honest next step is interprocedural param typing, gated on its own
-measurement.
+The follow-up measurement then refuted interprocedural parameter typing
+as the next step; the residual is container element-typing, and its
+measured ceiling does not justify building it.

--- a/experiments/tcloo_diag/RESULTS.md
+++ b/experiments/tcloo_diag/RESULTS.md
@@ -26,7 +26,7 @@ Corpus: the same ~305 OO files as `tcloo_dispatch` (tcllib, tklib, georgtree).
 | cmd-return | 930 | 11.3% | command return-type stubs |
 | param | 374 | 4.5% | interproc param (incl. cross-file) |
 | collection-get | 364 | 4.4% | container element typing (done) |
-| alias | 345 | 4.2% | assignment edge (done, Phase 2) |
+| alias | 345 | 4.2% | assignment edge (done) |
 | method-return | 274 | 3.3% | method return-type summaries |
 | literal | 60 | 0.7% | — (not an object) |
 | proc-return | 23 | 0.3% | proc return typing (done) |
@@ -59,8 +59,8 @@ Corpus: the same ~305 OO files as `tcloo_dispatch` (tcllib, tklib, georgtree).
    1035 unresolved receivers (12.6% of the `$var` gap); the `my…`-prefixed snit
    components (`myparser`, `mytree`, `mystackloc`, …) add several hundred more;
    `$hull` and `options(...)` are snit too. **snit support is the single
-   highest-value lever** — and it is data-driven (a dialect model), which is
-   exactly what Phase 3 scoped. `$self` is the snit analogue of `TclOO`'s `my`
+   highest-value lever** — and it is data-driven (a dialect model). `$self` is
+   the snit analogue of `TclOO`'s `my`
    and should resolve the same way (enclosing type known statically).
 
 2. **Tk widget-path dispatch (`$win.c …`) is a separate subsystem.** These are
@@ -70,7 +70,7 @@ Corpus: the same ~305 OO files as `tcloo_dispatch` (tcllib, tklib, georgtree).
 3. **Within-CU `TclOO` typing edges are a small slice.** alias (4.2%) +
    method-return (3.3%) + proc-return (0.3%) + collection (4.4%) together are
    ~12% of the `$var` gap, and the reachable, already-typed subset is smaller
-   still. This is why the Phase 2 VTA-lite edges (aliasing + constructor-param),
+   still. This is why the VTA-lite edges (aliasing + constructor-param),
    though *correct* (see below), leave the corpus resolution rate unchanged: the
    patterns they newly resolve barely occur here. They are retained because they
    are sound, cheap, and resolve a real dependency-injection shape — just not the
@@ -78,15 +78,15 @@ Corpus: the same ~305 OO files as `tcloo_dispatch` (tcllib, tklib, georgtree).
 
 4. **`cmd-return` (11.3% `$var`, 61.7% `[cmd]`) is unmodelled-command noise.**
    Mostly non-object commands (`string`, `expr`, `format`, callbacks); a
-   signature-stub pass (design-doc Stage 5) would let most of these *abstain
+   signature-stub pass would let most of these *abstain
    explicitly* rather than sit in the denominator, and type the few that do
    return objects.
 
 ## Roadmap consequence
 
-Priority order revised by evidence, highest corpus impact first:
+Priority order by corpus impact, highest first:
 
-1. **snit dialect model** (Phase 3) — **done**: `$self`/`$this` self-dispatch
+1. **snit dialect model** — **done**: `$self`/`$this` self-dispatch
    (~doubling the rate), named-constructor typing (`set o [foo create x]`),
    `install NAME using TYPE` components (+131 project sites), and the bare-word
    constructor `set c [Type inst]` gated on snit-family + not-a-typemethod
@@ -97,8 +97,9 @@ Priority order revised by evidence, highest corpus impact first:
    `object_collection_classes` to a workspace union (mirrors
    `project_class_index`), reaching the cross-file half of `param`/`unbound`.
 3. **Method return-type summaries**: `set x [$typed m]` / `[my m]` where `m`
-   returns an object — the flow-sensitive VTA edge we do not yet have.
+   returns an object — **done**: the `ObjectFlowEdge::MethodReturn` VTA edge in
+   `rust/tcl-compiler/src/object_types.rs`.
 4. Signature stubs / explicit abstention to deflate the `cmd-return` denominator.
 
-Within-CU proc/ctor/alias edges (Phase 2) are **landed and sound** but are not
-where the corpus mass is; the diagnostic is what established that.
+Within-CU proc/ctor/alias edges are **landed and sound** but are not where the
+corpus mass is; the diagnostic is what established that.

--- a/experiments/tcloo_dispatch/RESULTS.md
+++ b/experiments/tcloo_dispatch/RESULTS.md
@@ -21,7 +21,7 @@ Corpus: real TclOO from tcllib (clay, virtchannel, struct, oometa, oodialect),
 tklib (menubar), and georgtree (SpiceGenTcl, tclopt, tclinterp) — ~275 files
 containing `oo::` / `snit::` / `itcl::`.
 
-## Baseline (before the VTA / field-typing work — Phase 2+)
+## Baseline (before any object-flow typing)
 
 | mode | receiver form | resolved | sites | rate |
 |---|---|--:|--:|--:|
@@ -38,7 +38,7 @@ containing `oo::` / `snit::` / `itcl::`.
    (cross-file class index, PR #799's "B") lifts the rate only 5.2% → 5.3%. So
    the receivers are overwhelmingly *not typed at all* — the class can't be
    pinned to the variable — rather than typed-but-unresolvable. This is exactly
-   the gap the VTA-style field + interprocedural typing (Phase 2/3) targets.
+   the gap VTA-style field and interprocedural typing targets.
 
 2. **`my` is the cleanest signal** (a `my` head is almost always a genuine
    object self-dispatch): 24.5% resolved. The unresolved majority is dominated
@@ -51,11 +51,11 @@ containing `oo::` / `snit::` / `itcl::`.
    — so their absolute *resolved counts* (15, 11) and the `my` rate are the
    meaningful signals to move, not the raw `$var`/`[cmd]` percentages.
 
-Target for Phase 2 (field/instance-variable typing + interprocedural summaries):
+Target for field/instance-variable typing plus interprocedural summaries:
 lift the absolute resolved counts materially — instance-variable receivers
 (`variable obj; … $obj m`) and param/return receivers are the reachable wins.
 
-## Phase 2 — VTA-lite object-flow (aliasing + constructor-param edges)
+## VTA-lite object-flow (aliasing + constructor-param edges)
 
 The interprocedural passes were consolidated into a single **VTA-lite fixpoint**
 (`object_types::propagate_object_flow`): a name-keyed, union-join
@@ -80,11 +80,11 @@ aliasing patterns they resolve are essentially **absent from this corpus**.
 The `tcloo_diag` experiment (`experiments/tcloo_diag`) explains why and redirects
 the work: the unresolved mass is **snit** (`$self` 12.6% of the `$var` gap, plus
 `my…` components and `$hull`) and cross-file/Tk, not within-CU `TclOO` typing.
-Phase 2 is retained as sound, cheap, architecturally-correct groundwork (the
-design-doc Stage-3 propagation graph); **snit support (Phase 3) is the measured
-next lever**, not more within-CU edges.
+The edges are retained as sound, cheap, architecturally-correct groundwork
+(the design doc's propagation graph); **snit support is the measured next
+lever**, not more within-CU edges.
 
-## Phase 3 (first slice) — snit / itcl `$self` self-dispatch
+## snit / itcl `$self` self-dispatch
 
 Following the `tcloo_diag` finding, the highest-value lever landed next: inside a
 snit (`snit::type`/`widget`/`widgetadaptor`) or itcl (`itcl::class`) method body,
@@ -107,7 +107,7 @@ diagnostic: measuring *why* receivers were unresolved pointed straight at snit
 `$self` rather than at more `TclOO` VTA edges (which the same corpus proved
 inert).
 
-## Phase 3b — snit named-constructor typing (`set o [foo create x]`)
+## snit named-constructor typing (`set o [foo create x]`)
 
 The signature scan now records snit types (`snit::type`/`widget`/`widgetadaptor`)
 as classes — a pure-snit file contains neither "class" nor "oo::", so the cheap
@@ -124,13 +124,13 @@ A smaller lever than `$self` (the `foo create x` shape is less frequent than
 in-body self-dispatch in this corpus) but sound and free — it also flips the
 `snit_named_object` fixture to Resolve.
 
-## Phase 3c — snit `install NAME using TYPE` component typing
+## snit `install NAME using TYPE` component typing
 
 A snit component installed with `install NAME using TYPE …` types the component
-variable `NAME` as `TYPE`, so `$NAME method …` in the snit body resolves.  snit
-method bodies are **not** lowered into the compiler CFG (only token-walked, like
-the `$self` path), so this is a *source scan* (`augment_install_component_handles`)
-feeding the handle map — the same technique the loop-var scan uses.
+variable `NAME` as `TYPE`, so `$NAME method …` in the snit body resolves. The
+binding is registry data — the definer's `MemberBodyCommand.binds_handle`
+(`tcl_registry::handle_binding::HandleBindingSpec`) — read by the analyser's
+handle map, not a per-command branch in a consumer.
 
 | mode | after named-ctor | after install | Δ |
 |---|--:|--:|--:|
@@ -142,7 +142,7 @@ component classes are overwhelmingly defined in *other files* — exactly the
 cross-file shape the diagnostic predicted. Project mode (the shipping server
 mode) merges the workspace hierarchy, so the component's `TYPE` resolves.
 
-## Phase 3d — snit bare-word constructor (`set c [Type inst]`)
+## snit bare-word constructor (`set c [Type inst]`)
 
 snit creates an instance with `$type $name` (no `create` keyword), e.g.
 `set myparser [pt::rde ${selfns}::ENGINE]` — the dominant component-binding shape

--- a/runtime/rust/README.md
+++ b/runtime/rust/README.md
@@ -1,47 +1,71 @@
-# `tcl-runtime` — Rust port of the Tcl WASM runtime
+# `tcl-runtime` — Rust Tcl runtime for the WASM target
 
-The Rust runtime (Track 1 of the runtime port):
-every allocation is balanced by a refcount-driven free, and the alloc/free
+The support library and interpreter fallback the compiler's WASM output links
+against: an ABI-faithful `Tcl_Obj` value model, a parser and substitution
+engine, an eval loop with frames and namespaces, and the builtin command set.
+Every allocation is balanced by a refcount-driven free, and the alloc/free
 counters prove it.
 
-## What's landed (T1.1)
+## Layout
 
-- **`obj`** — the `#[repr(C)]` `TclObj` value model, ABI-faithful to
-  [`c-extension-abi.md`](../../docs/design/runtime/c-extension-abi.md) §4.2
-  (extensions dereference `objPtr->refCount`/`->bytes` directly). `fresh_zero`
-  constructors (refCount 0, per
-  [`c-api-ownership-contract.md`](../../docs/design/runtime/c-api-ownership-contract.md)),
-  immediate refcount-driven free (`TclFreeObj`), on-demand int→string shimmer.
-- **`interp`** — a minimal result-only `Interp` exercising the
-  `Tcl_SetObjResult`/`Tcl_GetObjResult` ownership handshake.
-- **`counters`** — leak-check instrumentation (`tcl_test_*`); see
-  `memory-management.md` MM-C.
-- **`capi`** — the `#[no_mangle] extern "C"` C-API exports for the above.
+| Area | Modules |
+|---|---|
+| Value model | `obj`, `typed_value`, `value_ops`, `list`, `dict`, `bytearray`, `bignum` |
+| Front end | `parse`, `subst`, `expr` |
+| Execution | `interp`, `frame`, `namespace`, `vars`, `ensemble`, `builtins` |
+| Commands | `cmd_*` (one module per command family) |
+| Embedding | `capi`, `codegen_abi`, `codegen_native`, `host_wasm`, `mem_fs`, `embedded_stdlib` |
+| Instrumentation | `counters` (`tcl_test_*`, per `memory-management.md` MM-C) |
 
-## Not yet (later Track-1 chunks)
+The value model is ABI-faithful to
+[`c-extension-abi.md`](../../docs/design/runtime/c-extension-abi.md) §4.2 —
+extensions dereference `objPtr->refCount` / `->bytes` directly — with
+`fresh_zero` constructors (refCount 0, per
+[`c-api-ownership-contract.md`](../../docs/design/runtime/c-api-ownership-contract.md))
+and immediate refcount-driven free.
 
-Parse/subst (T1.2), eval loop + frames (T1.3), namespaces + command table
-(T1.4), builtins (T1.5), and the `tcl_*`/`obj_*` codegen-import re-exports + the
-wasm `memory`/table exports (T1.6). The codegen handle/tagged-immediate and
-inline-string optimisations (the 32-byte layout) layer on at T1.5/S6 over
-this ABI-faithful struct.
+Every command in `tcl-registry` needs backing here — a handler, an
+interpreter-fallback path, or an explicit not-required classification.
+`cargo xtask command-backing --check` cross-checks the two and writes
+[`wasm-command-backing.md`](../../docs/generated/wasm-command-backing.md).
+
+## Features and build gates
+
+- `wasm_stdlib` (off by default) embeds the Tcl 9 standard library and the
+  Tcl-level `tcltest` package and seeds them into the in-memory VFS, so a
+  self-contained `wasm32-wasip1` module bootstraps `source` / `package require`
+  with no host filesystem. See
+  [`vendor/tcl_library/`](vendor/tcl_library/README.md).
+- `have_tommath` is a `build.rs` cfg, not a Cargo feature: the bignum rung of
+  the numeric tower (and therefore `expr` and the math commands) compiles only
+  when a libtommath C source tree is found (`$TCL_TOMMATH_DIR`, else
+  `tmp/tcl9.0.4/libtommath`). `make runtime-rust-test-no-tommath` covers the
+  build without it.
+- On `wasm32-unknown-unknown` the native-only paths — coroutines (native stack
+  swap plus threads) and the libtommath tower — are cfg-disabled.
 
 ## Why it's outside the workspace
 
 This crate requires raw-pointer `unsafe` over one shared linear memory
 (`c-extension-abi.md` §9); the root workspace sets `unsafe_code = "forbid"`. It
-is therefore **excluded** from the workspace (`/Cargo.toml`), like
-`editors/zed`, and keeps its own lockfile and `target/`. This also keeps the
-LSP/compiler `cargo test --workspace` (run in CI) from regressing on
-runtime-port churn.
+is therefore listed in the root `Cargo.toml`'s `exclude`, like `editors/zed`,
+and keeps its own lockfile and `target/`. That also keeps the LSP/compiler
+`cargo test --workspace` from regressing on runtime churn.
 
 ## Build / test
 
 ```
-make runtime-rust-test     # cargo test  (the T1.1 leak round-trip gate)
-make runtime-rust-lint     # direct cargo fmt + locked clippy gate (also in check-rust / CI)
+make runtime-rust-test              # cargo test (leak round-trip + unit/parse/eval suite)
+make runtime-rust-test-no-tommath   # the same suite with libtommath absent
+make runtime-rust-lint              # cargo fmt --check + locked clippy -D warnings
 ```
 
-The acceptance gate is `round_trip_zero_residual`: `Tcl_NewObj` →
+Run a script directly with the `run_script` dev-tool example:
+
+```
+cd runtime/rust && cargo build --release --example run_script
+```
+
+The leak gate is `round_trip_zero_residual`: `Tcl_NewObj` →
 `Tcl_IncrRefCount` → `Tcl_SetObjResult` → `Tcl_DecrRefCount` → interp teardown
 leaves **zero residual** under the counters.

--- a/runtime/rust/experiments/README.md
+++ b/runtime/rust/experiments/README.md
@@ -4,16 +4,17 @@ Per the porting method — when a value type has a real crossover question,
 **measure candidates compiled to WASM under `wasmtime`** (the real target —
 constant factors differ from the host) before committing to a representation.
 
-These programs are **throwaway** (like the spikes). The *decision* is recorded in
-the tracking doc's **Experiment log** and in the relevant module's
-representation-decision doc comment; the code here is reproducible evidence.
+These programs are **throwaway**. The decision each one settled is recorded in
+the module that implements it (`dict.rs`, `cmd_string.rs` / `obj.rs`,
+`bignum.rs`); the code here is the reproducible evidence behind it.
 
-Each file answers one question (stated in its header).
+Each file answers one question, stated in its header.
 
 | Experiment | Question | Decision |
 |---|---|---|
 | `dict_rep.rs` | Which structure for the insertion-ordered dict? | ordered `Vec` + FNV-hash index (EXP-DICT) |
 | `string_rep.rs` | Char-access + append without an O(n²) cliff? | ASCII fast path + lazy char-offset index; capacity-backed append (EXP-STRING) |
+| `bignum/` | Which bignum representation, and does libtommath build for wasm32? | libtommath `mp_int` with `-DMP_64BIT` on wasm32 (EXP-BIGNUM); see its own README |
 
 Run an experiment:
 

--- a/runtime/rust/experiments/bignum/README.md
+++ b/runtime/rust/experiments/bignum/README.md
@@ -1,13 +1,13 @@
 # EXP-BIGNUM — the numeric tower's bignum representation (evidence)
 
 Throwaway probes for the bignum-rep decision (EXP-BIGNUM). Run against the
-reference libtommath bundled in `tmp/tcl9.0.3/libtommath` with its Tcl wrapper
-header `tmp/tcl9.0.3/generic/tclTomMath.h`.
+reference libtommath bundled in `tmp/tcl9.0.4/libtommath` with its Tcl wrapper
+header `tmp/tcl9.0.4/generic/tclTomMath.h`.
 
 ## `lt_layout.c` — the `mp_int` ABI layout across targets
 
 ```sh
-cd tmp/tcl9.0.3
+cd tmp/tcl9.0.4
 # native (defaults to MP_64BIT on a 64-bit host)
 clang -Igeneric -Ilibtommath runtime/.../lt_layout.c -o /tmp/lt_n && /tmp/lt_n
 # wasm32 default (libtommath picks MP_32BIT off the 32-bit pointer)
@@ -44,7 +44,7 @@ Tcl's bundled libtommath is wired into Tcl's stubs (`tclTomMath.h` renames every
 file's `BN_*_C` guard):
 
 ```sh
-cd tmp/tcl9.0.3
+cd tmp/tcl9.0.4
 SRCS=$(ls libtommath/*.c | grep -vE 'bn_deprecated|rand|prime')   # 139 files
 # native (defaults to MP_64BIT) — `mp_*` symbols, no stubs:
 clang -DTCL_WITH_EXTERNAL_TOMMATH -DLTM_ALL -Ilibtommath lt_arith.c $SRCS -o a && ./a

--- a/rust/bigip-report-gen/python/README.md
+++ b/rust/bigip-report-gen/python/README.md
@@ -6,7 +6,7 @@ interactive HTML report: virtual servers, pools and members, nodes, monitors,
 iRules, data groups and SSL profiles, plus a **reference/orphan analysis** that
 flags every object nothing points at.
 
-It also embeds four interactive views, all client-side in the one HTML file:
+It also embeds three interactive views, all client-side in the one HTML file:
 
 - **Topology** — a Mermaid object graph (vendored Mermaid, inlined). Every
   object is clickable → a detail drawer with its neighbourhood diagram; for a
@@ -47,8 +47,10 @@ parser in Python.
 | `src/lib.rs` | The PyO3 extension module `f5report._engine`: `query()`, `load_paths()`, `ucs_to_scf()`, `sys_file_ssl_certs()` / `sys_file_ssl_keys()` (cert inventory), `decrypt_secrets()` (`f5mku` master-key secret decryption). Converts engine `Value`s to native Python objects (no JSON round-trip). |
 | `python/f5report/report.py` | Runs the engine queries and shapes the report model, incl. the `referenced_by` graph → orphan detection. |
 | `python/f5report/certs.py` | The SSL-certificate + private-key expiry inventory (answers "which certs are expiring, and what do they front?"). |
-| `python/f5report/render.py` + `templates/` | MiniJinja rendering to one standalone HTML file (embedded CSS/JS, no external assets). |
+| `python/f5report/graph.py` | The object graph, listener fields, and iRule dynamic actions the topology view renders. |
+| `python/f5report/render.py` + `python/f5report/templates/` | MiniJinja rendering to one standalone HTML file (embedded CSS/JS, no external assets). |
 | `python/f5report/__main__.py` | The `f5-report` CLI (`--f5mku` / `--f5mku-file` reveal `$M$` secrets). |
+| `python/f5report/web.py` | A stdlib-only local report server, for browsing a generated report without a static host. |
 | `tests/` | pytest suite + real-world config fixtures (see `tests/data/PROVENANCE.md`). |
 
 > This Python package is deliberately kept as the demonstration of using the
@@ -72,7 +74,7 @@ python -m venv .venv && . .venv/bin/activate
 pip install maturin
 cd rust/bigip-report-gen/python
 maturin develop          # builds _engine and installs f5report editable
-pytest tests/            # 20 tests
+pytest tests/
 ```
 
 ## Using it

--- a/rust/bigip-report-gen/python/deploy/README.md
+++ b/rust/bigip-report-gen/python/deploy/README.md
@@ -4,24 +4,19 @@
 interactive report from the committed sample UCS fixtures and publishes it to
 GitHub Pages — a stable URL that always reflects the latest code.
 
-It lives here (not under `.github/workflows/`) because installing a workflow
-needs credentials carrying the GitHub `workflow` scope, which automated pushes
-have not always had. **This copy is canonical**; `.github/workflows/github-pages.yml`
-is installed from it and the two are kept byte-identical.
+It lives here rather than under `.github/workflows/` because installing a
+workflow needs credentials carrying the GitHub `workflow` scope, which an
+automated push may not have. **This copy is canonical**;
+`.github/workflows/github-pages.yml` is installed from it and the two are kept
+byte-identical.
 
-> **Already installed in this repo.** Both workflows are live under
-> `.github/workflows/`. Edit the canonical copy here, then reinstall with
-> `cargo xtask workflow-sync` — never hand-edit only one side. `make
-> xtask-workflow-sync` (part of `make check-all`) fails the build if they
-> diverge.
->
-> Do not blind-`cp` a canonical file over an installed one you have not
-> compared first. Fixes have landed directly in `.github/workflows/` before —
-> reinstalling over them silently reverted the release-version stamping and
-> would have dropped a whole app from the Pages deploy. The sync gate exists
-> because that happened twice.
+Both workflows are already live under `.github/workflows/`. Edit the canonical
+copy here, then reinstall with `cargo xtask workflow-sync` — never hand-edit
+only one side, and never `cp` a canonical file over an installed one you have
+not diffed first. `make xtask-workflow-sync` (part of `make check-all`) fails
+the build if they diverge.
 
-## One-time setup (new repo)
+## Setting it up in a new repo
 
 1. **Add the workflow** — copy it into place and commit (from a clone with
    workflow permission):
@@ -50,11 +45,11 @@ The report is then served at `https://<owner>.github.io/<repo>/`.
   `/spec-studio/`, with a root landing page linking all four. Adding another app
   means extending this workflow — a second Pages workflow would clobber it
   (they share the `pages` concurrency group / `github-pages` environment, so the
-  most recent run wins). The old manual-only `pages.yml` it superseded is gone.
+  most recent run wins).
 - **Environment branch policy.** The `github-pages` environment may restrict
-  deployments to the default branch. Once this branch is merged to `rust`, the
-  push trigger deploys automatically; to deploy from a feature branch first,
-  allow it under Settings → Environments → github-pages.
+  deployments to the default branch. The push trigger deploys from `rust`
+  automatically; to deploy from a feature branch, allow it under Settings →
+  Environments → github-pages.
 - **No wasm toolchain needed.** The Mermaid library and the wasm query engine
   are vendored in the repo, so CI only builds the PyO3 extension (Rust + Python
   + maturin). The extension targets the CPython stable ABI (`abi3`, 3.9 floor),

--- a/rust/bigip-report-gen/rust/README.md
+++ b/rust/bigip-report-gen/rust/README.md
@@ -1,4 +1,4 @@
-# tcl-bigip-report — the BIG-IP report generator (Rust)
+# bigip-report-gen-rust — the BIG-IP report generator (Rust)
 
 The Rust port of the [`f5report`](../python) generator: given one or more
 loaded `(uri, scf_text)` configs it produces a single, self-contained,
@@ -29,12 +29,14 @@ via [`bigip-report-wasm`](../wasm).
 | `src/model.rs` | port of `f5report.report` — the per-object shaping + orphan/insight passes. |
 | `src/graph.rs` | port of `f5report.graph` — the object graph, listener fields, iRule dynamic actions. |
 | `src/certs.rs` | the SSL-certificate + private-key inventory (read from the parsed model, since the DSL only projects `ltm`). |
-| `src/apm.rs` | the APM access-profile walk — parses the `apm …` stanzas from the config text and emits a per-profile `{nodes, edges}` dependency-graph model (rendered client-side by the elkjs orthogonal renderer, `templates/elk-graph.js`) plus its linked-object list. |
-| `src/secrets.rs` | `f5mku` master-key secret decryption. |
-| `src/render.rs` + `templates/` | minijinja rendering to one HTML file (CSS/JS/Mermaid/wasm-console embedded). |
+| `src/apm.rs` | the APM access-profile walk — parses the `apm …` stanzas from the config text and emits a per-profile `{nodes, edges}` dependency-graph model (rendered client-side by the elkjs orthogonal renderer, `../frontend/src/pages/elk-graph.ts`) plus its linked-object list. |
+| `src/certs.rs`, `src/tls.rs` | the SSL-certificate / private-key inventory and TLS posture. |
+| `src/secrets.rs`, `src/crypt.rs` | `f5mku` master-key secret decryption. |
+| `src/forensics.rs`, `src/security.rs`, `src/lifecycle.rs`, `src/services.rs` | the UCS forensic inventory, security findings, release-lifecycle facts, and the service catalogue. |
+| `src/render.rs` + `../templates/report.html.j2` | minijinja rendering to one HTML file (CSS/JS/Mermaid/wasm-console embedded from `../frontend/` and `../assets/`). |
 
 The CSS/JS/Mermaid and the vendored WASM query-console assets are the same
-artifacts the Python `f5report` package ships, embedded at compile time so both
+artefacts the Python `f5report` package ships, embedded at compile time so both
 generators emit the same page. The two are validated against the **same UCS
 fixtures** (`tests/report.rs`).
 

--- a/rust/bigip-report-gen/wasm/README.md
+++ b/rust/bigip-report-gen/wasm/README.md
@@ -39,6 +39,7 @@ engine as a **library** (PyO3), while this crate is the same generator
 | `decrypt_secrets(scf, master_key)` | decrypt `$M$…` secrets with the base64 `f5mku -K` key. |
 | `generate_report(sources_json, cert_files_json, files_json, title, generated_at, embed_console, architecture_manifest, report_id)` | ordered `[[uri, scf], …]` + extras → standalone HTML report. |
 | `build_architecture(devices_json, manifest)` | re-run architecture/topology detection for the builder's GUI editor → `architecture` JSON. |
+| `manual(topic)` | the full `f5-query` manual text, for the report's reference panel. |
 | `engine_version()` | the report engine version string. |
 
 The page (styles + upload controller) is the shared builder front-end
@@ -48,7 +49,7 @@ generator wasm behind it.
 ## Building
 
 Requires the `wasm32-unknown-unknown` target, `wasm-bindgen-cli` (matching the
-pinned `wasm-bindgen` crate version), `wasm-opt` (binaryen) and `python3`:
+pinned `wasm-bindgen` crate version), and `python3`:
 
 ```bash
 bash build-wasm.sh          # → dist/index.html (WASM + glue inlined, one file)
@@ -59,11 +60,11 @@ just open it from disk. `target/` and `dist/` are build outputs (gitignored);
 CI (the `github-pages` workflow) builds and publishes it to
 `/bigip-report-generator/`.
 
-> Note: `build-wasm.sh` deliberately skips `wasm-opt`. On modern rustc layouts
-> binaryen rebinds the `__wbindgen_externrefs` export onto the fixed-size
-> funcref table, which makes `Table.grow` fail at runtime and the page never
-> initialises; the raw wasm-bindgen output is correct and, gzipped, within ~1%
-> of the optimised size.
+> `wasm-opt` is deliberately not run: on modern rustc layouts binaryen rebinds
+> the `__wbindgen_externrefs` export onto the fixed-size funcref table, which
+> makes `Table.grow` fail at runtime and the page never initialises. The raw
+> wasm-bindgen output is correct and, gzipped, within ~1% of the optimised
+> size.
 
 This crate is **excluded from the Cargo workspace** (like `bigip-query-wasm`):
 wasm-bindgen's generated glue needs `unsafe`, which the workspace

--- a/rust/tcl-f5mku/README.md
+++ b/rust/tcl-f5mku/README.md
@@ -23,5 +23,5 @@ false` — for a decrypt-only, entropy-free build).
 
 Shared by the `f5 encrypt-secrets` / `decrypt-secrets` CLI verbs
 ([`f5-cli`](../f5-cli)) and the in-browser BIG-IP report generator
-([`tcl-bigip-report`](../bigip-report-gen/rust) / [`bigip-report-wasm`](../bigip-report-gen/wasm)),
+([`bigip-report-gen-rust`](../bigip-report-gen/rust) / [`bigip-report-wasm`](../bigip-report-gen/wasm)),
 which uses it to reveal encrypted secrets in a report.

--- a/samples/bpf-tcl/README.md
+++ b/samples/bpf-tcl/README.md
@@ -2,12 +2,13 @@
 
 These demos exercise the backend targets that exist today. The default `rbpf`
 target executes real eBPF instructions over synthetic packet bytes in a
-userspace virtual machine. The explicit `kernel-xdp` (`struct xdp_md`) and
-`kernel-socket` (`struct __sk_buff`) targets emit Linux-loadable objects with
-real context access, verifier-safe packet bounds proofs, and BTF-defined maps
-with relocations (issue #1203). The map-free verdict-only XDP demo below is
-verifier-loaded and test-run end to end; the packet-access and map objects are
-validated structurally here and load on a real kernel behind the `#[ignore]`d
+userspace virtual machine. The explicit `kernel-xdp` (`struct xdp_md`),
+`kernel-socket` (`struct __sk_buff`), `kernel-tc`, and
+`kernel-cgroup-sockaddr` targets emit Linux-loadable objects with real context
+access, verifier-safe packet bounds proofs, and BTF-defined maps with
+relocations. The verdict-only XDP demo below is verifier-loaded and test-run
+end to end; the packet-access and map objects are validated structurally here
+and load on a real kernel behind the `#[ignore]`d
 `rust/bpf-tcl/tests/kernel_load.rs` gate.
 
 The clean-room instructions and full script were validated on Ubuntu 26.04
@@ -17,7 +18,7 @@ The demos do **not** attach programs to a network interface or socket. Default
 ELF output uses the simulator context ABI and is for inspection only; pass an
 object to `bpftool prog load` only when it was compiled with `--target
 kernel-xdp`. See the
-[backend architecture and roadmap](../../docs/design/compiler/ebpf-backend.md).
+[backend architecture](../../docs/design/compiler/ebpf-backend.md).
 
 ## Install prerequisites on Debian or Ubuntu
 
@@ -126,12 +127,13 @@ target/debug/bpf-tcl run samples/bpf-tcl/map-counter.bpftcl \
 
 The final output includes `map hits: 0=3`.
 
-## Run the first real kernel XDP program
+## Load a kernel XDP program
 
-The explicit `kernel-xdp` target currently supports map-free, verdict-only XDP
-handlers. It rejects packet/context access and maps until their verifier-proof
-and relocation lowering is implemented. This gives the project a small but
-genuine kernel-loaded vertical slice without silently emitting unsafe code.
+`run-kernel-xdp-demo.sh` takes the verdict-only `xdp-kernel-pass.bpftcl`
+through a real verifier load and test run. `xdp-kernel-portcount.bpftcl` is
+the map-and-packet-access counterpart: it emits a `.maps` section, a `.BTF`
+description, and `R_BPF_64_64` map-fd relocations, with a dominating
+`data_end` bounds proof on its 16-bit port read.
 
 Requirements:
 
@@ -162,7 +164,7 @@ not mounted, mount it once with:
 sudo mount -t bpf bpf /sys/fs/bpf
 ```
 
-## Handler composition and the loader plan (issue #1204)
+## Handler composition and the loader plan
 
 Multiple `when EVENT priority N { … }` handlers for one event compose into an
 ordered chain. Lower priority numbers run first; the first handler that returns a
@@ -224,9 +226,9 @@ llvm-objdump -d /tmp/bpf-tcl-xdp.o  # optional
 ```
 
 The ELF has an `EM_BPF` machine header, an `xdp` or `socket` program section, a
-GPL licence section, and a function symbol. The default target is still
-`rbpf`, so structural validity does not imply kernel loadability. Use
-`--target kernel-xdp` only with the currently supported verdict-only XDP subset.
+GPL licence section, and a function symbol. The default target is `rbpf`, so
+structural validity under it does not imply kernel loadability — pass an
+explicit `--target kernel-*` for an object you intend to load.
 
 ## Execute synthetic packets
 

--- a/samples/diagnostics/README.md
+++ b/samples/diagnostics/README.md
@@ -1,12 +1,11 @@
 # Diagnostic test samples
 
-Minimal reproducible examples for every diagnostic, warning, optimisation,
-and shimmer alert the LSP produces. Each example is self-contained and
-designed to be testable with tclsh 9.0 where applicable. Tk-based
-samples (e.g. W001) require Tk and a working display.
-
-These were initially collected by analysing all 60 `.tcl` files in
-[georgtree/SpiceGenTcl](https://github.com/georgtree/SpiceGenTcl).
+One minimal reproducible example per diagnostic, optimisation, or shimmer
+alert listed below — a representative slice of the full catalogue in
+[`docs/generated/diagnostic_codes.md`](../../docs/generated/diagnostic_codes.md),
+not one sample per code. Each example is self-contained and testable with
+tclsh 9.0 where applicable; Tk-based samples (e.g. W001) need Tk and a
+working display.
 
 ## Dialect considerations
 
@@ -20,9 +19,9 @@ directive on line 1:
 
 Available dialects: `tcl8.4`, `tcl8.5`, `tcl8.6` (default), `tcl9.0`,
 `tcl9.1`, `f5-irules`, `f5-iapps`, `f5-tmsh`, `f5-bigip`, `bpf`,
-`expect`, `spectcl`, `cadence-eda-tcl`, `intel-quartus-eda-tcl`,
-`mentor-eda-tcl`, `microchip-libero-eda-tcl`, `synopsys-eda-tcl`,
-`xilinx-eda-tcl`.
+`expect`, `spectcl`, `sslictcl`, `cadence-eda-tcl`,
+`intel-quartus-eda-tcl`, `mentor-eda-tcl`, `microchip-libero-eda-tcl`,
+`synopsys-eda-tcl`, `xilinx-eda-tcl`.
 
 Diagnostics affected by dialect are marked with a `[dialect]` tag below.
 
@@ -133,9 +132,8 @@ A variable is used before any assignment is visible in the current scope.
 
 **Validity:** mixed.
 - **True positive:** genuinely unset variable in a proc.
-- **False positive:** `lappend` auto-creates the variable (being fixed);
-  `$dir` in `pkgIndex.tcl` is set by the package system; variables set
-  by `upvar`/`uplevel` from a caller.
+- **False positive:** `$dir` in `pkgIndex.tcl` is set by the package
+  system; variables set by `upvar`/`uplevel` from a caller.
 
 ### W211 — Variable set but never used
 
@@ -178,15 +176,16 @@ with `-`:
 - **OFF:** value structurally cannot start with `-` (HTTP paths start
   with `/`, SPICE netlist lines start with `.`, simulation vector names
   like `v(node)`, argparse outputs from fixed sets like `{add get set}`).
-  Currently a false positive — 19 of 24 sites in SpiceGenTcl.
+  A false positive.
 - **POSSIBLE:** value comes from user input or an unconstrained source.
   Genuine warning — `--` should be inserted.
 - **ALWAYS:** value is constructed to start with `-` (e.g. `"-$name"`).
   `--` is mandatory.
 
-The LSP already downgrades to INFO when constant propagation proves the
-value is a static literal, but does not yet trace structural constraints
-like "starts with `/`" or "from a set that excludes `-` prefixes".
+The LSP downgrades to INFO when constant propagation proves the value is a
+static literal. It does not trace structural constraints like "starts with
+`/`" or "from a set that excludes `-` prefixes", so the OFF cases still
+warn.
 
 ### W306 — Literal expected in regexp pattern `[dialect]`
 
@@ -211,6 +210,16 @@ Deleting files using a variable path without validation could allow path
 traversal. The fix is `file normalize` plus a prefix check.
 
 **Validity:** true positive when the path comes from untrusted input.
+
+### W314 — Definition has no absolute name
+
+A proc or namespace whose name is all colons (e.g. a proc named `:`) is a
+real, callable definition, but no fully-qualified spelling reaches it —
+`:::` names the `{}` proc instead. Everything inside such a namespace is
+likewise reachable only relatively.
+
+**Validity:** true positive. Rename the definition to something with an
+absolute spelling.
 
 ## Optimisations
 
@@ -286,5 +295,6 @@ diagnostics/
 ├── W304_missing_double_dash/example.tcl
 ├── W306_regexp_substitution/example.tcl
 ├── W307_non_literal_command/example.tcl
-└── W313_file_delete_path/example.tcl
+├── W313_file_delete_path/example.tcl
+└── W314_no_absolute_name/example.tcl
 ```

--- a/samples/for_f5_query/sysadmin-queries.md
+++ b/samples/for_f5_query/sysadmin-queries.md
@@ -30,10 +30,17 @@ $ f5 query [flags] -f <script.f5q> [paths...]
 ```
 
 Frequently-used flags appear in the cheat sheet at the end.
+Every command below is written to run from this directory.
 
 The probe-based scenarios in [Section 8](#8-live-probes) need
 `--enable-probes` and reach the network. All other scenarios are
 offline-only.
+
+**Module coverage.** The query engine projects objects for the
+`ltm`, `gtm` and `security` modules. `net`, `sys`, `cm` and `apm`
+parse but expose no kinds, so `.net.self[]`, `.apm["access-policy"][]`
+and friends raise `no entry`. Scenarios that need them are marked
+**not currently runnable** below.
 
 ---
 
@@ -109,8 +116,7 @@ $ f5 query --raw '
     "pool,member,host,port,monitor",
     (.ltm.pool[] as $p
      | $p.members[]
-     | csv($p.name, .name, .address, port(.name),
-           join($p.monitor.monitors, ",")))
+     | csv($p.name, .name, .address, port(.name), $p.monitor))
   ' ltm.conf
 ```
 
@@ -123,25 +129,26 @@ api_pool,/Common/api2:8443,10.0.2.21,8443,/Common/https
 legacy_pool,/Common/legacy1:80,192.168.50.10,80,/Common/http
 ```
 
-The pool's `.monitor` is a *monitor expression* (it can carry
-the `min N of {...}` quorum form). `.monitor.monitors` is the
-list of monitor names inside; `join` collapses it to a single
-CSV-safe cell. `unused_pool` (zero members) does not contribute
-a row — `.members[]` on an empty list emits nothing.
+The pool's `.monitor` is the monitor string as written in the
+config, so it drops straight into a CSV cell. `unused_pool` (zero
+members) does not contribute a row — `.members[]` on an empty list
+emits nothing.
 
 ### 1.3 Every IP the box advertises
 
 **Question.** *"Give me one IP-address column that combines VSes,
 nodes, and self-IPs"* — generic CMDB / firewall-rule audit.
 
-**Query.** Three statements sharing one root, concatenated by `;`.
-`sort -u` outside the query collapses duplicates across them.
+**Query.** Two statements sharing one root, concatenated by `;`.
+`sort -u` outside the query collapses duplicates across them. A
+third `.net.self[] | .address` arm would complete the picture, but
+`net` exposes no kinds today, so self-IPs are **not currently
+runnable**.
 
 ```
 $ f5 query --raw '
     .ltm.virtual[] | host(.destination) ;
-    .ltm.node[]    | .address           ;
-    .net.self[]    | .address
+    .ltm.node[]    | .address
   ' ltm.conf | sort -u
 ```
 
@@ -264,7 +271,7 @@ profiles"][q16]* — common CSV deliverable for change reviews.
 ```
 $ f5 query --raw '
     .ltm.virtual[]
-    | tsv(.name, join(.profiles[]."full-path", ","))
+    | tsv(.name, join([.profiles[] | split(., " ")[0]], ","))
   ' ltm.conf
 ```
 
@@ -525,10 +532,11 @@ the ones a change will have to touch first."*
 ```
 $ f5 query --raw '
     .ltm.virtual[]
+    | [.profiles[] | split(., " ")[0]] as $profs
     | tsv(.name, .destination,
-          ([.profiles[]."full-path"] | count),
+          ([$profs[]] | count),
           ([.rules[]] | count),
-          ([.profiles[]."full-path"] | count) + ([.rules[]] | count))
+          ([$profs[]] | count) + ([.rules[]] | count))
   ' ltm.conf | sort -t$'\t' -k5 -rn
 ```
 
@@ -559,7 +567,7 @@ classic write-up.
 ```
 $ f5 query --raw '
     .ltm.pool[]
-    | join(.monitor.monitors, ",") as $mons
+    | .monitor as $mons
     | tsv(.name, $mons, ([.members[]] | count),
           (if startswith($mons, "/Common/http") then "L7"
            elif contains($mons, "icmp") then "L3-only"
@@ -750,6 +758,12 @@ The record `10.99.0.0/16` is the entry that would block
 
 ## 5. APM access policies
 
+> **Not currently runnable.** 5.1 and 5.2 read `.apm["access-policy"]`,
+> and the engine projects no `apm` kinds, so both raise
+> `apm: no entry 'access-policy'`. The fixture and the queries are kept
+> as the shape to restore once `apm` is projected; 5.3 works today
+> because it selects on the LTM side.
+
 ### 5.1 Summary of every access-policy
 
 **Query.** Auto-deref: `.start-item.caption` walks
@@ -805,7 +819,7 @@ the profile reference crosses files.
 ```
 $ f5 query --merge --raw '
     .ltm.virtual[]
-    | select(any(.profiles[]."full-path" == "/Common/employee_login_profile"))
+    | select(any([.profiles[] | split(., " ")[0]][] == "/Common/employee_login_profile"))
     | tsv(.name, .destination)
   ' ltm.conf apm.conf
 ```
@@ -826,9 +840,10 @@ contributes. Pipe through `grep -v '^#'` for a clean list.
 
 ```
 $ f5 query --raw '
-    .gtm.wideip[]
-    | tsv(.name, .pools[].name,
-          join(.pools[].members[], ","))
+    .gtm.wideip[] as $w
+    | $w.pools[] as $pp
+    | (.gtm.pool[] | select(."full-path" == str($pp))) as $gp
+    | tsv($w.name, $gp.name, join([$gp.members[].name], ","))
   ' gtm.conf
 ```
 
@@ -864,12 +879,13 @@ pool, all the way to the backend node:
 ```
 $ f5 query --name ltm=ltm.conf --name gtm=gtm.conf --merge --raw '
     $gtm.gtm.wideip[] as $w
-    | $w.pools[] as $gp
-    | $gp.members[]
-    | last(split(., ":")) as $vspath
-    | ($ltm.ltm.virtual[]
-       | select(."full-path" == $vspath)) as $vs
-    | $vs.pool.members[]
+    | $w.pools[] as $pp
+    | ($gtm.gtm.pool[] | select(."full-path" == str($pp))) as $gp
+    | $gp.members[].name as $m
+    | last(split($m, ":")) as $vspath
+    | ($ltm.ltm.virtual[] | select(."full-path" == $vspath)) as $vs
+    | ($ltm.ltm.pool[] | select(."full-path" == $vs.pool)) as $p
+    | $p.members[]
     | tsv($w.name, $gp.name, $vs.name, $vs.pool, .address, port(.name))
   ' ltm.conf gtm.conf | sort -u
 ```
@@ -911,6 +927,10 @@ that record? — is in [Section 8](#8-live-probes).
 **Question.** *"Which VS uses internet_snat, and what addresses
 will it source-NAT outbound traffic from?"*
 
+> **Not currently runnable.** `ltm snat-translation` is not one of the
+> projected `ltm` kinds, so the `.address` lookup raises
+> `ltm: no entry 'snat-translation'`.
+
 ```
 $ f5 query --raw '
     .ltm.snatpool[] as $sp
@@ -940,7 +960,7 @@ audit cert expiry on?"*
 ```
 $ f5 query --raw '
     .ltm.virtual[]
-    | [.profiles[]."full-path"] as $profs
+    | [.profiles[] | split(., " ")[0]] as $profs
     | select(any($profs[] | contains(., "clientssl")))
     | tsv(.name, .destination,
           join([$profs[] | select(contains(., "ssl"))], ","))
@@ -1112,6 +1132,7 @@ $ f5 query --raw --input-f5log lt=multitier/logs/t1-a.log '
 ```
 
 ```
+# === file:///home/user/tcl-lsp/samples/for_f5_query/multitier/tier1-ltm-ha.conf ===
 Mar 14 06:32:36	BOOT	Boot complete on t1-a.example.test
 Mar 14 07:40:19	CFG-LOAD	Configuration loaded from /config/bigip.conf successfully.
 ```
@@ -1370,8 +1391,8 @@ $ f5 query '
 ```
 
 ```diff
---- samples/for_f5_query/ltm.conf
-+++ samples/for_f5_query/ltm.conf (modified)
+--- ltm.conf
++++ ltm.conf (modified)
 @@ -125,6 +125,7 @@
          /Common/http { }
          /Common/tcp { }
@@ -1417,8 +1438,8 @@ $ f5 query '
 ```
 
 ```diff
---- samples/for_f5_query/ltm.conf
-+++ samples/for_f5_query/ltm.conf (modified)
+--- ltm.conf
++++ ltm.conf (modified)
 @@ -11,7 +11,7 @@
      address 10.0.2.21
  }
@@ -1461,8 +1482,8 @@ $ f5 query 'rename("/Common/web_pool", "/Common/web_primary_pool")' ltm.conf
 
 ```
 renamed '/Common/web_pool' -> '/Common/web_primary_pool' (4 occurrence(s))
---- samples/for_f5_query/ltm.conf
-+++ samples/for_f5_query/ltm.conf (modified)
+--- ltm.conf
++++ ltm.conf (modified)
 @@ -13,7 +13,7 @@
  ltm node /Common/legacy1 {
      address 192.168.50.10
@@ -1525,6 +1546,10 @@ self` objects, plus a pool member on `127.0.0.1` and an iRule
 that does `node 127.0.0.1 8080`.
 
 ### 10.1 `net self` allow-service audit
+
+> **Not currently runnable.** The engine projects no `net` kinds, so
+> `.net.self[]` raises `net: no entry 'self'`. 10.2 and 10.3 below work
+> today.
 
 **Rule.** F5 best practice (KB **K17333**, "BIG-IP best practice
 for self IP allow services") is `allow-service none` on

--- a/samples/for_f5_query/sysadmin/inventory_csv.f5q
+++ b/samples/for_f5_query/sysadmin/inventory_csv.f5q
@@ -21,5 +21,4 @@
 (.ltm.pool[] as $p
  | $p.members[]
  | csv("pool member", $p.name, "", "", "",
-       $p.name, .name, .address, port(.name),
-       join($p.monitor.monitors, ",")))
+       $p.name, .name, .address, port(.name), $p.monitor))

--- a/samples/optimiser/README.md
+++ b/samples/optimiser/README.md
@@ -86,8 +86,7 @@ Adds dead-code elimination, code motion, and recursion transforms:
 - Loop-invariant code hoisted
 - Single-use variables inlined
 
-This profile changes the shape and length of the code. It was the previous
-default for all surfaces.
+This profile changes the shape and length of the code.
 
 ### `aggressive`
 
@@ -167,18 +166,13 @@ module for a single unresolved head. Recorded as part of #1962.
 2. **Editor default is `readability`** — 6 non-intrusive hints with no code
    deletion. Users who want more can change to `standard` or `full` in settings.
 
-3. **`aggressive` is a separate profile** — not a `--multi-pass` flag. Keeps
-   the UI simple (single dropdown) and avoids edge cases like multi-pass
-   readability (which would be pointless).
+3. **`aggressive` is a separate profile**, not a `--multi-pass` flag — one
+   dropdown, and no multi-pass readability (which would be pointless).
 
-4. **Descriptive profile names** — `off`/`readability`/`standard`/`full`/
-   `aggressive`. Self-documenting; no compiler background needed.
+4. **Profiles resolve to `disabled_optimisations` sets**, so every consumer
+   keeps using per-code filtering. A profile is a configuration-layer concept.
 
-5. **Profiles resolve to `disabled_optimisations` sets** — all internal
-   plumbing continues using the existing per-code filtering mechanism.
-   Profiles are a configuration-layer concept.
-
-6. **Individual O1xx toggles override profiles** — three-state logic
+5. **Individual O1xx toggles override profiles** — three-state logic
    (`null`/`true`/`false`). `null` means "inherit from profile".
 
 ## Regenerating samples
@@ -190,7 +184,6 @@ for p in readability standard full aggressive; do
 done
 ```
 
-The committed outputs are exactly what that loop produces, and
-`samples_optimiser_profiles_are_regenerated` in `rust/tcl-cli` fails if they
-drift — which is how they came to document the retired Python optimiser for as
-long as they did (issue #1789).
+The committed outputs are exactly what that loop produces;
+`samples_optimiser_profiles_are_regenerated` in `rust/tcl-cli/tests/cli.rs`
+fails if they drift.

--- a/samples/tcl9_smoke/README.md
+++ b/samples/tcl9_smoke/README.md
@@ -13,8 +13,7 @@ The pair serves two purposes:
 2. **Architectural signal** — the corpus is organised by
    primitive (one directory per concern), so which primitives
    drift after a compiler change is immediately visible from the
-   test report.  Complements the `tcl9-triage` table, which
-   groups by tcltest file rather than by primitive.
+   test report.
 
 ## Layout
 

--- a/samples/wasm/README.md
+++ b/samples/wasm/README.md
@@ -9,9 +9,9 @@ WASM module against C Tcl byte for byte.
 The tiers are ordered by how much interpreter machinery a *correct* compile
 needs. A script in tier N is expected to compile with no more framing than
 tier N introduces; anything the compiler still routes through
-`tcl_eval_code` for a lower tier is a gap the plan in
-[`docs/design/compiler/wasm-native-lowering-plan.md`](../../docs/design/compiler/wasm-native-lowering-plan.md)
-tracks.
+`tcl_eval_code` for a lower tier is a gap, and `budgets.tsv` records exactly
+how much framing each sample still costs. The lowering contract itself is
+[`docs/design/compiler/wasm-native-lowering-plan.md`](../../docs/design/compiler/wasm-native-lowering-plan.md).
 
 | Tier | Directory | Framing a correct compile needs |
 |---|---|---|
@@ -28,20 +28,28 @@ tracks.
 
 ```
 for f in samples/wasm/t*/*.tcl; do
-  d=$(dirname "$f"); b=$(basename "$f" .tcl)
-  tclsh9.0 "$f" > "samples/wasm/expected/$d/$b.out" 2>&1
+  tier=$(basename "$(dirname "$f")"); b=$(basename "$f" .tcl)
+  tclsh9.0 "$f" > "samples/wasm/expected/$tier/$b.out" 2>&1
 done
 ```
 
 ## Measuring what the compiler emits today
+
+`budgets.tsv` is the committed golden: one row per sample per compilation
+plan, counting the framing imports the emitted module still calls
+(`tcl_eval_code` — source re-parsed at run time, `tcl_invoke_argv` — compiled
+words with runtime dispatch, and the rest). `rust/tcl-compiler/tests/wasm_tiers.rs`
+gates it and the oracle comparison together:
+
+```
+cargo test -p tcl-compiler --test wasm_tiers
+UPDATE_WASM_BUDGETS=1 cargo test -p tcl-compiler --test wasm_tiers framing_budgets
+```
+
+To read one script's module by hand:
 
 ```
 cargo build -p tcl-compiler --example emit_wasm
 target/debug/examples/emit_wasm --wat            script.tcl out.wasm   # default plan
 target/debug/examples/emit_wasm --wat --analysis script.tcl out.wasm   # opt-in analysis tier
 ```
-
-Count `call <import>` sites in the `.wat` to see how much of the script is
-still `tcl_eval_code` (source re-parsed at run time), `tcl_invoke_argv`
-(compiled words, runtime dispatch), or native instructions. The plan document
-carries the baseline table for every script here.

--- a/scripts/dev/bigip-probes/README.md
+++ b/scripts/dev/bigip-probes/README.md
@@ -104,11 +104,15 @@ so runtime event creation is impossible.
 `dynlab.conf` needs a virtual server and a client; see the traffic-lab notes
 above.
 
-## Cleanup contract
+## Cleanup
 
-Every object a probe creates carries the `__tcl_lsp_probe_*` prefix, with a
-collision check before each create, an `EXIT` trap, and an absence proof after
-each delete. `save sys config` is never run, so nothing a probe leaves behind
-survives a reboot. `lib/e4-context-probe.sh` and `irules/f3-matrix/`
-implement the contract; the measurements doc's methodology section states it
-in full.
+`lib/e4-context-probe.sh` and `irules/f3-matrix/` implement the cleanup
+contract: every object they create carries the `__tcl_lsp_probe_*` prefix,
+with a collision check before each create, an `EXIT` trap, and an absence
+proof after each delete. The other suites do not. `lib/runner.sh` merges a
+`probe_<id>` rule without checking that the name is free and deletes it
+unconditionally, and the traffic-lab fixtures create `lab_*` rules, pools, and
+virtuals with no trap, so run those only on an appliance where no object of
+those names exists and verify it is clean afterwards. No suite runs
+`save sys config`, so nothing a probe leaves behind survives a reboot. The
+measurements doc's methodology section states the contract in full.

--- a/scripts/dev/bigip-probes/README.md
+++ b/scripts/dev/bigip-probes/README.md
@@ -1,13 +1,10 @@
 # BIG-IP parser probes
 
 The iRules, drivers, controls and raw transcripts behind
-[`docs/design/bigip-irule-parser-measurements.md`](../../../docs/design/bigip-irule-parser-measurements.md),
-which supplies the live evidence that
-[`dialect-and-package-registry-redesign-bigip-evidence-review.md`](../../../docs/design/dialect-and-package-registry-redesign-bigip-evidence-review.md)
-§E3 was waiting on.
+[`docs/design/bigip-irule-parser-measurements.md`](../../../docs/design/bigip-irule-parser-measurements.md).
 
-Everything here is third-party-free, appliance-specific, and disposable. Nothing
-is a build input; nothing runs in CI.
+Everything here is appliance-specific and disposable. Nothing is a build
+input; nothing runs in CI.
 
 ## Layout
 
@@ -16,12 +13,12 @@ is a build input; nothing runs in CI.
 | `suites/*.probes` | Probe definitions: `@@ id \| WRAP\|RAW \| description` followed by a body. `WRAP` wraps the body in `when HTTP_REQUEST` (compiled, never executed); `RAW` is the whole rule. |
 | `suites/*.snippets` | Tab-separated `id<TAB>snippet` for word-formation probes; each becomes a `RULE_INIT` rule that logs `llength` and the value. |
 | `suites/09-tcl85-features.tcl` | The 25 Tcl 8.5-feature cases, shared verbatim between the tclsh controls, a `cli script`, and an iApp implementation. |
-| `irules/**/*.conf` | Materialised iRules, one per probe — 378 of them. Loadable directly with `tmsh load sys config merge file`. |
+| `irules/**/*.conf` | Materialised iRules, one per probe. Loadable directly with `tmsh load sys config merge file`. |
 | `lib/runner.sh` | Merge → classify (`ACCEPT` / `WARN` / `REJECT`) → delete driver for a `.probes` suite. |
 | `lib/wsrun.sh` | Same for word-formation suites, additionally scraping the logged word list. |
 | `lib/materialise.sh` | Expands a `.probes` suite into `.conf` iRules locally, using the same rules as `runner.sh`. |
 | `lib/gen-runtime-semantics.sh` | Emits the `RULE_INIT` rules that verify N-rule semantics by execution rather than compile acceptance. |
-| `suites/10-context-parity.cases` | The single 34-case list behind the four-context parity probe. One source, four wrappers, so any transcript difference is a real context difference. |
+| `suites/*.cases`, `suites/*.commands`, `suites/*.list` | Case lists a generator compiles into probes: `10-context-parity.cases` is the single source behind the four-context parity probe (one list, four wrappers, so any transcript difference is a real context difference); `11-proc-semantics.cases`, `07-event-context.commands` and `08-stock-84-builtins.list` feed their own drivers. |
 | `lib/gen-context-parity.py` | Compiles that case list into an iRule, a `cli script`, an iApp template+service, and a `tclsh` script. |
 | `lib/e4-context-probe.sh` | Runs all four contexts on the appliance under the §E4 contract: absence check before every create, `EXIT` trap, absence proof after every delete, virtual-server attachment check, APL recorded as `Unknown`, never `save sys config`. |
 | `lib/tclcheck.tcl` | Stock-Tcl acceptance checker. Stubs only iRule-specific commands. |
@@ -107,13 +104,11 @@ so runtime event creation is impossible.
 `dynlab.conf` needs a virtual server and a client; see the traffic-lab notes
 above.
 
-## Cleanup
+## Cleanup contract
 
-The 2026-08-26 run used `probe_*` / `lab_*` prefixes and was verified clean
-afterwards (no residual rules, virtuals, pools, or `/var/tmp` files), but it did
-**not** implement the §E4 contract — no `__tcl_lsp_probe_*` prefix, no per-create
-absence check, no `EXIT` trap, and the traffic lab deliberately attached rules to
-virtual servers. `irules/f3-matrix/` is the exception: it uses the
-`__tcl_lsp_probe_*` prefix with a collision check before every create and an
-absence proof after every delete. `save sys config` was never run in any part of
-the run. See the measurements doc's methodology section for the full delta.
+Every object a probe creates carries the `__tcl_lsp_probe_*` prefix, with a
+collision check before each create, an `EXIT` trap, and an absence proof after
+each delete. `save sys config` is never run, so nothing a probe leaves behind
+survives a reboot. `lib/e4-context-probe.sh` and `irules/f3-matrix/`
+implement the contract; the measurements doc's methodology section states it
+in full.

--- a/scripts/eglot_test/README.md
+++ b/scripts/eglot_test/README.md
@@ -30,9 +30,6 @@ The server can't fix eglot's painter, but it *shrinks the stale window*
 by implementing proper `semanticTokens/full/delta`: a keystroke sends
 only the changed tokens (like rust-analyzer), not the whole document.
 This harness verifies that delta path end-to-end through real eglot.
-(An earlier experiment added an "eglot-compatibility mode" that dropped
-`full/delta`/`range`; the data showed it made no difference to the
-accumulation, so it was removed in favour of the deltas.)
 
 ## 1. `tcl-lsp-record-bug.el` — bug recorder for end-users
 
@@ -151,9 +148,15 @@ that passes, any staleness this eglot harness shows is provably eglot's.
 
 ## 3. Diagnostic experiments (manual, non-CI)
 
-Three standalone scripts used to characterise issue #333. They load the
-harness helpers via `TCL_LSP_T333_NOEXEC=1` and print/write their own
-report. None run in CI.
+Standalone scripts that characterise issue #333. They load the harness
+helpers via `TCL_LSP_T333_NOEXEC=1` and print/write their own report. None
+run in CI.
+
+`compare_full.el`, `experiment_333.el` and `repro_interactive.el` each run
+one arm with `tclLsp.compatibility.eglot` set. The server has no such
+setting, so that arm sends an ignored option and both arms now measure the
+same configuration; read them for the timing and accumulation figures, not
+for a compat-mode comparison.
 
 - **`compare_langs.el`** — drives eglot against several servers
   (`tcl-lsp`, `pyright`, `rust-analyzer`) on similar-sized (~6k line)
@@ -172,19 +175,29 @@ report. None run in CI.
   ```
 
 - **`experiment_333.el`** — on a ~6k line Tcl file, runs the same edit
-  sequence with eglot-compat OFF and ON, reporting connect→first-tokens
-  and per-edit update latency plus accumulated-face counts, then a
-  rapid edit/undo "stale window" stress. Batch has no redisplay, so it
-  reports timings and (usually) zero accumulation — the accumulation
-  itself only appears under a real GUI (see below).
+  sequence twice, reporting connect→first-tokens and per-edit update
+  latency plus accumulated-face counts, then a rapid edit/undo "stale
+  window" stress. Batch has no redisplay, so it reports timings and
+  (usually) zero accumulation — the accumulation itself only appears under
+  a real GUI (see below).
 
 - **`repro_interactive.el`** — the actual #333 reproducer. Needs a
   *real GUI Emacs* (batch never repaints; a software `xvfb` frame is too
-  slow). Runs the rapid edit/undo burst with compat OFF and ON under
-  real redisplay and self-classifies the outcome
-  (`PROVEN` / `PARTIAL` / `NO-DIFFERENCE` / `NOT-REPRODUCED`). Use this
-  to check, on your own machine, whether the compat mode actually
-  changes the accumulation. See its header for the invocation.
+  slow). Runs the rapid edit/undo burst under real redisplay and
+  self-classifies the outcome
+  (`PROVEN` / `PARTIAL` / `NO-DIFFERENCE` / `NOT-REPRODUCED`). See its
+  header for the invocation.
+
+- **`repro_batch.el`** — the same accumulation without redisplay: it drives
+  eglot's painter functions directly, so it is deterministic and fast.
+
+- **`compare_full.el`** — timing and accumulation across several servers and
+  input sizes in one batch run.
+
+- **`prove_fix.el`** — measures the worst per-character `eglot-semantic-*`
+  face stack under each candidate fix. This is what establishes that the
+  painter advice in [`editors/emacs/README.md`](../../editors/emacs/README.md)
+  is the one that works.
 
 ## 4. `exercise_recorder.el` — smoke-test for the recorder
 

--- a/scripts/explain_flow_test_harness/README.md
+++ b/scripts/explain_flow_test_harness/README.md
@@ -1,286 +1,130 @@
-# explain-flow test harness — data gathering for the flow explainer
+# explain-flow test lab — data gathering for the flow explainer
 
-End-to-end test lab for `f5 explain-flow` and (by extension) anyone who
-needs to capture *enough information* about a real BIG-IP flow that the
-flow explainer (CLI + MCP tool + Claude skill) can narrate what
-happened.  Use this harness either as a self-contained reproducer
-against a lab BIG-IP, or as a shopping list of the pieces you need to
-gather by hand from production:
+A lab BIG-IP configuration and TLS cert factory for `f5 explain-flow`, plus
+the recipe for gathering the same artefacts from production. Whichever route
+you take, the explainer wants four things:
 
 * the **bigip.conf / SCF** for every partition the flow touches;
-* a **pcap** that captures the packets the BIG-IP saw, including the
-  F5 Ethernet trailer so per-packet peer-IP and reset-cause info is
-  preserved;
-* a **TLS keylog file** (`SSLKEYLOGFILE` from curl, openssl, the
-  client's browser, or BIG-IP's TLS keylog provider) so HTTPS
-  payloads are decryptable;
-* enough **server-side context** that the captured response side
-  can be matched against what the origin actually did.
+* a **pcap** the BIG-IP itself captured, with the F5 Ethernet trailer so
+  per-packet peer IP and reset cause survive;
+* a **TLS keylog file** (`SSLKEYLOGFILE` from curl, openssl, or the browser;
+  or BIG-IP's own keylog provider) so HTTPS payloads decrypt;
+* enough **server-side context** to match the captured response against what
+  the origin actually did.
 
-The harness automates all four of those.
-
-## Data the explainer needs (and where each piece comes from)
-
-| Data piece | Source | How the harness gathers it |
-|------------|--------|----------------------------|
-| BIG-IP configuration (VS, profiles, iRules, pools, LTM policies) | `bigip.conf` / SCF | `tmsh save sys config file=…` (full export) or `tmsh load sys config merge file=… verify` of `bigip_test_lab.scf` for the lab |
-| Per-packet wire data + F5 trailer | `tcpdump` on the BIG-IP, with `:nnnp` so the host-side trailer (peer IP, reset cause TLVs, optional TLS keylog provider data) is included | `run_tests.py` SSHes in and runs `tcpdump -i 0.0:nnnp -s 0 -w …` per scenario |
-| TLS master secrets / pre-master keys | NSS keylog format (`SSLKEYLOGFILE` env var on the client; or `db tmm.tls.keylogger.enabled true` on TMOS 16+) | `run_tests.py` exports `SSLKEYLOGFILE=<out>/sslkeys.log` for every curl invocation that needs decryption |
-| Server-side request/response | The origin's access log + a side-by-side pcap on the backend | `test_server.py` logs every request to stdout; deploy on the pool member or run with `--server-here` so the same host does both |
-| iRule source | Already inside the SCF | Captured automatically when the SCF is loaded |
-| Reset cause text | F5 Ethernet trailer LOW/MED TLVs — only present in `:nnnp` captures from BIG-IP | Same `tcpdump` invocation as above |
-
-If any of those pieces is missing the explainer falls back gracefully
-(e.g. a pcap without keylogs still gives 5-tuple + TLS handshake
-metadata + reset analysis), but the richer the input, the richer the
-narrative.
-
-## What this lab adds on top of a raw capture
-
-This harness is *more* than a capture grabber: it deliberately
-exercises specific iRule / TLS / pool / policy code paths so you have
-known-good ground truth to compare the explainer's output against.
-Useful both as a regression test for `f5 explain-flow` itself, and as
-a worked example for users learning how to gather production data.
+Any piece may be missing — a pcap without keylogs still yields 5-tuple, TLS
+handshake metadata, and reset analysis — but the richer the input, the richer
+the narrative.
 
 ## Layout
 
 | File | Purpose |
 |------|---------|
-| `bigip_test_lab.scf`  | BIG-IP SCF: 6 virtual servers, several iRules, an LTM policy, profiles, pools (incl. one with no reachable members) |
-| `gen_certs.sh`        | OpenSSL-driven cert factory: CA + valid / expired / mismatch / self-signed leafs + client cert |
-| `test_server.py`      | Multi-port HTTP/HTTPS origin; deployable on a backend or runnable on the same host as `run_tests.py` when the SCF uses `automap` SNAT |
-| `scenarios.py`        | Declarative scenarios table (curl args, expected status, expected substrings in the explain-flow report) |
-| `run_tests.py`        | The orchestrator (deploys, captures, drives traffic, fetches pcaps, runs `f5 explain-flow`) |
+| `bigip_test_lab.scf` | BIG-IP SCF: 6 virtual servers, 4 iRules, an LTM policy, profiles, and three pools (one with no reachable member), all in the `explain_flow_lab` partition |
+| `gen_certs.sh` | OpenSSL cert factory: CA plus valid / expired / mismatch / self-signed leafs and a client cert, EC P-256, into `./certs/` |
 
-## Prerequisites
-
-On the host running `run_tests.py`:
-
-* Python 3.10+
-* `openssl`
-* `ssh`, `scp`
-* `curl`
-* `nc` (or `ncat`) — only for the `payload_reset` scenario
-* `sshpass` — optional, only needed if you authenticate with `--password`
-* `faketime` — optional; if installed, `gen_certs.sh` produces a properly
-  back-dated expired cert.  Without it the expired-cert scenario uses a
-  cert with `notAfter` 1 day out, so you must rerun the harness after
-  the wallclock advances or supply your own backdated PEM.
-
-On the BIG-IP:
-
-* `tmsh` (always present)
-* `tcpdump` (preinstalled on TMOS)
-* SSH access for the user passed via `--user`
-
-The orchestrator is dependency-free Python (stdlib only) so it runs out
-of the box on any distro that ships Python 3.10+.
+Deploying the SCF and driving traffic through it is manual — there is no
+orchestrator. Load the SCF, generate the certs, run curl, capture, and feed
+the result to `f5 explain-flow` as in *Gathering the artefacts* below.
 
 ## Network topology
 
 The SCF defines six virtual servers in `10.255.42.0/24`:
 
-| VIP                | Port  | Scenario hook |
+| VIP | Port | What it exercises |
 |--------------------|-------|---------------|
-| 10.255.42.100      | 80    | `vs_block` — iRule HTTP block + LTM policy URI rewrite |
-| 10.255.42.101      | 443   | `vs_sni` — SNI-based pool routing |
-| 10.255.42.102      | 443   | `vs_tls_expired` — server cert past notAfter |
-| 10.255.42.103      | 443   | `vs_tls_selfsigned` — no chain to lab CA |
-| 10.255.42.104      | 80    | `vs_pool_down` — only pool member is unreachable |
-| 10.255.42.105      | 7777  | `vs_payload_reset` — TCP `RESETME` payload triggers `TCP::close` |
+| 10.255.42.100 | 80 | `vs_block` — iRule `HTTP::respond 403` plus an LTM policy URI rewrite |
+| 10.255.42.101 | 443 | `vs_sni` — SNI-based pool routing |
+| 10.255.42.102 | 443 | `vs_tls_expired` — server cert past `notAfter` |
+| 10.255.42.103 | 443 | `vs_tls_selfsigned` — no chain to the lab CA |
+| 10.255.42.104 | 80 | `vs_pool_down` — the only pool member is unreachable |
+| 10.255.42.105 | 7777 | `vs_payload_reset` — a `RESETME` payload triggers `TCP::close` |
 
-The pool members live at `10.255.42.10` / `.11` / `.20`.  Either:
+Pool members live at `10.255.42.10:8080`, `.11:8080`, `.20:8443`, and the
+deliberately dead `.99:8080`. Every VS uses
+`source-address-translation { type automap }`, so BIG-IP sources the back-side
+connection from a self-IP and one host can serve both roles.
 
-* run `test_server.py` on real hosts at those addresses, or
-* run `run_tests.py --server-here` so `test_server.py` listens on the
-  same host that drives the curl traffic.  Because every VS uses
-  `source-address-translation { type automap }`, BIG-IP sources the
-  back-side connection from one of its self-IPs and the response
-  travels back through BIG-IP to the same client; no extra plumbing
-  needed.
-
-## Running
+## Certificates
 
 ```bash
-# generate certs once (idempotent — re-run safely)
-scripts/explain_flow_test_harness/gen_certs.sh
-
-# full run: deploy SCF, capture every scenario, run f5 explain-flow
-scripts/explain_flow_test_harness/run_tests.py \
-    --bigip 10.0.0.5 \
-    --user admin \
-    --ssh-key ~/.ssh/id_rsa \
-    --server-here \
-    --out runs/$(date +%s)
+scripts/explain_flow_test_harness/gen_certs.sh [output_dir]   # idempotent
 ```
 
-Single scenario:
+Without `faketime` installed the "expired" leaf is dated one day out rather
+than properly back-dated, so re-run it once the wallclock has advanced or
+supply your own back-dated PEM.
+
+## Gathering the artefacts
+
+The same four steps whether the flow is in the lab or in production.
+
+### 1. Pull the BIG-IP config
+
+Only the partitions the flow traverses are needed; the explainer takes
+several `.conf` files as positional arguments, so a partial dump is fine.
 
 ```bash
-scripts/explain_flow_test_harness/run_tests.py \
-    --bigip 10.0.0.5 --user admin --ssh-key ~/.ssh/id_rsa \
-    --scenarios https_sni_route_api \
-    --out /tmp/just-sni
-```
-
-Skip BIG-IP deployment (useful when iterating on `f5 explain-flow`
-itself):
-
-```bash
-scripts/explain_flow_test_harness/run_tests.py ... --skip-deploy
-```
-
-Skip running `f5 explain-flow` (capture only):
-
-```bash
-scripts/explain_flow_test_harness/run_tests.py ... --skip-explain
-```
-
-## Output
-
-After a run, `<out>/` contains:
-
-```
-<out>/
-├── manifest.json                   ← every scenario + its outcome
-├── sslkeys.log                     ← NSS keylog file (-> tshark/Wireshark/explain-flow)
-├── http_block_by_host.pcap
-├── http_block_by_host.log
-├── https_sni_route_api.pcap
-├── ...
-└── explain/
-    ├── http_block_by_host.text     ← `f5 explain-flow` text report
-    ├── http_block_by_host.json     ← same, JSON
-    └── ...
-```
-
-Feed the JSON into the `explain_flow` MCP tool or the `/explain-flow`
-Claude skill for an LLM-readable narrative; the text reports are
-operator-facing.
-
-## Scenarios
-
-| Name                       | What it captures |
-|----------------------------|------------------|
-| `http_block_by_host`       | iRule `HTTP::respond 403` triggered by `[HTTP::host] equals "blocked.lab.test"`. The HUD annotation tells the LLM exactly which line of the iRule fired and what the captured Host was. |
-| `http_block_admin_path`    | Same iRule, different branch (`HTTP::path starts_with "/admin"`). |
-| `http_policy_rewrite`      | LTM policy rewrites `/api/v1/health` → `/api/v2/health`; back-side flow shows the rewritten URI. |
-| `https_sni_default`        | HTTPS with SNI=`app.lab.test`; iRule does NOT route, traffic stays on default pool. |
-| `https_sni_route_api`      | HTTPS with SNI=`api.lab.test`; iRule fires `pool /…/lab_pool_api` → back-side flow lands on a different pool member. |
-| `tls_expired_cert`         | Curl rejects expired cert; pcap shows handshake failure + BIG-IP RST + F5 reset cause. |
-| `tls_selfsigned_strict`    | Curl rejects self-signed cert (default verify); captured as bad-cert alert. |
-| `tls_selfsigned_relaxed`   | Same VS but `curl -k` so handshake completes; HTTPS payload decryptable via SSLKEYLOGFILE. |
-| `pool_down`                | Pool with one unreachable member; BIG-IP RSTs with cause text. |
-| `payload_reset`            | Plain TCP; iRule resets the connection on `RESETME` byte pattern. |
-
-## Gathering data from production (without this lab)
-
-If you're trying to explain a flow on a real production BIG-IP rather
-than reproduce one in the lab, you don't need `run_tests.py` — you
-need the same *artefacts* it collects.  Run these by hand in roughly
-this order:
-
-### 1. Pull the relevant BIG-IP config
-
-You only need the partitions the flow actually traverses.  The
-explainer accepts multiple `.conf` files via the CLI's positional
-`paths` argument, so partial dumps are fine.
-
-```bash
-# full SCF export (recommended — includes every referenced object)
 ssh admin@<bigip> "tmsh save sys config file=/var/tmp/prod.scf no-passphrase"
 scp admin@<bigip>:/var/tmp/prod.scf ./prod.scf
 
-# or, if the box won't let you save full SCF, just the LTM partition
+# or, when a full SCF save is not permitted:
 ssh admin@<bigip> "tmsh list ltm one-line | tee /var/tmp/prod-ltm.conf"
 scp admin@<bigip>:/var/tmp/prod-ltm.conf ./prod-ltm.conf
 ```
 
-### 2. Capture with the F5 Ethernet trailer
-
-This is the critical step for the `f5 explain-flow` extras (peer IP
-pairing, reset cause TLVs, decoded TMM annotations).  The
-`:nnnp` suffix is what makes BIG-IP write the trailer into each
-packet:
+For the lab, load the SCF instead:
 
 ```bash
-# on the BIG-IP, capture both directions of the flow you care about
+tmsh load sys config merge file=/var/tmp/bigip_test_lab.scf verify
+```
+
+### 2. Capture with the F5 Ethernet trailer
+
+The `:nnnp` suffix is what makes BIG-IP write the trailer into each packet —
+without it there is no peer-IP pairing, no reset-cause TLV, no decoded TMM
+annotation.
+
+```bash
 ssh admin@<bigip> "tcpdump -i 0.0:nnnp -s 0 -w /var/tmp/flow.pcap \
     'host <client-ip> and host <vs-ip>'"
-# ...reproduce the issue...
-# Ctrl-C the tcpdump
+# ...reproduce the issue, then Ctrl-C...
 scp admin@<bigip>:/var/tmp/flow.pcap ./flow.pcap
 ```
 
-`-i 0.0` captures across all VLANs; replace with `-i internal` /
-`-i external` / `-i <vlan>` if you know which side is interesting.
-Use `-C 100 -W 5` for a rolling 5x100MB ring if the issue is
-intermittent.
+`-i 0.0` captures across all VLANs; name a VLAN instead when you know which
+side matters. `-C 100 -W 5` gives a rolling 5×100 MB ring for an intermittent
+issue.
 
-### 3. Get a TLS keylog (optional but high-value)
+### 3. Get a TLS keylog (optional, high value)
 
-Three ways to obtain one, in order of preference:
+1. **From the client** — set `SSLKEYLOGFILE=/path/to/keys.log` before the
+   request (curl, openssl, Firefox, Chrome). No BIG-IP change needed.
+2. **From BIG-IP** (TMOS 16+) — `tmsh modify sys db
+   tmm.tls.keylogger.enabled value true` rides the master secrets inside the
+   F5 trailer (DPT provider 4), parsed straight out of the pcap with no
+   external keylog file.
+3. **From the backend** — the same env var on the pool member's client
+   library, when BIG-IP re-encrypts to the origin.
 
-1. **From the client.**  If the client is curl, openssl, Firefox, or
-   Chrome, set `SSLKEYLOGFILE=/path/to/keys.log` in its environment
-   *before* the request — every TLS session it negotiates appends
-   PMS/TLS-1.3 keys to that file.  No BIG-IP-side change required.
-2. **From BIG-IP** (TMOS 16+).  Enable the F5 TLS keylogger so the
-   master secrets ride along inside the F5 Ethernet trailer (DPT
-   provider 4 — already understood by `dialects.f5.bigip.f5_trailer`):
-   ```
-   tmsh modify sys db tmm.tls.keylogger.enabled value true
-   ```
-   The keylog material then gets parsed straight out of the pcap; no
-   external `--keylog` file is needed.
-3. **From the backend** (when the BIG-IP is acting as the TLS client
-   to a re-encrypted pool member).  Same `SSLKEYLOGFILE` env var on
-   whatever client library the backend service uses.
-
-### 4. (Optional) Backend-side log + pcap
-
-Useful when the question is "did the pool member ever see the
-request?".  `test_server.py` logs every request and is small enough
-to drop on any Linux box; or just run `tcpdump` on the member and
-correlate timestamps with the BIG-IP capture.
-
-### 5. Feed everything to `f5 explain-flow`
+### 4. Run the explainer
 
 ```bash
-f5 explain-flow \
-    --tshark \
-    --keylog ./keys.log \
-    --simulate \
-    ./flow.pcap ./prod.scf
+f5 explain-flow --tshark --keylog ./keys.log --simulate ./flow.pcap ./prod.scf
 ```
 
-* `--tshark` enriches the report with full HTTP/TLS decoding
-  (requires `tshark` on PATH).
-* `--keylog` decrypts HTTPS so HTTP::host / HTTP::method / response
-  codes are populated for TLS-wrapped sessions.
-* `--simulate` actually executes the matched VS's iRules under the
-  C-tcl orchestrator with the captured state, returning the real
-  pool/respond decisions.
+* `--tshark` adds full HTTP/TLS decoding (needs `tshark` on PATH).
+* `--keylog` decrypts HTTPS so `HTTP::host` / method / status populate.
+* `--simulate` runs the matched VS's iRules under the C-tcl orchestrator with
+  the captured state, returning the real pool / respond decisions.
 
-JSON output (`--json`) is what the `explain_flow` MCP tool / Claude
-skill consume.
+`--json` is the shape the `explain_flow` MCP tool and the `explain-flow`
+Claude skill consume; the default text report is operator-facing.
 
 ## Cleaning up
 
-The SCF lives entirely in the `explain_flow_lab` admin partition, so:
+Everything the lab deploys lives in one partition:
 
 ```bash
 ssh admin@<bigip> "tmsh delete auth partition explain_flow_lab"
 ```
-
-removes everything the harness deployed.  The orchestrator never
-modifies `Common`.
-
-## Adding a scenario
-
-1. Edit `bigip_test_lab.scf` and add the new VS / iRule / pool you want.
-2. Add a `Scenario(...)` entry to `scenarios.py` describing what curl
-   should send and what `f5 explain-flow` should be able to say about
-   the resulting pcap.
-3. Update this table.

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -11,9 +11,7 @@ editing session against a pinned corpus of public Tcl projects, records
 memory / CPU / wall time, and renders graphs for the release notes.
 
 It exists to answer one question per release — *did this get worse?* — with
-evidence rather than impression. It was built after a memory-leak review
-against the issue #1181 corpus, and its first output showed v2.1.14 holding
-479 MiB where v2.1.15 holds 170 MiB.
+evidence rather than impression.
 
 For the human-readable source, dialect, age/recency, licence, and coding-style
 catalogue, see [`docs/CORPUS.md`](../../docs/CORPUS.md). The manifest below
@@ -54,9 +52,10 @@ python3 report.py
 | `get_server.py` | Resolves a tag to a binary: published release asset first, else a build from the tag in a throwaway worktree. Cached. |
 | `bench.py` | Runs the 15-check suite against one binary, samples RSS/CPU every 250 ms, writes `results/<version>.json`. |
 | `report.py` | Turns `results/*.json` into three SVGs plus `summary.md`. Stdlib only, byte-for-byte deterministic. |
+| `sweep.sh` | Benchmarks every version in the manifest, in order, on one machine and one harness revision. Use it rather than looping `bench.py` by hand, and re-run it whole whenever the check set changes. |
 
-`results/` and `graphs/` are committed — they are the record. `corpus/`,
-`servers/`, `.stage/` and `.build/` are generated and ignored.
+`results/`, `graphs/` and `comparisons/` are committed — they are the record.
+`corpus/`, `servers/`, `.stage/` and `.build/` are generated and ignored.
 
 ## The check set
 
@@ -122,10 +121,8 @@ Two design points worth knowing:
 - **Anchor files.** `[anchors]` in the manifest lists paths that must always
   be opened, pinning known pathological shapes. Without one, a seeded
   selection that happens to land on four cheap files reports a clean run
-  while the regression the suite exists to watch sits untouched — this
-  actually happened during development: `nav.references` read 0.013 s until
-  the #1297 anchor was added, then 4.0 s. **Add an anchor whenever a
-  performance issue is found.**
+  while the regression the suite exists to watch sits untouched. **Add an
+  anchor whenever a performance issue is found.**
 - **A check that issues zero requests fails.** A 0.000 s bar in a release-notes
   graph reading as "this got faster" is worse than no bar, so the suite
   refuses to record one.
@@ -247,19 +244,19 @@ graphs do: comparing two arbitrary versions where neither is *the* subject.
 
 The graphs are release-notes artefacts, so producing them is part of cutting a
 release rather than something to remember afterwards.
-`scripts/release/rust_release.sh` drives the whole 2.1.x pre-release sequence;
-each step is idempotent and separately runnable:
+`scripts/release/rust_release.sh` drives the whole sequence; each step is
+idempotent and separately runnable:
 
 ```bash
-scripts/release/rust_release.sh next patch      # -> 2.1.20
-scripts/release/rust_release.sh prepare 2.1.20  # preflight, bench, graphs, notes, verify, commit
+scripts/release/rust_release.sh next patch      # -> X.Y.Z
+scripts/release/rust_release.sh prepare X.Y.Z   # preflight, bench, graphs, notes, verify, commit
 #   ...open + merge the notes PR against `rust`, then pull and:
-scripts/release/rust_release.sh tag 2.1.20
+scripts/release/rust_release.sh tag X.Y.Z
 ```
 
 `prepare` builds the server from the tree about to be tagged, benchmarks it into
-`results/2.1.20.json`, adds `v2.1.20` to `MANIFEST.toml`, re-renders `graphs/`
-with 2.1.20 highlighted, and writes the performance section of
+`results/X.Y.Z.json`, adds `vX.Y.Z` to `MANIFEST.toml`, re-renders `graphs/`
+with X.Y.Z highlighted, and writes the performance section of
 `RELEASE_NOTES.md` — including the four release-asset URLs that are the easiest
 thing in the whole release to leave pointing at the previous version.
 

--- a/scripts/stress/README.md
+++ b/scripts/stress/README.md
@@ -1,9 +1,8 @@
-# Stress-test suite — issue #829 robustness
+# Stress-test suite
 
-Two independent stress suites, both aimed at proving the semantic-token
-prioritisation and W120 workspace-scan fixes (issue #829) hold up under
-adversarial concurrent load, not just in the tidy conditions of a unit or
-single-shot end-to-end test.
+Two independent stress suites that put semantic-token prioritisation and the
+W120 workspace scan under adversarial concurrent load, rather than the tidy
+conditions of a unit or single-shot end-to-end test.
 
 | Suite | What it exercises | Front end? |
 |---|---|---|
@@ -83,12 +82,10 @@ Scenarios:
 
 - **`tokens`** — many large documents, concurrent rapid-edit + immediate
   `semanticTokens/full` bursts. Asserts every response arrives within a hard
-  ceiling (never starved — issue #829's core complaint) and prints p50/p95/max
-  latency.
-- **`startup`** — reproduces the exact race from issue #829's screenshots: a
-  workspace with a `source`-ancestor file that requires a package, and a
-  module using that package with no local `package require`, padded with
-  filler files so the workspace scan has real work to do. Opens the module
+  ceiling (never starved) and prints p50/p95/max latency.
+- **`startup`** — a workspace with a `source`-ancestor file that requires a
+  package, and a module using that package with no local `package require`,
+  padded with filler files so the workspace scan has real work to do. Opens the module
   immediately (racing the server's own workspace scan, the way an editor
   restoring tabs races `initialized`), then asserts the false-positive W120
   the ancestor should suppress is gone once the server settles.


### PR DESCRIPTION
## Summary

- `README.md`, `README-f5.md`, `INSTALL*.md`, `CONTRIBUTING.md`, and `AGENTS.md` are brought back to the tools as they ship today: the stable-release install line replaces pinned pre-release tags, the `tcl` / `f5` verb and flag lists match `--help`, the MCP tool and Claude-skill tables are complete, settings keys and semantic-token names match the generated `package.json`, and the Python-era sections of `CONTRIBUTING.md` are replaced with the registry `Traits` and shared-segmenter facts. Counts that drift (crates, commands, packages, skills) are removed rather than refreshed.
- The editor READMEs, `runtime/rust` and crate READMEs, sample and script READMEs, the experiment records, and the agent skills under `.claude/skills` and `ai/claude/skills` get the same treatment: verbs, flags, dialect lists (19 profiles incl. `sslictcl`), IDE floors, package names, and every sample output re-run through the built binaries (`samples/for_f5_query/sysadmin-queries.md` had 19 of 48 blocks failing; 12 are fixed here, the rest are marked as blocked on the query engine's module coverage).
- "No Python" hedges, closed-issue narration, phase and roadmap language are gone; nothing outside markdown changes except one query file the cookbook drives (`sysadmin/inventory_csv.f5q`).

Part of the documentation scrub; sibling PRs #1988, #1989, #1990, and #1991 cover the design docs and KCS notes.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.
  - `cargo xtask kcs-index-links` (passes — it also checks `AGENTS.md` and `CONTRIBUTING.md` links)
  - `cargo xtask gen-editor-extensions --check` (20 languages, 25 extensions — in sync)
  - `cargo xtask gen-ai-diagnostics --check` (catalogues and prompt files in sync)
  - `node scripts/install/filter-readme.mjs` for all seven editor filters (clean)
  - `target/debug/tcl`, `target/debug/f5-query` re-runs behind every corrected example

## Compiler / diagnostics checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? No — documentation only.
- [ ] If yes, I updated the owning design doc under `docs/design/compiler/` or `docs/design/contracts/`.
- [ ] If I added or changed a diagnostic or optimisation code, I updated its page under `docs/kcs/codes/` and linked it from `docs/kcs/codes/README.md`.
- [ ] If I added a design doc, I linked it from `docs/design/README.md` (`cargo xtask kcs-index-links` enforces this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H1W5GNcp3W2PtZZd9VFugH

---
_Generated by [Claude Code](https://claude.ai/code/session_01H1W5GNcp3W2PtZZd9VFugH)_