### PR TITLE
ci: reuse SpecTcl compatibility toolchains

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1318,10 +1318,37 @@ jobs:
   spectcl-compat:
     needs: [channel]
     runs-on: ubuntu-26.04
+    env:
+      SCCACHE_GHA_ENABLED: "true"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
+
+      - name: Resolve the exact Tcl 9.0 cache identity
+        if: needs.channel.outputs.spectcl_compat_changed == 'true' && needs.channel.outputs.already_green != 'true'
+        id: tcl-oracle
+        shell: bash
+        run: |
+          set -euo pipefail
+          . scripts/dev/tcl-reference-toolchains.sh
+          tcl_reference_load_toolchains "$PWD"
+          patchlevel="$(tcl_reference_patchlevel 9.0)"
+          echo "path=tmp/tcl${patchlevel}" >> "$GITHUB_OUTPUT"
+          echo "key=spectcl-tcl90-ubuntu-26.04-x64-${{ hashFiles('rust/tcl-dialect/data/reference-toolchains.tsv', '.claude/skills/fetch-tcl-source/fetch_tcl_source.sh', 'scripts/dev/ensure-test-deps.sh', 'scripts/dev/tcl-reference-toolchains.sh') }}" >> "$GITHUB_OUTPUT"
+
+      # The static Tcl shell is only about 23 MB with its source tree, but a
+      # cold runner otherwise fetches, configures and builds it on every gate.
+      # Restore and save are separate so a failed bootstrap cannot publish a
+      # partial tree. The Make target below still probes the exact patchlevel
+      # and repairs a missing or unusable binary before any test can run.
+      - name: Restore the exact Tcl 9.0 source and build tree
+        if: needs.channel.outputs.spectcl_compat_changed == 'true' && needs.channel.outputs.already_green != 'true'
+        id: tcl-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ steps.tcl-oracle.outputs.path }}
+          key: ${{ steps.tcl-oracle.outputs.key }}
 
       - name: Set up Rust
         if: needs.channel.outputs.spectcl_compat_changed == 'true' && needs.channel.outputs.already_green != 'true'
@@ -1330,9 +1357,48 @@ jobs:
           toolchain: stable
           cache-key: spectcl-compat
 
+      - name: Set up sccache
+        id: sccache
+        if: needs.channel.outputs.spectcl_compat_changed == 'true' && needs.channel.outputs.already_green != 'true'
+        continue-on-error: true
+        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
+        with:
+          version: v0.17.0
+          disable_annotations: true
+
+      - name: Enable sccache when available
+        if: needs.channel.outputs.spectcl_compat_changed == 'true' && needs.channel.outputs.already_green != 'true'
+        shell: bash
+        env:
+          SCCACHE_SETUP_OUTCOME: ${{ steps.sccache.outcome }}
+        run: |
+          if [[ "$SCCACHE_SETUP_OUTCOME" == success ]] \
+              && command -v sccache >/dev/null 2>&1 \
+              && sccache --version >/dev/null 2>&1; then
+            echo 'RUSTC_WRAPPER=sccache' >> "$GITHUB_ENV"
+          else
+            echo '::warning::sccache is unavailable; continuing with uncached compilation'
+          fi
+
       - name: Run exact SpecTcl 1.x + 2.0 + real-Tcl compatibility gate
         if: needs.channel.outputs.spectcl_compat_changed == 'true' && needs.channel.outputs.already_green != 'true'
         run: make test-spectcl-compat
+
+      - name: Save the validated Tcl 9.0 source and build tree
+        if: needs.channel.outputs.spectcl_compat_changed == 'true' && needs.channel.outputs.already_green != 'true' && success() && steps.tcl-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ steps.tcl-oracle.outputs.path }}
+          key: ${{ steps.tcl-oracle.outputs.key }}
+
+      - name: Report sccache statistics
+        if: always() && needs.channel.outputs.spectcl_compat_changed == 'true' && needs.channel.outputs.already_green != 'true'
+        continue-on-error: true
+        shell: bash
+        run: |
+          if command -v sccache >/dev/null 2>&1; then
+            sccache --show-stats || true
+          fi
 
   # The heavy VM-simulation suites, split out to run concurrently with
   # `rust-tests-shard` (see that job's header). Doctests are covered there.

--- a/scripts/dev/test-spectcl-compat-paths.sh
+++ b/scripts/dev/test-spectcl-compat-paths.sh
@@ -75,6 +75,109 @@ esac
 
 echo "SpecTcl compatibility target contract tests passed"
 
+# The focused job's caches are accelerators, never alternate correctness
+# paths. It must derive Tcl identity from the manifest owner, restore before
+# the unchanged Make target, save only after success, and enable sccache only
+# after its optional setup succeeds.
+spectcl_job=$(awk '
+    /^  spectcl-compat:/ { in_job = 1 }
+    in_job && /^  [A-Za-z0-9_-]+:/ && $1 != "spectcl-compat:" { exit }
+    in_job { print }
+' "$REPO_ROOT/.github/workflows/ci.yml")
+
+spectcl_job_header=$(printf '%s\n' "$spectcl_job" | awk '
+    /^    steps:/ { exit }
+    { print }
+')
+
+case "$spectcl_job_header" in
+    *'env:'*'SCCACHE_GHA_ENABLED: "true"'*) ;;
+    *)
+        echo "spectcl-compat must enable the GitHub Actions sccache backend at job scope" >&2
+        exit 1
+        ;;
+esac
+
+spectcl_step() {
+    step_name=$1
+    step_count=$(printf '%s\n' "$spectcl_job" | awk -v header="      - name: $step_name" '
+        $0 == header { count += 1 }
+        END { print count + 0 }
+    ')
+    if [ "$step_count" -ne 1 ]; then
+        echo "spectcl-compat must contain exactly one step named: $step_name" >&2
+        exit 1
+    fi
+    printf '%s\n' "$spectcl_job" | awk -v header="      - name: $step_name" '
+        $0 == header { in_step = 1 }
+        in_step && /^      - / && $0 != header { exit }
+        in_step { print }
+    '
+}
+
+require_in_spectcl_step() {
+    required_step_name=$1
+    required_step_text=$2
+    required_step_block=$(spectcl_step "$required_step_name")
+    case "$required_step_block" in
+        *"$required_step_text"*) ;;
+        *)
+            echo "SpecTcl CI cache step '$required_step_name' is missing: $required_step_text" >&2
+            exit 1
+            ;;
+    esac
+}
+
+require_in_spectcl_step 'Resolve the exact Tcl 9.0 cache identity' 'id: tcl-oracle'
+require_in_spectcl_step 'Resolve the exact Tcl 9.0 cache identity' 'tcl_reference_patchlevel 9.0'
+require_in_spectcl_step 'Resolve the exact Tcl 9.0 cache identity' "hashFiles('rust/tcl-dialect/data/reference-toolchains.tsv', '.claude/skills/fetch-tcl-source/fetch_tcl_source.sh', 'scripts/dev/ensure-test-deps.sh', 'scripts/dev/tcl-reference-toolchains.sh')"
+
+require_in_spectcl_step 'Restore the exact Tcl 9.0 source and build tree' 'id: tcl-cache'
+require_in_spectcl_step 'Restore the exact Tcl 9.0 source and build tree' 'actions/cache/restore@'
+require_in_spectcl_step 'Restore the exact Tcl 9.0 source and build tree' 'path: ${{ steps.tcl-oracle.outputs.path }}'
+require_in_spectcl_step 'Restore the exact Tcl 9.0 source and build tree' 'key: ${{ steps.tcl-oracle.outputs.key }}'
+
+require_in_spectcl_step 'Set up sccache' 'id: sccache'
+require_in_spectcl_step 'Set up sccache' 'continue-on-error: true'
+require_in_spectcl_step 'Set up sccache' 'mozilla-actions/sccache-action@'
+
+require_in_spectcl_step 'Enable sccache when available' 'SCCACHE_SETUP_OUTCOME: ${{ steps.sccache.outcome }}'
+require_in_spectcl_step 'Enable sccache when available' 'RUSTC_WRAPPER=sccache'
+require_in_spectcl_step 'Enable sccache when available' 'continuing with uncached compilation'
+
+require_in_spectcl_step 'Run exact SpecTcl 1.x + 2.0 + real-Tcl compatibility gate' 'run: make test-spectcl-compat'
+
+require_in_spectcl_step 'Save the validated Tcl 9.0 source and build tree' "success() && steps.tcl-cache.outputs.cache-hit != 'true'"
+require_in_spectcl_step 'Save the validated Tcl 9.0 source and build tree' 'actions/cache/save@'
+require_in_spectcl_step 'Save the validated Tcl 9.0 source and build tree' 'path: ${{ steps.tcl-oracle.outputs.path }}'
+require_in_spectcl_step 'Save the validated Tcl 9.0 source and build tree' 'key: ${{ steps.tcl-oracle.outputs.key }}'
+
+require_in_spectcl_step 'Report sccache statistics' 'if: always()'
+require_in_spectcl_step 'Report sccache statistics' 'continue-on-error: true'
+require_in_spectcl_step 'Report sccache statistics' 'sccache --show-stats'
+
+previous_step_line=0
+while IFS= read -r ordered_step_name; do
+    ordered_step_line=$(printf '%s\n' "$spectcl_job" | awk -v header="      - name: $ordered_step_name" '
+        $0 == header { print NR }
+    ')
+    if [ "$ordered_step_line" -le "$previous_step_line" ]; then
+        echo "SpecTcl CI cache step is out of order: $ordered_step_name" >&2
+        exit 1
+    fi
+    previous_step_line=$ordered_step_line
+done <<'EOF'
+Resolve the exact Tcl 9.0 cache identity
+Restore the exact Tcl 9.0 source and build tree
+Set up sccache
+Enable sccache when available
+Run exact SpecTcl 1.x + 2.0 + real-Tcl compatibility gate
+Save the validated Tcl 9.0 source and build tree
+Report sccache statistics
+EOF
+
+echo "SpecTcl compatibility cache contract tests passed"
+
 # The repository's existing required check is `pr-gate`, so a job that is not
 # itself required must feed a real failure into that check. A plain `needs`
 # edge is insufficient: Actions skips dependent jobs after a failed need.


### PR DESCRIPTION
## Root cause

The focused compatibility lane rebuilt two stable inputs on fresh hosted runners: the manifest-pinned Tcl 9.0.4 source tree/interpreter and workspace crates that the existing dependency cache deliberately excludes. The semantic tests themselves account for only about 25–39 seconds.

## Fix

- derive the Tcl cache path from the authoritative reference-toolchain manifest
- restore a cache keyed by the manifest plus every bootstrap implementation owner and the fixed runner image/architecture
- run the unchanged fail-closed `make test-spectcl-compat` target, which still probes the exact patchlevel
- save the exact Tcl source/build tree only after the complete gate succeeds
- add optional sccache using the same setup/fallback discipline as the root Rust lane
- structurally gate the job-scoped backend, every field in its owning step, unique named steps, and lifecycle ordering

## Experimental proof

Same commit and same hosted-runner job, CI run 34303809096:

| Measurement | Cold attempt | Warm rerun |
| --- | ---: | ---: |
| Whole `spectcl-compat` job | 2m58s | 1m16s |
| Exact compatibility gate | 2m33s | 52s |
| Rust compile | 1m12s | 12.37s |
| Exact Tcl cache | miss, then validated save | hit (13.17 MB) |
| sccache | 7 hits / 16 misses | 23 hits / 0 misses (100%) |

The warm job is 57% shorter than the cold proof and 31–52% shorter than the recent 1m50–2m37 baselines. Both attempts ran the unchanged complete gate and passed the same 20 loader, 3 golden, 1 real-Tcl, 4 source-E2E, and 5 corpus tests.

## Verification

- workflow YAML parses successfully
- `sh -n scripts/dev/test-spectcl-compat-paths.sh`
- `scripts/dev/test-spectcl-compat-paths.sh`
- `make rust-check`
- `make prep-pr`

Review feedback is addressed by extracting each named workflow step independently, rejecting missing or duplicate steps, checking fields only inside their owner, and enforcing restore/setup/run/save/statistics order.

Fixes #2006
