### PR TITLE
fix(f5-query): install the rustls crypto provider before building a ClientConfig

### DIFF
--- a/rust/tcl-bigip-query/src/probes/tls.rs
+++ b/rust/tcl-bigip-query/src/probes/tls.rs
@@ -27,7 +27,7 @@
 //! handshake reached the certificate message, else `null`.
 
 use std::net::{TcpStream, ToSocketAddrs};
-use std::sync::{Arc, Once};
+use std::sync::Arc;
 use std::time::Duration;
 
 use indexmap::IndexMap;
@@ -155,28 +155,20 @@ fn classify_verify_kind(msg: &str) -> String {
     .to_owned()
 }
 
-/// Install the process-level `rustls` crypto provider, once.
+/// Build the probe's `rustls` client config, naming its crypto provider.
 ///
 /// Both providers are linked in — `rustls`'s own default features select
 /// `aws-lc-rs` and `ureq` pulls `ring` — so rustls cannot infer one from the
-/// feature set, and [`rustls::ClientConfig::builder`] panics with "Could not
-/// automatically determine the process-level `CryptoProvider`" until a default
-/// is installed. `aws-lc-rs` is the provider this crate's own `rustls`
-/// dependency asks for, so that is the one installed.
+/// feature set, and the plain [`rustls::ClientConfig::builder`] panics with
+/// "Could not automatically determine the process-level `CryptoProvider`".
 ///
-/// The default is process-wide state rustls owns, not configuration of ours:
-/// [`Once`] keeps two probes from racing the install, and an already-installed
-/// provider — another consumer of the same process got there first — is the
-/// wanted outcome, not a failure.
-fn install_crypto_provider() {
-    static INSTALL: Once = Once::new();
-    INSTALL.call_once(|| {
-        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
-    });
-}
-
+/// The provider is therefore passed to *this* config rather than installed as
+/// the process default: a library that calls `install_default` would decide
+/// for the whole process, so an embedder wanting `ring` or its own provider
+/// gets `AlreadyInstalled`, and every other rustls user in the process —
+/// `ureq` included — silently switches to ours. `aws-lc-rs` is what this
+/// crate's own `rustls` dependency asks for, and the choice stops here.
 fn client_config(ca_bundle: Option<&str>) -> Result<rustls::ClientConfig, rustls::Error> {
-    install_crypto_provider();
     let mut roots = rustls::RootCertStore::empty();
     if let Some(path) = ca_bundle {
         if let Ok(pem) = std::fs::read(path) {
@@ -191,9 +183,12 @@ fn client_config(ca_bundle: Option<&str>) -> Result<rustls::ClientConfig, rustls
             let _ = roots.add(cert);
         }
     }
-    Ok(rustls::ClientConfig::builder()
-        .with_root_certificates(roots)
-        .with_no_client_auth())
+    Ok(rustls::ClientConfig::builder_with_provider(Arc::new(
+        rustls::crypto::aws_lc_rs::default_provider(),
+    ))
+    .with_safe_default_protocol_versions()?
+    .with_root_certificates(roots)
+    .with_no_client_auth())
 }
 
 #[cfg(test)]
@@ -201,19 +196,21 @@ mod tests {
     use std::net::TcpListener;
     use std::thread;
 
-    use super::{classify_verify_kind, client_config, handshake, install_crypto_provider};
+    use super::{classify_verify_kind, client_config, handshake};
 
-    /// Without an installed default provider `ClientConfig::builder()` panics
-    /// ("Could not automatically determine the process-level
-    /// `CryptoProvider`"), which is what every `tls_handshake` consumer hit in
-    /// a debug build. Installing twice must be a no-op, not a second install.
+    /// `ClientConfig::builder()` panics here ("Could not automatically
+    /// determine the process-level `CryptoProvider`") because two providers
+    /// are linked in — which is what every `tls_handshake` consumer hit in a
+    /// debug build. Naming the provider per config fixes it without touching
+    /// the process default, so building twice must work with no global
+    /// installed and no `AlreadyInstalled` in between.
     #[test]
-    fn the_crypto_provider_installs_once_and_a_client_config_builds() {
-        install_crypto_provider();
-        install_crypto_provider();
+    fn a_client_config_builds_repeatedly_without_a_process_default() {
+        assert!(client_config(None).is_ok(), "first build");
+        assert!(client_config(None).is_ok(), "second build");
         assert!(
-            client_config(None).is_ok(),
-            "a ClientConfig must build once the provider is installed"
+            rustls::crypto::CryptoProvider::get_default().is_none(),
+            "the probe must not install a process-wide default"
         );
     }
 

--- a/rust/tcl-bigip-query/src/probes/tls.rs
+++ b/rust/tcl-bigip-query/src/probes/tls.rs
@@ -27,7 +27,7 @@
 //! handshake reached the certificate message, else `null`.
 
 use std::net::{TcpStream, ToSocketAddrs};
-use std::sync::Arc;
+use std::sync::{Arc, Once};
 use std::time::Duration;
 
 use indexmap::IndexMap;
@@ -155,7 +155,28 @@ fn classify_verify_kind(msg: &str) -> String {
     .to_owned()
 }
 
+/// Install the process-level `rustls` crypto provider, once.
+///
+/// Both providers are linked in — `rustls`'s own default features select
+/// `aws-lc-rs` and `ureq` pulls `ring` — so rustls cannot infer one from the
+/// feature set, and [`rustls::ClientConfig::builder`] panics with "Could not
+/// automatically determine the process-level `CryptoProvider`" until a default
+/// is installed. `aws-lc-rs` is the provider this crate's own `rustls`
+/// dependency asks for, so that is the one installed.
+///
+/// The default is process-wide state rustls owns, not configuration of ours:
+/// [`Once`] keeps two probes from racing the install, and an already-installed
+/// provider — another consumer of the same process got there first — is the
+/// wanted outcome, not a failure.
+fn install_crypto_provider() {
+    static INSTALL: Once = Once::new();
+    INSTALL.call_once(|| {
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+    });
+}
+
 fn client_config(ca_bundle: Option<&str>) -> Result<rustls::ClientConfig, rustls::Error> {
+    install_crypto_provider();
     let mut roots = rustls::RootCertStore::empty();
     if let Some(path) = ca_bundle {
         if let Ok(pem) = std::fs::read(path) {
@@ -177,7 +198,43 @@ fn client_config(ca_bundle: Option<&str>) -> Result<rustls::ClientConfig, rustls
 
 #[cfg(test)]
 mod tests {
-    use super::classify_verify_kind;
+    use std::net::TcpListener;
+    use std::thread;
+
+    use super::{classify_verify_kind, client_config, handshake, install_crypto_provider};
+
+    /// Without an installed default provider `ClientConfig::builder()` panics
+    /// ("Could not automatically determine the process-level
+    /// `CryptoProvider`"), which is what every `tls_handshake` consumer hit in
+    /// a debug build. Installing twice must be a no-op, not a second install.
+    #[test]
+    fn the_crypto_provider_installs_once_and_a_client_config_builds() {
+        install_crypto_provider();
+        install_crypto_provider();
+        assert!(
+            client_config(None).is_ok(),
+            "a ClientConfig must build once the provider is installed"
+        );
+    }
+
+    /// The shared entry point, over a listener that accepts and hangs up: the
+    /// handshake cannot succeed, but it must *fail*, not panic — which is what
+    /// `tls_handshake` did before the provider was installed here. Local-only
+    /// and deterministic; no certificate or network is involved.
+    #[test]
+    fn a_handshake_against_a_closing_listener_reports_an_error_rather_than_panicking() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind a loopback listener");
+        let port = i64::from(listener.local_addr().expect("local addr").port());
+        let accepted = thread::spawn(move || drop(listener.accept()));
+
+        let result = handshake("127.0.0.1", port, "localhost", None);
+        accepted.join().expect("listener thread");
+
+        assert!(
+            result.is_err(),
+            "a peer that hangs up mid-handshake is a connection error, got {result:?}"
+        );
+    }
 
     #[test]
     fn classify_verify_kind_buckets_rustls_messages() {


### PR DESCRIPTION
## Summary

`tls_handshake` panicked on **every** call in a debug build:

```
Could not automatically determine the process-level CryptoProvider from Rustls crate features
```

Both providers are linked in. `rust/tcl-bigip-query/Cargo.toml` declares `rustls = { version = "0.23", optional = true }` with default features, which select `aws-lc-rs`; `ureq = { version = "3", optional = true }` (same `probes` feature) and `f5-cli`'s `ureq = "3"` pull `ring`. Cargo.lock lists both under `rustls`, and both are compiled into the workspace (`libaws_lc_rs*.rlib` and `ring*` build dirs are present in a plain `cargo check`). With two providers and no process default, `rustls::ClientConfig::builder()` refuses to guess and panics.

`client_config` — the one path every consumer reaches TLS through (`f5-query` CLI, `tcl-mcp`, the report generator; `client_config` / `ClientConfig` appear nowhere else in the workspace) — now names the provider for **this config**:

```rust
rustls::ClientConfig::builder_with_provider(Arc::new(
    rustls::crypto::aws_lc_rs::default_provider(),
))
.with_safe_default_protocol_versions()?
.with_root_certificates(roots)
.with_no_client_auth()
```

The first cut installed a process default from a `Once`-guarded helper; review (#1996 thread, now resolved) correctly pushed back — a library that calls `install_default` decides for the whole process, so an embedder wanting `ring` or its own provider would get `AlreadyInstalled`, and every other rustls user in the process would silently switch. Nothing global is touched now; nothing else in the workspace calls `install_default`, and `f5-cli`'s REST agent brings its own provider via `ureq::tls::TlsConfig`, so `ureq` keeps its Ring fallback.

Two tests:

- `a_client_config_builds_repeatedly_without_a_process_default` — builds a `ClientConfig` twice and asserts `CryptoProvider::get_default()` is still `None`, so a future edit cannot quietly reintroduce the global.
- `a_handshake_against_a_closing_listener_reports_an_error_rather_than_panicking` — drives the real `handshake()` entry point against a `std::net::TcpListener` on `127.0.0.1:0` that accepts and hangs up. Local-only, deterministic, no certificate and no network. A server-side TLS test would need a cert generator (`rcgen` or similar), which is not in the dev-dependency set, so it is not attempted.

Both tests reproduce the original panic verbatim when the provider argument is dropped from the builder (verified; not committed).

`docs/references/f5_query/builtins.md`'s `tls_handshake` entry still describes the builtin correctly — a full handshake against *(host, port)* with SNI defaulting to *host*, returning protocol / cipher / ALPN / peer-cert dict / verify status, gated on `--enable-probes`. No doc change needed; it was simply never reachable before.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

```
cargo test -p tcl-bigip-query                                  # 71 + 67 passed, 0 failed
cargo test -p tcl-bigip-query --lib probes::tls                # 3 passed
cargo clippy -p tcl-bigip-query --all-targets -- -D warnings   # clean
cargo xtask f5-query-builtins-doc --check                      # OK: 267 builtins documented
make rust-check                                                # PASSED (fmt + clippy pedantic + drift gates)
```

Negative control (not committed): replacing `builder_with_provider(…)` with the plain `builder()` makes both tests panic with the reported message.

## Compiler / diagnostics checklist

Not applicable — no compiler behaviour, diagnostic, or analysis contract is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H1W5GNcp3W2PtZZd9VFugH