### PR TITLE
fix(tclvm): fire array get element read traces

### DIFF
--- a/docs/design/contracts/shared-utility-contracts-rust.md
+++ b/docs/design/contracts/shared-utility-contracts-rust.md
@@ -48,9 +48,10 @@ entry point, or gate moves without this contract being updated.
 | option words / subcommands | `rust/tcl-cmd-core/src/prefix.rs`; `rust/tcl-cmd-core/src/ensemble.rs`; `rust/tcl-registry/src/hover.rs`; `rust/tcl-registry/src/spec.rs` | `OptionTable`; `OptionSpec`; `SubCommand`; `first_positional_index`; `ensemble::EnsembleToken`; `ensemble::InvocationLayout`; `ensemble::invocation_layout`; `ensemble::UNKNOWN_DELETED_MESSAGE`; `ensemble::UNKNOWN_DELETED_ERROR_CODE`; `ensemble::CREATE_OPTIONS`; `ensemble::CONFIG_OPTIONS`; `ensemble::SUBCOMMANDS`; `ensemble::resolve_subcommand`; `ensemble::subcommand_choices`; `ensemble::unknown_subcommand_message`; `ensemble::validate_map_targets` | option surface per release/dialect; ensemble token lifecycle and invocation layout invariant | `xtask-option-registry-drift` |
 | trace argument decoding | `rust/tcl-cmd-core/src/trace.rs` | `TraceKind`; `resolve_option`; `resolve_type`; `parse_ops`; `parse_legacy_variable_ops`; `legacy_ops_letters`; `callback_op_word` | option surface per release (the 8.x-only `variable`/`vdelete`/`vinfo` forms) | none |
 | sort numeric parsing | `rust/tcl-cmd-core/src/sort.rs` | `parse_wide`; `parse_real` | `NumberSyntax` per release | none |
-| command errors | `rust/tcl-cmd-core/src/error.rs` | `CmdError`; `wrong_args`; `bad_choice` | invariant | none |
+| command errors | `rust/tcl-cmd-core/src/error.rs` | `CmdError`; `wrong_args`; `bad_choice`; `with_error_details` | invariant | none |
 | channel output configuration / encoding | `rust/tcl-platform/src/lib.rs`; `rust/tcl-cmd-core/src/channel.rs`; `rust/tcl-registry/src/commands/tcl/fconfigure_.rs` | `SystemEncoding`; `Host::system_encoding`; `ChannelConfig`; `StandardChannelConfigs`; `OpenAccess`; `resolve_open_access_mode`; `ChannelDirection`; `ChannelEncoding`; `EncodingProfile`; `OutputTranslation`; `resolve_fconfigure_option`; `config_list`; `config_value`; `set_config_value`; `encode_output`; `encode_output_bytes`; `EncodedOutput`; `EILSEQ_ERROR_CODE` | system encoding per host locale and interpreter tree; option availability per dialect profile; open-access validation and profile/binary defaults per Tcl release; mutable direction-specific state per channel | none |
-| Tcl completion options / structured error stacks | `rust/tcl-runtime-api/src/completion_options.rs`; `rust/tcl-runtime-api/src/error_stack.rs` | `completion_options::plan`; `completion_options::ErrorOptions`; `completion_options::OptionValue`; `error_stack::ErrorStack`; `error_stack::validate_error_stack`; `error_stack::ErrorStackValueError` | standard option overlay follows completion code/level; TIP 348 `-errorstack` is available from Tcl 8.6; shifted contexts use the concrete runtime's frame count | none |
+| Tcl completion options / structured error stacks | `rust/tcl-runtime-api/src/completion_options.rs`; `rust/tcl-runtime-api/src/error_stack.rs` | `completion_options::plan`; `completion_options::retained_array_read_options`; `completion_options::ControlOptionPolicy`; `completion_options::ErrorOptions`; `completion_options::OptionValue`; `error_stack::ErrorStack`; `error_stack::validate_error_stack`; `error_stack::ErrorStackValueError` | standard option overlay follows completion code/level; control commands independently select inherited/fresh body options and forwarded/settled success options; TIP 348 `-errorstack` is available from Tcl 8.6; shifted contexts use the concrete runtime's frame count | none |
+| trace-aware array enumeration | `rust/tcl-runtime-api/src/lib.rs`; `rust/tcl-cmd-core/src/array.rs`; `rust/tcl-syntax/src/value.rs` | `ArrayTarget`; `ArrayElementRead`; `ArrayReadMiss`; `ArrayReadFailure`; `ArrayInvalidation`; `VarStore::array_target`; `VarStore::array_read_elem_at`; `ValueOps::pin_value`; `ValueOps::unpin_value`; `array::dispatch_at` | Tcl variable-cell identity and array-before-element trace ordering; linked-element recovery/reporting follows the selected release | none |
 | expression grammar / evaluation | `rust/tcl-syntax/src/expr/parser.rs`; `rust/tcl-syntax/src/expr/eval.rs`; `rust/tcl-registry/src/expr_surface.rs` | `parse_expr`; `eval`; `RuntimeExprSurface` | `RuntimeExprSurface` per release | none |
 | expr math functions and the `rand` generator | `rust/tcl-syntax/src/expr/mathfunc.rs`; `rust/tcl-syntax/src/expr/rand.rs` | `NumValue`; `dispatch`; `dispatch_with_backend_int_width`; `try_dispatch_with_backend_int_width`; `IntWidth`; `MathFuncError`; `MathFuncSince`; `spec`; `all`; `added_in`; `seed_from_wide`; `next_draw`; `seed_and_draw` | `MathFuncSince` per release for the function surface and `IntWidth` for `int()`'s width; the Park-Miller generator is release-invariant | none |
 | command / word segmentation | `rust/tcl-lexer/src/script.rs`; `rust/tcl-compiler/src/segmenter.rs`; `rust/tcl-compiler/src/parsing/syntax/build.rs`; `rust/tcl-compiler/src/parsing/syntax/segment.rs` | `group_commands`; `CommandSpan`; `WordSpan`; `WordKind`; `SegmentedCommand`; `segment_commands` | `LexerConfig` per document dialect | `xtask-segmentation-drift` |
@@ -128,11 +129,46 @@ entry point, or gate moves without this contract being updated.
   TIP 348 `-errorstack`. A carried option named `-errorstack` remains an
   ordinary custom pair on Tcl 8.4/8.5 and must not be deleted or validated as
   TIP 348 metadata there.
+- `completion_options::retained_array_read_options` owns the carried metadata
+  for a candidate read that `array get` skips. Both runtime adapters materialise
+  the typed `ArrayReadMiss` into their value model and pass the pairs through
+  `plan`; neither assembles a private return-options dictionary.
+- `completion_options::ControlOptionPolicy` owns control-command boundaries as
+  two independent axes: whether a nested body activation begins with inherited
+  or fresh options, and whether the successful owner forwards that body's
+  options or settles an ordinary option set. Both runtime engines consume this
+  vocabulary; bytecode carries the activation scope as instruction metadata
+  instead of recognising command names in the executor. Alias trampolines use
+  the same fresh/forwarded policy, including when they cross interpreters, so
+  target-produced options cross the wrapper but caller options do not leak in.
 - `error_stack::ErrorStack` owns TIP 348's flat tag/value shape, lazy reset,
   explicit-stack adoption, and procedure-boundary `CALL` rule. The native VM
   and portable runtime render their own value types but do not reproduce that
   lifecycle. `TclVersion::has_error_stack` is the release fact: Tcl 8.6 and
   later expose it; older and vendor profiles inherit their selected runtime.
+
+### `tcl-runtime-api` + `tcl-cmd-core` — trace-aware array enumeration
+
+- `ArrayTarget` is the variable cell located before an array-operation trace.
+  `array::dispatch_at` snapshots candidate keys from that cell, then asks
+  `VarStore::array_read_elem_at` to perform each live, trace-aware read. This is
+  the one boundary at which a runtime may combine its stable cell identity,
+  frame/namespace lookup, alias movement, and trace engine.
+- The runtime fires the containing-array and element read traces in Tcl order,
+  resolving the element group only after the containing-array callbacks have
+  completed. It then reports `Value`, `Missing(ArrayReadMiss)`,
+  `TraceError(ArrayReadFailure)`, or `ArrayInvalidated`. A callback error wins
+  when that callback also invalidated the base; otherwise the shared command
+  owner skips a missing candidate and chronologically merges miss metadata.
+- `ArrayElementRead` returns its `Value` variant transiently owned across the
+  runtime boundary.
+  Pointer-backed runtimes call `ValueOps::pin_value` before releasing the
+  selected cell; the shared owner calls `unpin_value` after `new_list` has
+  retained every element, and on every earlier hard-error exit. Owning value
+  models implement those hooks as no-ops.
+- The cell/ordering rules apply across the runtime releases. The callback name
+  recovered through a scalar-looking alias to an array element does not:
+  engines continue to gate that spelling through their selected Tcl release.
 
 ### `tcl-syntax` — the parse grammars and value seam
 

--- a/runtime/rust/src/cmd_array.rs
+++ b/runtime/rust/src/cmd_array.rs
@@ -145,18 +145,45 @@ fn array_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         let Some(name_obj) = argv.get(index) else {
             return interp.set_error(b"array subcommand has incomplete registry metadata");
         };
-        if let Some(code) = interp.fire_array_trace(&obj_bytes(*name_obj)) {
-            return code;
-        }
+        let name = obj_bytes(*name_obj);
+        return interp.with_array_trace_target(&name, |interp, target| {
+            array_cmd_after_trace(
+                interp,
+                argv,
+                sub,
+                for_variables,
+                default_option,
+                Some(target),
+            )
+        });
     }
+    array_cmd_after_trace(interp, argv, sub, for_variables, default_option, None)
+}
+
+fn array_cmd_after_trace(
+    interp: &mut Interp,
+    argv: &[*mut TclObj],
+    sub: &[u8],
+    for_variables: Option<[Vec<u8>; 2]>,
+    default_option: Option<&'static [u8]>,
+    target: Option<&tcl_runtime_api::ArrayTarget>,
+) -> Code {
     let sub_str = String::from_utf8_lossy(sub);
     // The read-side + `unset` are the shared `tcl_cmd_core::array` core (over
     // this runtime's `VarStore`/`Frames`/`ValueOps`); a fresh-or-borrowed result
     // object is retained by `set_result`.
-    if let Some(result) = tcl_cmd_core::array::dispatch(interp, &sub_str, &argv[2..]) {
+    if let Some(result) = tcl_cmd_core::array::dispatch_at(interp, &sub_str, &argv[2..], target) {
         return match result {
-            Ok(v) => {
-                interp.set_result(v);
+            Ok(result) => {
+                if let Some(miss) = result.read_miss {
+                    interp.set_return_options(
+                        tcl_runtime_api::completion_options::retained_array_read_options(
+                            &miss,
+                            <[u8]>::to_vec,
+                        ),
+                    );
+                }
+                interp.set_result(result.value);
                 Code::Ok
             }
             Err(e) => interp.report_cmd_error(e),
@@ -277,6 +304,8 @@ fn array_for(
     argv: &[*mut TclObj],
     prepared_variables: Option<[Vec<u8>; 2]>,
 ) -> Code {
+    use tcl_runtime_api::completion_options::ControlOptionPolicy;
+
     if argv.len() != 5 {
         return interp.wrong_args(b"array for {key value} arrayName script");
     }
@@ -297,6 +326,8 @@ fn array_for(
     // change to the *set* of keys (not their values) aborts the loop.
     let snapshot = interp.array_names(&name).unwrap_or_default();
     let snapshot_set: std::collections::BTreeSet<Vec<u8>> = snapshot.iter().cloned().collect();
+    let policy = ControlOptionPolicy::FRESH_SETTLED;
+    interp.begin_control_options(policy);
 
     for idx in 0..=snapshot.len() {
         // Detect a structural change since the snapshot (C's search invalidation).
@@ -312,6 +343,7 @@ fn array_for(
         if idx == snapshot.len() {
             break;
         }
+        interp.begin_control_options(policy);
         let key = &snapshot[idx];
         // Read the value through the trace-firing path (var-23.13 counts reads).
         if let Some(c) = interp.fire_read_trace(&name, Some(key)) {
@@ -342,6 +374,7 @@ fn array_for(
         }
     }
     interp.set_result_bytes(b"");
+    interp.settle_control_options(policy, Code::Ok);
     Code::Ok
 }
 

--- a/runtime/rust/src/cmd_control.rs
+++ b/runtime/rust/src/cmd_control.rs
@@ -648,6 +648,8 @@ fn lmap(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
 /// and the body-frame command name — exactly as C factors them through one
 /// `EachloopCmd`.
 fn each_loop(interp: &mut Interp, argv: &[*mut TclObj], collect: bool) -> Code {
+    use tcl_runtime_api::completion_options::ControlOptionPolicy;
+
     let name: &[u8] = if collect { b"lmap" } else { b"foreach" };
     // [cmd] + N×(varlist, list) pairs + body ⇒ an even arg count ≥ 4.
     if argv.len() < 4 || argv.len() % 2 != 0 {
@@ -686,8 +688,18 @@ fn each_loop(interp: &mut Interp, argv: &[*mut TclObj], collect: bool) -> Code {
 
     // Collected body results (bytes; rematerialised into the result list at the
     // end). Only populated for `lmap`.
+    let policy = if collect {
+        ControlOptionPolicy::FRESH_FORWARDED
+    } else {
+        ControlOptionPolicy::FRESH_SETTLED
+    };
+    // Even a zero-iteration each-loop is a fresh command completion. Every
+    // iteration body is a fresh activation too; `lmap` forwards the final
+    // body's options, while `foreach` settles its own empty result/options.
+    interp.begin_control_options(policy);
     let mut collected: Vec<Vec<u8>> = Vec::new();
     for it in 0..iterations {
+        interp.begin_control_options(policy);
         for (vars, vals) in &groups {
             for (k, var) in vars.iter().enumerate() {
                 let val = vals.get(it * vars.len() + k).cloned().unwrap_or_default();
@@ -739,6 +751,7 @@ fn each_loop(interp: &mut Interp, argv: &[*mut TclObj], collect: bool) -> Code {
     } else {
         interp.set_result_bytes(b"");
     }
+    interp.settle_control_options(policy, Code::Ok);
     Code::Ok
 }
 

--- a/runtime/rust/src/cmd_dict.rs
+++ b/runtime/rust/src/cmd_dict.rs
@@ -803,6 +803,8 @@ fn dict_path_unset(dict: *mut TclObj, keys: &[*mut TclObj]) -> Result<(), PathEr
 /// `dict for {keyVar valueVar} dictValue body` — iterate in insertion order,
 /// evaluating `body` in the current scope with the loop vars set.
 fn for_(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
+    use tcl_runtime_api::completion_options::ControlOptionPolicy;
+
     if argv.len() != 5 {
         return interp.wrong_args(b"dict for {keyVarName valueVarName} dictionary script");
     }
@@ -820,7 +822,10 @@ fn for_(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         Err(e) => return bad_dict(interp, e),
     };
 
+    let policy = ControlOptionPolicy::FRESH_SETTLED;
+    interp.begin_control_options(policy);
     for (k, v) in pairs {
+        interp.begin_control_options(policy);
         if interp.var_set(&kvar, k).is_err() {
             return cant_set(interp, &kvar);
         }
@@ -840,6 +845,7 @@ fn for_(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         }
     }
     interp.set_result_bytes(b"");
+    interp.settle_control_options(policy, Code::Ok);
     Code::Ok
 }
 
@@ -847,6 +853,8 @@ fn for_(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
 /// iteration's body result becomes the new value for that key; returns the
 /// transformed dict. `continue` drops the key, `break` stops.
 fn map(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
+    use tcl_runtime_api::completion_options::ControlOptionPolicy;
+
     if argv.len() != 5 {
         return interp.wrong_args(b"dict map {keyVarName valueVarName} dictionary script");
     }
@@ -863,7 +871,10 @@ fn map(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     };
     let acc = dict::new_dict_obj(&[]);
     unsafe { obj::incr_ref_count(acc) };
+    let policy = ControlOptionPolicy::FRESH_FORWARDED;
+    interp.begin_control_options(policy);
     for (k, v) in pairs {
+        interp.begin_control_options(policy);
         if interp.var_set(&vars[0], k).is_err() || interp.var_set(&vars[1], v).is_err() {
             unsafe { obj::decr_ref_count(acc) };
             return cant_set(interp, &vars[0]);
@@ -889,6 +900,7 @@ fn map(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     }
     interp.set_result(acc);
     unsafe { obj::decr_ref_count(acc) };
+    interp.settle_control_options(policy, Code::Ok);
     Code::Ok
 }
 

--- a/runtime/rust/src/cmd_error.rs
+++ b/runtime/rust/src/cmd_error.rs
@@ -53,6 +53,11 @@ fn catch_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     if argv.len() < 2 || argv.len() > 4 {
         return interp.wrong_args(b"catch script ?resultVarName? ?optionVarName?");
     }
+    // The caught body is a fresh completion scope. Commands within it retain
+    // carried options until a later command replaces them, but neither the
+    // caller's prior options nor the caught body's options belong to the
+    // successful `catch` command itself.
+    interp.clear_return_options();
     // `catch` is bytecode-compiled inline (C's `TclCompileCatchCmd`): a literal
     // body runs in the **same** `info frame` level and the same `codePtr->source`
     // as the enclosing proc/script. `eval_control_body` reproduces that — sharing
@@ -69,15 +74,20 @@ fn catch_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     // catch return value (read the value before clearing the result). `var_set`
     // retains it into the result var, so it survives the later `set_result`.
     let result = interp.get_obj_result();
+    let options = argv.get(3).map(|_| completion_options(interp, code));
+    interp.clear_return_options();
 
     if let Some(&rv) = argv.get(2) {
         let name = obj_bytes(rv);
         if let Err(e) = set_var_or_elem(interp, &name, result) {
+            if let Some(opts) = options {
+                drop_fresh(opts);
+            }
             return crate::builtins::var_error(interp, &name, e);
         }
     }
     if let Some(&ov) = argv.get(3) {
-        let opts = completion_options(interp, code); // rc 0
+        let opts = options.expect("options requested above"); // rc 0
         let name = obj_bytes(ov);
         if let Err(e) = set_var_or_elem(interp, &name, opts) {
             drop_fresh(opts);

--- a/runtime/rust/src/cmd_switch.rs
+++ b/runtime/rust/src/cmd_switch.rs
@@ -31,6 +31,7 @@
 #![allow(clippy::not_unsafe_ptr_arg_deref)]
 
 use tcl_cmd_core::switch::{self as core_switch, Options, Selection};
+use tcl_runtime_api::completion_options::ControlOptionPolicy;
 
 use crate::cmd_regex::AreEngine;
 use crate::frame::split_array_ref;
@@ -102,6 +103,7 @@ fn switch_inline_form(
     }
     // The pattern objects are the inline body args at even indices (borrowed argv).
     let patterns: Vec<*mut TclObj> = (0..npairs).map(|p| words[p * 2]).collect();
+    interp.begin_control_options(ControlOptionPolicy::FRESH_FORWARDED);
     let matched = match core_switch::select::<Interp, AreEngine, _>(interp, opts, &value, &patterns)
     {
         Ok(Selection::Matched { index, writes }) => {
@@ -178,6 +180,7 @@ fn switch_list_form(
     // own), so mint temporary objects for the shared `select`, then free them — it
     // only reads them, and the result never references a pattern.
     let pat_objs: Vec<*mut TclObj> = pat_bytes.iter().map(|b| new_string(b)).collect();
+    interp.begin_control_options(ControlOptionPolicy::FRESH_FORWARDED);
     let outcome = core_switch::select::<Interp, AreEngine, _>(interp, opts, &value, &pat_objs);
     for &o in &pat_objs {
         drop_fresh(o);

--- a/runtime/rust/src/cmd_trace.rs
+++ b/runtime/rust/src/cmd_trace.rs
@@ -243,9 +243,6 @@ pub struct TraceTable {
     /// records registrations a callback *removed* rather than ones it is
     /// running.
     pub firing_exec_traces: Vec<u64>,
-    /// Variable cells whose trace callbacks are currently running. Other
-    /// variables remain traceable from within a callback.
-    pub active_var_scopes: Vec<VarTraceScope>,
     /// Non-zero while an **execution** trace callback (`enter`/`leave`/
     /// `enterstep`/`leavestep`) is running — C's `INTERP_TRACE_IN_PROGRESS`,
     /// which `TraceExecutionProc` sets around exactly those callbacks

--- a/runtime/rust/src/frame.rs
+++ b/runtime/rust/src/frame.rs
@@ -46,11 +46,20 @@
 //! overwriting/unsetting/dropping releases. Links own nothing.
 
 use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicU32, Ordering};
 
-use tcl_runtime_api::FrameLinkOrigin;
+use tcl_runtime_api::{FrameLinkOrigin, VarId};
 
 use crate::namespace::NsId;
 use crate::obj::{self, TclObj};
+
+static NEXT_VAR_ID: AtomicU32 = AtomicU32::new(1);
+
+fn fresh_var_id() -> VarId {
+    let raw = NEXT_VAR_ID.fetch_add(1, Ordering::Relaxed);
+    assert_ne!(raw, u32::MAX, "standalone variable identity exhausted");
+    VarId(raw)
+}
 
 /// A variable cell: the `tclInt.h` `Var` union as an enum.
 pub enum Var {
@@ -140,6 +149,23 @@ pub enum VarError {
 struct Cell {
     name: Vec<u8>,
     var: Option<Var>,
+    /// Identity of the currently bound variable. The slot survives `unset` for
+    /// compiled access, while this token normally does not. An in-flight
+    /// operation retains the exact Tcl `Var` cell, so recreation during that
+    /// operation refills this identity instead of capturing an unrelated one.
+    binding_id: Option<VarId>,
+    /// In-flight array ensemble operations retaining this binding. A direct
+    /// unset leaves the Tcl cell available for same-name recreation until the
+    /// final operation releases it, while an ordinary unset starts a new
+    /// binding immediately.
+    operation_refs: usize,
+    /// Stable identities of the current array elements. Values stay in
+    /// [`Var::Array`]; this parallel identity table lets a trace-aware read tell
+    /// an unset-and-recreated element from the one selected before its callback.
+    element_ids: BTreeMap<Vec<u8>, VarId>,
+    /// Per-element trace reads currently retaining the selected cell. Tcl
+    /// refills that cell when its own callback unsets and recreates the element.
+    element_operation_refs: BTreeMap<Vec<u8>, usize>,
     /// Flagged `const` (TIP 677): a write or unset errors with `variable is a
     /// constant`. On the cell rather than in a side set so a compiled slot's
     /// write check is the same O(1) index as the write itself.
@@ -201,6 +227,10 @@ impl VarTable {
         self.cells.push(Cell {
             name: name.to_vec(),
             var: None,
+            binding_id: None,
+            operation_refs: 0,
+            element_ids: BTreeMap::new(),
+            element_operation_refs: BTreeMap::new(),
             constant: false,
             link_origin: FrameLinkOrigin::Ordinary,
             traced: core::cell::Cell::new((0, false)),
@@ -246,15 +276,132 @@ impl VarTable {
     /// Store `var` under `name`, returning the variable it displaced.
     fn put(&mut self, name: &[u8], var: Var) -> Option<Var> {
         let slot = self.slot_for(name);
-        self.cells[slot].link_origin = FrameLinkOrigin::Ordinary;
-        self.cells[slot].var.replace(var)
+        let cell = &mut self.cells[slot];
+        cell.link_origin = FrameLinkOrigin::Ordinary;
+        if cell.binding_id.is_none() {
+            cell.binding_id = Some(fresh_var_id());
+        }
+        cell.element_ids.clear();
+        cell.element_operation_refs.clear();
+        if let Var::Array(elements) = &var {
+            cell.element_ids
+                .extend(elements.keys().cloned().map(|key| (key, fresh_var_id())));
+        }
+        cell.var.replace(var)
     }
 
     /// Empty `name`'s cell, returning what it held. The cell and its slot stay
     /// reserved so a compiled slot keeps addressing the same variable.
     fn take(&mut self, name: &[u8]) -> Option<Var> {
         let slot = *self.slots.get(name)?;
-        self.cells[slot].var.take()
+        let cell = &mut self.cells[slot];
+        if cell.operation_refs == 0 {
+            cell.binding_id = None;
+        }
+        cell.element_ids.clear();
+        cell.element_operation_refs.clear();
+        cell.var.take()
+    }
+
+    /// Identity of the variable currently bound at `name`.
+    pub(crate) fn binding_id(&self, name: &[u8]) -> Option<VarId> {
+        let slot = *self.slots.get(name)?;
+        self.cells[slot].var.as_ref()?;
+        self.cells[slot].binding_id
+    }
+
+    /// Retain the exact current binding for an array operation.
+    pub(crate) fn retain_binding(&mut self, name: &[u8], id: VarId) -> bool {
+        let Some(slot) = self.slots.get(name).copied() else {
+            return false;
+        };
+        let cell = &mut self.cells[slot];
+        if cell.binding_id != Some(id) {
+            return false;
+        }
+        cell.operation_refs += 1;
+        true
+    }
+
+    /// Release a retained array binding, discarding an undefined identity once
+    /// no operation can still observe it.
+    pub(crate) fn release_binding(&mut self, name: &[u8], id: VarId) {
+        let Some(slot) = self.slots.get(name).copied() else {
+            return;
+        };
+        let cell = &mut self.cells[slot];
+        if cell.binding_id != Some(id) || cell.operation_refs == 0 {
+            return;
+        }
+        cell.operation_refs -= 1;
+        if cell.operation_refs == 0 && cell.var.is_none() {
+            cell.binding_id = None;
+        }
+    }
+
+    /// Identity of a defined element of the current array binding.
+    pub(crate) fn element_id(&self, name: &[u8], key: &[u8]) -> Option<VarId> {
+        let slot = *self.slots.get(name)?;
+        let cell = &self.cells[slot];
+        matches!(cell.var.as_ref(), Some(Var::Array(map)) if map.contains_key(key))
+            .then(|| cell.element_ids.get(key).copied())
+            .flatten()
+    }
+
+    pub(crate) fn retain_element(&mut self, name: &[u8], key: &[u8], id: VarId) -> bool {
+        let Some(slot) = self.slots.get(name).copied() else {
+            return false;
+        };
+        let cell = &mut self.cells[slot];
+        if cell.element_ids.get(key) != Some(&id) {
+            return false;
+        }
+        *cell.element_operation_refs.entry(key.to_vec()).or_default() += 1;
+        true
+    }
+
+    pub(crate) fn release_element(&mut self, name: &[u8], key: &[u8], id: VarId) {
+        let Some(slot) = self.slots.get(name).copied() else {
+            return;
+        };
+        let cell = &mut self.cells[slot];
+        if cell.element_ids.get(key) != Some(&id) {
+            return;
+        }
+        let Some(count) = cell.element_operation_refs.get_mut(key) else {
+            return;
+        };
+        *count -= 1;
+        if *count == 0 {
+            cell.element_operation_refs.remove(key);
+            let defined = matches!(
+                cell.var.as_ref(),
+                Some(Var::Array(elements)) if elements.contains_key(key)
+            );
+            if !defined {
+                cell.element_ids.remove(key);
+            }
+        }
+    }
+
+    /// Read an element only if both its array and element identities still
+    /// match the cells selected before a trace callback.
+    pub(crate) fn load_elem_with_ids(
+        &self,
+        name: &[u8],
+        array: VarId,
+        key: &[u8],
+        element: VarId,
+    ) -> Option<*mut TclObj> {
+        let slot = *self.slots.get(name)?;
+        let cell = &self.cells[slot];
+        if cell.binding_id != Some(array) || cell.element_ids.get(key) != Some(&element) {
+            return None;
+        }
+        match cell.var.as_ref()? {
+            Var::Array(map) => map.get(key).copied(),
+            Var::Scalar(_) | Var::Link(_) => None,
+        }
     }
 
     /// Every defined variable, in name order.
@@ -397,34 +544,34 @@ impl VarTable {
         key: &[u8],
         obj: *mut TclObj,
     ) -> Result<(), VarError> {
-        match self.get_mut(name) {
-            Some(Var::Scalar(_)) => Err(VarError::IsScalar),
-            Some(Var::Array(map)) => {
-                // SAFETY: retain the new element value; release any prior one.
-                unsafe { obj::incr_ref_count(obj) };
-                if let Some(old) = map.insert(key.to_vec(), obj) {
-                    unsafe { obj::decr_ref_count(old) };
+        if let Some(slot) = self.slots.get(name).copied() {
+            let cell = &mut self.cells[slot];
+            match cell.var.as_mut() {
+                Some(Var::Scalar(_)) => return Err(VarError::IsScalar),
+                Some(Var::Array(map)) => {
+                    // SAFETY: retain the new element value; release any prior one.
+                    unsafe { obj::incr_ref_count(obj) };
+                    let fresh = !map.contains_key(key);
+                    if let Some(old) = map.insert(key.to_vec(), obj) {
+                        unsafe { obj::decr_ref_count(old) };
+                    }
+                    if fresh && !cell.element_ids.contains_key(key) {
+                        cell.element_ids.insert(key.to_vec(), fresh_var_id());
+                    }
+                    return Ok(());
                 }
-                Ok(())
-            }
-            // The declared-but-undefined marker: the first element write
-            // defines the array over it (see `store_scalar`).
-            Some(Var::Link(l)) if l.name == name && l.elem.is_none() => {
-                let mut map = BTreeMap::new();
-                unsafe { obj::incr_ref_count(obj) };
-                map.insert(key.to_vec(), obj);
-                self.put(name, Var::Array(map));
-                Ok(())
-            }
-            Some(Var::Link(_)) => unreachable!("the coordinator never lands on a link"),
-            None => {
-                let mut map = BTreeMap::new();
-                unsafe { obj::incr_ref_count(obj) };
-                map.insert(key.to_vec(), obj);
-                self.put(name, Var::Array(map));
-                Ok(())
+                // The declared-but-undefined marker: the first element write
+                // defines the array over it (see `store_scalar`).
+                Some(Var::Link(l)) if l.name == name && l.elem.is_none() => {}
+                Some(Var::Link(_)) => unreachable!("the coordinator never lands on a link"),
+                None => {}
             }
         }
+        let mut map = BTreeMap::new();
+        unsafe { obj::incr_ref_count(obj) };
+        map.insert(key.to_vec(), obj);
+        self.put(name, Var::Array(map));
+        Ok(())
     }
 
     /// `set name(key)` — borrowed.
@@ -472,8 +619,15 @@ impl VarTable {
 
     /// Remove one array element `name(key)`; returns whether it existed.
     pub(crate) fn remove_elem(&mut self, name: &[u8], key: &[u8]) -> bool {
-        if let Some(Var::Array(map)) = self.get_mut(name) {
+        let Some(slot) = self.slots.get(name).copied() else {
+            return false;
+        };
+        let cell = &mut self.cells[slot];
+        if let Some(Var::Array(map)) = cell.var.as_mut() {
             if let Some(old) = map.remove(key) {
+                if !cell.element_operation_refs.contains_key(key) {
+                    cell.element_ids.remove(key);
+                }
                 // SAFETY: the array element owned a +1; releasing balances it.
                 unsafe { obj::decr_ref_count(old) };
                 return true;
@@ -495,8 +649,14 @@ impl VarTable {
         origin: FrameLinkOrigin,
     ) {
         let slot = self.slot_for(name);
-        self.cells[slot].link_origin = origin;
-        if let Some(old) = self.cells[slot].var.replace(Var::Link(link)) {
+        let cell = &mut self.cells[slot];
+        cell.link_origin = origin;
+        if cell.binding_id.is_none() {
+            cell.binding_id = Some(fresh_var_id());
+        }
+        cell.element_ids.clear();
+        cell.element_operation_refs.clear();
+        if let Some(old) = cell.var.replace(Var::Link(link)) {
             old.release();
         }
     }

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -465,6 +465,8 @@ pub(crate) struct CoroContext {
     return_code: Code,
     return_level: usize,
     return_options: Vec<(Vec<u8>, Vec<u8>)>,
+    array_operation_targets: Vec<ArrayOperationTarget>,
+    active_var_trace_scopes: Vec<crate::cmd_trace::VarTraceScope>,
     exc: ExceptionState,
     error_stack: ErrorStack<Vec<u8>>,
     error_line: u32,
@@ -487,6 +489,8 @@ impl CoroContext {
             return_code: Code::Ok,
             return_level: 1,
             return_options: Vec::new(),
+            array_operation_targets: Vec::new(),
+            active_var_trace_scopes: Vec::new(),
             exc: ExceptionState::default(),
             error_stack: ErrorStack::default(),
             error_line: 1,
@@ -787,11 +791,26 @@ struct CmdArena {
     fqns: Vec<Vec<u8>>,
 }
 
+#[derive(Clone, Debug)]
+struct ArrayOperationTarget {
+    target: crate::vars::ArrayCellTarget,
+}
+
 pub struct InterpState {
     pub(crate) frames: RefCell<FrameStack>,
     /// The command-table-as-core-service: the namespace tree + the one
     /// `resolve(currentNs, name)` resolver (T1.5).
     namespaces: RefCell<Namespaces>,
+    /// Exact array bindings retained by nested `array` operations. The public
+    /// runtime contract carries only the opaque `VarId`; this stack keeps the
+    /// standalone table owner and slot private while callbacks re-enter Tcl.
+    /// It is swapped with [`CoroContext::array_operation_targets`] so a yield
+    /// cannot make one flow pop and release another flow's target.
+    array_operation_targets: RefCell<Vec<ArrayOperationTarget>>,
+    /// Variable cells whose trace callbacks are active in the current flow.
+    /// This must move with coroutine execution context: a suspended callback
+    /// cannot suppress or unbalance another coroutine's trace walk.
+    active_var_trace_scopes: RefCell<Vec<crate::cmd_trace::VarTraceScope>>,
     /// Runtime-issued speculative guards and explicitly attested builtin IDs.
     guards: RefCell<GuardManager>,
     guarded_commands:
@@ -1272,6 +1291,8 @@ impl Interp {
         let mut interp = Interp(Rc::new(InterpState {
             frames: RefCell::new(FrameStack::new()),
             namespaces: RefCell::new(Namespaces::new()),
+            array_operation_targets: RefCell::new(Vec::new()),
+            active_var_trace_scopes: RefCell::new(Vec::new()),
             guards: RefCell::new(guards),
             guarded_commands: RefCell::new(std::collections::BTreeMap::new()),
             current_ns: Cell::new(GLOBAL),
@@ -2799,6 +2820,45 @@ impl Interp {
         self.return_options.borrow().clone()
     }
 
+    /// Move the active completion's carried option pairs out of the
+    /// interpreter. SaveInterpState-style callbacks use this to run with a
+    /// fresh completion and restore the caller's pairs when the callback's
+    /// completion is ignored.
+    fn take_return_options(&self) -> Vec<(Vec<u8>, Vec<u8>)> {
+        std::mem::take(&mut *self.return_options.borrow_mut())
+    }
+
+    /// Restore a previously saved carried-options set.
+    fn restore_return_options(&self, options: Vec<(Vec<u8>, Vec<u8>)>) {
+        *self.return_options.borrow_mut() = options;
+    }
+
+    /// Begin an evaluation/completion boundary with no carried options.
+    pub(crate) fn clear_return_options(&self) {
+        self.return_options.borrow_mut().clear();
+    }
+
+    /// Enter a control-command body under the shared completion-option policy.
+    pub(crate) fn begin_control_options(
+        &self,
+        policy: tcl_runtime_api::completion_options::ControlOptionPolicy,
+    ) {
+        if policy.begins_fresh() {
+            self.clear_return_options();
+        }
+    }
+
+    /// Settle a control command's successful completion under the shared policy.
+    pub(crate) fn settle_control_options(
+        &self,
+        policy: tcl_runtime_api::completion_options::ControlOptionPolicy,
+        code: Code,
+    ) {
+        if code == Code::Ok && policy.settles_success() {
+            self.clear_return_options();
+        }
+    }
+
     /// The pending `return` `-code`/`-level` (the options a body that completed
     /// via `return` would propagate) — for `catch`/`try`'s options dict and TIP
     /// 329 `-during` chaining.
@@ -2838,6 +2898,7 @@ impl Interp {
         name: &[u8],
         project: impl FnOnce(&mut Self, Code) -> T,
     ) -> T {
+        self.clear_return_options();
         self.script_stack.borrow_mut().push(name.to_vec());
         // A `source`d file is its own `info frame` level: `type source` + the
         // file path, inheriting the enclosing proc/level. Its commands are
@@ -2909,6 +2970,7 @@ impl Interp {
     /// frame, so its commands — and the method bodies they define — report
     /// file-absolute `info frame` lines (TIP 280). Otherwise it runs inline.
     pub(crate) fn eval_def_body(&mut self, body: &[u8], src: Option<(Rc<[u8]>, u32)>) -> Code {
+        self.clear_return_options();
         match src {
             Some((file, line_base)) => {
                 let mut frame = self.inherited_cmd_frame();
@@ -2927,6 +2989,7 @@ impl Interp {
     /// together), then restore. Transparent — the body's completion
     /// code (incl. `return`) propagates unchanged.
     pub(crate) fn eval_uplevel(&mut self, target_level: usize, script: &[u8]) -> Code {
+        self.clear_return_options();
         let prev_level = self.frames.borrow_mut().set_active_level(target_level);
         let prev_ns = self.current_ns.get();
         self.current_ns
@@ -2987,6 +3050,7 @@ impl Interp {
         loc: Option<(Option<Rc<[u8]>>, u32)>,
         add_eval_frame: bool,
     ) -> Code {
+        self.clear_return_options();
         let dying_name = {
             let namespaces = self.namespaces.borrow();
             namespaces
@@ -3753,38 +3817,21 @@ impl Interp {
         // `TclIsVarTraceActive(varPtr)` (tclTrace.c 9.0.4:2513). Per *cell*: a
         // callback writing a different element of the same array is a different
         // `Var` and fires (issue #1574).
-        if traces.active_var_scopes.contains(&cell) {
+        if self.active_var_trace_scopes.borrow().contains(&cell) {
             return false;
         }
-        let array_active = elem.is_some() && traces.active_var_scopes.contains(&cell.array());
-        // C fires the containing array's traces before the element's own
-        // (`TclCallVarTraces`, tclTrace.c 9.0.4: the `arrayPtr` loop at :2581
-        // precedes the `varPtr` loop at :2623), and walks each list head→tail
-        // — newest-first, since `TraceVarEx` prepends (:3090-3092). Our Vec
-        // pushes newest-last, so each group is reversed. Issue #1440.
-        let selected = |whole_array: bool| {
-            traces
-                .traces
-                .iter()
-                .rev()
-                .filter(move |t| t.elem.is_none() == whole_array)
-                .filter(|t| {
-                    crate::cmd_trace::matches(t, base, elem, op, access_ns, access_frame_level)
-                })
-        };
-        let array_group = (access.whole_array && !array_active)
-            .then(|| selected(true))
-            .into_iter()
-            .flatten();
-        // The walk order is fixed here, but *what runs* is re-read at each step:
-        // C follows `active.nextTracePtr`, which `Tcl_UntraceVar2` rewrites when
-        // a callback removes a trace mid-walk, so a trace removed during the
-        // firing does not fire in that same pass. Snapshotting the callbacks
-        // themselves would run one that is already gone (issue #1633). Ids are
-        // enough to re-find each registration, and are never reused.
-        let order: Vec<u64> = array_group.chain(selected(false)).map(|t| t.id).collect();
+        let array_active = elem.is_some()
+            && self
+                .active_var_trace_scopes
+                .borrow()
+                .contains(&cell.array());
+        let any = traces.traces.iter().any(|trace| {
+            let whole = trace.elem.is_none();
+            (!whole || (access.whole_array && !array_active))
+                && crate::cmd_trace::matches(trace, base, elem, op, access_ns, access_frame_level)
+        });
         drop(traces);
-        if order.is_empty() {
+        if !any {
             return false;
         }
         // C aborts the chain on the first callback error for every op *except*
@@ -3794,77 +3841,88 @@ impl Interp {
         // Preserve the result object across the callbacks.
         let saved = self.result.get();
         unsafe { obj::incr_ref_count(saved) };
+        let saved_options = self.take_return_options();
 
         // The cell is marked active for the whole firing, as C marks `varPtr`
         // once on entry and clears it on the way out — not per callback.
-        self.traces
-            .borrow_mut()
-            .active_var_scopes
-            .push(cell.clone());
+        self.active_var_trace_scopes.borrow_mut().push(cell.clone());
 
         let mut errored = false;
         let op_name = String::from_utf8_lossy(op).into_owned();
-        for id in order {
-            // Still registered? A previous callback in this same firing may have
-            // removed it (C's `nextTracePtr` rewrite).
-            let Some((cmd, old_style)) = self
+        'groups: for whole_array in [true, false] {
+            if whole_array && (!access.whole_array || array_active) {
+                continue;
+            }
+            // Resolve each group only when Tcl reaches it. A whole-array
+            // callback can therefore add or remove the selected element's
+            // trace before the element group begins.
+            let order: Vec<u64> = self
                 .traces
                 .borrow()
                 .traces
                 .iter()
-                .find(|t| t.id == id)
-                .map(|t| (t.command.clone(), t.old_style))
-            else {
-                continue;
-            };
-            // Append `base element op` as properly-quoted trailing words. A
-            // trace installed by the deprecated `trace variable` form is
-            // called with the single `rwua` letter (C's `TCL_TRACE_OLD_STYLE`).
-            let op_word = tcl_cmd_core::trace::callback_op_word(&op_name, old_style);
-            let args = crate::list::new_list_obj(&[
-                new_string(reported),
-                new_string(access.report_elem.as_deref().unwrap_or(b"")),
-                new_string(op_word.as_bytes()),
-            ]);
-            let mut line = cmd;
-            line.push(b' ');
-            line.extend_from_slice(&obj_bytes(args));
-            drop_fresh(args);
-            let code = self.eval_str(&line);
-            if propagate && code == Code::Error {
-                // Capture the callback's error message; stop firing (C aborts
-                // the trace chain on the first error).
-                let msg = self.result_bytes();
-                self.traces.borrow_mut().pending_err = Some(msg);
-                // C's `TclCallVarTraces` error tail (tclTrace.c 9.0.4:2662-2696)
-                // keeps the callback's own errorInfo chain and appends a
-                // `(<type> trace on "name")` frame to it; only the *result* is
-                // replaced afterwards, by `TclVarErrMsg`. The element named
-                // here is the one from the access **spelling** — C snapshots
-                // `part2` before recovering one from a linked element — so
-                // `set a(k) 2` reports `(write trace on "a(k)")` while
-                // `set e 5` through `upvar #0 a(k) e` reports
-                // `(write trace on "e")`.
-                let mut frame = op.to_vec();
-                frame.extend_from_slice(b" trace on \"");
-                frame.extend_from_slice(reported);
-                if let Some(k) = access.spelling_elem.as_deref() {
-                    frame.push(b'(');
-                    frame.extend_from_slice(k);
-                    frame.push(b')');
+                .rev()
+                .filter(|trace| trace.elem.is_none() == whole_array)
+                .filter(|trace| {
+                    crate::cmd_trace::matches(trace, base, elem, op, access_ns, access_frame_level)
+                })
+                .map(|trace| trace.id)
+                .collect();
+            for id in order {
+                // Still registered? A previous callback in this group may
+                // have removed it from C's live linked-list walk.
+                let Some((cmd, old_style)) = self
+                    .traces
+                    .borrow()
+                    .traces
+                    .iter()
+                    .find(|trace| trace.id == id)
+                    .map(|trace| (trace.command.clone(), trace.old_style))
+                else {
+                    continue;
+                };
+                let op_word = tcl_cmd_core::trace::callback_op_word(&op_name, old_style);
+                let args = crate::list::new_list_obj(&[
+                    new_string(reported),
+                    new_string(access.report_elem.as_deref().unwrap_or(b"")),
+                    new_string(op_word.as_bytes()),
+                ]);
+                let mut line = cmd;
+                line.push(b' ');
+                line.extend_from_slice(&obj_bytes(args));
+                drop_fresh(args);
+                self.clear_return_options();
+                let code = self.eval_str(&line);
+                if propagate && code == Code::Error {
+                    // Capture the callback's error message; stop firing (C
+                    // aborts the trace chain on the first error).
+                    let msg = self.result_bytes();
+                    self.traces.borrow_mut().pending_err = Some(msg);
+                    let mut frame = op.to_vec();
+                    frame.extend_from_slice(b" trace on \"");
+                    frame.extend_from_slice(reported);
+                    if let Some(k) = access.spelling_elem.as_deref() {
+                        frame.push(b'(');
+                        frame.extend_from_slice(k);
+                        frame.push(b')');
+                    }
+                    frame.push(b'"');
+                    self.append_frame_noline(&frame);
+                    errored = true;
+                    break 'groups;
                 }
-                frame.push(b'"');
-                self.append_frame_noline(&frame);
-                errored = true;
-                break;
+                self.restore_return_options(saved_options.clone());
             }
         }
-        let popped = self.traces.borrow_mut().active_var_scopes.pop();
+        let popped = self.active_var_trace_scopes.borrow_mut().pop();
         debug_assert_eq!(popped, Some(cell));
         // Restore the saved result (release the trace's, adopt our held +1).
         unsafe {
             obj::decr_ref_count(self.result.get());
             self.result.set(saved);
+        }
+        if !errored {
+            self.restore_return_options(saved_options);
         }
         errored
     }
@@ -3905,6 +3963,238 @@ impl Interp {
             exc.code_explicit = false;
         }
         Code::Error
+    }
+
+    /// Locate one array binding, retain its opaque identity across the array
+    /// operation trace, and expose it to the shared command core.
+    pub(crate) fn with_array_trace_target(
+        &mut self,
+        name: &[u8],
+        operation: impl FnOnce(&mut Self, &tcl_runtime_api::ArrayTarget) -> Code,
+    ) -> Code {
+        let frame = tcl_runtime_api::FrameId(self.frames.borrow().current_level());
+        let located = crate::vars::array_target_at(
+            &self.frames.borrow(),
+            &self.namespaces.borrow(),
+            name,
+            frame.0,
+        );
+        let display = String::from_utf8_lossy(name).into_owned();
+        let target = located.as_ref().map_or_else(
+            || tcl_runtime_api::ArrayTarget::named(frame, display.clone()),
+            |record| tcl_runtime_api::ArrayTarget::cell(frame, display.clone(), record.id()),
+        );
+        if let Some(record) = located {
+            let retained = crate::vars::retain_array_target(
+                &mut self.frames.borrow_mut(),
+                &mut self.namespaces.borrow_mut(),
+                &record,
+            );
+            debug_assert!(retained);
+            self.array_operation_targets
+                .borrow_mut()
+                .push(ArrayOperationTarget { target: record });
+        }
+        let result = match self.fire_array_trace(name) {
+            Some(code) => code,
+            None => operation(self, &target),
+        };
+        if let Some(id) = target.cell_id() {
+            let popped = self.array_operation_targets.borrow_mut().pop();
+            debug_assert_eq!(popped.as_ref().map(|record| record.target.id()), Some(id));
+            if let Some(record) = popped {
+                crate::vars::release_array_target(
+                    &mut self.frames.borrow_mut(),
+                    &mut self.namespaces.borrow_mut(),
+                    &record.target,
+                );
+            }
+        }
+        result
+    }
+
+    fn array_operation_target(
+        &self,
+        target: &tcl_runtime_api::ArrayTarget,
+    ) -> Option<crate::vars::ArrayCellTarget> {
+        let id = target.cell_id()?;
+        self.array_operation_targets
+            .borrow()
+            .iter()
+            .rev()
+            .find(|record| record.target.id() == id)
+            .map(|record| record.target.clone())
+    }
+
+    pub(crate) fn array_keys_at_target(
+        &self,
+        target: &tcl_runtime_api::ArrayTarget,
+    ) -> Option<Vec<Vec<u8>>> {
+        let record = self.array_operation_target(target)?;
+        crate::vars::array_names_at_target(
+            &self.frames.borrow(),
+            &self.namespaces.borrow(),
+            &record,
+        )
+    }
+
+    /// Tcl's `TclPtrGetVarIdx` read used by `array get`: select the live
+    /// element before callbacks, fire containing-array then element traces,
+    /// and read that same element afterwards. Trace errors are swallowed but
+    /// published to `errorInfo`/`errorCode`; destruction of the array selected
+    /// for the enclosing operation remains a hard read error.
+    pub(crate) fn array_read_elem_at_target(
+        &mut self,
+        target: &tcl_runtime_api::ArrayTarget,
+        key: &[u8],
+    ) -> tcl_runtime_api::ArrayElementRead<*mut TclObj> {
+        let live_array = crate::vars::array_target_at(
+            &self.frames.borrow(),
+            &self.namespaces.borrow(),
+            target.name().as_bytes(),
+            target.frame().0,
+        );
+        let live_was_array = live_array.as_ref().is_some_and(|live| {
+            crate::vars::array_names_at_target(
+                &self.frames.borrow(),
+                &self.namespaces.borrow(),
+                live,
+            )
+            .is_some()
+        });
+        let selected = crate::vars::array_element_target_at(
+            &self.frames.borrow(),
+            &self.namespaces.borrow(),
+            target.name().as_bytes(),
+            key,
+            target.frame().0,
+        );
+        let selected_retained = selected.as_ref().is_some_and(|(array, element)| {
+            crate::vars::retain_array_element_target(
+                &mut self.frames.borrow_mut(),
+                &mut self.namespaces.borrow_mut(),
+                array,
+                key,
+                *element,
+            )
+        });
+        let trace_errored = self
+            .fire_read_trace(target.name().as_bytes(), Some(key))
+            .is_some();
+        let trace_failure = trace_errored.then(|| {
+            (
+                self.result_bytes(),
+                self.error_code(),
+                self.error_info(),
+                i64::from(self.error_line()),
+            )
+        });
+
+        let outcome = match self.array_operation_target(target) {
+            Some(operation)
+                if crate::vars::array_names_at_target(
+                    &self.frames.borrow(),
+                    &self.namespaces.borrow(),
+                    &operation,
+                )
+                .is_some() =>
+            {
+                if let Some((_, _, info, line)) = trace_failure {
+                    self.publish_and_reset_error();
+                    tcl_runtime_api::ArrayElementRead::Missing(
+                        tcl_runtime_api::ArrayReadMiss::trace_error(Some(info), line),
+                    )
+                } else {
+                    let value = selected.as_ref().map_or_else(
+                        || self.var_get_elem(target.name().as_bytes(), key),
+                        |(array, element)| {
+                            crate::vars::get_element_at_target(
+                                &self.frames.borrow(),
+                                &self.namespaces.borrow(),
+                                array,
+                                key,
+                                *element,
+                            )
+                        },
+                    );
+                    value.map_or_else(
+                        || {
+                            let miss = if live_was_array {
+                                tcl_runtime_api::ArrayReadMiss::missing()
+                            } else {
+                                tcl_runtime_api::ArrayReadMiss::lookup(error_code_list(&[
+                                    b"TCL",
+                                    b"LOOKUP",
+                                    b"VARNAME",
+                                    target.name().as_bytes(),
+                                ]))
+                            };
+                            tcl_runtime_api::ArrayElementRead::Missing(miss)
+                        },
+                        tcl_runtime_api::ArrayElementRead::Value,
+                    )
+                }
+            }
+            Some(operation) => {
+                let invalidation = if crate::vars::array_target_is_set(
+                    &self.frames.borrow(),
+                    &self.namespaces.borrow(),
+                    &operation,
+                ) {
+                    tcl_runtime_api::ArrayInvalidation::Retyped
+                } else {
+                    tcl_runtime_api::ArrayInvalidation::Unset
+                };
+                trace_failure.map_or_else(
+                    || tcl_runtime_api::ArrayElementRead::ArrayInvalidated(invalidation),
+                    |(message, code, info, line)| {
+                        tcl_runtime_api::ArrayElementRead::TraceError(
+                            tcl_runtime_api::ArrayReadFailure::new(
+                                String::from_utf8_lossy(&message),
+                                code,
+                                Some(info),
+                                Some(line),
+                            ),
+                        )
+                    },
+                )
+            }
+            None => trace_failure.map_or_else(
+                || {
+                    tcl_runtime_api::ArrayElementRead::ArrayInvalidated(
+                        tcl_runtime_api::ArrayInvalidation::Unset,
+                    )
+                },
+                |(message, code, info, line)| {
+                    tcl_runtime_api::ArrayElementRead::TraceError(
+                        tcl_runtime_api::ArrayReadFailure::new(
+                            String::from_utf8_lossy(&message),
+                            code,
+                            Some(info),
+                            Some(line),
+                        ),
+                    )
+                },
+            ),
+        };
+        if let tcl_runtime_api::ArrayElementRead::Value(value) = &outcome {
+            // The selected element's retained cell is released immediately
+            // below. Transfer one hold to the shared array core first so no
+            // raw pointer can die between this return and list materialisation.
+            tcl_syntax::value::ValueOps::pin_value(self, value);
+        }
+        if selected_retained {
+            if let Some((array, element)) = selected {
+                crate::vars::release_array_element_target(
+                    &mut self.frames.borrow_mut(),
+                    &mut self.namespaces.borrow_mut(),
+                    &array,
+                    key,
+                    element,
+                );
+            }
+        }
+        outcome
     }
 
     /// Fire `name`'s `array` traces — C's `TclCheckArrayTraces`, which every
@@ -4040,6 +4330,7 @@ impl Interp {
         // Preserve the result object across the callbacks.
         let saved = self.result.get();
         unsafe { obj::incr_ref_count(saved) };
+        let saved_options = self.take_return_options();
 
         // Only `firing_cmd_traces` is raised, never `exec_firing`: C sets
         // `INTERP_TRACE_IN_PROGRESS` in exactly one place — `TraceExecutionProc`
@@ -4069,7 +4360,9 @@ impl Interp {
             line.push(b' ');
             line.extend_from_slice(&obj_bytes(args));
             drop_fresh(args);
+            self.clear_return_options();
             let _ = self.eval_str(&line);
+            self.restore_return_options(saved_options.clone());
         }
         {
             let mut traces = self.traces.borrow_mut();
@@ -4083,6 +4376,7 @@ impl Interp {
             obj::decr_ref_count(self.result.get());
             self.result.set(saved);
         }
+        self.restore_return_options(saved_options);
     }
 
     /// The callback prefix of the live command/execution trace `id`, or `None`
@@ -4148,6 +4442,7 @@ impl Interp {
         }
         let saved = self.result.get();
         unsafe { obj::incr_ref_count(saved) };
+        let saved_options = self.take_return_options();
         self.traces.borrow_mut().exec_firing += 1;
         let mut abort: Option<Code> = None;
         for id in ids {
@@ -4165,6 +4460,7 @@ impl Interp {
             line.extend_from_slice(&obj_bytes(args));
             drop_fresh(args);
             self.traces.borrow_mut().firing_exec_traces.push(id);
+            self.clear_return_options();
             let c = self.eval_str(&line);
             self.traces.borrow_mut().firing_exec_traces.pop();
             if c != Code::Ok {
@@ -4182,6 +4478,7 @@ impl Interp {
                 obj::decr_ref_count(self.result.get());
                 self.result.set(saved);
             }
+            self.restore_return_options(saved_options);
         }
         abort
     }
@@ -4211,6 +4508,7 @@ impl Interp {
         // result is observed by the next one.
         let saved = self.result.get();
         unsafe { obj::incr_ref_count(saved) };
+        let saved_options = self.take_return_options();
         let code_str = code.as_int().to_string().into_bytes();
 
         self.traces.borrow_mut().exec_firing += 1;
@@ -4236,6 +4534,7 @@ impl Interp {
             line.extend_from_slice(&obj_bytes(args));
             drop_fresh(args);
             self.traces.borrow_mut().firing_exec_traces.push(id);
+            self.clear_return_options();
             let c = self.eval_str(&line);
             self.traces.borrow_mut().firing_exec_traces.pop();
             if c != Code::Ok {
@@ -4257,6 +4556,7 @@ impl Interp {
                     obj::decr_ref_count(self.result.get());
                     self.result.set(saved);
                 }
+                self.restore_return_options(saved_options);
                 code
             }
         }
@@ -4823,6 +5123,7 @@ impl Interp {
         }
         let saved = self.result.get();
         unsafe { obj::incr_ref_count(saved) };
+        let saved_options = self.take_return_options();
         for (name, elem, cmd, old_style) in victims {
             // A trace registered the deprecated way is called with the `rwua`
             // letter, not the operation name — the teardown path must honour
@@ -4838,12 +5139,15 @@ impl Interp {
             line.push(b' ');
             line.extend_from_slice(&obj_bytes(args));
             drop_fresh(args);
+            self.clear_return_options();
             let _ = self.eval_str(&line);
+            self.restore_return_options(saved_options.clone());
         }
         unsafe {
             obj::decr_ref_count(self.result.get());
             self.result.set(saved);
         }
+        self.restore_return_options(saved_options);
     }
 
     /// Resolve a (relative/absolute) namespace name to its id, or `None`.
@@ -5216,7 +5520,22 @@ impl Interp {
     /// Publish a portable command-layer error through this runtime's result
     /// and exception-state ABI without losing a structured error code.
     pub(crate) fn report_cmd_error(&mut self, error: tcl_cmd_core::CmdError) -> Code {
-        let (message, code) = error.into_parts();
+        let (message, code, info, line) = error.into_details();
+        if let Some(info) = info {
+            self.set_result_bytes(message.as_bytes());
+            *self.exc.borrow_mut() = ExceptionState {
+                info: Some(info),
+                code: code.map_or_else(|| b"NONE".to_vec(), String::into_bytes),
+                code_explicit: false,
+                // The variable-trace frame is already present, but the array
+                // command which propagated it still has to log while unwinding.
+                already_logged: false,
+            };
+            if let Some(line) = line.and_then(|value| u32::try_from(value).ok()) {
+                self.error_line.set(line);
+            }
+            return Code::Error;
+        }
         match code {
             Some(code) => self.error_with_code(message.as_bytes(), code.as_bytes()),
             None => self.set_error(message.as_bytes()),
@@ -5315,6 +5634,14 @@ impl Interp {
         std::mem::swap(
             &mut *self.return_options.borrow_mut(),
             &mut ctx.return_options,
+        );
+        std::mem::swap(
+            &mut *self.array_operation_targets.borrow_mut(),
+            &mut ctx.array_operation_targets,
+        );
+        std::mem::swap(
+            &mut *self.active_var_trace_scopes.borrow_mut(),
+            &mut ctx.active_var_trace_scopes,
         );
         let ed = self.eval_depth.replace(ctx.eval_depth);
         ctx.eval_depth = ed;
@@ -5993,6 +6320,9 @@ impl Interp {
         src: &[u8],
         project: impl FnOnce(&mut Self, Code) -> T,
     ) -> T {
+        if self.eval_depth.get() == 0 {
+            self.clear_return_options();
+        }
         let owned = self.cmd_frames.borrow().is_empty().then(CmdFrame::root);
         let code = self.eval_script_mode_unpublished(src, owned, false);
         let projected = project(self, code);
@@ -6316,6 +6646,7 @@ impl Interp {
     /// `TclEvalObjEx` of a non-literal). The errorInfo `("eval" body line N)`
     /// frame is appended separately by the caller.
     pub(crate) fn eval_body(&mut self, script: &[u8]) -> Code {
+        self.clear_return_options();
         self.eval_unlocated_body(script)
     }
 
@@ -6366,6 +6697,7 @@ impl Interp {
     /// `type source` at its original file+line (the test-body case) rather than
     /// `type eval`.
     pub(crate) fn eval_body_obj(&mut self, obj: *mut TclObj) -> Code {
+        self.clear_return_options();
         // A pure list is one command, dispatched by element identity (so a
         // contained literal keeps its source location — C's list-eval path),
         // inside its own `type eval` frame.
@@ -6428,6 +6760,7 @@ impl Interp {
     /// [`eval_body_obj`](Self::eval_body_obj). A located literal keeps its source
     /// provenance; a dynamic body is `type eval`, no file.
     pub(crate) fn eval_uplevel_obj(&mut self, target_level: usize, obj: *mut TclObj) -> Code {
+        self.clear_return_options();
         let loc = self.arg_loc(obj);
         let prev_level = self.frames.borrow_mut().set_active_level(target_level);
         let prev_ns = self.current_ns.get();
@@ -6618,12 +6951,6 @@ impl Interp {
         // native ABI. `argv` owns/borrows its objects independently, so dropping
         // the prior result here cannot invalidate an argument.
         self.set_result_bytes(b"");
-        // A parsed/direct command starts a new completion. Execution-trace
-        // callbacks run under SaveInterpState semantics and must not erase the
-        // option pairs returned by the command whose leave trace they observe.
-        if self.traces.borrow().exec_firing == 0 {
-            self.return_options.borrow_mut().clear();
-        }
         self.cmd_count.set(self.cmd_count.get() + 1);
         // Fast path: nothing is registered, so nothing can fire. Being inside a
         // trace callback is *not* a reason to skip: C's
@@ -6784,6 +7111,7 @@ impl Interp {
         }
         let saved = self.result.get();
         unsafe { obj::incr_ref_count(saved) };
+        let saved_options = self.take_return_options();
         let code_str = code.map(|c| c.as_int().to_string().into_bytes());
         let op_label: &[u8] = if is_enter { b"enterstep" } else { b"leavestep" };
 
@@ -6805,6 +7133,7 @@ impl Interp {
             line.push(b' ');
             line.extend_from_slice(&obj_bytes(args));
             drop_fresh(args);
+            self.clear_return_options();
             let c = self.eval_str(&line);
             if c != Code::Ok {
                 outcome = Some(c);
@@ -6823,6 +7152,7 @@ impl Interp {
                     obj::decr_ref_count(self.result.get());
                     self.result.set(saved);
                 }
+                self.restore_return_options(saved_options);
                 None
             }
         }
@@ -8183,6 +8513,8 @@ impl Interp {
         prefix: &[Vec<u8>],
         argv: &[*mut TclObj],
     ) -> Code {
+        let policy = tcl_runtime_api::completion_options::ControlOptionPolicy::FRESH_FORWARDED;
+        self.begin_control_options(policy);
         let Some(parent_state) = self.parent.borrow().upgrade() else {
             return self.error(b"cannot invoke a parent alias from the root interpreter");
         };
@@ -8206,11 +8538,14 @@ impl Interp {
         // `parent` is an owned handle sharing the parent's `InterpState`; the
         // dispatch mutates it through interior mutability (no aliased `&mut`).
         let mut parent = Interp(parent_state);
+        parent.begin_control_options(policy);
         let code = parent.dispatch(&new_argv);
         let res = parent.result_bytes();
+        let options = parent.pending_return_options();
         CROSS_INTERP_DEPTH.with(|d| d.set(d.get().saturating_sub(1)));
         release_all(&new_argv);
         self.set_result_bytes(&res);
+        self.set_return_options(options);
         code
     }
 
@@ -8417,6 +8752,7 @@ impl Interp {
         let native = meta
             .native
             .filter(|_| self.traces.borrow().step_active.is_empty());
+        self.clear_return_options();
         let code = match native {
             Some(entry) => match self.run_native_body(entry, call_args, proc_frame) {
                 Ok(code) => code,
@@ -8897,8 +9233,13 @@ impl Interp {
     /// `[target, *prefix, *caller_tail]`, and invoke. Alias-of-alias chains fall
     /// out naturally (the resolved target may itself be an `Alias`) and are
     /// bounded by [`MAX_ALIAS_DISPATCH_DEPTH`], so a cycle that escaped the
-    /// definition-time gate errors instead of exhausting the native stack.
+    /// definition-time gate errors instead of exhausting the native stack. The
+    /// wrapper begins a fresh completion-option scope before invoking its
+    /// target, including across an interpreter boundary.
     fn dispatch_alias(&mut self, target: &[u8], prefix: &[Vec<u8>], argv: &[*mut TclObj]) -> Code {
+        self.begin_control_options(
+            tcl_runtime_api::completion_options::ControlOptionPolicy::FRESH_FORWARDED,
+        );
         if ALIAS_DISPATCH_DEPTH.with(|d| d.get()) >= MAX_ALIAS_DISPATCH_DEPTH {
             return self.error(b"too many nested alias invocations (infinite loop?)");
         }

--- a/runtime/rust/src/state_traits.rs
+++ b/runtime/rust/src/state_traits.rs
@@ -27,8 +27,8 @@
 //! `Commands::dispatch_id` invokes (the resolve-then-invoke pairing).
 
 use tcl_runtime_api::{
-    CommandId, Commands, Completion, FrameId, Frames, Introspect, Namespaces, NsId, ProcInfo,
-    ProcParam, Procs, Traces, VarStore, VarUnsetError,
+    ArrayElementRead, ArrayTarget, CommandId, Commands, Completion, FrameId, Frames, Introspect,
+    Namespaces, NsId, ProcInfo, ProcParam, Procs, Traces, VarStore, VarUnsetError,
 };
 
 use crate::frame::Link;
@@ -129,6 +129,38 @@ impl VarStore for Interp {
                 .map(|k| String::from_utf8_lossy(k).into_owned())
                 .collect()
         })
+    }
+
+    fn array_target(&self, frame: FrameId, name: &str) -> ArrayTarget {
+        crate::vars::array_target_at(
+            &self.frames.borrow(),
+            &self.namespaces(),
+            name.as_bytes(),
+            frame.0,
+        )
+        .map_or_else(
+            || ArrayTarget::named(frame, name),
+            |target| ArrayTarget::cell(frame, name, target.id()),
+        )
+    }
+
+    fn array_keys_at(&self, target: &ArrayTarget) -> Option<Vec<String>> {
+        if target.cell_id().is_none() {
+            return self.array_keys(target.frame(), target.name());
+        }
+        self.array_keys_at_target(target).map(|keys| {
+            keys.into_iter()
+                .map(|key| String::from_utf8_lossy(&key).into_owned())
+                .collect()
+        })
+    }
+
+    fn array_read_elem_at(
+        &mut self,
+        target: &ArrayTarget,
+        key: &str,
+    ) -> ArrayElementRead<*mut TclObj> {
+        self.array_read_elem_at_target(target, key.as_bytes())
     }
 }
 

--- a/runtime/rust/src/value_ops.rs
+++ b/runtime/rust/src/value_ops.rs
@@ -104,6 +104,14 @@ impl ValueOps for Interp {
         list::new_list_obj(&items)
     }
 
+    fn pin_value(&mut self, value: &*mut TclObj) {
+        unsafe { obj::incr_ref_count(*value) };
+    }
+
+    fn unpin_value(&mut self, value: &*mut TclObj) {
+        unsafe { obj::decr_ref_count(*value) };
+    }
+
     fn as_str(&mut self, v: &*mut TclObj) -> Rc<str> {
         bytes_to_str(&obj_bytes(*v))
     }

--- a/runtime/rust/src/vars.rs
+++ b/runtime/rust/src/vars.rs
@@ -42,7 +42,7 @@
 //! [`make_upvar`]). The coordinator borrows both the frame stack and the
 //! namespace tree (the two var-table owners) from the interp.
 
-use tcl_runtime_api::FrameLinkOrigin;
+use tcl_runtime_api::{FrameLinkOrigin, VarId};
 use tcl_syntax::naming::is_qualified;
 
 use crate::frame::{FrameStack, Link, Var, VarError, VarHome, VarTable};
@@ -69,6 +69,27 @@ enum Resolved {
     /// A qualified name whose namespace does not exist. Writes raise
     /// `parent namespace doesn't exist`; reads/unsets treat it as not-found.
     NoNamespace,
+}
+
+/// One resolved standalone variable binding selected by stable identity.
+///
+/// The table slot is deliberately not the identity: compiled slots survive an
+/// ordinary `unset`, while a later recreation receives a new identity. During
+/// an operation on this exact binding Tcl retains the `Var` cell, however, so
+/// an unset-and-recreate inside one callback refills the retained identity.
+/// `array get` holds this record across callbacks and compares `id` before
+/// observing the table again.
+#[derive(Clone, Debug)]
+pub(crate) struct ArrayCellTarget {
+    home: VarHome,
+    name: Vec<u8>,
+    id: VarId,
+}
+
+impl ArrayCellTarget {
+    pub(crate) const fn id(&self) -> VarId {
+        self.id
+    }
 }
 
 /// The var home where the current context's *local* (unqualified, non-`::`)
@@ -251,6 +272,118 @@ fn resolve_at(frames: &FrameStack, ns: &Namespaces, name: &[u8], level: usize) -
         Resolved::Place(p) => Resolved::Place(follow_links(frames, ns, p)),
         other => other,
     }
+}
+
+/// Resolve an array-command spelling to the concrete variable binding it
+/// currently reaches. The binding may be undefined or scalar; callers retain
+/// it so a callback cannot steer the operation onto a replacement.
+pub(crate) fn array_target_at(
+    frames: &FrameStack,
+    ns: &Namespaces,
+    name: &[u8],
+    level: usize,
+) -> Option<ArrayCellTarget> {
+    let Resolved::Place(place) = resolve_at(frames, ns, name, level) else {
+        return None;
+    };
+    if place.elem.is_some() {
+        return None;
+    }
+    let id = table(frames, ns, place.home)?.binding_id(&place.name)?;
+    Some(ArrayCellTarget {
+        home: place.home,
+        name: place.name,
+        id,
+    })
+}
+
+/// Enumerate an exact binding only while it is still the array selected when
+/// an operation began.
+pub(crate) fn array_names_at_target(
+    frames: &FrameStack,
+    ns: &Namespaces,
+    target: &ArrayCellTarget,
+) -> Option<Vec<Vec<u8>>> {
+    let table = table(frames, ns, target.home)?;
+    if table.binding_id(&target.name) != Some(target.id) {
+        return None;
+    }
+    table
+        .array_names(&target.name)
+        .map(|keys| keys.into_iter().map(<[u8]>::to_vec).collect())
+}
+
+pub(crate) fn array_target_is_set(
+    frames: &FrameStack,
+    ns: &Namespaces,
+    target: &ArrayCellTarget,
+) -> bool {
+    let Some(table) = table(frames, ns, target.home) else {
+        return false;
+    };
+    table.binding_id(&target.name) == Some(target.id) && table.is_set(&target.name)
+}
+
+pub(crate) fn retain_array_target(
+    frames: &mut FrameStack,
+    ns: &mut Namespaces,
+    target: &ArrayCellTarget,
+) -> bool {
+    table_mut(frames, ns, target.home).retain_binding(&target.name, target.id)
+}
+
+pub(crate) fn release_array_target(
+    frames: &mut FrameStack,
+    ns: &mut Namespaces,
+    target: &ArrayCellTarget,
+) {
+    table_mut(frames, ns, target.home).release_binding(&target.name, target.id);
+}
+
+/// Stable identities of the live array and element reached by a spelling just
+/// before its read traces fire.
+pub(crate) fn array_element_target_at(
+    frames: &FrameStack,
+    ns: &Namespaces,
+    name: &[u8],
+    key: &[u8],
+    level: usize,
+) -> Option<(ArrayCellTarget, VarId)> {
+    let target = array_target_at(frames, ns, name, level)?;
+    let element = table(frames, ns, target.home)?.element_id(&target.name, key)?;
+    Some((target, element))
+}
+
+pub(crate) fn retain_array_element_target(
+    frames: &mut FrameStack,
+    ns: &mut Namespaces,
+    target: &ArrayCellTarget,
+    key: &[u8],
+    element: VarId,
+) -> bool {
+    table_mut(frames, ns, target.home).retain_element(&target.name, key, element)
+}
+
+pub(crate) fn release_array_element_target(
+    frames: &mut FrameStack,
+    ns: &mut Namespaces,
+    target: &ArrayCellTarget,
+    key: &[u8],
+    element: VarId,
+) {
+    table_mut(frames, ns, target.home).release_element(&target.name, key, element);
+}
+
+/// Read the exact element selected before a callback, returning `None` after
+/// either the array or the element was unset and recreated under the same name.
+pub(crate) fn get_element_at_target(
+    frames: &FrameStack,
+    ns: &Namespaces,
+    target: &ArrayCellTarget,
+    key: &[u8],
+    element: VarId,
+) -> Option<*mut TclObj> {
+    table(frames, ns, target.home)?.load_elem_with_ids(&target.name, target.id, key, element)
 }
 
 /// The identity a variable trace on `name` belongs to, following

--- a/runtime/rust/tests/array_trace_oracle.rs
+++ b/runtime/rust/tests/array_trace_oracle.rs
@@ -95,6 +95,162 @@ fn runtime_tcltest_result(tree: &TclSourceTree, sheet: &str) -> Option<String> {
 }
 
 #[test]
+fn upstream_trace_1_11_through_1_14_pass_through_real_tcltest_startup() {
+    let Some(tree) = tcl_9_0_4() else {
+        eprintln!("skipping: Tcl 9.0.4 source tree is not installed");
+        return;
+    };
+    let source = std::fs::read_to_string(tree.tests_dir().join("trace.test"))
+        .expect("read pinned upstream trace.test");
+    let definitions =
+        upstream_test_definition(&source, "test trace-1.11 {", "# Basic write-tracing")
+            .expect("extract upstream trace-1.11 through trace-1.14 definitions");
+    let sheet = format!(
+        "package require tcltest\n\
+         namespace import -force ::tcltest::*\n\
+         {definitions}\n\
+         set ::tcl_lsp_summary [list \
+             $::tcltest::numTests(Total) $::tcltest::numTests(Passed) \
+             $::tcltest::numTests(Skipped) $::tcltest::numTests(Failed)]\n\
+         ::tcltest::cleanupTests\n\
+         set ::tcl_lsp_summary"
+    );
+    let oracle = run_oracle(
+        &tree,
+        &format!("{sheet}\nputs -nonewline $::tcl_lsp_summary"),
+    );
+    let Some(runtime) = runtime_tcltest_result(&tree, &sheet) else {
+        eprintln!("skipping real tcltest startup: runtime has no numeric tower");
+        return;
+    };
+
+    const SUMMARY: &str = "4 4 0 0";
+    if let Some(oracle) = oracle {
+        assert!(
+            oracle.ends_with(SUMMARY),
+            "unexpected Tcl 9.0.4 result: {oracle:?}"
+        );
+    }
+    assert_eq!(
+        runtime, SUMMARY,
+        "unexpected standalone-runtime tcltest counters"
+    );
+}
+
+#[test]
+fn array_get_reads_candidates_through_the_shared_trace_contract() {
+    let sheet = std::fs::read_to_string(
+        repository_root().join("tests/fixtures/tcl9/array-get-read-traces.tcl"),
+    )
+    .expect("read shared array-get trace fixture");
+    let expected = "{basic {x traced} {{whole A x read} {elem A x read}} traced {x y}} \
+        {missing 0 {} {TCL READ VARNAME} 0 0} \
+        {destroy 1 {can't read \"C(x)\": no such variable} {TCL READ VARNAME}} \
+        {retype 1 {can't read \"D(x)\": no such element in array} {TCL READ VARNAME} scalar} \
+        {boom 0 {} {TCL READ VARNAME} 1 1 1 {TCL READ VARNAME}} \
+        {carried 0 after 1 1 {TCL READ VARNAME}} \
+        {harddestroy 1 {can't read \"J(x)\": BOOM} {TCL READ VARNAME} 1 1 0} \
+        {hardretype 1 {can't read \"JR(x)\": BOOM} {TCL READ VARNAME} 1 1 scalar} \
+        {aggregate 0 {} {TCL READ VARNAME} 1 1 1 {TCL READ VARNAME}} \
+        {livegroup {x X} {whole new}} {owned {11 200}} \
+        {relem 0 {x NEW} 0 {x NEW}} \
+        {rbase 0 {} {TCL READ VARNAME} {x NEW}} \
+        {opretarget {x B}} {elemretarget {{x A} {x B}}} \
+        {uplevel {x traced} {local x read}} \
+        {namespace {x traced} {a x read}} \
+        {calls {x traced} {x traced}}";
+
+    assert_eq!(runtime_result(&sheet), expected);
+    if let Some(oracle) = tcl_9_0_4().and_then(|tree| oracle_result(&tree, &sheet)) {
+        assert_eq!(oracle, expected, "Tcl 9.0.4 array-get trace oracle");
+    }
+}
+
+#[test]
+fn retained_read_options_follow_completion_scopes_and_execution_trace_saves() {
+    let sheet = r#"
+proc BOOM {n1 n2 op} {error BOOM}
+array set E {x X}
+trace add variable E(x) read BOOM
+set rows {}
+set c [catch {array get E; set v after} m o]
+lappend rows [list $c $m [dict exists $o -errorcode] [dict get $o -errorcode]]
+set c [catch {array get E; list after} m o]
+lappend rows [list $c $m [dict exists $o -errorcode] [dict get $o -errorcode]]
+set c [catch {array get E; concat after} m o]
+lappend rows [list $c $m [dict exists $o -errorcode] [dict get $o -errorcode]]
+set c [catch {array get E; string cat after} m o]
+lappend rows [list $c $m [dict exists $o -errorcode] [dict get $o -errorcode]]
+proc LEAVE args {return -level 0 -code ok -foo callback}
+trace add execution array leave LEAVE
+set c [catch {array get E; list after} m o]
+lappend rows [list trace $c $m [dict exists $o -foo] [dict get $o -errorcode]]
+set out $rows
+"#;
+    let expected = "{0 after 1 {TCL READ VARNAME}} \
+        {0 after 1 {TCL READ VARNAME}} \
+        {0 after 1 {TCL READ VARNAME}} \
+        {0 after 1 {TCL READ VARNAME}} \
+        {trace 0 after 0 {TCL READ VARNAME}}";
+
+    assert_eq!(runtime_result(sheet), expected);
+    if let Some(oracle) = tcl_9_0_4().and_then(|tree| oracle_result(&tree, sheet)) {
+        assert_eq!(oracle, expected, "Tcl 9.0.4 completion-state oracle");
+    }
+}
+
+#[test]
+fn control_commands_apply_the_tcl9_completion_option_scope_matrix() {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../tests/fixtures/tcl9/completion-options-control.tcl");
+    let mut sheet = std::fs::read_to_string(path).expect("read shared completion-options fixture");
+    sheet.push_str("\nset out\n");
+    let expected = "{0 1 {TCL READ VARNAME}} {0 1 {TCL READ VARNAME}} \
+        {0 1 {TCL READ VARNAME}} {0 1 {TCL READ VARNAME}} \
+        {0 1 {TCL READ VARNAME}} {0 0 {}} {0 0 {}} {0 0 {}} \
+        {0 1 {TCL READ VARNAME}} {0 0 {}} {0 0 {}} {0 0 {}} \
+        {0 0 {}} {0 0 {}} {0 0 {}}";
+
+    assert_eq!(runtime_result(&sheet), expected);
+    if let Some(oracle) = tcl_9_0_4().and_then(|tree| oracle_result(&tree, &sheet)) {
+        assert_eq!(oracle, expected, "Tcl 9.0.4 completion-scope oracle");
+    }
+}
+
+#[test]
+fn alias_wrappers_begin_a_fresh_completion_option_scope() {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../tests/fixtures/tcl9/completion-options-alias.tcl");
+    let mut sheet = std::fs::read_to_string(path).expect("read shared alias-options fixture");
+    sheet.push_str("\nset out\n");
+    let expected = "{{list 0 inside 0} {try 0 inside 0} {eval 0 inside 0} \
+        {switch 0 inside 0}} {0 inside 0} {0 value BAR}";
+
+    assert_eq!(runtime_result(&sheet), expected);
+    if let Some(oracle) = tcl_9_0_4().and_then(|tree| oracle_result(&tree, &sheet)) {
+        assert_eq!(oracle, expected, "Tcl 9.0.4 alias completion-scope oracle");
+    }
+}
+
+#[test]
+fn interleaved_coroutines_keep_array_operation_targets_with_their_flow() {
+    let sheet = r#"
+proc Y {n1 n2 op} {yield $n1}
+array set A {x A}
+array set B {x B}
+trace add variable A(x) read Y
+trace add variable B(x) read Y
+set ya [coroutine ca apply {{} {array get ::A}}]
+set yb [coroutine cb apply {{} {array get ::B}}]
+set ra [ca]
+set rb [cb]
+list $ya $yb $ra $rb
+"#;
+
+    assert_eq!(runtime_result(sheet), "::A ::B {x A} {x B}");
+}
+
+#[test]
 fn upstream_trace_5_1_passes_through_real_tcltest_startup() {
     let Some(tree) = tcl_9_0_4() else {
         eprintln!("skipping: Tcl 9.0.4 source tree is not installed");

--- a/runtime/rust/tests/array_trace_oracle.rs
+++ b/runtime/rust/tests/array_trace_oracle.rs
@@ -200,6 +200,7 @@ set out $rows
 }
 
 #[test]
+#[cfg(have_tommath)]
 fn control_commands_apply_the_tcl9_completion_option_scope_matrix() {
     let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("../../tests/fixtures/tcl9/completion-options-control.tcl");

--- a/runtime/rust/tests/tcltest_channel_output.rs
+++ b/runtime/rust/tests/tcltest_channel_output.rs
@@ -16,6 +16,8 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+#![cfg(have_tommath)]
+
 use std::cell::RefCell;
 use std::path::Path;
 use std::rc::Rc;

--- a/rust/tcl-bytecode/src/lib.rs
+++ b/rust/tcl-bytecode/src/lib.rs
@@ -1216,6 +1216,10 @@ pub struct Instruction {
     /// and its own opcode continuation; an outer source command's `START_CMD`
     /// carries [`SourceCommandBoundary::Start`].
     pub source_command_boundary: SourceCommandBoundary,
+    /// Completion-option scope entered before this instruction executes.
+    /// Structured control commands use this out-of-band semantic marker where
+    /// their Tcl bytecode has no result-options opcode of its own.
+    pub completion_option_scope: Option<tcl_runtime_api::completion_options::ActivationOptionScope>,
     /// Byte span of the source construct this instruction was lowered
     /// from, when known. `None` for synthetic instructions with no
     /// direct source (loop-result pushes, fallthrough jumps, padding
@@ -1278,6 +1282,7 @@ impl Instruction {
             error_stack_context: None,
             source_command_namespace: String::new(),
             source_command_boundary: SourceCommandBoundary::None,
+            completion_option_scope: None,
             source_span: None,
             foreach_vars: None,
             foreach_collect: false,

--- a/rust/tcl-cmd-core/src/array.rs
+++ b/rust/tcl-cmd-core/src/array.rs
@@ -36,7 +36,10 @@
 //!
 //! Semantics verified against tclsh 9.0.
 
-use tcl_runtime_api::{ArrayTarget, Frames, VarStore, VarUnsetError};
+use tcl_runtime_api::{
+    ArrayElementRead, ArrayInvalidation, ArrayReadMiss, ArrayTarget, Frames, VarStore,
+    VarUnsetError,
+};
 use tcl_syntax::glob::string_match;
 use tcl_syntax::value::ValueOps;
 
@@ -45,12 +48,53 @@ use crate::error::CmdError;
 /// Dispatch an `array` subcommand handled by the shared core. `rest` is the
 /// arguments after the subcommand (`rest[0]` is the array name). Returns `None`
 /// for `set`/`default`/`for` and any unknown subcommand, letting the adapter
-/// handle them.
-pub fn dispatch<O, V>(ops: &mut O, sub: &str, rest: &[V]) -> Option<Result<V, CmdError>>
+/// handle them. Handled commands return [`ArrayCommandResult`] rather than the
+/// bare value so callers cannot silently discard retained read metadata.
+///
+/// ```compile_fail
+/// # use tcl_runtime_api::{Frames, VarStore};
+/// # use tcl_syntax::value::ValueOps;
+/// fn lossy<O, V>(ops: &mut O, sub: &str, rest: &[V]) -> V
+/// where
+///     O: ValueOps<Value = V> + VarStore<Value = V> + Frames,
+///     V: Clone,
+/// {
+///     tcl_cmd_core::array::dispatch(ops, sub, rest)
+///         .expect("handled")
+///         .expect("success")
+/// }
+/// ```
+pub fn dispatch<O, V>(
+    ops: &mut O,
+    sub: &str,
+    rest: &[V],
+) -> Option<Result<ArrayCommandResult<V>, CmdError>>
 where
     O: ValueOps<Value = V> + VarStore<Value = V> + Frames,
+    V: Clone,
 {
     dispatch_at(ops, sub, rest, None)
+}
+
+/// A shared `array` result plus any options retained by swallowed element
+/// reads. Most subcommands carry no options; keeping the exceptional metadata
+/// here lets both runtime adapters construct their native completion without
+/// moving command assembly out of this shared owner.
+#[derive(Debug, Clone)]
+pub struct ArrayCommandResult<V> {
+    /// The ordinary Tcl result value.
+    pub value: V,
+    /// Metadata from the last failed candidate read, if any.
+    pub read_miss: Option<ArrayReadMiss>,
+}
+
+impl<V> ArrayCommandResult<V> {
+    fn plain(value: V) -> Self {
+        Self {
+            value,
+            read_miss: None,
+        }
+    }
 }
 
 /// [`dispatch`] with an array target located before the operation trace fired.
@@ -61,16 +105,19 @@ pub fn dispatch_at<O, V>(
     sub: &str,
     rest: &[V],
     located: Option<&ArrayTarget>,
-) -> Option<Result<V, CmdError>>
+) -> Option<Result<ArrayCommandResult<V>, CmdError>>
 where
     O: ValueOps<Value = V> + VarStore<Value = V> + Frames,
+    V: Clone,
 {
     match sub {
         "exists" => Some(match rest {
             [n] => {
                 let name = ops.as_str(n);
                 let target = locate(ops, &name, located);
-                Ok(ops.new_bool(ops.array_keys_at(&target).is_some()))
+                Ok(ArrayCommandResult::plain(
+                    ops.new_bool(ops.array_keys_at(&target).is_some()),
+                ))
             }
             _ => Err(CmdError::wrong_args("array exists arrayName")),
         }),
@@ -79,23 +126,25 @@ where
                 let name = ops.as_str(n);
                 let target = locate(ops, &name, located);
                 let count = ops.array_keys_at(&target).map_or(0, |k| k.len());
-                Ok(ops.new_int(i64::try_from(count).unwrap_or(i64::MAX)))
+                Ok(ArrayCommandResult::plain(
+                    ops.new_int(i64::try_from(count).unwrap_or(i64::MAX)),
+                ))
             }
             _ => Err(CmdError::wrong_args("array size arrayName")),
         }),
         "names" => Some(match rest {
-            [n] => Ok(names(ops, n, None, located)),
-            [n, p] => Ok(names(ops, n, Some(p), located)),
+            [n] => Ok(ArrayCommandResult::plain(names(ops, n, None, located))),
+            [n, p] => Ok(ArrayCommandResult::plain(names(ops, n, Some(p), located))),
             _ => Err(CmdError::wrong_args("array names arrayName ?pattern?")),
         }),
         "get" => Some(match rest {
-            [n] => Ok(get(ops, n, None, located)),
-            [n, p] => Ok(get(ops, n, Some(p), located)),
+            [n] => get(ops, n, None, located),
+            [n, p] => get(ops, n, Some(p), located),
             _ => Err(CmdError::wrong_args("array get arrayName ?pattern?")),
         }),
         "unset" => Some(match rest {
-            [n] => unset(ops, n, None, located),
-            [n, p] => unset(ops, n, Some(p), located),
+            [n] => unset(ops, n, None, located).map(ArrayCommandResult::plain),
+            [n, p] => unset(ops, n, Some(p), located).map(ArrayCommandResult::plain),
             _ => Err(CmdError::wrong_args("array unset arrayName ?pattern?")),
         }),
         _ => None,
@@ -127,26 +176,74 @@ where
 
 /// `array get arrayName ?pattern?` — a flat `key value …` list (glob-filtered on
 /// the key).
-fn get<O, V>(ops: &mut O, name: &V, pattern: Option<&V>, located: Option<&ArrayTarget>) -> V
+fn get<O, V>(
+    ops: &mut O,
+    name: &V,
+    pattern: Option<&V>,
+    located: Option<&ArrayTarget>,
+) -> Result<ArrayCommandResult<V>, CmdError>
 where
     O: ValueOps<Value = V> + VarStore<Value = V> + Frames,
+    V: Clone,
 {
-    let here = Frames::current(ops);
     let name = ops.as_str(name);
     let pattern = pattern.map(|p| ops.as_str(p).to_string());
     let target = locate(ops, &name, located);
     let keys = ops.array_keys_at(&target).unwrap_or_default();
     let mut items: Vec<V> = Vec::with_capacity(keys.len() * 2);
+    let mut pinned = Vec::with_capacity(keys.len());
+    let mut read_miss = None;
     for k in &keys {
         if pattern.as_deref().is_some_and(|p| !string_match(p, k)) {
             continue;
         }
-        if let Some(v) = ops.get_elem(here, &name, k) {
-            items.push(ops.new_str(k));
-            items.push(v);
+        match ops.array_read_elem_at(&target, k) {
+            ArrayElementRead::Value(value) => {
+                // `array_read_elem_at` returns a transiently-owned handle: it
+                // has to acquire that hold before releasing its selected cell,
+                // closing the raw-pointer handoff gap. `new_list` takes its own
+                // ownership before the holds are released below.
+                pinned.push(value.clone());
+                items.push(ops.new_str(k));
+                items.push(value);
+            }
+            ArrayElementRead::Missing(miss) => {
+                read_miss = Some(
+                    read_miss.map_or(miss.clone(), |prior: ArrayReadMiss| prior.followed_by(miss)),
+                );
+            }
+            ArrayElementRead::TraceError(failure) => {
+                for value in &pinned {
+                    ops.unpin_value(value);
+                }
+                let (message, code, info, line) = failure.into_parts();
+                return Err(CmdError::with_error_details(
+                    message,
+                    String::from_utf8_lossy(&code),
+                    info,
+                    line,
+                ));
+            }
+            ArrayElementRead::ArrayInvalidated(invalidation) => {
+                for value in &pinned {
+                    ops.unpin_value(value);
+                }
+                let reason = match invalidation {
+                    ArrayInvalidation::Unset => "no such variable",
+                    ArrayInvalidation::Retyped => "no such element in array",
+                };
+                return Err(CmdError::variable_read_missing(
+                    &format!("{name}({k})"),
+                    reason,
+                ));
+            }
         }
     }
-    ops.new_list(items)
+    let value = ops.new_list(items);
+    for candidate in &pinned {
+        ops.unpin_value(candidate);
+    }
+    Ok(ArrayCommandResult { value, read_miss })
 }
 
 /// `array unset arrayName ?pattern?` — remove matching elements, or (no pattern)

--- a/rust/tcl-cmd-core/src/error.rs
+++ b/rust/tcl-cmd-core/src/error.rs
@@ -29,7 +29,8 @@
 use tcl_platform::HostError;
 use tcl_syntax::value::ValueError;
 
-/// A failed Tcl command: its result message and optional structured error code.
+/// A failed Tcl command: its result message and optional structured error
+/// metadata.
 ///
 /// The shared command core owns the semantic error identity; each runtime
 /// adapter publishes it through its native completion/error state.
@@ -37,6 +38,8 @@ use tcl_syntax::value::ValueError;
 pub struct CmdError {
     message: String,
     error_code: Option<String>,
+    error_info: Option<Vec<u8>>,
+    error_line: Option<i64>,
 }
 
 impl CmdError {
@@ -45,6 +48,8 @@ impl CmdError {
         Self {
             message: message.into(),
             error_code: None,
+            error_info: None,
+            error_line: None,
         }
     }
 
@@ -53,6 +58,24 @@ impl CmdError {
         Self {
             message: message.into(),
             error_code: Some(error_code.into()),
+            error_info: None,
+            error_line: None,
+        }
+    }
+
+    /// A command error carrying the already-accumulated callback error trace.
+    #[must_use]
+    pub fn with_error_details(
+        message: impl Into<String>,
+        error_code: impl Into<String>,
+        error_info: Option<Vec<u8>>,
+        error_line: Option<i64>,
+    ) -> Self {
+        Self {
+            message: message.into(),
+            error_code: Some(error_code.into()),
+            error_info,
+            error_line,
         }
     }
 
@@ -79,6 +102,17 @@ impl CmdError {
     #[must_use]
     pub fn into_parts(self) -> (String, Option<String>) {
         (self.message, self.error_code)
+    }
+
+    /// Consume the error, including any accumulated callback trace metadata.
+    #[must_use]
+    pub fn into_details(self) -> (String, Option<String>, Option<Vec<u8>>, Option<i64>) {
+        (
+            self.message,
+            self.error_code,
+            self.error_info,
+            self.error_line,
+        )
     }
 
     /// `wrong # args: should be "…"` — the canonical Tcl arity error.
@@ -112,6 +146,15 @@ impl CmdError {
     #[must_use]
     pub fn argument_format(message: impl Into<String>) -> Self {
         Self::with_error_code(message, "TCL ARGUMENT FORMAT")
+    }
+
+    /// A trace-aware variable read whose selected cell disappeared.
+    #[must_use]
+    pub fn variable_read_missing(name: &str, reason: &str) -> Self {
+        Self::with_error_code(
+            format!("can't read \"{name}\": {reason}"),
+            "TCL READ VARNAME",
+        )
     }
 }
 
@@ -182,6 +225,13 @@ mod tests {
         assert_eq!(
             CmdError::argument_format("bad shape").error_code(),
             Some("TCL ARGUMENT FORMAT")
+        );
+        assert_eq!(
+            CmdError::variable_read_missing("a(k)", "no such variable").into_parts(),
+            (
+                "can't read \"a(k)\": no such variable".to_string(),
+                Some("TCL READ VARNAME".to_string())
+            )
         );
     }
 }

--- a/rust/tcl-compiler/src/codegen/control_flow.rs
+++ b/rust/tcl-compiler/src/codegen/control_flow.rs
@@ -24,6 +24,7 @@
 use tcl_bytecode::ErrorStackContext;
 use tcl_registry::hooks::{InlineCodegenHookId, LoweringHookId};
 use tcl_registry::{CommandRegistry, Traits, TryClauseKind, TryCompletionSelector};
+use tcl_runtime_api::completion_options::ControlOptionPolicy;
 
 use crate::cfg::Function as CfgFunction;
 use crate::expr_ast::{BinOp, ExprNode};
@@ -426,12 +427,13 @@ impl CodegenCtx<'_> {
 
         // Load the dict value, then begin the iterator under a catch range.
         self.emit_value(dict_text, true);
-        self.emit(
+        let begin_idx = self.emit(
             Op::BEGIN_CATCH4,
             vec![Operand::Imm(
                 i32::try_from(self.catch_depth).expect("catch_depth fits in i32"),
             )],
         );
+        self.mark_completion_option_scope(begin_idx, ControlOptionPolicy::FRESH_SETTLED);
         self.catch_depth += 1;
         let dict_first_idx = self.emit(Op::DICT_FIRST, vec![Operand::Imm(0)]);
         // Tag the loop-control jumps `dict_for` so the layout pass keeps them
@@ -446,7 +448,9 @@ impl CodegenCtx<'_> {
 
         // Loop body: bind key/value, run the body, advance.
         self.place_label(&loop_lbl);
-        self.emit_comment(Op::STORE_SCALAR1, vec![Operand::Imm(k_slot)], &vnames[0]);
+        let iteration_idx =
+            self.emit_comment(Op::STORE_SCALAR1, vec![Operand::Imm(k_slot)], &vnames[0]);
+        self.mark_completion_option_scope(iteration_idx, ControlOptionPolicy::FRESH_SETTLED);
         self.emit(Op::POP, vec![]);
         self.emit_comment(Op::STORE_SCALAR1, vec![Operand::Imm(v_slot)], &vnames[1]);
         self.emit(Op::POP, vec![]);
@@ -480,7 +484,8 @@ impl CodegenCtx<'_> {
 
         // Normal exit: drop the leftover key/value from the final dictNext.
         self.place_label(&end_lbl);
-        self.emit(Op::POP, vec![]);
+        let settle_idx = self.emit(Op::POP, vec![]);
+        self.mark_completion_option_scope(settle_idx, ControlOptionPolicy::FRESH_SETTLED);
         self.emit(Op::POP, vec![]);
         // `dict for` yields the empty string.
         self.push_lit("");
@@ -536,12 +541,13 @@ impl CodegenCtx<'_> {
         self.emit(Op::POP, vec![]);
 
         self.emit_value(dict_text, true);
-        self.emit(
+        let begin_idx = self.emit(
             Op::BEGIN_CATCH4,
             vec![Operand::Imm(
                 i32::try_from(self.catch_depth).expect("catch_depth fits in i32"),
             )],
         );
+        self.mark_completion_option_scope(begin_idx, ControlOptionPolicy::FRESH_FORWARDED);
         self.catch_depth += 1;
         let dict_first_idx = self.emit(Op::DICT_FIRST, vec![Operand::Imm(0)]);
         self.emit_comment(
@@ -551,7 +557,9 @@ impl CodegenCtx<'_> {
         );
 
         self.place_label(&loop_lbl);
-        self.emit_comment(Op::STORE_SCALAR1, vec![Operand::Imm(k_slot)], &vnames[0]);
+        let iteration_idx =
+            self.emit_comment(Op::STORE_SCALAR1, vec![Operand::Imm(k_slot)], &vnames[0]);
+        self.mark_completion_option_scope(iteration_idx, ControlOptionPolicy::FRESH_FORWARDED);
         self.emit(Op::POP, vec![]);
         self.emit_comment(Op::STORE_SCALAR1, vec![Operand::Imm(v_slot)], &vnames[1]);
         self.emit(Op::POP, vec![]);

--- a/rust/tcl-compiler/src/codegen/emitter/generate.rs
+++ b/rust/tcl-compiler/src/codegen/emitter/generate.rs
@@ -633,10 +633,14 @@ fn emit_inline_block_command_boundary(
 
     ctx.set_command_boundary_site(Some(site));
     let end_label = ctx.fresh_label("inline_block_cmd_end");
-    ctx.emit_comment(
+    let begin = ctx.emit_comment(
         Op::START_CMD,
         vec![Operand::Label(end_label.clone()), Operand::Imm(1)],
         "",
+    );
+    ctx.mark_completion_option_scope(
+        begin,
+        tcl_runtime_api::completion_options::ControlOptionPolicy::FRESH_FORWARDED,
     );
     state
         .command_boundary_end_labels
@@ -658,6 +662,16 @@ fn emit_block_terminator(
 ) {
     let next_block = block_order.get(i + 1).map(String::as_str);
     if let Some(term) = &blk.terminator {
+        let switch_dispatch = matches!(
+            term,
+            Terminator::Branch {
+                true_target,
+                false_target,
+                ..
+            } if cfg.block_name(*true_target).starts_with("switch_arm_body_")
+                && (cfg.block_name(*false_target).starts_with("switch_next_")
+                    || cfg.block_name(*false_target).starts_with("switch_default_"))
+        );
         // A constant-true `if` and its first selected-body command begin at the
         // same bytecode offset. In a proc, Tcl emits the owning count-two
         // marker only when an earlier generic invocation could have changed
@@ -709,7 +723,14 @@ fn emit_block_terminator(
         } else if ctx.is_proc && matches!(term, Terminator::Return { .. }) {
             ctx.emit_proc_return(term, bname, next_block, block_order, i, cfg);
         } else {
+            let begin = ctx.instructions.len();
             ctx.emit_term(cfg, term, next_block);
+            if switch_dispatch && begin < ctx.instructions.len() {
+                ctx.mark_completion_option_scope(
+                    begin,
+                    tcl_runtime_api::completion_options::ControlOptionPolicy::FRESH_FORWARDED,
+                );
+            }
         }
     } else if next_block.is_some() {
         // Terminal block not last in layout — emit done to prevent

--- a/rust/tcl-compiler/src/codegen/emitter/terminator.rs
+++ b/rust/tcl-compiler/src/codegen/emitter/terminator.rs
@@ -375,6 +375,10 @@ impl CodegenCtx<'_> {
         let ordered = super::super::helpers::tcl_hash_table_order(&cases);
         let jt: std::collections::HashMap<String, String> = ordered.into_iter().collect();
         let idx = self.emit(Op::JUMP_TABLE, vec![Operand::Imm(0)]);
+        self.mark_completion_option_scope(
+            idx,
+            tcl_runtime_api::completion_options::ControlOptionPolicy::FRESH_FORWARDED,
+        );
         self.instructions[idx].jump_table = Some(jt);
 
         if Some(default_target.as_str()) != next_block {

--- a/rust/tcl-compiler/src/codegen/mod.rs
+++ b/rust/tcl-compiler/src/codegen/mod.rs
@@ -727,6 +727,18 @@ impl<'r> CodegenCtx<'r> {
         idx
     }
 
+    /// Mark an emitted instruction as the start of a control completion's
+    /// option scope. The marker stays out-of-band so Tcl bytecode layout and
+    /// disassembly remain stable while every runtime consumer sees the same
+    /// typed policy.
+    pub(crate) fn mark_completion_option_scope(
+        &mut self,
+        instruction: usize,
+        policy: tcl_runtime_api::completion_options::ControlOptionPolicy,
+    ) {
+        self.instructions[instruction].completion_option_scope = Some(policy.activation);
+    }
+
     /// Generate a unique label name with the given prefix.
     #[must_use]
     pub fn fresh_label(&mut self, prefix: &str) -> String {

--- a/rust/tcl-compiler/src/codegen/statements.rs
+++ b/rust/tcl-compiler/src/codegen/statements.rs
@@ -597,8 +597,15 @@ impl CodegenCtx<'_> {
             // bytecode level (the body already ran in the caller's
             // frame in the original ``uplevel`` semantics).
             Statement::Block { body, .. } => {
+                let begin = self.instructions.len();
                 for inner in &body.statements {
                     self.emit_stmt(inner, used_generic_invoke);
+                }
+                if let Some(first) = (begin < self.instructions.len()).then_some(begin) {
+                    self.mark_completion_option_scope(
+                        first,
+                        tcl_runtime_api::completion_options::ControlOptionPolicy::FRESH_FORWARDED,
+                    );
                 }
             }
 

--- a/rust/tcl-runtime-api/src/completion_options.rs
+++ b/rust/tcl-runtime-api/src/completion_options.rs
@@ -16,7 +16,81 @@
 
 use tcl_dialect::TclVersion;
 
-use crate::Code;
+use crate::{ArrayReadMiss, Code};
+
+/// Whether a control-command activation inherits the surrounding completion's
+/// carried options or begins with a fresh option set.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ActivationOptionScope {
+    /// The body is compiled transparently into the surrounding completion.
+    Inherited,
+    /// The body is a distinct Tcl command activation with fresh options.
+    Fresh,
+}
+
+impl ActivationOptionScope {
+    /// Whether this activation starts without surrounding carried options.
+    #[must_use]
+    pub const fn begins_fresh(self) -> bool {
+        matches!(self, Self::Fresh)
+    }
+}
+
+/// How a successful control command settles the options produced by its body.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SuccessOptionSettlement {
+    /// Forward the options produced by the selected or final body activation.
+    Forward,
+    /// Produce an ordinary successful completion with no carried options.
+    Settle,
+}
+
+/// Completion-option policy for a Tcl control-command activation.
+///
+/// Result flow and option flow are deliberately separate. For example,
+/// `lmap` manufactures a list result but forwards the final iteration's
+/// options, while `foreach` manufactures both its result and successful
+/// options. Keeping the two option axes here gives bytecode and tree-walking
+/// runtimes one vocabulary for those boundaries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ControlOptionPolicy {
+    /// The option scope in which a nested body starts.
+    pub activation: ActivationOptionScope,
+    /// The successful command's final option settlement.
+    pub success: SuccessOptionSettlement,
+}
+
+impl ControlOptionPolicy {
+    /// A body compiled transparently in the surrounding completion.
+    pub const TRANSPARENT: Self = Self {
+        activation: ActivationOptionScope::Inherited,
+        success: SuccessOptionSettlement::Forward,
+    };
+
+    /// A fresh body activation whose produced options become the command's.
+    pub const FRESH_FORWARDED: Self = Self {
+        activation: ActivationOptionScope::Fresh,
+        success: SuccessOptionSettlement::Forward,
+    };
+
+    /// A fresh activation whose successful completion is settled by its owner.
+    pub const FRESH_SETTLED: Self = Self {
+        activation: ActivationOptionScope::Fresh,
+        success: SuccessOptionSettlement::Settle,
+    };
+
+    /// Whether the nested body must start without surrounding carried options.
+    #[must_use]
+    pub const fn begins_fresh(self) -> bool {
+        self.activation.begins_fresh()
+    }
+
+    /// Whether an ordinary successful owner completion discards body options.
+    #[must_use]
+    pub const fn settles_success(self) -> bool {
+        matches!(self.success, SuccessOptionSettlement::Settle)
+    }
+}
 
 /// A planned option value which an engine materialises in its Tcl value model.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -44,6 +118,29 @@ pub struct ErrorOptions<V> {
 
 /// One carried return-option pair.
 pub type CarriedOption<V> = (Vec<u8>, V);
+
+/// Materialise the standard option pairs left by a failed `array get`
+/// candidate read on the surrounding successful completion.
+///
+/// This is deliberately a completion-options operation rather than adapter
+/// policy: native and standalone runtimes supply only their value constructor,
+/// then feed these carried pairs back through [`plan`].
+pub fn retained_array_read_options<V>(
+    miss: &ArrayReadMiss,
+    mut materialise: impl FnMut(&[u8]) -> V,
+) -> Vec<CarriedOption<V>> {
+    let mut options = vec![(b"-errorcode".to_vec(), materialise(&miss.code))];
+    if let Some(info) = &miss.info {
+        options.push((b"-errorinfo".to_vec(), materialise(info)));
+    }
+    if let Some(line) = miss.line {
+        options.push((
+            b"-errorline".to_vec(),
+            materialise(line.to_string().as_bytes()),
+        ));
+    }
+    options
+}
 
 /// Plan the complete return-options dictionary for one completion.
 ///
@@ -113,6 +210,16 @@ mod tests {
     }
 
     #[test]
+    fn control_option_policy_keeps_activation_and_settlement_independent() {
+        assert!(!ControlOptionPolicy::TRANSPARENT.begins_fresh());
+        assert!(!ControlOptionPolicy::TRANSPARENT.settles_success());
+        assert!(ControlOptionPolicy::FRESH_FORWARDED.begins_fresh());
+        assert!(!ControlOptionPolicy::FRESH_FORWARDED.settles_success());
+        assert!(ControlOptionPolicy::FRESH_SETTLED.begins_fresh());
+        assert!(ControlOptionPolicy::FRESH_SETTLED.settles_success());
+    }
+
+    #[test]
     fn errors_receive_standard_metadata_and_keep_custom_options() {
         let carried = vec![(b"-foo".to_vec(), "bar")];
         let error = ErrorOptions {
@@ -152,5 +259,26 @@ mod tests {
         let modern = plan(TclVersion::V9_0, Code::Error, 1, &carried, Some(&error));
         assert!(keys(&modern).contains(&b"-errorstack".as_slice()));
         assert!(keys(&modern).contains(&b"-errorinfo".as_slice()));
+    }
+
+    #[test]
+    fn swallowed_array_reads_carry_only_the_metadata_the_read_created() {
+        assert_eq!(
+            retained_array_read_options(&ArrayReadMiss::missing(), |bytes| {
+                String::from_utf8_lossy(bytes).into_owned()
+            }),
+            [(b"-errorcode".to_vec(), "TCL READ VARNAME".into())]
+        );
+        assert_eq!(
+            retained_array_read_options(
+                &ArrayReadMiss::trace_error(Some(b"boom trace".to_vec()), 3),
+                |bytes| String::from_utf8_lossy(bytes).into_owned(),
+            ),
+            [
+                (b"-errorcode".to_vec(), "TCL READ VARNAME".into()),
+                (b"-errorinfo".to_vec(), "boom trace".into()),
+                (b"-errorline".to_vec(), "3".into()),
+            ]
+        );
     }
 }

--- a/rust/tcl-runtime-api/src/lib.rs
+++ b/rust/tcl-runtime-api/src/lib.rs
@@ -98,6 +98,147 @@ pub struct ArrayTarget {
     cell: Option<VarId>,
 }
 
+/// Result of one trace-aware element read performed for `array get`.
+///
+/// The command snapshots keys from [`ArrayTarget`] but reads each candidate
+/// through the source spelling. A callback can therefore make the element
+/// disappear without invalidating the walk, or destroy/retype the captured
+/// array, which is a command error. Keeping that distinction in the runtime
+/// contract prevents the shared command core from guessing storage identity.
+#[derive(Debug, Clone)]
+pub enum ArrayElementRead<V> {
+    /// The selected element still has a value after its read traces. Pointer
+    /// runtimes return this with one transient ownership hold already acquired;
+    /// the shared command core releases it after list materialisation.
+    Value(V),
+    /// The element is absent, or its read trace errored. Tcl skips it while the
+    /// captured base remains an array; the runtime retains any swallowed trace
+    /// completion in its interpreter error state.
+    Missing(ArrayReadMiss),
+    /// A read trace failed and invalidated the captured base in the same
+    /// callback. Unlike an ordinary trace miss, Tcl propagates the callback's
+    /// contextual variable-read error rather than replacing it with a generic
+    /// array invalidation diagnostic.
+    TraceError(ArrayReadFailure),
+    /// The array cell captured for the operation is no longer an array.
+    ArrayInvalidated(ArrayInvalidation),
+}
+
+/// A variable-read trace failure which an `array get` candidate must
+/// propagate because that same callback invalidated the captured array.
+///
+/// The message is already the variable subsystem's contextual `can't read
+/// "a(k)": reason` result. The remaining fields preserve the callback's
+/// accumulated error trace across the shared command/runtime boundary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ArrayReadFailure {
+    message: String,
+    code: Vec<u8>,
+    info: Option<Vec<u8>>,
+    line: Option<i64>,
+}
+
+impl ArrayReadFailure {
+    /// Construct a hard traced-read failure.
+    #[must_use]
+    pub fn new(
+        message: impl Into<String>,
+        code: Vec<u8>,
+        info: Option<Vec<u8>>,
+        line: Option<i64>,
+    ) -> Self {
+        Self {
+            message: message.into(),
+            code,
+            info,
+            line,
+        }
+    }
+
+    /// Consume the failure into its command-error parts.
+    #[must_use]
+    pub fn into_parts(self) -> (String, Vec<u8>, Option<Vec<u8>>, Option<i64>) {
+        (self.message, self.code, self.info, self.line)
+    }
+}
+
+/// Completion metadata retained when `array get` swallows one candidate's
+/// failed variable read.
+///
+/// Tcl exposes the variable subsystem's read classification on the surrounding
+/// successful completion (`TCL READ VARNAME`, or `TCL LOOKUP VARNAME name`
+/// when an operation trace retargeted the source alias away from an array). A
+/// callback error also contributes its accumulated trace and source line; a
+/// callback that merely removes the element contributes no error trace and
+/// does not publish the error globals.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ArrayReadMiss {
+    code: Vec<u8>,
+    info: Option<Vec<u8>>,
+    line: Option<i64>,
+}
+
+impl Default for ArrayReadMiss {
+    fn default() -> Self {
+        Self::missing()
+    }
+}
+
+impl ArrayReadMiss {
+    /// A read that found no value after otherwise-successful callbacks.
+    #[must_use]
+    pub fn missing() -> Self {
+        Self {
+            code: b"TCL READ VARNAME".to_vec(),
+            info: None,
+            line: None,
+        }
+    }
+
+    /// A source-spelling lookup that no longer resolves to an array.
+    #[must_use]
+    pub fn lookup(error_code: Vec<u8>) -> Self {
+        Self {
+            code: error_code,
+            info: None,
+            line: None,
+        }
+    }
+
+    /// A read whose trace callback errored before `array get` swallowed it.
+    #[must_use]
+    pub fn trace_error(error_info: Option<Vec<u8>>, error_line: i64) -> Self {
+        Self {
+            code: b"TCL READ VARNAME".to_vec(),
+            info: error_info,
+            line: Some(error_line),
+        }
+    }
+
+    /// Merge a later candidate miss into this operation's retained metadata.
+    ///
+    /// Tcl exposes the most recent read classification, but an ordinary later
+    /// miss has no callback trace of its own and must not erase the earlier
+    /// callback's `errorInfo` or source line.
+    #[must_use]
+    pub fn followed_by(self, later: Self) -> Self {
+        Self {
+            code: later.code,
+            info: later.info.or(self.info),
+            line: later.line.or(self.line),
+        }
+    }
+}
+
+/// Why a captured array can no longer supply a candidate element.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArrayInvalidation {
+    /// The captured variable is now undefined.
+    Unset,
+    /// The captured variable is now a defined non-array.
+    Retyped,
+}
+
 impl ArrayTarget {
     /// Construct a name-addressed target.
     #[must_use]
@@ -684,6 +825,33 @@ pub trait VarStore {
     /// [`array_target`](Self::array_target).
     fn unset_elem_at(&mut self, target: &ArrayTarget, key: &str) -> bool {
         self.unset_elem(target.frame(), target.name(), key)
+    }
+
+    /// Read one `array get` candidate through variable-read traces.
+    ///
+    /// The default preserves storage-only implementations. Tcl runtimes
+    /// override this to pin the live element before callbacks, retain a
+    /// swallowed callback error in interpreter metadata, and distinguish a
+    /// missing element from destruction of `target`.
+    fn array_read_elem_at(
+        &mut self,
+        target: &ArrayTarget,
+        key: &str,
+    ) -> ArrayElementRead<Self::Value> {
+        let value = self.get_elem(target.frame(), target.name(), key);
+        if self.array_keys_at(target).is_none() {
+            let invalidation = if self.exists(target.frame(), target.name()) {
+                ArrayInvalidation::Retyped
+            } else {
+                ArrayInvalidation::Unset
+            };
+            ArrayElementRead::ArrayInvalidated(invalidation)
+        } else {
+            value.map_or_else(
+                || ArrayElementRead::Missing(ArrayReadMiss::missing()),
+                ArrayElementRead::Value,
+            )
+        }
     }
 }
 

--- a/rust/tcl-syntax/src/value.rs
+++ b/rust/tcl-syntax/src/value.rs
@@ -232,6 +232,16 @@ pub trait ValueOps {
     /// A list value from element handles.
     fn new_list(&mut self, items: Vec<Self::Value>) -> Self::Value;
 
+    /// Keep a borrowed value handle alive across later runtime callbacks.
+    ///
+    /// Owning value models need no extra work. Pointer-based runtimes override
+    /// this with their object reference-count increment; every successful pin
+    /// must be paired with [`Self::unpin_value`], including error exits.
+    fn pin_value(&mut self, _value: &Self::Value) {}
+
+    /// Release one transient hold established by [`Self::pin_value`].
+    fn unpin_value(&mut self, _value: &Self::Value) {}
+
     // -- string access (UTF-8; char-indexed downstream) --
 
     /// The string representation, generated and cached on first call

--- a/rust/tcl-vm/src/cmd_array.rs
+++ b/rust/tcl-vm/src/cmd_array.rs
@@ -24,9 +24,14 @@
 //! (leaving an empty array) instead of removing the whole array.
 
 use tcl_registry::{ArgRole, InvocationWord, InvocationWords};
+use tcl_runtime_api::completion_options::{
+    self as shared_options, ControlOptionPolicy, OptionValue,
+};
 use tcl_runtime_api::{ArrayTarget, Code, Completion, VarStore};
 
-use crate::command::{completion_from_cmd_error, completion_from_tcl_error};
+use crate::command::{
+    completion_from_cmd_error, completion_from_tcl_error, settle_control_options,
+};
 use crate::interp::{Vm, err, ok};
 use crate::value::Value;
 
@@ -110,7 +115,27 @@ fn array_op_after_trace(
     // The read-side + `unset` live in the shared core.
     if let Some(result) = tcl_cmd_core::array::dispatch_at(vm, sub, rest, target) {
         return match result {
-            Ok(v) => ok(v),
+            Ok(result) => {
+                let Some(miss) = result.read_miss else {
+                    return ok(result.value);
+                };
+                let carried = shared_options::retained_array_read_options(&miss, |bytes| {
+                    Value::string(String::from_utf8_lossy(bytes))
+                });
+                let rows = shared_options::plan(vm.runtime_version(), Code::Ok, 0, &carried, None);
+                let options = Value::list(
+                    rows.into_iter()
+                        .flat_map(|(key, value)| {
+                            let value = match value {
+                                OptionValue::Integer(value) => Value::int(value),
+                                OptionValue::Value(value) => value,
+                            };
+                            [Value::string(String::from_utf8_lossy(&key)), value]
+                        })
+                        .collect(),
+                );
+                Completion::new(Code::Ok, result.value, options)
+            }
             Err(e) => completion_from_cmd_error(e),
         };
     }
@@ -302,7 +327,7 @@ fn array_for_after_trace(
             return array_for_changed();
         }
     }
-    ok(Value::empty())
+    settle_control_options(ok(Value::empty()), ControlOptionPolicy::FRESH_SETTLED)
 }
 
 fn same_array_target(vm: &Vm, name: &str, original: &ArrayTarget, revision: Option<u64>) -> bool {

--- a/rust/tcl-vm/src/cmd_dict.rs
+++ b/rust/tcl-vm/src/cmd_dict.rs
@@ -18,9 +18,10 @@
 
 //! The `dict` ensemble over the VM's typed dictionary representation.
 
+use tcl_runtime_api::completion_options::ControlOptionPolicy;
 use tcl_runtime_api::{Code, Completion};
 
-use crate::command::BuiltinFn;
+use crate::command::{BuiltinFn, settle_control_options};
 use crate::interp::{Vm, err, ok};
 use crate::value::Value;
 
@@ -539,7 +540,7 @@ fn cmd_dict_for(vm: &mut Vm, rest: &[Value]) -> Completion<Value> {
             Err(e) => return err(e.message),
         }
     }
-    ok(Value::empty())
+    settle_control_options(ok(Value::empty()), ControlOptionPolicy::FRESH_SETTLED)
 }
 
 /// `dict map {keyVar valueVar} dictionary body` — like `dict for`, but collect
@@ -566,6 +567,7 @@ fn cmd_dict_map(vm: &mut Vm, rest: &[Value]) -> Completion<Value> {
     let (kname, vname) = (kvar.to_str(), vvar.to_str());
     let body_src = body.to_str();
     let mut out: Vec<(String, Value)> = Vec::new();
+    let mut last_options = Value::empty();
     for (k, v) in ps {
         if let Err(e) = vm.set_var(&kname, Value::string(k.clone())) {
             return e;
@@ -578,18 +580,27 @@ fn cmd_dict_map(vm: &mut Vm, rest: &[Value]) -> Completion<Value> {
                 Code::Ok => {
                     let key = vm.get_var(&kname).map_or(k, |kv| kv.to_str().to_string());
                     upsert(&mut out, &key, c.result);
+                    last_options = c.options;
                 }
-                Code::Continue => {}
+                Code::Continue => last_options = c.options,
                 // `break` discards the *whole* accumulated result (C
                 // `DictMapNRCmd` drops it on TCL_BREAK), returning the empty dict
                 // — not the pairs collected before the break.
-                Code::Break => return ok(Value::empty()),
+                Code::Break => {
+                    return settle_control_options(
+                        ok(Value::empty()),
+                        ControlOptionPolicy::FRESH_SETTLED,
+                    );
+                }
                 _ => return c,
             },
             Err(e) => return err(e.message),
         }
     }
-    ok(from_pairs(&out))
+    settle_control_options(
+        Completion::new(Code::Ok, from_pairs(&out), last_options),
+        ControlOptionPolicy::FRESH_FORWARDED,
+    )
 }
 
 /// `dict update dictVar key varName ?key varName ...? body` — expose the named

--- a/rust/tcl-vm/src/cmd_namespace.rs
+++ b/rust/tcl-vm/src/cmd_namespace.rs
@@ -26,9 +26,10 @@
 //! no-ops for now (the codegen already records export/import metadata).
 
 use tcl_dialect::model::SurfaceQuery;
+use tcl_runtime_api::completion_options::ControlOptionPolicy;
 use tcl_runtime_api::{Code, Completion};
 
-use crate::command::{command_lookup_error, err_with_code, lookup_error};
+use crate::command::{command_lookup_error, err_with_code, lookup_error, settle_control_options};
 use crate::interp::{Vm, canonical_cmd_key, err, ok};
 use crate::value::Value;
 use tcl_dialect::model::surface_admits;
@@ -90,11 +91,12 @@ fn eval_in_ns(
     vm.leave_ns_script();
     vm.pop_ns();
     vm.pop_call_frame();
-    match result {
-        Ok(c) if c.code == Code::Return => ok(c.result),
+    let completion = match result {
+        Ok(c) if c.code == Code::Return => Completion::new(Code::Ok, c.result, c.options),
         Ok(c) => c,
         Err(e) => err(e.message),
-    }
+    };
+    settle_control_options(completion, ControlOptionPolicy::FRESH_FORWARDED)
 }
 
 pub(crate) fn register(vm: &mut Vm) {

--- a/rust/tcl-vm/src/cmd_switch.rs
+++ b/rust/tcl-vm/src/cmd_switch.rs
@@ -30,8 +30,10 @@
 
 use tcl_cmd_core::switch::{self as core_switch, Selection};
 use tcl_runtime_api::Completion;
+use tcl_runtime_api::completion_options::ControlOptionPolicy;
 
 use crate::cmd_regexp::CrateEngine;
+use crate::command::settle_control_options;
 use crate::interp::{Vm, err, ok};
 use crate::value::Value;
 
@@ -94,7 +96,7 @@ fn cmd_switch(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
         Err(e) => return crate::command::completion_from_cmd_error(e),
     };
     let Selection::Matched { index, writes } = sel else {
-        return ok(Value::empty());
+        return settle_control_options(ok(Value::empty()), ControlOptionPolicy::FRESH_FORWARDED);
     };
     // TIP #75 `-matchvar`/`-indexvar` writes happen before the body runs.
     for (name, val) in writes {
@@ -109,8 +111,9 @@ fn cmd_switch(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
         b += 1;
     }
     let body = pairs[b].1.to_str().to_string();
-    match vm.eval_source(&body) {
+    let completion = match vm.eval_source(&body) {
         Ok(c) => c,
         Err(e) => err(e.message),
-    }
+    };
+    settle_control_options(completion, ControlOptionPolicy::FRESH_FORWARDED)
 }

--- a/rust/tcl-vm/src/command.rs
+++ b/rust/tcl-vm/src/command.rs
@@ -1394,11 +1394,28 @@ pub(crate) fn err_with_code(message: impl Into<String>, code: &str) -> Completio
 
 /// Convert a portable command-layer error without losing its Tcl identity.
 pub(crate) fn completion_from_cmd_error(error: CmdError) -> Completion<Value> {
-    let (message, code) = error.into_parts();
-    match code {
-        Some(code) => err_with_code(message, &code),
-        None => err(message),
+    let (message, code, info, line) = error.into_details();
+    if info.is_none() && line.is_none() {
+        return match code {
+            Some(code) => err_with_code(message, &code),
+            None => err(message),
+        };
     }
+    let mut extra = Vec::with_capacity(3);
+    if let Some(code) = code {
+        extra.push(("-errorcode", Value::string(code)));
+    }
+    if let Some(info) = info {
+        extra.push(("-errorinfo", Value::string(String::from_utf8_lossy(&info))));
+    }
+    if let Some(line) = line {
+        extra.push(("-errorline", Value::int(line)));
+    }
+    Completion::new(
+        Code::Error,
+        Value::string(message),
+        options_dict(Code::Error, 0, &extra),
+    )
 }
 
 /// An `ERROR` completion carrying a structured Tcl lookup error code.
@@ -1449,6 +1466,30 @@ pub(crate) fn completion_options(comp: &Completion<Value>) -> Value {
     } else {
         comp.options.clone()
     }
+}
+
+/// Settle an adapter-owned control completion under the shared option policy.
+///
+/// A native completion's empty `options` value normally means “this command did
+/// not replace the surrounding carried options”. Fresh control activations need
+/// to distinguish that from an explicitly empty option set, so a successful
+/// fresh/settled completion materialises the standard `-code 0 -level 0` dict.
+/// The dispatcher can then replace the prior state without command-name logic.
+pub(crate) fn settle_control_options(
+    mut completion: Completion<Value>,
+    policy: tcl_runtime_api::completion_options::ControlOptionPolicy,
+) -> Completion<Value> {
+    if completion.code != Code::Ok {
+        return completion;
+    }
+    let empty = completion
+        .options
+        .as_list()
+        .is_ok_and(|options| options.is_empty());
+    if policy.settles_success() || (policy.begins_fresh() && empty) {
+        completion.options = options_dict(Code::Ok, 0, &[]);
+    }
+    completion
 }
 
 /// Resolve the `-errorcode` an error completion publishes to `$errorCode`.
@@ -1760,12 +1801,15 @@ fn cmd_time(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     } else {
         Value::double(total / count as f64)
     };
-    ok(Value::list(vec![
-        num,
-        Value::string("microseconds"),
-        Value::string("per"),
-        Value::string("iteration"),
-    ]))
+    settle_control_options(
+        ok(Value::list(vec![
+            num,
+            Value::string("microseconds"),
+            Value::string("per"),
+            Value::string("iteration"),
+        ])),
+        tcl_runtime_api::completion_options::ControlOptionPolicy::FRESH_SETTLED,
+    )
 }
 
 /// `encoding subcommand ?arg …?` — matches the tree-walking runtime

--- a/rust/tcl-vm/src/exec.rs
+++ b/rust/tcl-vm/src/exec.rs
@@ -164,6 +164,12 @@ pub(crate) struct Frame {
     catch_ranges: Vec<CatchRange>,
     /// Last value dropped by `POP` — the `DONE` result when the stack is empty.
     last_result: Value,
+    /// Carried return options in this evaluation frame. An ordinary successful
+    /// command preserves them; a command that supplies options replaces them,
+    /// and a fresh proc/eval/catch frame begins empty. Keeping the options beside
+    /// `last_result` makes compiled catch ranges and transparent child
+    /// activations observe the same completion as native command dispatch.
+    last_options: Value,
     /// Whether this activation owns a `Vm` call-frame (a proc body) that must be
     /// popped, and whose boundary absorbs `Return`.
     is_proc: bool,
@@ -372,6 +378,7 @@ impl Frame {
             expand_markers: Vec::new(),
             catch_ranges: Vec::new(),
             last_result: Value::empty(),
+            last_options: Value::empty(),
             is_proc,
             is_script: false,
             replay_namespace_restore: None,
@@ -481,8 +488,9 @@ impl Frame {
     /// A **try-phase** activation ([`Frame::try_ctx`]): runs `req.script` (the
     /// current phase's compiled script) as ordinary bytecode, tagged with the
     /// state `Vm::unwind` hands to `cmd_try::advance_try` on completion.
-    pub(crate) fn new_try(req: crate::cmd_try::TryReq) -> Self {
+    pub(crate) fn new_try(req: crate::cmd_try::TryReq, initial_options: Value) -> Self {
         let mut f = Self::from_compiled_unit(req.script);
+        f.last_options = initial_options;
         f.try_ctx = Some(Box::new(req.state));
         f
     }
@@ -570,7 +578,10 @@ enum Tick {
     /// (yieldable) via a try-phase activation ([`Frame::new_try`]); its
     /// completion decides the next phase via `cmd_try::advance_try`. Drained
     /// from `Vm.pending.try_phase` (issue #1311).
-    PushTry(crate::cmd_try::TryReq),
+    PushTry {
+        req: crate::cmd_try::TryReq,
+        initial_options: Value,
+    },
     /// `tailcall cmd ?arg …?` — the current proc finishes and `cmd args` runs in
     /// its place (in the caller's activation), its result becoming the proc's.
     /// `words` is `[cmd, arg, …]` (the `tailcall` prefix word already dropped).
@@ -1462,8 +1473,11 @@ impl Vm {
                     }
                     acts.push(fr);
                 }
-                Tick::PushTry(req) => {
-                    let mut fr = Frame::new_try(req);
+                Tick::PushTry {
+                    req,
+                    initial_options,
+                } => {
+                    let mut fr = Frame::new_try(req, initial_options);
                     if let Some(ctx) = self.pending_exec_leave.take() {
                         fr.exec_leave.push(ctx);
                     }
@@ -1899,7 +1913,7 @@ impl Vm {
                 }
                 match crate::cmd_try::advance_try(self, *ctx, c) {
                     crate::cmd_try::TryOutcome::Push(req) => {
-                        let mut next = Frame::new_try(req);
+                        let mut next = Frame::new_try(req, Value::empty());
                         next.exec_leave.append(&mut act.exec_leave);
                         acts.push(next);
                         return None;
@@ -1961,6 +1975,7 @@ impl Vm {
                 None => return Some(c),
                 Some(parent) => {
                     if c.code.is_ok() {
+                        parent.last_options = c.options;
                         parent.stack.push(c.result);
                         return None;
                     }
@@ -2234,11 +2249,20 @@ impl Vm {
         };
         if done {
             let st = f.each_loop.take().expect("each_loop frame carries state");
-            return Tick::Return(ok(if st.collect {
-                Value::list(st.collected)
+            let options = if st.collect {
+                f.last_options.clone()
             } else {
                 Value::empty()
-            }));
+            };
+            return Tick::Return(Completion::new(
+                Code::Ok,
+                if st.collect {
+                    Value::list(st.collected)
+                } else {
+                    Value::empty()
+                },
+                options,
+            ));
         }
         let body = {
             let st = f.each_loop.as_mut().expect("each_loop frame carries state");
@@ -2288,9 +2312,13 @@ impl Vm {
                 if st.collect {
                     st.collected.push(c.result);
                 }
+                parent.last_options = c.options;
             }
-            Code::Continue => {}
-            Code::Break => st.it = st.iterations,
+            Code::Continue => parent.last_options = c.options,
+            Code::Break => {
+                st.it = st.iterations;
+                parent.last_options = Value::empty();
+            }
             Code::Error | Code::Return | Code::Other(_) => unreachable!("handled above"),
         }
         EachLoopFold::Resume
@@ -2363,11 +2391,14 @@ impl Vm {
             .retain(|entered| entered.continuation > f.pc);
         let asm = Rc::clone(&f.asm);
         if f.pc >= asm.instructions.len() {
-            return Tick::Return(ok(f
-                .stack
-                .last()
-                .cloned()
-                .unwrap_or_else(|| f.last_result.clone())));
+            return Tick::Return(Completion::new(
+                Code::Ok,
+                f.stack
+                    .last()
+                    .cloned()
+                    .unwrap_or_else(|| f.last_result.clone()),
+                f.last_options.clone(),
+            ));
         }
         let instr = &asm.instructions[f.pc];
         // Tcl resets the interpreter result at the start of every source
@@ -2442,6 +2473,12 @@ impl Vm {
             self.capture_entered_command(f, &asm, instr, f.pc.saturating_add(1))
         {
             return Tick::Return(completion);
+        }
+        if instr
+            .completion_option_scope
+            .is_some_and(tcl_runtime_api::completion_options::ActivationOptionScope::begins_fresh)
+        {
+            f.last_options = Value::empty();
         }
         f.pc += 1;
         // Line-watch seam: keep the embedder's cell on the dispatching
@@ -2631,7 +2668,14 @@ impl Vm {
             // `BEGIN_CATCH4` pushed nothing, so its paired `END_CATCH` finds
             // the stack empty and stays a no-op.
             Op::END_CATCH => {
-                f.catch_ranges.pop();
+                if f.catch_ranges.pop().is_some() {
+                    // The protected completion's options have already been read
+                    // by PUSH_RETURN_OPTS. A live END_CATCH completes `catch`
+                    // itself, whose successful integer result has ordinary
+                    // options. Decorative try/dict cleanup ranges preserve the
+                    // completion they are forwarding.
+                    f.last_options = Value::empty();
+                }
             }
 
             // -- variables (stack form, by name) --
@@ -2805,10 +2849,9 @@ impl Vm {
                         tcl_runtime_api::VarStore::array_keys_at(vm, target).is_some(),
                     ))
                 });
-                if completion.code != Code::Ok {
+                if let Err(completion) = Self::deliver_sync(f, completion) {
                     return Tick::Return(completion);
                 }
-                f.stack.push(completion.result);
             }
             Op::ARRAY_EXISTS_STK => {
                 // The stack form resolves an arbitrary (possibly qualified) name,
@@ -2819,10 +2862,9 @@ impl Vm {
                         tcl_runtime_api::VarStore::array_keys_at(vm, target).is_some(),
                     ))
                 });
-                if completion.code != Code::Ok {
+                if let Err(completion) = Self::deliver_sync(f, completion) {
                     return Tick::Return(completion);
                 }
-                f.stack.push(completion.result);
             }
             // `array set`'s materialising half (C `INST_ARRAY_MAKE_*`): make the
             // variable an empty array when undefined, no-op when it already is
@@ -3329,6 +3371,14 @@ impl Vm {
             //    instruction; foreach_start jumps to step; step binds the loop
             //    vars and jumps back to the body, or falls through to end. --
             Op::FOREACH_START => {
+                let policy = if instr.foreach_collect {
+                    tcl_runtime_api::completion_options::ControlOptionPolicy::FRESH_FORWARDED
+                } else {
+                    tcl_runtime_api::completion_options::ControlOptionPolicy::FRESH_SETTLED
+                };
+                if policy.begins_fresh() {
+                    f.last_options = Value::empty();
+                }
                 let start_idx = f.pc - 1;
                 let body_idx = f.pc;
                 let groups = instr.foreach_vars.clone().unwrap_or_default();
@@ -3385,6 +3435,7 @@ impl Vm {
                     }
                 };
                 if more {
+                    f.last_options = Value::empty();
                     for (name, v) in binds {
                         try_op!(self.set_var(&name, v));
                     }
@@ -3406,10 +3457,12 @@ impl Vm {
                 // A collecting loop (`lmap`) yields `list(accum)`; a plain
                 // `foreach` yields nothing (its `""` result is pushed by the
                 // loop-end block).
-                if let Some(st) = st
-                    && st.collect
-                {
-                    f.stack.push(Value::list(st.accum));
+                if let Some(st) = st {
+                    if st.collect {
+                        f.stack.push(Value::list(st.accum));
+                    } else {
+                        f.last_options = Value::empty();
+                    }
                 }
             }
 
@@ -3969,9 +4022,7 @@ impl Vm {
                         result,
                     ],
                 );
-                if c.code == Code::Ok {
-                    f.stack.push(c.result);
-                } else {
+                if let Err(c) = Self::deliver_sync(f, c) {
                     return Tick::Return(c);
                 }
             }
@@ -3989,9 +4040,7 @@ impl Vm {
                 let opts = pop(f);
                 let c =
                     crate::command::cmd_return(self, &[Value::string("-options"), opts, result]);
-                if c.code == Code::Ok {
-                    f.stack.push(c.result);
-                } else {
+                if let Err(c) = Self::deliver_sync(f, c) {
                     return Tick::Return(c);
                 }
             }
@@ -4490,11 +4539,14 @@ impl Vm {
 
             // -- termination --
             Op::DONE => {
-                return Tick::Return(ok(f
-                    .stack
-                    .last()
-                    .cloned()
-                    .unwrap_or_else(|| f.last_result.clone())));
+                return Tick::Return(Completion::new(
+                    Code::Ok,
+                    f.stack
+                        .last()
+                        .cloned()
+                        .unwrap_or_else(|| f.last_result.clone()),
+                    f.last_options.clone(),
+                ));
             }
 
             // The compiled catch epilogue's reads (C `INST_PUSH_RESULT`/
@@ -4513,7 +4565,13 @@ impl Vm {
             }
             Op::PUSH_RETURN_OPTS => {
                 let opts = Self::innermost_caught(f).map_or_else(
-                    || crate::command::options_dict(Code::Ok, 0, &[]),
+                    || {
+                        crate::command::completion_options(&Completion::new(
+                            Code::Ok,
+                            f.last_result.clone(),
+                            f.last_options.clone(),
+                        ))
+                    },
                     |c| c.options.clone(),
                 );
                 f.stack.push(opts);
@@ -4974,7 +5032,7 @@ impl Vm {
                     | Tick::PushCatch(_)
                     | Tick::PushSubst(_)
                     | Tick::PushEachLoop(_)
-                    | Tick::PushTry(_) => self.pending_exec_leave = Some(ctx),
+                    | Tick::PushTry { .. } => self.pending_exec_leave = Some(ctx),
                     // Control shapes with no owning frame (a traced `yield` /
                     // `tailcall` builtin itself): settle with an empty ok —
                     // their real result forms elsewhere.
@@ -5098,6 +5156,9 @@ impl Vm {
         res: Completion<Value>,
     ) -> Result<Option<Tick>, Completion<Value>> {
         if res.code.is_ok() {
+            if !res.options.to_str().is_empty() {
+                f.last_options = res.options;
+            }
             f.stack.push(res.result);
             Ok(None)
         } else {
@@ -5151,7 +5212,10 @@ impl Vm {
         // subsequent phase) to a try-phase frame (see `Frame::try_ctx`,
         // issue #1311).
         if let Some(req) = self.pending.try_phase.take() {
-            return Ok(Some(Tick::PushTry(req)));
+            return Ok(Some(Tick::PushTry {
+                req,
+                initial_options: f.last_options.clone(),
+            }));
         }
         Self::deliver_sync(f, res)
     }
@@ -5514,7 +5578,7 @@ impl Vm {
         // `run_activation` call carries the whole construct through to
         // its final completion.
         if let Some(req) = self.pending.try_phase.take() {
-            return self.run_activation(Frame::new_try(req));
+            return self.run_activation(Frame::new_try(req, Value::empty()));
         }
         res
     }
@@ -5695,6 +5759,7 @@ impl Vm {
             return match acts.last_mut() {
                 None => Some(c),
                 Some(parent) => {
+                    parent.last_options = c.options;
                     parent.stack.push(c.result);
                     None
                 }

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -36,19 +36,22 @@ use tcl_dialect::{PackagePrefer, model::SurfaceQuery};
 use tcl_bytecode::{FunctionAsm, ModuleAsm, ProcedureProvenance};
 use tcl_core_types::RecursionLimit;
 use tcl_platform::Host;
+use tcl_runtime_api::completion_options::ControlOptionPolicy;
 use tcl_runtime_api::error_stack::{ErrorStack, validate_error_stack};
 use tcl_runtime_api::guard::{
     GuardDomain, GuardDomains, GuardError, GuardIdentity, GuardManager, GuardToken,
 };
 use tcl_runtime_api::{
-    ArrayTarget, Code, CommandId, Commands, CompileService, Completion, FrameId, FrameLinkOrigin,
-    Frames, Introspect, Namespaces, NsId, ProcInfo, ProcParam, ProcedureCompileTarget,
-    ProcedureDispatch, Procs, ROOT_NS, ScriptCompileTarget, Traces, VarId, VarStore, VarUnsetError,
+    ArrayElementRead, ArrayInvalidation, ArrayReadFailure, ArrayReadMiss, ArrayTarget, Code,
+    CommandId, Commands, CompileService, Completion, FrameId, FrameLinkOrigin, Frames, Introspect,
+    Namespaces, NsId, ProcInfo, ProcParam, ProcedureCompileTarget, ProcedureDispatch, Procs,
+    ROOT_NS, ScriptCompileTarget, Traces, VarId, VarStore, VarUnsetError,
 };
 use tcl_syntax::expr::{eval, parse_expr};
 
 use crate::command::{
     BuiltinFn, Command, EnsembleDef, ProcDef, err_with_code, lookup_error, register_builtins,
+    settle_control_options,
 };
 use crate::compiled::{CompiledUnit, CompilerProvenance};
 use crate::error::TclError;
@@ -1520,6 +1523,15 @@ enum TraceGroup {
 enum Step {
     Live(u64),
     Taken(String, bool),
+}
+
+/// One variable-trace access, kept together across cell selection and firing.
+#[derive(Clone, Copy)]
+struct VarTraceInvocation<'a> {
+    name: &'a str,
+    op: &'a str,
+    reported: (&'a str, &'a str),
+    element_access: bool,
 }
 
 /// One `trace add command|execution` registration: the op set
@@ -4416,6 +4428,8 @@ impl Vm {
     /// `invoke_command` re-entry has — tclsh reports `cannot yield: C stack
     /// busy`), but a cross-interp alias call now *can*, because the target's
     /// interpreter is reached by switching state rather than by suspending.
+    /// The alias wrapper begins a fresh option scope and forwards only options
+    /// produced by the target completion.
     pub(crate) fn invoke_alias_words(
         &mut self,
         target_interp: InterpId,
@@ -4433,21 +4447,22 @@ impl Vm {
             {
                 let completion = self.invoke_command(&head.to_str(), tail);
                 self.pop_ns();
-                return completion;
+                return settle_control_options(completion, ControlOptionPolicy::FRESH_FORWARDED);
             }
             let script = crate::exec::alias_invoke_script(argv);
             let evaled = self.eval_source(&script);
             self.pop_ns();
-            return match evaled {
+            let completion = match evaled {
                 Ok(c) => c,
                 Err(e) => err(e.message),
             };
+            return settle_control_options(completion, ControlOptionPolicy::FRESH_FORWARDED);
         }
         if !self.interp_alive(target_interp) {
             return err("could not find interpreter");
         }
         let script = crate::exec::alias_invoke_script(argv);
-        self.in_interp(target_interp, |vm| {
+        let completion = self.in_interp(target_interp, |vm| {
             vm.push_ns(String::new());
             if let Some((head, tail)) = argv.split_first()
                 && vm.lookup_command(&head.to_str()).is_none()
@@ -4462,7 +4477,8 @@ impl Vm {
                 Ok(c) => c,
                 Err(e) => err(e.message),
             }
-        })
+        });
+        settle_control_options(completion, ControlOptionPolicy::FRESH_FORWARDED)
     }
 
     /// `interp delete path …` — destroy interpreter `id`: unhook it from its
@@ -7692,13 +7708,68 @@ impl Vm {
         name: &str,
         key: &str,
     ) -> Result<Option<Value>, Completion<Value>> {
-        let full = format!("{name}({key})");
-        let cell = self.trace_cell(&full).and_then(|cell| cell.id);
-        self.fire_var_traces(&full, "read")?;
-        Ok(cell.map_or_else(
-            || self.get_array_elem(name, key),
-            |id| self.read_resolved_cell(id),
-        ))
+        self.read_elem_traced_from(name, key, self.current_level())
+            .1
+    }
+
+    /// Frame-addressed, already-split element read. The boolean records whether
+    /// the live source spelling named an array before callbacks; `array get`
+    /// uses that to distinguish `READ` from `LOOKUP` metadata when it swallows
+    /// a miss after an operation-trace alias retarget.
+    fn read_elem_traced_from(
+        &mut self,
+        name: &str,
+        key: &str,
+        start: usize,
+    ) -> (bool, Result<Option<Value>, Completion<Value>>) {
+        let (live_was_array, cell) =
+            self.resolve_var_from(name, start)
+                .map_or((false, None), |resolved| {
+                    if resolved.elem.is_some() {
+                        return (false, None);
+                    }
+                    let Some(array) = resolved.id else {
+                        return (false, None);
+                    };
+                    let (is_array, id) =
+                        match self.var_arena.get(array).map(crate::vars::VarCell::state) {
+                            Some(Local::Array(elements)) => (
+                                true,
+                                elements
+                                    .get(key)
+                                    .copied()
+                                    .and_then(|id| self.var_arena.resolve(id)),
+                            ),
+                            Some(Local::Scalar(_) | Local::Undefined | Local::Link(_)) | None => {
+                                (false, None)
+                            }
+                        };
+                    (
+                        is_array,
+                        Some(VarTraceCell {
+                            id,
+                            array: Some(array),
+                            elem: Some(key.to_owned()),
+                        }),
+                    )
+                });
+        let selected = cell.as_ref().and_then(|cell| cell.id);
+        if let Some(id) = selected {
+            self.var_arena.retain_operation(id);
+        }
+        let trace = self.fire_elem_traces_from_cell(name, key, "read", cell);
+        let value = if trace.is_ok() {
+            selected.map_or_else(
+                || self.get_array_elem_from(start, name, key),
+                |id| self.read_resolved_cell(id),
+            )
+        } else {
+            None
+        };
+        if let Some(id) = selected {
+            self.var_arena.release_operation(id);
+        }
+        (live_was_array, trace.map(|()| value))
     }
 
     /// `info exists` form of a traced lookup. Trace errors are deliberately
@@ -7909,21 +7980,63 @@ impl Vm {
             || (name.to_string(), String::new()),
             |(b, k)| (b.to_string(), k.to_string()),
         );
+        self.fire_var_traces_from_parts(
+            VarTraceInvocation {
+                name,
+                op,
+                reported: (reported_name1.unwrap_or(&base), &elem),
+                element_access: elem_ref(name).is_some(),
+            },
+            taken,
+            located,
+        )
+    }
+
+    /// Two-part array-element form of [`Self::fire_var_traces_from_cell`].
+    /// Carrying `base` and `key` separately avoids reparsing a display spelling
+    /// when the legal base name itself contains an opening parenthesis.
+    fn fire_elem_traces_from_cell(
+        &mut self,
+        base: &str,
+        key: &str,
+        op: &str,
+        located: Option<VarTraceCell>,
+    ) -> Result<(), Completion<Value>> {
+        let display = format!("{base}({key})");
+        self.fire_var_traces_from_parts(
+            VarTraceInvocation {
+                name: &display,
+                op,
+                reported: (base, key),
+                element_access: true,
+            },
+            None,
+            located,
+        )
+    }
+
+    fn fire_var_traces_from_parts(
+        &mut self,
+        invocation: VarTraceInvocation<'_>,
+        taken: Option<TakenVarTraces>,
+        located: Option<VarTraceCell>,
+    ) -> Result<(), Completion<Value>> {
         // C's `VAR_TRACE_ACTIVE` belongs to the reached `Var`: the whole array
         // and every element are separate cells. A callback may therefore enter
         // a different element, while a recursive access to this exact cell is
         // suppressed regardless of operation. Issue #1574.
         let Some(cell) = located.or_else(|| {
-            taken
-                .as_ref()
-                .map_or_else(|| self.trace_cell(name), |taken| Some(taken.cell.clone()))
+            taken.as_ref().map_or_else(
+                || self.trace_cell(invocation.name),
+                |taken| Some(taken.cell.clone()),
+            )
         }) else {
             return Ok(());
         };
         // Unset moves the trace list to a dummy `Var` and clears its active
         // bit, so unsetting the cell from its own write callback still fires
         // that taken list. Other recursive operations on the cell stay gated.
-        let taken_unset = op == "unset" && taken.is_some();
+        let taken_unset = invocation.op == "unset" && taken.is_some();
         if cell.id.is_some_and(|id| self.active_traces.contains(&id)) && !taken_unset {
             return Ok(());
         }
@@ -7933,14 +8046,7 @@ impl Vm {
         if let Some(id) = cell.id {
             self.active_traces.push(id);
         }
-        let r = self.fire_var_traces_inner(
-            name,
-            op,
-            (reported_name1.unwrap_or(&base), &elem),
-            &cell,
-            array_active,
-            taken,
-        );
+        let r = self.fire_var_traces_inner(invocation, &cell, array_active, taken);
         if let Some(id) = cell.id {
             let popped = self.active_traces.pop();
             debug_assert_eq!(popped, Some(id));
@@ -7953,7 +8059,7 @@ impl Vm {
     /// alias to an array element; the release policy owns that distinction.
     fn variable_trace_groups(
         &self,
-        name: &str,
+        element_access: bool,
         elem: &str,
         cell: &VarTraceCell,
         array_active: bool,
@@ -7963,7 +8069,7 @@ impl Vm {
         let mut groups = Vec::with_capacity(2);
         let mut name2 = elem.to_string();
         let include_array = taken.as_ref().is_none_or(|taken| taken.include_array);
-        if elem_ref(name).is_some() {
+        if element_access {
             if include_array
                 && !array_active
                 && let Some(array) = cell.array_id()
@@ -7998,20 +8104,24 @@ impl Vm {
     /// marked active by the caller.
     fn fire_var_traces_inner(
         &mut self,
-        name: &str,
-        op: &str,
-        reported: (&str, &str),
+        invocation: VarTraceInvocation<'_>,
         cell: &VarTraceCell,
         array_active: bool,
         taken: Option<TakenVarTraces>,
     ) -> Result<(), Completion<Value>> {
-        let (name1, elem) = reported;
+        let VarTraceInvocation {
+            name,
+            op,
+            reported: (name1, elem),
+            element_access,
+        } = invocation;
         // For an element access C walks the containing array's trace list
         // first and the element's own list second (`TclCallVarTraces`,
         // tclTrace.c 9.0.4: the `arrayPtr` loop at :2581 precedes the
         // `varPtr` loop at :2623) — regardless of which was registered first.
         // Issue #1440.
-        let (groups, name2) = self.variable_trace_groups(name, elem, cell, array_active, taken, op);
+        let (groups, name2) =
+            self.variable_trace_groups(element_access, elem, cell, array_active, taken, op);
         for group in groups {
             // Walk newest-first (the Vec is oldest-first), by identity: a
             // callback's `trace remove` unlinks its record from the live list
@@ -11119,6 +11229,57 @@ impl VarStore for Vm {
             self.array_unset_elem_reporting_at(id, target.name(), key, None)
         } else {
             self.unset_array_elem_from(target.frame().0, target.name(), key)
+        }
+    }
+
+    fn array_read_elem_at(&mut self, target: &ArrayTarget, key: &str) -> ArrayElementRead<Value> {
+        let (live_was_array, read) =
+            self.read_elem_traced_from(target.name(), key, target.frame().0);
+        let invalidation = VarStore::array_keys_at(self, target).is_none().then(|| {
+            match target
+                .cell_id()
+                .and_then(|id| self.var_arena.get(id))
+                .map(crate::vars::VarCell::state)
+            {
+                Some(Local::Scalar(_) | Local::Link(_)) => ArrayInvalidation::Retyped,
+                Some(Local::Undefined | Local::Array(_)) | None => ArrayInvalidation::Unset,
+            }
+        });
+        match read {
+            Err(failure) if invalidation.is_some() => {
+                let info = self
+                    .error_info_value()
+                    .map(|value| value.as_bytes().to_vec())
+                    .or_else(|| Some(failure.result.to_str().as_bytes().to_vec()));
+                ArrayElementRead::TraceError(ArrayReadFailure::new(
+                    failure.result.to_str().to_string(),
+                    b"TCL READ VARNAME".to_vec(),
+                    info,
+                    Some(i64::from(self.error_line())),
+                ))
+            }
+            Err(failure) => {
+                let info = self
+                    .take_error_info()
+                    .unwrap_or_else(|| failure.result.to_str().to_string());
+                let line = i64::from(self.error_line());
+                self.publish_error(&info, &Value::string("TCL READ VARNAME"));
+                ArrayElementRead::Missing(ArrayReadMiss::trace_error(Some(info.into_bytes()), line))
+            }
+            Ok(_) if let Some(invalidation) = invalidation => {
+                ArrayElementRead::ArrayInvalidated(invalidation)
+            }
+            Ok(Some(value)) => ArrayElementRead::Value(value),
+            Ok(None) => {
+                let miss = if live_was_array {
+                    ArrayReadMiss::missing()
+                } else {
+                    let code =
+                        tcl_syntax::list::join_list(["TCL", "LOOKUP", "VARNAME", target.name()]);
+                    ArrayReadMiss::lookup(code.into_bytes())
+                };
+                ArrayElementRead::Missing(miss)
+            }
         }
     }
 }

--- a/rust/tcl-vm/tests/tcltest_load.rs
+++ b/rust/tcl-vm/tests/tcltest_load.rs
@@ -334,6 +334,27 @@ fn upstream_set_stem_emits_a_parseable_summary_after_real_startup() {
     );
 }
 
+/// Tcl 9.0.4's canonical array-read trace mutation cases run verbatim through
+/// the real startup and `tcltest` package. They exercise key snapshotting,
+/// element removal, and whole-array destruction during `array get`.
+#[test]
+fn upstream_array_get_read_trace_definitions_pass_after_real_startup() {
+    let Some((ok, error, output)) = run_upstream_definitions(
+        "trace.test",
+        "test trace-1.11 {",
+        "# Basic write-tracing",
+        "tcltest-array-get-read-traces",
+    ) else {
+        eprintln!("skipping: no Tcl 9.0.4 source tree available");
+        return;
+    };
+    assert!(ok, "focused upstream trace.test failed: {error}\n{output}");
+    assert!(
+        output.contains("Total\t4\tPassed\t4\tSkipped\t0\tFailed\t0"),
+        "missing parseable upstream trace-1.11/1.14 summary: {output:?}"
+    );
+}
+
 /// The four upstream `dict info` definitions are executed verbatim through
 /// Tcl 9.0.4's real `tcltest` package. They cover a successful result, both
 /// arity errors, and malformed-dictionary validation without restating the

--- a/rust/tcl-vm/tests/variable_trace_semantics_e2e.rs
+++ b/rust/tcl-vm/tests/variable_trace_semantics_e2e.rs
@@ -672,6 +672,7 @@ proc PS {} {
     trace add variable x array {R bs}
     list [array size x] [array size x]
 }
+
 set size [PS]
 array set an {a 1}
 array set bn {b1 1 b2 2}
@@ -731,6 +732,68 @@ puts [list $size $names $get $setrow $unsetrow $pattern $forrow]
         vm_output(script),
         "{1 2} {1 {b1 b2} 2} {} {0 1} {1 0} {0 1} {{array changed during iteration}}"
     );
+}
+
+#[test]
+fn array_get_reads_candidates_through_the_shared_trace_contract() {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../tests/fixtures/tcl9/array-get-read-traces.tcl");
+    let mut script = std::fs::read_to_string(path).expect("read shared array-get trace fixture");
+    script.push_str("\nputs $out\n");
+    let expected = "{basic {x traced} {{whole A x read} {elem A x read}} traced {x y}} \
+        {missing 0 {} {TCL READ VARNAME} 0 0} \
+        {destroy 1 {can't read \"C(x)\": no such variable} {TCL READ VARNAME}} \
+        {retype 1 {can't read \"D(x)\": no such element in array} {TCL READ VARNAME} scalar} \
+        {boom 0 {} {TCL READ VARNAME} 1 1 1 {TCL READ VARNAME}} \
+        {carried 0 after 1 1 {TCL READ VARNAME}} \
+        {harddestroy 1 {can't read \"J(x)\": BOOM} {TCL READ VARNAME} 1 1 0} \
+        {hardretype 1 {can't read \"JR(x)\": BOOM} {TCL READ VARNAME} 1 1 scalar} \
+        {aggregate 0 {} {TCL READ VARNAME} 1 1 1 {TCL READ VARNAME}} \
+        {livegroup {x X} {whole new}} {owned {11 200}} \
+        {relem 0 {x NEW} 0 {x NEW}} \
+        {rbase 0 {} {TCL READ VARNAME} {x NEW}} \
+        {opretarget {x B}} {elemretarget {{x A} {x B}}} \
+        {uplevel {x traced} {local x read}} \
+        {namespace {x traced} {a x read}} \
+        {calls {x traced} {x traced}}";
+
+    assert_eq!(vm_output(&script), expected);
+    if let Some(oracle) = tclsh_output("TCL_LSP_TCLSH90", &["tclsh9.0"], &script) {
+        assert_eq!(oracle, expected, "Tcl 9.0.4 array-get trace oracle");
+    }
+}
+
+#[test]
+fn control_commands_apply_the_tcl9_completion_option_scope_matrix() {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../tests/fixtures/tcl9/completion-options-control.tcl");
+    let mut script = std::fs::read_to_string(path).expect("read shared completion-options fixture");
+    script.push_str("\nputs $out\n");
+    let expected = "{0 1 {TCL READ VARNAME}} {0 1 {TCL READ VARNAME}} \
+        {0 1 {TCL READ VARNAME}} {0 1 {TCL READ VARNAME}} \
+        {0 1 {TCL READ VARNAME}} {0 0 {}} {0 0 {}} {0 0 {}} \
+        {0 1 {TCL READ VARNAME}} {0 0 {}} {0 0 {}} {0 0 {}} \
+        {0 0 {}} {0 0 {}} {0 0 {}}";
+
+    assert_eq!(vm_output(&script), expected);
+    if let Some(oracle) = tclsh_output("TCL_LSP_TCLSH90", &["tclsh9.0"], &script) {
+        assert_eq!(oracle, expected, "Tcl 9.0.4 completion-scope oracle");
+    }
+}
+
+#[test]
+fn alias_wrappers_begin_a_fresh_completion_option_scope() {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../tests/fixtures/tcl9/completion-options-alias.tcl");
+    let mut script = std::fs::read_to_string(path).expect("read shared alias-options fixture");
+    script.push_str("\nputs $out\n");
+    let expected = "{{list 0 inside 0} {try 0 inside 0} {eval 0 inside 0} \
+        {switch 0 inside 0}} {0 inside 0} {0 value BAR}";
+
+    assert_eq!(vm_output(&script), expected);
+    if let Some(oracle) = tclsh_output("TCL_LSP_TCLSH90", &["tclsh9.0"], &script) {
+        assert_eq!(oracle, expected, "Tcl 9.0.4 alias completion-scope oracle");
+    }
 }
 
 #[test]

--- a/tests/fixtures/tcl9/array-get-read-traces.tcl
+++ b/tests/fixtures/tcl9/array-get-read-traces.tcl
@@ -1,0 +1,169 @@
+set out {}
+
+proc W {n1 n2 op} {lappend ::events [list whole $n1 $n2 $op]}
+proc MX {n1 n2 op} {
+    lappend ::events [list elem $n1 $n2 $op]
+    set ::A($n2) traced
+    set ::probe $::A($n2)
+    set ::A(y) NEW
+}
+set events {}
+array set A {x X}
+trace add variable A read W
+trace add variable A(x) read MX
+lappend out [list basic [array get A] $events $probe [lsort [array names A]]]
+
+proc DROP {n1 n2 op} {unset ::B($n2)}
+array set B {x X}
+trace add variable B(x) read DROP
+set cb [catch {array get B} mb ob]
+lappend out [list missing $cb $mb [dict get $ob -errorcode] \
+    [info exists ::errorInfo] [info exists ::errorCode]]
+
+proc DESTROY {n1 n2 op} {unset ::C}
+array set C {x X}
+trace add variable C(x) read DESTROY
+set cc [catch {array get C} mc oc]
+lappend out [list destroy $cc $mc [dict get $oc -errorcode]]
+
+proc RETYPE {n1 n2 op} {unset ::D; set ::D scalar}
+array set D {x X}
+trace add variable D(x) read RETYPE
+set cd [catch {array get D} md od]
+lappend out [list retype $cd $md [dict get $od -errorcode] $D]
+
+proc BOOM {n1 n2 op} {error BOOM}
+array set E {x X}
+trace add variable E(x) read BOOM
+set ce [catch {array get E} me oe]
+lappend out [list boom $ce $me [dict get $oe -errorcode] \
+    [string match {*read trace on "E(x)"*} [dict get $oe -errorinfo]] \
+    [dict get $oe -errorline] \
+    [string match {*read trace on "E(x)"*} $::errorInfo] $::errorCode]
+set cleak [catch {array get E; list after} mleak oleak]
+lappend out [list carried $cleak $mleak [dict exists $oleak -errorcode] \
+    [string match {*read trace on "E(x)"*} $::errorInfo] $::errorCode]
+
+proc HARDD {n1 n2 op} {unset ::J; error BOOM}
+array set J {x X}
+trace add variable J(x) read HARDD
+set cj [catch {array get J} mj oj]
+lappend out [list harddestroy $cj $mj [dict get $oj -errorcode] \
+    [string match {*read trace on "J(x)"*} [dict get $oj -errorinfo]] \
+    [dict get $oj -errorline] [array exists J]]
+
+proc HARDR {n1 n2 op} {unset ::JR; set ::JR scalar; error BOOM}
+array set JR {x X}
+trace add variable JR(x) read HARDR
+set cjr [catch {array get JR} mjr ojr]
+lappend out [list hardretype $cjr $mjr [dict get $ojr -errorcode] \
+    [string match {*read trace on "JR(x)"*} [dict get $ojr -errorinfo]] \
+    [dict get $ojr -errorline] $JR]
+
+proc MIX {n1 n2 op} {
+    incr ::mix
+    if {$::mix == 1} {error FIRST}
+    unset ::K($n2)
+}
+set mix 0
+array set K {a A b B}
+trace add variable K read MIX
+set ck [catch {array get K} mk ok]
+lappend out [list aggregate $ck $mk [dict get $ok -errorcode] \
+    [string match {*FIRST*read trace on "K(*} [dict get $ok -errorinfo]] \
+    [dict get $ok -errorline] \
+    [string match {*FIRST*read trace on "K(*} $::errorInfo] $::errorCode]
+
+proc OLD {n1 n2 op} {lappend ::live_events old}
+proc NEW {n1 n2 op} {lappend ::live_events new}
+proc CHANGE {n1 n2 op} {
+    lappend ::live_events whole
+    set variable ::L($n2)
+    trace remove variable $variable read OLD
+    trace add variable $variable read NEW
+}
+set live_events {}
+array set L {x X}
+trace add variable L(x) read OLD
+trace add variable L read CHANGE
+lappend out [list livegroup [array get L] $live_events]
+
+proc QPINA {n1 n2 op} {
+    unset ::Q(b)
+    set ::trashA [string repeat z 400]
+    set ::Q(b) overwritten
+}
+proc QPINB {n1 n2 op} {
+    unset ::Q(a)
+    set ::trashB [string repeat z 400]
+    set ::Q(a) overwritten
+}
+array set Q [list a [string repeat A 200] b [string repeat B 200]]
+trace add variable Q(a) read QPINA
+trace add variable Q(b) read QPINB
+set qr [array get Q]
+lappend out [list owned [lsort -integer [list \
+    [string length [dict get $qr a]] [string length [dict get $qr b]]]]]
+
+proc RELEM {n1 n2 op} {unset ::F($n2); set ::F($n2) NEW}
+array set F {x X}
+trace add variable F(x) read RELEM
+set cf [catch {array get F} mf of]
+lappend out [list relem $cf $mf [dict exists $of -errorcode] [array get F]]
+
+proc RBASE {n1 n2 op} {unset ::G; array set ::G {x NEW}}
+array set G {x X}
+trace add variable G(x) read RBASE
+set cg [catch {array get G} mg og]
+lappend out [list rbase $cg $mg [dict get $og -errorcode] [array get G]]
+
+proc AROP args {uplevel 1 {upvar #0 ::IB alias}}
+array set IA {x A}
+array set IB {x B}
+proc PA {} {
+    upvar #0 ::IA alias
+    trace add variable alias array AROP
+    array get alias
+}
+lappend out [list opretarget [PA]]
+
+proc ERET {n1 n2 op} {uplevel 1 {upvar #0 ::JB alias}}
+array set JA {x A}
+array set JB {x B}
+proc PE {} {
+    upvar #0 ::JA alias
+    trace add variable ::JA(x) read ERET
+    list [array get alias] [array get ::JB]
+}
+lappend out [list elemretarget [PE]]
+
+proc UR {n1 n2 op} {
+    set ::u_seen [list $n1 $n2 $op]
+    set name {}
+    append name $n1 ( $n2 )
+    uplevel 1 [list set $name traced]
+}
+proc UGET {} {uplevel 1 {array get local}}
+proc UP {} {
+    array set local {x X}
+    trace add variable local(x) read UR
+    UGET
+}
+lappend out [list uplevel [UP] $u_seen]
+
+namespace eval ::N {
+    array set a {x X}
+    trace add variable a(x) read ::UR
+    set nr [array get a]
+}
+lappend out [list namespace $::N::nr $u_seen]
+
+proc MUT {n1 n2 op} {upvar #0 $n1 v; set v($n2) traced}
+array set H {x X}
+trace add variable H(x) read MUT
+array set I {x X}
+trace add variable I(x) read MUT
+set cmd array
+lappend out [list calls [array get H] [$cmd get I]]
+
+set out

--- a/tests/fixtures/tcl9/completion-options-alias.tcl
+++ b/tests/fixtures/tcl9/completion-options-alias.tcl
@@ -1,0 +1,34 @@
+proc BOOM {n1 n2 op} {error BOOM}
+array set E {x X}
+trace add variable E(x) read BOOM
+
+set rows {}
+foreach {target script} [list \
+    list {array get E; a inside} \
+    try {array get E; a {list inside}} \
+    eval {array get E; a {list inside}} \
+    switch {array get E; a x x {list inside}}] {
+    interp alias {} a {} $target
+    set code [catch $script message options]
+    lappend rows [list $target $code $message [dict exists $options -errorcode]]
+    rename a {}
+}
+
+interp create child
+child eval {
+    proc BOOM {n1 n2 op} {error BOOM}
+    array set E {x X}
+    trace add variable E(x) read BOOM
+}
+interp alias child a {} list
+set cross [child eval {
+    set code [catch {array get E; a inside} message options]
+    list $code $message [dict exists $options -errorcode]
+}]
+proc OPT {} {return -level 0 -code ok -foo BAR value}
+interp alias child opt {} OPT
+set cross_options [child eval {
+    set code [catch {opt} message options]
+    list $code $message [dict get $options -foo]
+}]
+set out [list $rows $cross $cross_options]

--- a/tests/fixtures/tcl9/completion-options-control.tcl
+++ b/tests/fixtures/tcl9/completion-options-control.tcl
@@ -1,0 +1,28 @@
+proc BOOM {n1 n2 op} {error BOOM}
+array set E {x X}
+trace add variable E(x) read BOOM
+
+set scripts {
+    {array get E; list plain}
+    {array get E; if 1 {list inside}}
+    {array get E; if 0 {list no}}
+    {array get E; while 0 {}}
+    {array get E; for {set i 0} {$i < 0} {incr i} {list inside}}
+    {array get E; foreach x {1} {list inside}}
+    {array get E; lmap x {1} {list inside}}
+    {array get E; switch x x {list inside}}
+    {array get E; try {list inside}}
+    {array get E; catch {list inside}}
+    {array get E; eval {list inside}}
+    {array get E; namespace eval :: {list inside}}
+    {array get E; apply {{} {list inside}}}
+    {array get E; dict for {k v} {a b} {list inside}}
+    {array get E; time {list inside} 1}
+}
+set out {}
+foreach script $scripts {
+    set code [catch $script message options]
+    set has [dict exists $options -errorcode]
+    set errorcode [expr {$has ? [dict get $options -errorcode] : {}}]
+    lappend out [list $code $has $errorcode]
+}

--- a/tests/fixtures/tcl9/completion-options-control.tcl
+++ b/tests/fixtures/tcl9/completion-options-control.tcl
@@ -23,6 +23,6 @@ set out {}
 foreach script $scripts {
     set code [catch $script message options]
     set has [dict exists $options -errorcode]
-    set errorcode [expr {$has ? [dict get $options -errorcode] : {}}]
+    set errorcode [dict get [dict merge {-errorcode {}} $options] -errorcode]
     lappend out [list $code $has $errorcode]
 }


### PR DESCRIPTION
## Summary

- route every `array get` candidate through the shared, target-aware array-element read contract so whole-array and live element traces run in Tcl order
- preserve Tcl 9 mutation, error-precedence, value-ownership, alias, namespace/upvar, and coroutine semantics in both the native VM and standalone runtime
- centralise command/alias completion-option scopes so swallowed read-trace metadata is retained or settled at the same boundaries as Tcl 9.0.4
- keep the public array dispatch result structured so no consumer can silently discard retained completion metadata

## Verification

- `make rust-check`
- `make prep-pr`
- `make test-spectcl-compat`
- focused shared-owner tests: 112 + 28 passed
- native trace regressions: 26 passed
- standalone Tcl 9 oracle regressions: 9 passed, including upstream trace-1.11–1.14 and trace-5.1 through real `tcltest`

Closes #1932