### PR TITLE
perf(spectcl): cut synthetic corpus compilation units

### DIFF
--- a/rust/tcl-spectcl/tests/spec_corpus.rs
+++ b/rust/tcl-spectcl/tests/spec_corpus.rs
@@ -403,10 +403,10 @@ fn synthesise(spec: &CommandSpec) -> Vec<String> {
     calls.into_iter().map(|c| c.trim_end().to_owned()).collect()
 }
 
-/// How many synthesised calls go into one analysed script. Batching keeps a
-/// 68-command vendor pack to three analyses rather than sixty-eight, without
-/// making any single script large enough to hide a failure.
-const SYNTHESISED_CALLS_PER_SCRIPT: usize = 25;
+/// How many synthesised calls go into one analysed script. This keeps the
+/// largest shipped pack to four fully analysed scripts while retaining a
+/// bounded script size.
+const SYNTHESISED_CALLS_PER_SCRIPT: usize = 256;
 
 // The engine wrapper: counts attempted and successful invocations, and
 // injects the one panic no Tcl body can be trusted to produce


### PR DESCRIPTION
## Root cause

The remaining corpus-gate work was dominated by complete compilation-unit setup for small groups of generated single-command probes. Profiling also showed that full analyser/optimiser state is not invariant across pack overlays: each overlay can change command roles, hooks, lowering, definition grammars, and optimisation semantics, so sharing that state would weaken the integration proof.

## Fix

Batch up to 256 generated calls into each fully analysed script. The largest shipped pack remains split across four bounded scripts, every generated call is retained, and the change removes 54 of 255 compilation-unit builds (21.2%).

## Experimental proof

Same worktree, toolchain, runner, and exact test; first post-edit rebuild excluded from warm ranges:

- serial control: 15.01–15.30s -> 14.26–14.47s
- four-worker control: 4.04–4.06s -> 3.95–3.96s
- complete normal reports at batch sizes 25 and 256 were byte-identical after normalising only timing columns
- both reported 24 packs, 1,515 commands, 4,088/4,088 hook invocations, 864 diagnostics, and 961 optimisations
- `SPECTCL_CORPUS_DIFF=1 SPECTCL_CORPUS_PACK_THREADS=4` passed the full shared-vs-legacy diagnostic and optimisation snapshot comparison

## Verification

- exact shipped-corpus test after rebasing: 4.00s, passed
- `make rust-check`
- `make prep-pr`

Fixes #1940