### PR TITLE
docs(f5-query): stop advertising the url_* probes and the unreachable cert paths

### DIFF
--- a/docs/references/f5_query/builtins.md
+++ b/docs/references/f5_query/builtins.md
@@ -10,8 +10,9 @@ plain and stream builtins are registered across
 and its submodules, special-form builtins (`select`, `map`, the `paths` /
 `getpath` family, …) in `src/special.rs`, and the network-probe builtins
 in `src/probes.rs`. When a builtin's signature, arity, or behaviour
-changes there, update this file by hand to match — there is no generator
-and no CI check keeping the two in sync.
+changes there, update this file by hand to match — there is no generator;
+`cargo xtask f5-query-builtins-doc --check` (in `make xtask-check`) gates the
+set of names against the registry, but the prose is maintained by hand.
 
 This is the **canonical per-function reference** for every builtin the
 `f5 query` DSL exposes.  For grammar, value-model, edit-pipeline, and
@@ -20,9 +21,9 @@ for the user-facing feature overview and worked-example KCS notes start
 from
 [`../../kcs/features/kcs-feature-bigip-query.md`](../../kcs/features/kcs-feature-bigip-query.md).
 
-The same per-function reference is available offline through the
-verb's own help action — ``f5 query --help-builtins NAME`` prints
-exactly the same content for one builtin.
+Offline, ``f5 query --help-builtins NAME`` prints what the registry itself
+knows about one builtin — category, arity, dispatch flags, and any
+implementation caveat — not the prose on this page.
 
 ## Categories
 
@@ -5736,6 +5737,13 @@ Raises when the object did not come from a file-backed UCS, when
 the stanza has no ``cache-path``, or when no matching member is in
 the archive.
 
+**Not reachable from the DSL yet.**  Like :func:`x509_from_config`,
+this needs a ``sys file ssl-cert`` / ``cm cert`` object, and the query
+projection covers the ``ltm``, ``gtm`` and ``security`` kinds only —
+there is no ``.sys`` / ``.cm`` container to pipe from.  The reader
+itself is wired and used by the report pipeline; the examples below
+are the shape a query will take once those kinds are projected.
+
 Related: ``x509_from_config`` (stanza metadata only), ``x509_eq``,
 ``cert_load``, ``tls_handshake``.
 
@@ -5786,7 +5794,8 @@ grep("nohup|curl .*\\| *sh", "home/*/.bashrc") # login-hook persistence
 
 ### `url_get`
 
-HTTP GET request.  Requires --enable-probes.
+HTTP GET request — **not implemented**; no request is made.  Requires
+--enable-probes.
 
 **Signatures**
 
@@ -5799,8 +5808,10 @@ wired up (deterministic golden-testing constraints); every call
 returns ``{status: null, headers: {}, body: "", body_json: null,
 peer_cert: null, error: "live HTTP probe is not yet implemented …"}``
 regardless of *url* or reachability.  The ``ureq`` dependency is in
-place for when this lands.  The deterministic probe surface
-(``x509_parse``, ``x509_eq``, ``dns``) is unaffected.
+place for when this lands, and ``f5 query --help-builtins url_get``
+says the same thing.  The deterministic probe surface
+(``x509_parse``, ``x509_eq``, ``dns``) and the live ``tls_handshake``
+/ ``dns`` / ``ping`` probes are unaffected.
 
 Optional second argument is a dict of request headers (accepted but,
 per the above, not yet sent anywhere).
@@ -5817,7 +5828,8 @@ url_get("https://api.example/v1", {"Authorization": "Bearer X"})
 
 ### `url_head`
 
-HTTP HEAD request.  Requires --enable-probes.
+HTTP HEAD request — **not implemented**; no request is made.  Requires
+--enable-probes.
 
 **Signatures**
 
@@ -5844,7 +5856,8 @@ url_head("https://api.example/v1", {"Authorization": "Bearer X"})
 
 ### `url_options`
 
-HTTP OPTIONS request.  Requires --enable-probes.
+HTTP OPTIONS request — **not implemented**; no request is made.  Requires
+--enable-probes.
 
 **Signatures**
 
@@ -5871,7 +5884,8 @@ url_options("https://api.example/v1", {"Authorization": "Bearer X"})
 
 ### `url_post`
 
-HTTP POST request.  Requires --enable-probes.
+HTTP POST request — **not implemented**; no request is made.  Requires
+--enable-probes.
 
 **Signatures**
 
@@ -6082,9 +6096,13 @@ Related: ``x509_parse``, ``x509_from_config``.
 **Examples**
 
 ```
-x509_eq(x509_parse(.body), x509_from_config($cert))
-.sys.file.ssl-cert[] | select(x509_eq(x509_from_config(.), $peer))
+x509_eq(tls_handshake("example.com", 443).peer_cert,
+        cert_load("/config/ssl/ssl.crt/example.crt"))
+x509_eq(x509_parse($peer_pem), x509_from_config($cert))
 ```
+
+(``$cert`` is a cert stanza bound with ``--input-json``; the ``.sys`` /
+``.cm`` containers are not projected — see :func:`x509_from_config`.)
 
 ### `x509_from_config`
 
@@ -6102,8 +6120,14 @@ returns a dict in the same shape :func:`x509_parse` produces:
 ``fingerprint_sha256`` / ``sans`` / ``key_alg`` / ``key_size``
 / ``version`` / etc.
 
-Supported config objects (anywhere a cert appears in the
-parsed model):
+**The ``sys`` and ``cm`` containers are not projected.**  The query
+surface covers the ``ltm``, ``gtm`` and ``security`` kinds only, so
+``.sys["file-ssl-cert"]`` / ``.cm.cert`` navigate into an empty
+container and a client-ssl profile's ``cert`` PathRef does not
+dereference.  Today the stanza has to arrive as an external input
+(``--input-json``) or from the report pipeline, which builds these
+objects directly.  The projections below are the ones this builtin
+understands once such an object reaches it:
 
 - ``sys file ssl-cert`` — cert / chain / bundle store, the
   target of every client-ssl / server-ssl ``cert-key-chain``
@@ -6139,9 +6163,11 @@ Related: ``x509_parse`` (parse a PEM string),
 **Examples**
 
 ```
-.sys.file.ssl-cert["/Common/example.crt"] | x509_from_config(.)
-.cm.cert["/Common/dtca.crt"] | x509_from_config(.)
-x509_eq(.sys.file.ssl-cert["/Common/example.crt"] | x509_from_config(.), x509_parse(url_get("https://example.com/cert.pem").body))
+$cert | x509_from_config(.)                       # $cert bound with --input-json
+x509_eq(x509_from_config($cert),
+        cert_load("/config/ssl/ssl.crt/example.crt"))
+x509_eq(x509_from_config($cert),
+        tls_handshake("example.com", 443).peer_cert)
 ```
 
 ### `x509_parse`

--- a/docs/references/f5_query/builtins.md
+++ b/docs/references/f5_query/builtins.md
@@ -5740,9 +5740,11 @@ the archive.
 **Not reachable from the DSL yet.**  Like :func:`x509_from_config`,
 this needs a ``sys file ssl-cert`` / ``cm cert`` object, and the query
 projection covers the ``ltm``, ``gtm`` and ``security`` kinds only —
-there is no ``.sys`` / ``.cm`` container to pipe from.  The reader
-itself is wired and used by the report pipeline; the examples below
-are the shape a query will take once those kinds are projected.
+there is no ``.sys`` / ``.cm`` container to pipe from, and an
+``--input-json`` stanza arrives as a plain object, which this builtin
+rejects.  The UCS reader hook itself is wired and unit-tested in the
+f5 CLI; the examples below are the shape a query will take once those
+kinds are projected.
 
 Related: ``x509_from_config`` (stanza metadata only), ``x509_eq``,
 ``cert_load``, ``tls_handshake``.
@@ -6097,7 +6099,7 @@ Related: ``x509_parse``, ``x509_from_config``.
 
 ```
 x509_eq(tls_handshake("example.com", 443).peer_cert,
-        cert_load("/config/ssl/ssl.crt/example.crt"))
+        cert_load("./example.crt"))     # a PEM copied off the device
 x509_eq(x509_parse($peer_pem), x509_from_config($cert))
 ```
 
@@ -6125,8 +6127,8 @@ surface covers the ``ltm``, ``gtm`` and ``security`` kinds only, so
 ``.sys["file-ssl-cert"]`` / ``.cm.cert`` navigate into an empty
 container and a client-ssl profile's ``cert`` PathRef does not
 dereference.  Today the stanza has to arrive as an external input
-(``--input-json``) or from the report pipeline, which builds these
-objects directly.  The projections below are the ones this builtin
+(``--input-json``); unlike :func:`ucs_cert` this builtin reads plain
+objects, so that form works.  The projections below are the ones it
 understands once such an object reaches it:
 
 - ``sys file ssl-cert`` — cert / chain / bundle store, the
@@ -6165,7 +6167,7 @@ Related: ``x509_parse`` (parse a PEM string),
 ```
 $cert | x509_from_config(.)                       # $cert bound with --input-json
 x509_eq(x509_from_config($cert),
-        cert_load("/config/ssl/ssl.crt/example.crt"))
+        cert_load("./example.crt"))               # a PEM copied off the device
 x509_eq(x509_from_config($cert),
         tls_handshake("example.com", 443).peer_cert)
 ```
@@ -6370,6 +6372,11 @@ required:
 Tilde expansion is honoured.  Raises :class:`BuiltinError` for
 missing files, unreadable formats, or wrong passwords.  No
 network access — purely local file IO.
+
+*path* is read on the machine running ``f5 query``, not on the
+BIG-IP, so a device path such as
+``/config/ssl/ssl.crt/example.crt`` raises ``cert_load: file not
+found`` unless that file has been copied off the appliance first.
 
 Related: ``x509_parse`` (parse an in-memory PEM string),
 ``tls_handshake`` (peer cert pre-parsed in ``peer_cert``).

--- a/rust/f5-cli/src/cli.rs
+++ b/rust/f5-cli/src/cli.rs
@@ -453,9 +453,9 @@ pub enum Command {
         /// Show the worked-example cookbook and exit.
         #[arg(long = "help-examples")]
         help_examples: bool,
-        /// Show the comprehensive manual (grammar + builtins + examples) and
-        /// exit. Not yet available: the builtins prose catalogue is not
-        /// implemented.
+        /// Show the comprehensive manual and exit: the DSL grammar
+        /// reference, the builtin catalogue (registry metadata — category,
+        /// arity, dispatch flags), and the worked-example cookbook.
         #[arg(long = "help-manual")]
         help_manual: bool,
         /// List the registered renderer plugins and exit.

--- a/rust/f5-cli/src/lib.rs
+++ b/rust/f5-cli/src/lib.rs
@@ -465,9 +465,11 @@ fn dispatch(command: &Command) -> anyhow::Result<u8> {
 /// Handle the `--help-*` actions, which short-circuit before requiring an
 /// expression / inputs.
 ///
-/// Returns `Ok(Some(code))` when a help action fired (so the caller exits with
-/// `code`), `Ok(None)` when no help flag was set, or an error for the
-/// unimplemented builtins-prose surfaces (`--help-builtins` / `--help-manual`).
+/// Returns `Some(code)` when a help action fired (so the caller exits with
+/// `code`), `None` when no help flag was set. Every action is implemented;
+/// `--help-builtins` and `--help-manual` render from the builtin registry's
+/// metadata because [`BuiltinSpec`](tcl_bigip_query::builtins::BuiltinSpec)
+/// carries no per-function prose.
 fn dispatch_query_help(command: &Command) -> Option<u8> {
     let Command::Query {
         help_dsl,

--- a/rust/tcl-bigip-query/src/builtins/mod.rs
+++ b/rust/tcl-bigip-query/src/builtins/mod.rs
@@ -96,6 +96,11 @@ pub struct BuiltinSpec {
     /// `referenced_by` are the exception (plain — and so broadcasting —
     /// but need `ctx` for the config here).
     pub broadcasts: bool,
+    /// A one-line implementation caveat the catalogue must surface — the
+    /// `url_*` family is registered but returns an `error` rather than making
+    /// a request, and `--help-builtins` would otherwise advertise it as a
+    /// working probe. `None` for every builtin that does what its name says.
+    pub note: Option<&'static str>,
     pub imp: Builtin,
 }
 
@@ -162,6 +167,9 @@ pub fn format_catalogue(filter: Option<&str>) -> String {
         if !flags.is_empty() {
             let _ = writeln!(out, "  flags:    {}", flags.join(", "));
         }
+        if let Some(note) = spec.note {
+            let _ = writeln!(out, "  note:     {note}");
+        }
         return out;
     }
 
@@ -173,7 +181,8 @@ pub fn format_catalogue(filter: Option<&str>) -> String {
     );
     out.push('\n');
     out.push_str(
-        "Each entry is name (arity). Arity is shown as N, MIN..MAX, or MIN+ for\n\
+        "Each entry is name (arity), with an implementation caveat after a dash\n\
+         where one applies. Arity is shown as N, MIN..MAX, or MIN+ for\n\
          variadic. For full signatures, prose, and examples see\n\
          docs/references/f5_query/ or run `f5 query --help-builtins NAME`.\n\n",
     );
@@ -186,7 +195,14 @@ pub fn format_catalogue(filter: Option<&str>) -> String {
             let _ = writeln!(out, "[{}]", spec.category);
             current = spec.category;
         }
-        let _ = writeln!(out, "  {:<26} ({})", spec.name, arity(spec));
+        match spec.note {
+            None => {
+                let _ = writeln!(out, "  {:<26} ({})", spec.name, arity(spec));
+            }
+            Some(note) => {
+                let _ = writeln!(out, "  {:<26} ({}) — {note}", spec.name, arity(spec));
+            }
+        }
     }
     out
 }
@@ -210,6 +226,7 @@ pub(crate) fn plain(
             with_ctx: false,
             stream_aware,
             broadcasts: true,
+            note: None,
             imp: Builtin::Plain(f),
         },
     )
@@ -257,6 +274,7 @@ fn ctx_spec(
             with_ctx: true,
             stream_aware: false,
             broadcasts,
+            note: None,
             imp: Builtin::Ctx(f),
         },
     )
@@ -279,9 +297,21 @@ pub(crate) fn special(
             with_ctx: false,
             stream_aware: false,
             broadcasts: false,
+            note: None,
             imp: Builtin::Special,
         },
     )
+}
+
+/// Attach an implementation caveat to a registration, so the catalogue and
+/// `--help-builtins` say what the builtin actually does.
+pub(crate) fn with_note(
+    entry: (&'static str, BuiltinSpec),
+    note: &'static str,
+) -> (&'static str, BuiltinSpec) {
+    let (name, mut spec) = entry;
+    spec.note = Some(note);
+    (name, spec)
 }
 
 fn build_registry() -> HashMap<&'static str, BuiltinSpec> {
@@ -1483,6 +1513,29 @@ mod catalogue_tests {
     fn unknown_builtin_reports_cleanly() {
         let miss = format_catalogue(Some("definitely-not-a-builtin"));
         assert!(miss.contains("no builtin named 'definitely-not-a-builtin'"));
+    }
+
+    /// A registered-but-inert builtin must say so wherever the catalogue
+    /// names it, or `--help-builtins` advertises a probe that makes no
+    /// request. The `url_*` family is the whole current population.
+    #[cfg(feature = "probes")]
+    #[test]
+    fn the_catalogue_says_which_builtins_are_not_implemented() {
+        for name in ["url_get", "url_head", "url_options", "url_post"] {
+            let spec = lookup(name).unwrap_or_else(|| panic!("{name} is registered"));
+            let note = spec.note.unwrap_or_else(|| panic!("{name} carries a note"));
+            assert!(note.contains("not implemented"), "{name}: {note}");
+
+            let one = format_catalogue(Some(name));
+            assert!(
+                one.contains(note),
+                "the single-builtin view carries it: {one}"
+            );
+            assert!(
+                format_catalogue(None).contains(note),
+                "the full listing carries it too"
+            );
+        }
     }
 }
 

--- a/rust/tcl-bigip-query/src/probes.rs
+++ b/rust/tcl-bigip-query/src/probes.rs
@@ -1043,7 +1043,7 @@ mod tls;
 // Registry wiring
 
 #[cfg(feature = "probes")]
-use crate::builtins::{BuiltinSpec, as_int, as_str, ctx, plain};
+use crate::builtins::{BuiltinSpec, as_int, as_str, ctx, plain, with_note};
 #[cfg(feature = "probes")]
 use crate::eval::EvalContext;
 
@@ -1211,8 +1211,11 @@ fn bi_cert_load(args: &[Value]) -> Result<Value, QueryError> {
 fn bi_ucs_cert(args: &[Value], ctx: &mut EvalContext) -> Result<Value, QueryError> {
     let Value::ObjectRef(obj) = &args[0] else {
         return Err(QueryError::builtin(
-            "ucs_cert: expects a sys file ssl-cert object (pipe through \
-             .sys[\"file-ssl-cert\"][ref] first)",
+            "ucs_cert: expects a `sys file ssl-cert` / `cm cert` object. The \
+             query projection covers the ltm, gtm and security kinds only, so \
+             there is no `.sys` / `.cm` container to reach one through yet; \
+             today the object has to arrive from the report pipeline, which \
+             builds it directly",
         ));
     };
     let full_path = obj.full_path.clone();
@@ -1261,6 +1264,13 @@ fn bi_ucs_cert(args: &[Value], ctx: &mut EvalContext) -> Result<Value, QueryErro
     }
 }
 
+/// The catalogue caveat every `url_*` builtin carries: the live request path
+/// is not wired, so a call returns the result dict with an `error` field
+/// instead of contacting the URL.
+#[cfg(feature = "probes")]
+const URL_NOT_LIVE: &str = "not implemented: returns the result shape with an `error` field, \
+                            makes no request";
+
 /// Probe builtin registrations — folded into the global registry by
 /// [`crate::builtins`].
 #[cfg(feature = "probes")]
@@ -1276,10 +1286,22 @@ pub(crate) fn registrations() -> Vec<(&'static str, BuiltinSpec)> {
         ctx("traceroute", "net", 1, Some(1), bi_traceroute),
         ctx("socket_get", "net", 2, Some(3), bi_socket_get),
         ctx("tls_handshake", "net", 2, Some(3), bi_tls_handshake),
-        ctx("url_get", "net", 1, Some(2), bi_url_get),
-        ctx("url_head", "net", 1, Some(2), bi_url_head),
-        ctx("url_options", "net", 1, Some(2), bi_url_options),
-        ctx("url_post", "net", 1, Some(3), bi_url_post),
+        // The `url_*` family is registered so a query mentioning it parses and
+        // degrades to a result dict, but no request is made — the catalogue
+        // has to say so rather than advertise a working probe.
+        with_note(ctx("url_get", "net", 1, Some(2), bi_url_get), URL_NOT_LIVE),
+        with_note(
+            ctx("url_head", "net", 1, Some(2), bi_url_head),
+            URL_NOT_LIVE,
+        ),
+        with_note(
+            ctx("url_options", "net", 1, Some(2), bi_url_options),
+            URL_NOT_LIVE,
+        ),
+        with_note(
+            ctx("url_post", "net", 1, Some(3), bi_url_post),
+            URL_NOT_LIVE,
+        ),
         ctx("ucs_cert", "net", 1, Some(1), bi_ucs_cert),
         // Pure x509 surface — ungated (plain, deterministic here).
         plain("x509_parse", "net", 1, Some(1), false, bi_x509_parse),

--- a/rust/tcl-bigip-query/src/probes.rs
+++ b/rust/tcl-bigip-query/src/probes.rs
@@ -1211,11 +1211,11 @@ fn bi_cert_load(args: &[Value]) -> Result<Value, QueryError> {
 fn bi_ucs_cert(args: &[Value], ctx: &mut EvalContext) -> Result<Value, QueryError> {
     let Value::ObjectRef(obj) = &args[0] else {
         return Err(QueryError::builtin(
-            "ucs_cert: expects a `sys file ssl-cert` / `cm cert` object. The \
-             query projection covers the ltm, gtm and security kinds only, so \
-             there is no `.sys` / `.cm` container to reach one through yet; \
-             today the object has to arrive from the report pipeline, which \
-             builds it directly",
+            "ucs_cert: expects a projected `sys file ssl-cert` / `cm cert` \
+             object. The query projection builds objects for the ltm, gtm and \
+             security kinds only, and an `--input-json` stanza arrives as a \
+             plain object, so nothing can supply one: this builtin is not \
+             reachable from `f5 query` until those kinds are projected",
         ));
     };
     let full_path = obj.full_path.clone();

--- a/rust/tcl-bigip-query/tests/integration/probes.rs
+++ b/rust/tcl-bigip-query/tests/integration/probes.rs
@@ -160,3 +160,22 @@ fn dns_is_ungated() {
         "dns must run without --enable-probes, got {out:?}"
     );
 }
+
+#[test]
+fn ucs_cert_rejects_a_plain_object() {
+    // `ucs_cert` needs a projected `sys file ssl-cert` / `cm cert`
+    // `Value::ObjectRef`, and `ObjectRef`s are only ever built by
+    // `projection.rs` for the ltm / gtm / security kinds. A stanza handed in
+    // with `--input-json` arrives as a plain `Value::Object` and so cannot
+    // reach the builtin either — the error must say so rather than point at a
+    // pipeline that would work.
+    let err = run_disabled(
+        "ucs_cert({\"full-path\": \"/Common/app.crt\", \
+         \"cache-path\": \"/config/filestore/files_d/Common_d/app.crt_1_1\"})",
+    )
+    .expect_err("a plain object is not a projected cert object");
+    assert!(
+        err.contains("not reachable from `f5 query`"),
+        "expected the unreachable-from-f5-query wording, got {err:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Three claims the `f5 query` surface made and did not honour.

### The `url_*` family is registered but inert

`rust/tcl-bigip-query/src/probes/http.rs` returns `{status: null, headers: {}, body: "", body_json: null, peer_cert: null, error: "live HTTP probe is not yet implemented …"}` for `url_get` / `url_head` / `url_options` / `url_post`, but `f5 query --help-builtins` listed them beside `dns`, `ping` and `tls_handshake` as ordinary net probes, and `builtins.md`'s one-line summaries read as live.

**Decision: keep the stub.** `ureq` is already a `probes`-feature dependency, but a real implementation is not small: it needs the same timeout and CA-bundle handling as `tls_handshake` (which means a `rustls` config threaded through `ureq` 3's TLS layer), `peer_cert` capture from that connection, and a local-listener test harness — a feature of its own, not a fix. So the catalogue is made honest instead:

- `BuiltinSpec` gains `note: Option<&'static str>` — "the doc-only fields" its own comment already carves out, minus the prose.
- `with_note(…)` attaches one at registration, so no existing `plain` / `ctx` / `special` call site changes.
- `format_catalogue` prints it in both views.

```
$ f5-query query --help-builtins url_get
url_get
  category: net
  arity:    1..2 arg(s)
  flags:    config-aware
  note:     not implemented: returns the result shape with an `error` field, makes no request
```

### `x509_eq` / `x509_from_config` documented unreachable paths

`projection.rs` covers `LTM_KINDS` / `GTM_KINDS` / `SECURITY_KINDS` only; `module_kinds("sys")` and `module_kinds("cm")` return empty, so `.sys.file.ssl-cert[]` and `.cm.cert[…]` navigate into an empty container. Following a client-ssl profile's `cert` PathRef does not help either — `resolve_pathref` calls `kind_to_label("sys file ssl-cert")`, which is `None`, and returns `None`.

The examples now use paths that resolve today (`tls_handshake(…).peer_cert`, `cert_load`, a stanza bound with `--input-json`), and `x509_from_config`'s Details says which containers are missing and where such an object does come from. `x509_from_config` reads its argument through `field_get`, so it accepts a plain `--input-json` object; the entry now says so.

`cert_load` reads with `std::fs::read` on the machine running the CLI, so its examples use a host-local PEM rather than an appliance path, and its entry says where the path is resolved.

### `ucs_cert` is not reachable from `f5 query` at all

Its error told the caller to "pipe through `.sys["file-ssl-cert"][ref]` first". `Value::ObjectRef` is built in exactly six places, all in `projection.rs`, and every one is an `ltm` / `gtm` / `security` kind; nothing else in the tree constructs one, `rust/bigip-report-gen` never mentions `ucs_cert`, and an `--input-json` stanza arrives as a plain `Value::Object` and fails the same `let` guard. Accepting that flat shape would not help either — the builtin needs `config_uri` to locate the archive, and that lives on the `ObjectRef` struct, not in the field map.

So the message now states plainly that the builtin is not reachable from `f5 query` until the `sys` / `cm` kinds are projected, and `ucs_cert`'s and `x509_from_config`'s doc entries drop the same report-pipeline claim. `ucs_cert_rejects_a_plain_object` pins the wording.

### Also

- `--help-manual`'s help text said "Not yet available: the builtins prose catalogue is not implemented" — `dispatch_query_help` calls `manual::format_manual()` and has for a while. It now says what it emits: grammar, builtin catalogue, cookbook.
- `dispatch_query_help`'s doc comment described an error return the `Option<u8>` signature does not have.
- `builtins.md`'s header said "there is no generator and no CI check keeping the two in sync"; `cargo xtask f5-query-builtins-doc --check` (in `make xtask-check`) gates the *set of names*, and the header now says exactly that. Its neighbouring claim that `--help-builtins NAME` "prints exactly the same content" is replaced with what that command actually prints.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

```
cargo test -p tcl-bigip-query               # 70 + 68 passed, 0 failed
cargo test -p f5-cli                        # all suites passed
cargo xtask f5-query-builtins-doc --check   # OK: 267 builtins documented
cargo xtask kcs-index-links                 # KCS docs checks passed
cargo fmt --check                           # clean
cargo clippy -p tcl-bigip-query -p f5-cli --all-targets -- -D warnings
make rust-check                             # PASSED on the first commit
f5-query query --help-builtins url_get      # shows the note (above)
```

Two tests: `the_catalogue_says_which_builtins_are_not_implemented` pins that each `url_*` builtin carries a "not implemented" note and that both catalogue views print it — so a future implementation that drops the stub has to drop the note with it. `ucs_cert_rejects_a_plain_object` pins the "not reachable from `f5 query`" wording against a plain object; negative control run, mangling the message fails it.

## Compiler / diagnostics checklist

Not applicable — no compiler behaviour, diagnostic, or analysis contract is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H1W5GNcp3W2PtZZd9VFugH