### PR TITLE
perf(ci): cache native extension server build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -530,6 +530,7 @@ jobs:
       # or the tag's SHA is already green).  Same condition as test-ext's
       # steps — keep the two in sync.
       RUN_EXT: ${{ (needs.channel.outputs.ext_changed == 'true' || startsWith(github.ref, 'refs/tags/')) && needs.channel.outputs.already_green != 'true' && needs.channel.outputs.prerelease != 'true' }}
+      SCCACHE_GHA_ENABLED: "true"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -541,6 +542,31 @@ jobs:
         with:
           toolchain: stable
           cache-key: build-tcl-lsp-server
+
+      # rust-cache deliberately drops workspace artefacts before save. Keep
+      # their compiler outputs reusable without making cache availability part
+      # of the extension gate's correctness.
+      - name: Set up sccache
+        id: sccache
+        if: env.RUN_EXT == 'true'
+        continue-on-error: true
+        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
+        with:
+          version: v0.17.0
+          disable_annotations: true
+
+      - name: Enable sccache when available
+        if: env.RUN_EXT == 'true'
+        env:
+          SCCACHE_SETUP_OUTCOME: ${{ steps.sccache.outcome }}
+        run: |
+          if [[ "$SCCACHE_SETUP_OUTCOME" == success ]] \
+              && command -v sccache >/dev/null 2>&1 \
+              && sccache --version >/dev/null 2>&1; then
+            echo 'RUSTC_WRAPPER=sccache' >> "$GITHUB_ENV"
+          else
+            echo '::warning::sccache is unavailable; continuing with uncached compilation'
+          fi
 
       # The `ci` profile (root Cargo.toml) is release-grade opt-level with thin
       # LTO and codegen-units=1 relaxed — measured, the full `--release`
@@ -559,6 +585,16 @@ jobs:
           path: target/ci/tcl-lsp-server
           if-no-files-found: error
           retention-days: 1
+
+      - name: Report sccache statistics
+        if: always() && env.RUN_EXT == 'true'
+        continue-on-error: true
+        run: |
+          if command -v sccache >/dev/null 2>&1; then
+            sccache --show-stats
+          else
+            echo '::warning::sccache statistics unavailable; compilation ran uncached'
+          fi
 
   # VS Code extension tests: Node.js + xvfb driving the VS Code test host
   # against the native server.  A distinct, heavier stack than the cargo

--- a/scripts/dev/test-rust-tests-runner.sh
+++ b/scripts/dev/test-rust-tests-runner.sh
@@ -186,6 +186,7 @@ END {
     shard_job = "jobs.rust-tests-shard"
     aggregate_job = "jobs.rust-tests"
     doctest_job = "jobs.rust-tests-doctest"
+    server_job = "jobs.build-tcl-lsp-server"
     need(values[shard_job ".name"] == "rust-tests-shard (${{ matrix.shard }})", "Rust shards must have an explicit matrix job name")
     need(values[shard_job ".if"] == "${{ needs.channel.outputs.rust_tests_changed == '\''true'\'' && !(startsWith(github.ref, '\''refs/tags/'\'') && needs.channel.outputs.already_green == '\''true'\'') }}", "unaffected changes and already-green tags must skip the shard matrix")
     need(values_seen[shard_job ".runs-on"], "rust-tests-shard must define runs-on")
@@ -307,6 +308,24 @@ END {
     contains(shard_job ".steps." stats ".run", "cache write errors", "degraded cache writes must emit a warning")
     contains(shard_job ".steps." stats ".run", "exit 0", "cache-statistics failures must not change correctness")
     for (path in nodes) if (path ~ /^jobs\.rust-tests-shard\.env\./ && path ~ /SCCACHE_BASEDIRS$/) fail("do not claim cross-checkout Rust remapping without pinned-source support")
+
+    need(values[server_job ".env.SCCACHE_GHA_ENABLED"] == "true", "extension server build must enable the GitHub Actions sccache backend")
+    need(!nodes[server_job ".env.RUSTC_WRAPPER"], "extension server compiler cache must not be correctness-critical at job scope")
+    server_sccache = step(server_job, "name", "Set up sccache")
+    need(server_sccache >= 0 && values[server_job ".steps." server_sccache ".id"] == "sccache", "extension server sccache setup must expose its outcome")
+    need(values[server_job ".steps." server_sccache ".if"] == "env.RUN_EXT == '\''true'\''" && values[server_job ".steps." server_sccache ".continue-on-error"] == "true", "extension server sccache setup must be gated and non-fatal")
+    need(index(values[server_job ".steps." server_sccache ".uses"], "mozilla-actions/sccache-action@") == 1 && values[server_job ".steps." server_sccache ".with.version"] == "v0.17.0" && values[server_job ".steps." server_sccache ".with.disable_annotations"] == "true", "extension server build must retain pinned resilient sccache setup")
+    server_enable = step(server_job, "name", "Enable sccache when available")
+    need(server_enable > server_sccache && values[server_job ".steps." server_enable ".if"] == "env.RUN_EXT == '\''true'\''" && values[server_job ".steps." server_enable ".env.SCCACHE_SETUP_OUTCOME"] == "${{ steps.sccache.outcome }}", "extension server wrapper enablement must follow optional setup")
+    contains(server_job ".steps." server_enable ".run", "RUSTC_WRAPPER=sccache", "successful extension server setup must enable compiler cache")
+    contains(server_job ".steps." server_enable ".run", "continuing with uncached compilation", "failed extension server setup must report uncached fallback")
+    server_build = step(server_job, "name", "Build tcl-lsp-server (ci profile)")
+    need(server_build > server_enable && values[server_job ".steps." server_build ".run"] == "cargo build -p tcl-lsp-server --profile ci", "extension server build command and profile must remain unchanged")
+    server_upload = step(server_job, "name", "Upload tcl-lsp-server binary")
+    need(server_upload > server_build && values[server_job ".steps." server_upload ".with.path"] == "target/ci/tcl-lsp-server", "extension tests must receive the unchanged server artefact")
+    server_stats = step(server_job, "name", "Report sccache statistics")
+    need(server_stats > server_upload && values[server_job ".steps." server_stats ".if"] == "always() && env.RUN_EXT == '\''true'\''" && values[server_job ".steps." server_stats ".continue-on-error"] == "true", "extension server cache statistics must be resilient and run after the build")
+    contains(server_job ".steps." server_stats ".run", "sccache --show-stats", "extension server compiler-cache reuse must be observable")
 }
 ' "$WORKFLOW"
 


### PR DESCRIPTION
Closes #2008.

## Root cause

The native extension critical path built `tcl-lsp-server` with rust-cache but no compiler cache. rust-cache deliberately removes workspace artefacts before saving, so similar revisions and same-SHA retries repeatedly compiled the server's workspace dependency closure before the five-minute extension suite could start.

Run 34305681428 measured the current path at 5m04s for `build-tcl-lsp-server`, followed serially by 5m00s for `test-ext`; the full workflow finished in about 10m57s.

## Fix

- Add pinned sccache setup to `build-tcl-lsp-server` with the GitHub Actions backend.
- Keep cache setup non-fatal and export `RUSTC_WRAPPER` only after both setup and a binary probe succeed.
- Preserve the exact `cargo build -p tcl-lsp-server --profile ci` command, artifact, path gating, and downstream extension suites.
- Report cache statistics after every active attempt.
- Extend the parsed-workflow contract so cache fields, fallback behavior, build command, artifact, and lifecycle order are checked in their owning steps.

## Local proof

- `sh -n scripts/dev/test-rust-tests-runner.sh`
- `sh scripts/dev/test-rust-tests-runner.sh`
- `make rust-check`
- `make prep-pr`
- `git diff --check`

## CI timing proof

- [CI run 34308118554, attempt 1](https://github.com/bitwisecook/tcl-lsp/actions/runs/34308118554/attempts/1) completed green. The cold `build-tcl-lsp-server` job took 5m46s; its unchanged Cargo command took 5m08s with 0/28 cache hits and no cache errors.
- The selected same-SHA build rerun ([attempt 2](https://github.com/bitwisecook/tcl-lsp/actions/runs/34308118554/attempts/2)) completed in 1m08s. Cargo took 41.24s with 28/28 Rust cache hits (100%), zero misses, timeouts, read errors, write errors, or cache errors.
- GitHub reran the dependent native extension job against that warm-produced binary. It passed all 975 single-root and 14 multi-root tests; the test step took 4m55s and the complete consumer job took 6m04s.
- The compiler cache therefore removes 4m38s from the Cargo build and 4m38s from its producer job on the proven warm path without changing the build command, binary handoff, or extension coverage.
