### PR TITLE
perf: partition native VS Code extension tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,7 +280,7 @@ jobs:
                   python_changed=true ;;
               esac
               case "$f" in
-                editors/vscode/* | rust/* | grammars/* | ai/* | Cargo.toml | Cargo.lock | rust-toolchain.toml | Makefile | .github/workflows/ci.yml)
+                editors/vscode/* | scripts/dev/json-no-duplicate-keys.mjs | scripts/dev/test-vscode-test-partitions.sh | scripts/dev/verify-vscode-test-partitions.mjs | scripts/dev/verify-vscode-test-results.mjs | rust/* | grammars/* | ai/* | Cargo.toml | Cargo.lock | rust-toolchain.toml | Makefile | .github/workflows/ci.yml)
                   ext_changed=true ;;
               esac
               case "$f" in
@@ -600,7 +600,194 @@ jobs:
   # against the native server.  A distinct, heavier stack than the cargo
   # surfaces, so it reports as its own status check and runs concurrently with
   # them.  Runs on every PR and push, so it can serve as a required check.
-  test-ext:
+  test-ext-partition:
+    # Steps are gated, the job is not (see the channel job header): the whole
+    # suite step-skips on pre-release tags, on already-green tags, and when
+    # nothing extension-facing changed (`ext_changed`), while the job still
+    # reports success so the release graph and required checks stay unbroken.
+    needs: [channel, build-tcl-lsp-server]
+    strategy:
+      fail-fast: false
+      matrix:
+        partition:
+          - { index: 1, id: one }
+          - { index: 2, id: two }
+          - { index: 3, id: three }
+    runs-on: ubuntu-26.04
+    env:
+      # Keep in sync with build-tcl-lsp-server's RUN_EXT — this job consumes
+      # the artifact that job only uploads under the same condition.
+      RUN_EXT: ${{ (needs.channel.outputs.ext_changed == 'true' || startsWith(github.ref, 'refs/tags/')) && needs.channel.outputs.already_green != 'true' && needs.channel.outputs.prerelease != 'true' }}
+      TCL_LSP_TEST_PARTITION: ${{ matrix.partition.index }}/3
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+          fetch-tags: ${{ !startsWith(github.ref, 'refs/tags/') }}
+
+      # `make test-ext` still needs `cargo` for `xtask-gen-zed-queries` /
+      # `zed-query-check` (generated Zed asset drift), even though the
+      # `tcl-lsp-server` binary itself now comes from build-tcl-lsp-server.
+      #
+      # That cargo work is small when cached and expensive when not (measured:
+      # `cargo xtask gen-zed-queries --check` is ~0s warm, ~157s cold), and this
+      # job sits on the workflow's critical path — `build-tcl-lsp-server` ->
+      # `test-ext` finishes after every other branch.  It was also the only
+      # cargo job here without an explicit `cache-key`, so it shared the default
+      # with whatever else did and could lose its cache to a collision.  Key it
+      # per job like the rest, so the critical path is not the one running on
+      # the least reliable cache.
+      - name: Set up Rust
+        if: env.RUN_EXT == 'true'
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+        with:
+          toolchain: stable
+          cache-key: test-ext
+
+      - name: Set up Node.js
+        if: env.RUN_EXT == 'true'
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "24"
+
+      # Pin the npm CLI via the `packageManager` field in
+      # editors/vscode/package.json. Corepack downloads and activates the
+      # pinned npm so `npm ci` runs the same version locally and in CI.
+      - name: Enable Corepack (pin npm via packageManager)
+        if: env.RUN_EXT == 'true'
+        env:
+          COREPACK_ENABLE_DOWNLOAD_PROMPT: "0"
+        run: |
+          # `corepack enable` alone only shims pnpm/yarn; npm must be named
+          # explicitly (`corepack enable npm`) or the shim isn't created and
+          # the npm bundled with setup-node wins. Assert the pin is live so a
+          # silent regression fails loudly instead of using the wrong npm.
+          corepack enable npm
+          cd editors/vscode
+          active="$(npm --version)"
+          echo "Active npm: $active (pinned via packageManager)"
+          case "$active" in
+            12.*) ;;
+            *) echo "::error::expected npm 12 from packageManager pin, got $active"; exit 1 ;;
+          esac
+
+      # `package-lock.json` is committed, so installs are pinned by hash.
+      # Cache the npm metadata directory keyed on the lockfile so the
+      # cache invalidates whenever the resolved dependency tree changes.
+      - name: Cache npm registry
+        if: env.RUN_EXT == 'true'
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-${{ hashFiles('editors/vscode/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-
+
+      - name: Install npm dependencies
+        if: env.RUN_EXT == 'true'
+        run: |
+          cd editors/vscode
+          npm ci
+          # `make test-ext` calls the ordinary compile target later. Record
+          # that this exact package/lock pair is already installed so it does
+          # not immediately run a second `npm install` in the same job.
+          mkdir -p ../../build/stamps
+          touch ../../build/stamps/npm-install
+
+      - name: Verify VS Code test partitions
+        if: env.RUN_EXT == 'true'
+        run: make check-vscode-test-partitions
+
+      # `@vscode/test-electron` downloads a full VS Code build on every run and
+      # nothing cached it, so the extension-test step paid that download each
+      # time — on the critical path (`build-tcl-lsp-server` -> `test-ext` is the
+      # last branch to finish, and its 275s step runs suites that report
+      # "14 passing (3s)": the cost is almost entirely fetch + host startup, not
+      # testing).
+      #
+      # The key carries the RESOLVED stable version, queried from the same
+      # endpoint test-electron itself uses.  Keying on anything coarser (a date
+      # window, say) is broken: `actions/cache` entries are immutable, so when a
+      # new stable ships mid-window test-electron downloads it, the save is
+      # skipped because the key already exists, and every remaining run in that
+      # window re-downloads — the cache silently stops working exactly when VS
+      # Code releases.  Version-keying rotates on release, stores the new build
+      # once, and hits thereafter, while still tracking the stable channel
+      # rather than pinning it.
+      #
+      # If the endpoint cannot be reached the key falls back to a date stamp:
+      # that only costs a download, whereas failing the step would take the
+      # whole critical path down over a cache.
+      - name: Resolve VS Code stable version
+        if: env.RUN_EXT == 'true'
+        id: vscode-version
+        run: |
+          set -uo pipefail
+          ver=""
+          if curl -fsSL --max-time 20 -o /tmp/vscode-stable.json \
+               https://update.code.visualstudio.com/api/update/linux-x64/stable/latest; then
+            ver=$(python3 -c 'import json; print(json.load(open("/tmp/vscode-stable.json"))["name"])' 2>/dev/null || true)
+          fi
+          if [ -z "$ver" ]; then
+            ver="unresolved-$(date -u +%Y-%m-%d)"
+            echo "::warning::could not resolve VS Code stable version; using $ver"
+          fi
+          echo "version=$ver" >> "$GITHUB_OUTPUT"
+          echo "VS Code stable resolves to: $ver"
+
+      - name: Cache VS Code test download
+        if: env.RUN_EXT == 'true'
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: editors/vscode/.vscode-test
+          key: vscode-test-${{ runner.os }}-${{ hashFiles('editors/vscode/package-lock.json') }}-${{ steps.vscode-version.outputs.version }}
+
+      - name: Lint TypeScript
+        if: env.RUN_EXT == 'true'
+        run: cd editors/vscode && npm run lint
+
+      - name: Copy canonical AI data
+        if: env.RUN_EXT == 'true'
+        run: make copy-canonical
+
+      - name: Compile TypeScript
+        if: env.RUN_EXT == 'true'
+        run: cd editors/vscode && npx tsc -p ./
+
+      # Replaces the `make rust-server` build `make test-ext` would otherwise
+      # run inline: build-tcl-lsp-server already built this exact binary, so
+      # fetch it instead of compiling a second copy.
+      - name: Download tcl-lsp-server binary
+        if: env.RUN_EXT == 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: tcl-lsp-server-release
+          path: target/release
+
+      - name: Make tcl-lsp-server binary executable
+        if: env.RUN_EXT == 'true'
+        run: chmod +x target/release/tcl-lsp-server
+
+      - name: Run extension tests
+        if: env.RUN_EXT == 'true'
+        # Pre-set so `make test-ext` honours it and skips its own
+        # `make rust-server` build (see the Makefile recipe's comment).
+        env:
+          TCL_LSP_SERVER_BIN: ${{ github.workspace }}/target/release/tcl-lsp-server
+        run: make test-ext-partition
+
+      - name: Upload single-root partition metadata
+        if: always() && env.RUN_EXT == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: vscode-test-partition-${{ matrix.partition.id }}
+          path: editors/vscode/.vscode-test/mocha-result.json
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
+
+  # The unchanged multi-folder suite remains a distinct producer.
+  test-ext-multi-folder:
     # Steps are gated, the job is not (see the channel job header): the whole
     # suite step-skips on pre-release tags, on already-green tags, and when
     # nothing extension-facing changed (`ext_changed`), while the job still
@@ -686,6 +873,10 @@ jobs:
           mkdir -p ../../build/stamps
           touch ../../build/stamps/npm-install
 
+      - name: Verify VS Code test partitions
+        if: env.RUN_EXT == 'true'
+        run: make check-vscode-test-partitions
+
       # `@vscode/test-electron` downloads a full VS Code build on every run and
       # nothing cached it, so the extension-test step paid that download each
       # time — on the critical path (`build-tcl-lsp-server` -> `test-ext` is the
@@ -762,7 +953,54 @@ jobs:
         # `make rust-server` build (see the Makefile recipe's comment).
         env:
           TCL_LSP_SERVER_BIN: ${{ github.workspace }}/target/release/tcl-lsp-server
-        run: make test-ext
+        run: make test-ext-multi-folder
+
+      - name: Upload multi-folder test metadata
+        if: always() && env.RUN_EXT == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: vscode-test-multi-folder
+          path: editors/vscode/.vscode-test/mocha-result-multifolder.json
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
+
+  # Stable required status: all three single-root partitions and the unchanged
+  # multi-folder producer must pass, and their metadata must prove exact once.
+  test-ext:
+    if: ${{ always() }}
+    needs: [channel, test-ext-partition, test-ext-multi-folder]
+    runs-on: ubuntu-26.04
+    env:
+      RUN_EXT: ${{ (needs.channel.outputs.ext_changed == 'true' || startsWith(github.ref, 'refs/tags/')) && needs.channel.outputs.already_green != 'true' && needs.channel.outputs.prerelease != 'true' }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+      - name: Propagate extension prerequisite failures
+        env:
+          CHANNEL: ${{ needs.channel.result }}
+          PARTITIONS: ${{ needs.test-ext-partition.result }}
+          MULTI: ${{ needs.test-ext-multi-folder.result }}
+        run: |
+          if [ "$CHANNEL" != success ] || { [ "$RUN_EXT" = true ] && { [ "$PARTITIONS" != success ] || [ "$MULTI" != success ]; }; }; then
+            echo "channel=$CHANNEL partitions=$PARTITIONS multi=$MULTI" >&2
+            exit 1
+          fi
+      - name: Download extension test metadata
+        if: env.RUN_EXT == 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: vscode-test-*
+          path: ${{ runner.temp }}/vscode-test-results
+          merge-multiple: false
+      - name: Verify extension test exact-once metadata
+        if: env.RUN_EXT == 'true'
+        run: |
+          mkdir -p "$RUNNER_TEMP/vscode-test-results/partition-1" "$RUNNER_TEMP/vscode-test-results/partition-2" "$RUNNER_TEMP/vscode-test-results/partition-3" "$RUNNER_TEMP/vscode-test-results/multi-folder"
+          for pair in '1 one' '2 two' '3 three'; do set -- $pair; mv "$RUNNER_TEMP/vscode-test-results/vscode-test-partition-$2/mocha-result.json" "$RUNNER_TEMP/vscode-test-results/partition-$1/"; done
+          mv "$RUNNER_TEMP/vscode-test-results/vscode-test-multi-folder/mocha-result-multifolder.json" "$RUNNER_TEMP/vscode-test-results/multi-folder/"
+          node scripts/dev/verify-vscode-test-results.mjs "$GITHUB_WORKSPACE" "$RUNNER_TEMP/vscode-test-results"
 
   # The same extension in a BROWSER extension host — vscode.dev / github.dev.
   #

--- a/Makefile
+++ b/Makefile
@@ -208,9 +208,9 @@ TS_SRCS  := $(shell find $(EXT_DIR)/src -name '*.ts' 2>/dev/null)
 # Top-level gates
 .PHONY: rust-check check-all prep-pr _prep-pr-checks _prep-pr-tests _prep-pr-smoke _prep-pr-smoke-tier
 # Tests
-.PHONY: test test-ext test-emacs test-jetbrains test-rust rust-server rust-tcl rust-f5 rust-mcp rust-clis ensure-server-cross-deps server-cross-build server-cross-build-all mcp-cross-build-all cli-cross-build-all server-cross-test server-cross-test-build print-server-targets-all print-server-targets-jetbrains
+.PHONY: test test-ext test-ext-partition test-ext-multi-folder test-emacs test-jetbrains test-rust rust-server rust-tcl rust-f5 rust-mcp rust-clis ensure-server-cross-deps server-cross-build server-cross-build-all mcp-cross-build-all cli-cross-build-all server-cross-test server-cross-test-build print-server-targets-all print-server-targets-jetbrains
 .PHONY: xtask-check xtask-editor-extensions xtask-kcs-index-links xtask-diag-tables xtask-diag-emission-check xtask-gen-editor-catalogs xtask-gen-bundled-environments xtask-gen-editor-dialects xtask-gen-irule-test-data xtask-gen-zed-queries xtask-gen-editor-settings xtask-gen-vscode-package xtask-gen-jetbrains-catalog xtask-gen-ai-diagnostics xtask-owner-resolution xtask-command-backing xtask-audit-option-dialects xtask-registry-oracle xtask-sslictcl-data xtask-runtime-stdlib tcltest-sweep tcltest-sweep-check xtask-f5query-builtins-doc xtask-bigip-data-schema xtask-c-api-ownership check-c-api-ownership
-.PHONY: xtask-workflow-sync xtask-resolution-drift xtask-retired-api-gate xtask-pack-goldens xtask-number-drift xtask-gen-tmlanguage-keywords xtask-option-registry-drift xtask-callback-inventory check-tcl-reference-toolchains check-spectcl-compat-paths check-runtime-rust-paths check-rust-tests-runner check-persistent-cargo-target check-rust-tests-paths check-lsp-e2e-paths check-lsp-e2e-partitions check-already-green check-monitoring-triggers check-smoke-targets check-wasm-cc-env check-homebrew-ci check-sign-and-upload check-release-dependency-graph xtask-dialect-drift xtask-segmentation-drift
+.PHONY: xtask-workflow-sync xtask-resolution-drift xtask-retired-api-gate xtask-pack-goldens xtask-number-drift xtask-gen-tmlanguage-keywords xtask-option-registry-drift xtask-callback-inventory check-tcl-reference-toolchains check-spectcl-compat-paths check-runtime-rust-paths check-rust-tests-runner check-persistent-cargo-target check-rust-tests-paths check-lsp-e2e-paths check-lsp-e2e-partitions check-lsp-wasi-lto check-vscode-test-partitions check-already-green check-monitoring-triggers check-smoke-targets check-wasm-cc-env check-homebrew-ci check-sign-and-upload check-release-dependency-graph xtask-dialect-drift xtask-segmentation-drift
 # Lint / format / typecheck
 .PHONY: lint format lint-ts format-ts typecheck-ts check-rust check-rust-pr _check-rust-pr rust-deny
 .PHONY: build-report-assets build-report-pyz lint-report-ts typecheck-report-ts check-report-assets lint-spec-studio-ts typecheck-spec-studio-ts
@@ -219,6 +219,9 @@ TS_SRCS  := $(shell find $(EXT_DIR)/src -name '*.ts' 2>/dev/null)
 # Compile + codegen + generated assets
 .PHONY: compile codegen generate check-generated gen-editor-settings check-editor-settings gen-irule-test-data copy-canonical npm-env logo
 .PHONY: update-source-data check-source-data
+
+check-vscode-test-partitions: ## Verify VS Code partition manifest and workflow lifecycle
+	@bash scripts/dev/test-vscode-test-partitions.sh
 # Compiler explorer (WASM GUI)
 .PHONY: explorer-wasm explorer-build compiler-explorer-gui
 # Skills bundle + smoke tests
@@ -789,6 +792,36 @@ test-ext: ## Run VS Code extension integration tests (single-root + multi-root);
 	echo "==> Running multi-root VS Code extension tests"; \
 	if [[ "$$(uname -s)" == "Linux" && -z "$${DISPLAY:-}" ]]; then \
 		cd "$(EXT_DIR)" && xvfb-run -a "$(NPM)" run test:multi-folder; \
+	else \
+		cd "$(EXT_DIR)" && "$(NPM)" run test:multi-folder; \
+	fi
+
+# Run a single explicit whole-file partition. The ordinary test-ext target
+# remains unpartitioned for local use.
+test-ext-partition:
+	@set -eu; test -n "$${TCL_LSP_TEST_PARTITION:-}" || { echo "TCL_LSP_TEST_PARTITION must be INDEX/COUNT" >&2; exit 2; }; \
+	$(MAKE) compile ensure-vscode-test-deps; \
+	cd "$(EXT_DIR)" && "$(NPM)" run copy-canonical && "$(NPM)" run bundle; \
+	if [[ "$$(uname -s)" == "Linux" && -z "$${DISPLAY:-}" ]]; then \
+		if command -v xvfb-run >/dev/null 2>&1; then \
+			cd "$(EXT_DIR)" && xvfb-run -a node ./out/test/runTest.js; \
+		else \
+			echo "ERROR: DISPLAY is unset and xvfb-run is not available." >&2; exit 1; \
+		fi; \
+	else \
+		cd "$(EXT_DIR)" && node ./out/test/runTest.js; \
+	fi
+
+test-ext-multi-folder:
+	@set -eu; \
+	$(MAKE) compile ensure-vscode-test-deps; \
+	cd "$(EXT_DIR)" && "$(NPM)" run copy-canonical && "$(NPM)" run bundle; \
+	if [[ "$$(uname -s)" == "Linux" && -z "$${DISPLAY:-}" ]]; then \
+		if command -v xvfb-run >/dev/null 2>&1; then \
+			cd "$(EXT_DIR)" && xvfb-run -a "$(NPM)" run test:multi-folder; \
+		else \
+			echo "ERROR: DISPLAY is unset and xvfb-run is not available." >&2; exit 1; \
+		fi; \
 	else \
 		cd "$(EXT_DIR)" && "$(NPM)" run test:multi-folder; \
 	fi

--- a/docs/design/contracts/test-tiers-and-ci-gates.md
+++ b/docs/design/contracts/test-tiers-and-ci-gates.md
@@ -36,6 +36,19 @@ closures: the archive producer and all three partition jobs must succeed
 without building, uploading, downloading, or running the archive, and the
 required aggregate must still succeed after checking every upstream result.
 
+The native VS Code suite remains one unpartitioned extension-host run for
+local `npm test`. In CI, three isolated `test-ext-partition` producers run the
+106 single-root test files as whole-file assignments from
+`editors/vscode/test-partitions.json`; the 14-test multi-folder host remains a
+separate mandatory producer. Each producer uploads its file inventory,
+per-file duration, discovered identities, completed identities, and outcome
+counts. The stable `test-ext` aggregate fails unless the producers succeed and
+their metadata proves exact-once coverage of all 976 single-root identities
+(975 passed plus the one deliberately pending manual edit-storm test) and all
+14 passing multi-folder identities. The checked-in assignment records its
+hosted timing evidence and is balanced by measured duration rather than file
+or test count.
+
 The root workspace suite is five binary-aware `rust-tests-shard` matrix
 consumers. Every leg retains the complete `--workspace --all-features`
 resolver graph and builds all lib/bin unit harnesses, while the committed
@@ -321,6 +334,9 @@ identity** (tree/SHA, never a label or commit message), and bounded in time.
   binary and testcase coverage proof.
 - `scripts/dev/verify-nextest-partitions.py` — disjoint/completeness and
   transfer-integrity proof for the three-way archived LSP suite.
+- `editors/vscode/test-partitions.json` and
+  `scripts/dev/verify-vscode-test-{partitions,results}.mjs` — whole-file
+  desktop extension assignment and exact producer-metadata proof.
 
 ## Discoverability
 

--- a/editors/vscode/src/test/index.ts
+++ b/editors/vscode/src/test/index.ts
@@ -18,8 +18,11 @@
 
 import * as fs from "fs";
 import * as path from "path";
+import * as assert from "assert";
+import * as vscode from "vscode";
 import Mocha from "mocha";
 import { glob } from "glob";
+import { LanguageClient, State } from "vscode-languageclient/node";
 import { beginTestDeadline, scaledTimeout } from "./signal";
 import { createHeartbeatWriter, MOCHA_TEST_TIMEOUT_BASE_MS } from "./runnerWatchdog";
 import { probeServer } from "./serverProbe";
@@ -38,6 +41,7 @@ export async function run(): Promise<void> {
   // (a hang). Only the latter may be swallowed as success.
   const resultMarker = path.resolve(__dirname, "../../", ".vscode-test", "mocha-result.json");
   const heartbeatMarker = path.resolve(__dirname, "../../", ".vscode-test", "mocha-heartbeat.json");
+  const extensionDevelopmentPath = path.resolve(__dirname, "../../");
   const mocha = new Mocha({
     ui: "tdd",
     color: true,
@@ -49,6 +53,28 @@ export async function run(): Promise<void> {
     // no-progress window is itself derived from this same constant, so the
     // two cannot drift out of the relationship it depends on.
     timeout: scaledTimeout(MOCHA_TEST_TIMEOUT_BASE_MS),
+  });
+
+  // Every partition gets its own extension host and language server. These
+  // root hooks therefore belong to the runner, not serverHealth.test.ts,
+  // whose named tests intentionally execute in only one partition.
+  mocha.suite.beforeAll(async function () {
+    this.timeout(scaledTimeout(60_000));
+    const ext = vscode.extensions.getExtension("bitwisecook.tcl-lsp");
+    assert.ok(ext, "tcl-lsp extension not found");
+    await ext.activate();
+    assert.ok(ext.isActive, "Extension failed to activate – server may have crashed on startup");
+  });
+  mocha.suite.afterAll(async function () {
+    this.timeout(scaledTimeout(30_000));
+    const ext = vscode.extensions.getExtension("bitwisecook.tcl-lsp");
+    assert.ok(ext, "tcl-lsp extension not found");
+    const client = (ext.exports as { getClient(): LanguageClient }).getClient();
+    assert.strictEqual(
+      client.state,
+      State.Running,
+      `Server should still be Running at end of tests, got state ${client.state}`,
+    );
   });
 
   // The follow-up diagnostics in `signal.ts` are load-scaled at the moment
@@ -100,11 +126,64 @@ export async function run(): Promise<void> {
 
   // The multiFolder/ subdirectory has its own runner (runMultiFolderTest)
   // because those tests need the .code-workspace fixture.  Skip them here.
-  const files = await glob("**/*.test.js", {
+  const canonicalFiles = await glob("**/*.test.js", {
     cwd: testsRoot,
     ignore: ["multiFolder/**"],
   });
+  canonicalFiles.sort();
+  const partitionSpec = process.env.TCL_LSP_TEST_PARTITION;
+  let files = canonicalFiles;
+  let partition: { index: number; count: number } | undefined;
+  if (partitionSpec) {
+    const match = /^(\d+)\/(\d+)$/.exec(partitionSpec);
+    if (!match || Number(match[1]) < 1 || Number(match[1]) > Number(match[2])) {
+      throw new Error(`invalid TCL_LSP_TEST_PARTITION: ${partitionSpec}`);
+    }
+    const index = Number(match[1]);
+    const count = Number(match[2]);
+    const manifestPath = path.resolve(extensionDevelopmentPath, "test-partitions.json");
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8")) as {
+      version: number;
+      canonical_glob: string;
+      exclude: string[];
+      partitions: Record<string, string[]>;
+    };
+    if (
+      manifest.version !== 1 ||
+      manifest.canonical_glob !== "**/*.test.js" ||
+      JSON.stringify(manifest.exclude) !== JSON.stringify(["multiFolder/**"])
+    ) {
+      throw new Error("unsupported VS Code test partition manifest");
+    }
+    const assigned = manifest.partitions[String(index)];
+    if (!assigned || Object.keys(manifest.partitions).length !== count) {
+      throw new Error(`partition manifest does not define ${partitionSpec}`);
+    }
+    const canonical = new Set(canonicalFiles);
+    const seen = new Set<string>();
+    for (const names of Object.values(manifest.partitions)) {
+      for (const name of names) {
+        if (seen.has(name) || !canonical.has(name)) {
+          throw new Error(`invalid or duplicate partition test file: ${name}`);
+        }
+        seen.add(name);
+      }
+    }
+    if (seen.size !== canonical.size) {
+      throw new Error("VS Code test partition manifest is incomplete");
+    }
+    files = [...assigned].sort();
+    partition = { index, count };
+  }
   files.sort();
+  let testsStarted = 0;
+  let testsCompleted = 0;
+  let testsPassed = 0;
+  let testsPending = 0;
+  const fileDurationsMs: Record<string, number> = {};
+  const testStartTimes = new Map<Mocha.Test, number>();
+  const testIdentities: string[] = [];
+  const discoveredTestIdentities: string[] = [];
   for (const f of files) {
     mocha.addFile(path.resolve(testsRoot, f));
   }
@@ -132,7 +211,22 @@ export async function run(): Promise<void> {
       heartbeatWriter.stop();
       restoreFixtureSettings();
       fs.mkdirSync(path.dirname(resultMarker), { recursive: true });
-      fs.writeFileSync(resultMarker, JSON.stringify({ failures }) + "\n", "utf8");
+      fs.writeFileSync(
+        resultMarker,
+        JSON.stringify({
+          failures,
+          partition,
+          files,
+          discoveredTestIdentities,
+          testIdentities,
+          fileDurationsMs,
+          testsStarted,
+          testsCompleted,
+          testsPassed,
+          testsPending,
+        }) + "\n",
+        "utf8",
+      );
       if (failures > 0) {
         reject(new Error(`${failures} test(s) failed.`));
       } else {
@@ -140,8 +234,30 @@ export async function run(): Promise<void> {
       }
     });
 
-    runner.on("test", (test: Mocha.Test) => heartbeatWriter.onTestStart(test.fullTitle()));
-    runner.on("test end", (test: Mocha.Test) => heartbeatWriter.onTestEnd(test.fullTitle()));
+    runner.suite.eachTest((test: Mocha.Test) => {
+      const file = test.file ? path.relative(testsRoot, test.file).split(path.sep).join("/") : "";
+      discoveredTestIdentities.push(`${file}:${test.fullTitle()}`);
+    });
+
+    runner.on("test", (test: Mocha.Test) => {
+      testsStarted++;
+      testStartTimes.set(test, Date.now());
+      heartbeatWriter.onTestStart(test.fullTitle());
+    });
+    runner.on("pass", () => {
+      testsPassed++;
+    });
+    runner.on("pending", () => {
+      testsPending++;
+    });
+    runner.on("test end", (test: Mocha.Test) => {
+      testsCompleted++;
+      const file = test.file ? path.relative(testsRoot, test.file).split(path.sep).join("/") : "";
+      testIdentities.push(`${file}:${test.fullTitle()}`);
+      fileDurationsMs[file] =
+        (fileDurationsMs[file] ?? 0) + (Date.now() - (testStartTimes.get(test) ?? Date.now()));
+      heartbeatWriter.onTestEnd(test.fullTitle());
+    });
     // Log failure details so they are visible even when the VS Code test
     // host terminates before mocha prints its summary.
     runner.on("fail", (test: Mocha.Test, err: Error) => {

--- a/editors/vscode/src/test/multiFolder/index.ts
+++ b/editors/vscode/src/test/multiFolder/index.ts
@@ -75,12 +75,34 @@ export async function run(): Promise<void> {
   }
 
   const heartbeatWriter = createHeartbeatWriter({ heartbeatMarker, probeServer });
+  let testsStarted = 0;
+  let testsCompleted = 0;
+  let testsPassed = 0;
+  let testsPending = 0;
+  const testIdentities: string[] = [];
+  const discoveredTestIdentities: string[] = [];
+  const fileDurationsMs: Record<string, number> = {};
+  const testStartTimes = new Map<Mocha.Test, number>();
 
   return new Promise<void>((resolve, reject) => {
     const runner = mocha.run((failures) => {
       heartbeatWriter.stop();
       fs.mkdirSync(path.dirname(resultMarker), { recursive: true });
-      fs.writeFileSync(resultMarker, JSON.stringify({ failures }) + "\n", "utf8");
+      fs.writeFileSync(
+        resultMarker,
+        JSON.stringify({
+          failures,
+          files,
+          discoveredTestIdentities,
+          testIdentities,
+          fileDurationsMs,
+          testsStarted,
+          testsCompleted,
+          testsPassed,
+          testsPending,
+        }) + "\n",
+        "utf8",
+      );
       if (failures > 0) {
         reject(new Error(`${failures} test(s) failed.`));
       } else {
@@ -88,8 +110,30 @@ export async function run(): Promise<void> {
       }
     });
 
-    runner.on("test", (test: Mocha.Test) => heartbeatWriter.onTestStart(test.fullTitle()));
-    runner.on("test end", (test: Mocha.Test) => heartbeatWriter.onTestEnd(test.fullTitle()));
+    runner.suite.eachTest((test: Mocha.Test) => {
+      const file = test.file ? path.relative(testsRoot, test.file).split(path.sep).join("/") : "";
+      discoveredTestIdentities.push(`${file}:${test.fullTitle()}`);
+    });
+
+    runner.on("test", (test: Mocha.Test) => {
+      testsStarted++;
+      testStartTimes.set(test, Date.now());
+      heartbeatWriter.onTestStart(test.fullTitle());
+    });
+    runner.on("pass", () => {
+      testsPassed++;
+    });
+    runner.on("pending", () => {
+      testsPending++;
+    });
+    runner.on("test end", (test: Mocha.Test) => {
+      testsCompleted++;
+      const file = test.file ? path.relative(testsRoot, test.file).split(path.sep).join("/") : "";
+      testIdentities.push(`${file}:${test.fullTitle()}`);
+      fileDurationsMs[file] =
+        (fileDurationsMs[file] ?? 0) + (Date.now() - (testStartTimes.get(test) ?? Date.now()));
+      heartbeatWriter.onTestEnd(test.fullTitle());
+    });
     runner.on("fail", (test: Mocha.Test, err: Error) => {
       heartbeatWriter.onFail();
       console.error(`\nFAIL: ${test.fullTitle()}`);

--- a/editors/vscode/src/test/multiFolder/multiFolderConfig.test.ts
+++ b/editors/vscode/src/test/multiFolder/multiFolderConfig.test.ts
@@ -81,9 +81,10 @@ suite("Multi-folder workspace configuration (#230)", () => {
     // Wait for the extension to activate so the LSP client is ready.
     const ext = vscode.extensions.getExtension("bitwisecook.tcl-lsp");
     assert.ok(ext, "tcl-lsp extension not found");
-    if (!ext.isActive) {
-      await ext.activate();
-    }
+    // Automatic workspace activation can already be in flight when Mocha
+    // starts. `isActive` may have flipped before the activation promise has
+    // registered the server-advertised commands, so always await that promise.
+    await ext.activate();
     // Poll the server for its resolved per-folder dialect rather than
     // sleeping on wall-clock time -- the previous setTimeout(3000) masked
     // the race that issue #407 actually reports.

--- a/editors/vscode/src/test/serverHealth.test.ts
+++ b/editors/vscode/src/test/serverHealth.test.ts
@@ -30,30 +30,8 @@ function getApi(): TclLspApi {
   return ext.exports as TclLspApi;
 }
 
-// Root-level hooks bracket the entire test run.
-
-// Runs before ALL test suites.  If the native tcl-lsp-server binary is
-// missing or crashes on startup then ext.activate() rejects because
-// client.start() fails, and the whole test run aborts with a clear message.
-suiteSetup(async function () {
-  this.timeout(scaledTimeout(60_000));
-  const ext = vscode.extensions.getExtension("bitwisecook.tcl-lsp")!;
-  await ext.activate();
-  assert.ok(ext.isActive, "Extension failed to activate – server may have crashed on startup");
-});
-
-// Runs after ALL test suites.  Catches server crashes that happen mid-run.
-suiteTeardown(async function () {
-  this.timeout(scaledTimeout(30_000));
-  const client = getApi().getClient();
-  assert.strictEqual(
-    client.state,
-    State.Running,
-    `Server should still be Running at end of tests, got state ${client.state}`,
-  );
-});
-
-// Explicit health-check suite with named tests.
+// The runner owns the root lifecycle health hooks so every isolated partition
+// checks activation and final server state. These named checks run once.
 
 suite("Server Health", () => {
   test("language client is in Running state", () => {

--- a/editors/vscode/test-partitions.json
+++ b/editors/vscode/test-partitions.json
@@ -1,0 +1,160 @@
+{
+  "version": 1,
+  "canonical_glob": "**/*.test.js",
+  "exclude": [
+    "multiFolder/**"
+  ],
+  "multi_folder_files": [
+    "multiFolderConfig.test.js"
+  ],
+  "expected_tests": {
+    "single_root": {
+      "identities": 976,
+      "passed": 975,
+      "pending": 1
+    },
+    "multi_folder": {
+      "identities": 14,
+      "passed": 14,
+      "pending": 0
+    }
+  },
+  "assignment": {
+    "status": "hosted-duration-balanced",
+    "method": "deterministic longest-processing-time assignment from hosted file durations, with serverHealth.test.js fixed in partition 1; filenames break duration ties and the lowest partition index breaks load ties",
+    "hosted_measurements": {
+      "run_id": 34320581260,
+      "head_sha": "a845d855216e282f7b9e918e3433a3712ee09ed9",
+      "producer_jobs": {
+        "1": 102366472957,
+        "2": 102366472969,
+        "3": 102366473057
+      },
+      "before_partition_ms": [
+        28817,
+        63001,
+        94948
+      ],
+      "projected_partition_ms": [
+        62255,
+        62256,
+        62255
+      ]
+    },
+    "measurement_field": "fileDurationsMs"
+  },
+  "partitions": {
+    "1": [
+      "aliasTracking.test.js",
+      "arityLoopPrecision.test.js",
+      "callHierarchy.test.js",
+      "chatUtilities.test.js",
+      "closedFileRetention.test.js",
+      "codeActions.test.js",
+      "commandAliasTracking.test.js",
+      "definition.test.js",
+      "diagnostics.test.js",
+      "errorRecovery.test.js",
+      "extensionActivation.test.js",
+      "grammar.test.js",
+      "highlightingHealth.test.js",
+      "hover.test.js",
+      "ilxReferences.test.js",
+      "inlayHints.test.js",
+      "issue1305RenamedMetaclass.test.js",
+      "issue954Followup.test.js",
+      "issue969.test.js",
+      "issue977.test.js",
+      "precisionReview2.test.js",
+      "progress.test.js",
+      "selectionTransforms.test.js",
+      "serverHealth.test.js",
+      "sourceIntegrity.test.js",
+      "specPackTorture.test.js",
+      "sslictclAuthoring.test.js",
+      "stickyScroll.test.js",
+      "unicodePositions.test.js",
+      "unusedParamPrecision.test.js",
+      "variableCompletion.test.js",
+      "w003.test.js",
+      "workspaceFileOps.test.js",
+      "workspaceSymbols.test.js"
+    ],
+    "2": [
+      "codeLens.test.js",
+      "compilerExplorerWebview.test.js",
+      "completion.test.js",
+      "crossFileDiagnostics.test.js",
+      "diffAnalysis.test.js",
+      "documentLinks.test.js",
+      "documentSymbols.test.js",
+      "formatting.test.js",
+      "iruleSkeleton.test.js",
+      "issue1019ProcArgs.test.js",
+      "issue1302ImportShadow.test.js",
+      "issue1312NamedObject.test.js",
+      "issue923NsPkgAudit.test.js",
+      "issue945.test.js",
+      "issue968.test.js",
+      "issue976.test.js",
+      "linkedEditingRange.test.js",
+      "nameResolution.test.js",
+      "nestedSelfRedefinition.test.js",
+      "packFileAssociations.test.js",
+      "refactorActions.test.js",
+      "references.test.js",
+      "reportStyle.test.js",
+      "runnerWatchdog.test.js",
+      "runtimeValidation.test.js",
+      "selectionRange.test.js",
+      "shimmerPrecision.test.js",
+      "showReferences.test.js",
+      "signatureHelp.test.js",
+      "stickyScrollHealth.test.js",
+      "templateSnippets.test.js",
+      "typeDefinition.test.js",
+      "w120WorkspaceReschedule.test.js",
+      "waitDiscipline.test.js",
+      "willSaveWaitUntil.test.js"
+    ],
+    "3": [
+      "callerFrameCluster.test.js",
+      "commandExecution.test.js",
+      "commands.test.js",
+      "configSettings.test.js",
+      "declaration.test.js",
+      "diagnosticTags.test.js",
+      "diagramPrompt.test.js",
+      "dialectDetection.test.js",
+      "documentHighlight.test.js",
+      "exprMathFunc.test.js",
+      "foldingRanges.test.js",
+      "i230WordOperator.test.js",
+      "implementation.test.js",
+      "issue1138ListBuiltScript.test.js",
+      "issue1281EnsembleRename.test.js",
+      "issue1296MetaclassChain.test.js",
+      "issue1303FactoryInference.test.js",
+      "issue1329SelfDispatch.test.js",
+      "issue923Callbacks.test.js",
+      "issue996.test.js",
+      "languageRegistration.test.js",
+      "precisionFalsePositives.test.js",
+      "precisionReview.test.js",
+      "previewTickets.test.js",
+      "progressiveDiagnostics.test.js",
+      "pullDiagnostics.test.js",
+      "renameSymbol.test.js",
+      "scaffold.test.js",
+      "semanticTokens.test.js",
+      "serverResolution.test.js",
+      "snippets.test.js",
+      "specPacks.test.js",
+      "tkChildInterp.test.js",
+      "tkPreviewHtml.test.js",
+      "uplevelIndirectSet.test.js",
+      "variableContexts.test.js",
+      "webWorkspaceSync.test.js"
+    ]
+  }
+}

--- a/scripts/dev/json-no-duplicate-keys.mjs
+++ b/scripts/dev/json-no-duplicate-keys.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// JSON.parse accepts duplicate object keys and silently keeps the last value.
+// Reject them before parsing so checked-in manifests cannot hide an operative
+// value behind a duplicate key.
+export function parseJsonNoDuplicateKeys(text, label) {
+  const stack = [];
+  let index = 0;
+
+  while (index < text.length) {
+    const character = text[index];
+    if (/\s/.test(character)) {
+      index++;
+      continue;
+    }
+    if (character === '"') {
+      const start = index++;
+      while (index < text.length) {
+        if (text[index] === "\\") {
+          index += 2;
+        } else if (text[index++] === '"') {
+          break;
+        }
+      }
+      const object = stack.at(-1);
+      if (object?.kind === "object" && object.expectKey) {
+        const key = JSON.parse(text.slice(start, index));
+        if (object.keys.has(key)) {
+          throw new Error(`${label} contains duplicate object key: ${key}`);
+        }
+        object.keys.add(key);
+        object.expectKey = false;
+      }
+      continue;
+    }
+    if (character === "{") {
+      stack.push({ kind: "object", keys: new Set(), expectKey: true });
+    } else if (character === "[") {
+      stack.push({ kind: "array" });
+    } else if (character === "}" || character === "]") {
+      stack.pop();
+    } else if (character === ",") {
+      const object = stack.at(-1);
+      if (object?.kind === "object") object.expectKey = true;
+    }
+    index++;
+  }
+
+  return JSON.parse(text);
+}

--- a/scripts/dev/test-vscode-test-partitions.sh
+++ b/scripts/dev/test-vscode-test-partitions.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+# tcl-lsp — a language server and toolchain for Tcl
+# Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+set -euo pipefail
+
+root=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+node "$root/scripts/dev/verify-vscode-test-partitions.mjs" "$root" >/dev/null
+
+manifest="$root/editors/vscode/test-partitions.json"
+for partition in 1 2 3; do
+  count=$(jq -r --arg p "$partition" '.partitions[$p] | length' "$manifest")
+  test "$count" -gt 0
+done
+test "$(jq '[.partitions[][]] | length' "$manifest")" -eq 106
+test "$(jq '[.partitions[][]] | unique | length' "$manifest")" -eq 106
+test "$(jq '.expected_tests.single_root.identities' "$manifest")" -eq 976
+test "$(jq '.expected_tests.single_root.passed' "$manifest")" -eq 975
+test "$(jq '.expected_tests.single_root.pending' "$manifest")" -eq 1
+test "$(jq '.expected_tests.multi_folder.identities' "$manifest")" -eq 14
+test "$(jq '.expected_tests.multi_folder.passed' "$manifest")" -eq 14
+test "$(jq '.expected_tests.multi_folder.pending' "$manifest")" -eq 0
+test "$(jq -r '.multi_folder_files | join(",")' "$manifest")" = "multiFolderConfig.test.js"
+echo "VS Code test partitions: exact-once proof passed (106 files, 975 passed + 1 pending single-root identities, 14 multi-folder tests, 3 partitions)"
+
+workflow="${root}/.github/workflows/ci.yml"
+check_workflow() {
+  set -uo pipefail
+  local file=$1 partition_job multi_job aggregate_job propagation download verify
+  job_block() {
+    awk -v wanted="  $1:" '$0 == wanted { in_job=1; found=1 } in_job && /^  [A-Za-z0-9_-]+:/ && $0 != wanted { exit } in_job { print } END { if (!found) exit 1 }' "$file"
+  }
+  step_block() {
+    local job=$1 name=$2
+    awk -v wanted="      - name: $name" '$0 == wanted { in_step=1; found=1 } in_step && /^      (- name:|#)/ && $0 != wanted { exit } in_step && /^  [#A-Za-z0-9_-]/ { exit } in_step { print } END { if (!found) exit 1 }' <<<"$job"
+  }
+  partition_job=$(job_block test-ext-partition); multi_job=$(job_block test-ext-multi-folder); aggregate_job=$(job_block test-ext)
+  test "$(grep -Fc '  test-ext-partition:' "$file")" -eq 1
+  test "$(grep -Fc '  test-ext-multi-folder:' "$file")" -eq 1
+  test "$(grep -Fc '  test-ext:' "$file")" -eq 1
+  test "$(grep -Fc '      - name: Verify VS Code test partitions' <<<"$partition_job")" -eq 1
+  test "$(grep -Fc '      - name: Verify VS Code test partitions' <<<"$multi_job")" -eq 1
+  test "$(grep -Fc '      - name: Propagate extension prerequisite failures' <<<"$aggregate_job")" -eq 1
+  test "$(grep -Fc '      - name: Download extension test metadata' <<<"$aggregate_job")" -eq 1
+  test "$(grep -Fc '      - name: Verify extension test exact-once metadata' <<<"$aggregate_job")" -eq 1
+  test "$(grep -Fc '          - { index: 1, id: one }' <<<"$partition_job")" -eq 1
+  test "$(grep -Fc '          - { index: 2, id: two }' <<<"$partition_job")" -eq 1
+  test "$(grep -Fc '          - { index: 3, id: three }' <<<"$partition_job")" -eq 1
+  grep -Fqx '    needs: [channel, build-tcl-lsp-server]' <<<"$partition_job"
+  grep -Fqx '      TCL_LSP_TEST_PARTITION: ${{ matrix.partition.index }}/3' <<<"$partition_job"
+  grep -Fqx '          name: vscode-test-partition-${{ matrix.partition.id }}' <<<"$partition_job"
+  test "$(step_block "$partition_job" 'Verify VS Code test partitions')" = "$(cat <<'EOF'
+      - name: Verify VS Code test partitions
+        if: env.RUN_EXT == 'true'
+        run: make check-vscode-test-partitions
+EOF
+)" || return 1
+  grep -Fqx '        run: make test-ext-multi-folder' <<<"$multi_job"
+  test "$(step_block "$multi_job" 'Verify VS Code test partitions')" = "$(cat <<'EOF'
+      - name: Verify VS Code test partitions
+        if: env.RUN_EXT == 'true'
+        run: make check-vscode-test-partitions
+EOF
+)" || return 1
+  grep -Fqx '    if: ${{ always() }}' <<<"$aggregate_job"
+  grep -Fqx '    needs: [channel, test-ext-partition, test-ext-multi-folder]' <<<"$aggregate_job"
+  propagation=$(step_block "$aggregate_job" 'Propagate extension prerequisite failures')
+  download=$(step_block "$aggregate_job" 'Download extension test metadata')
+  verify=$(step_block "$aggregate_job" 'Verify extension test exact-once metadata')
+  test "$propagation" = "$(cat <<'EOF'
+      - name: Propagate extension prerequisite failures
+        env:
+          CHANNEL: ${{ needs.channel.result }}
+          PARTITIONS: ${{ needs.test-ext-partition.result }}
+          MULTI: ${{ needs.test-ext-multi-folder.result }}
+        run: |
+          if [ "$CHANNEL" != success ] || { [ "$RUN_EXT" = true ] && { [ "$PARTITIONS" != success ] || [ "$MULTI" != success ]; }; }; then
+            echo "channel=$CHANNEL partitions=$PARTITIONS multi=$MULTI" >&2
+            exit 1
+          fi
+EOF
+)" || return 1
+  test "$download" = "$(cat <<'EOF'
+      - name: Download extension test metadata
+        if: env.RUN_EXT == 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: vscode-test-*
+          path: ${{ runner.temp }}/vscode-test-results
+          merge-multiple: false
+EOF
+)" || return 1
+  test "$verify" = "$(cat <<'EOF'
+      - name: Verify extension test exact-once metadata
+        if: env.RUN_EXT == 'true'
+        run: |
+          mkdir -p "$RUNNER_TEMP/vscode-test-results/partition-1" "$RUNNER_TEMP/vscode-test-results/partition-2" "$RUNNER_TEMP/vscode-test-results/partition-3" "$RUNNER_TEMP/vscode-test-results/multi-folder"
+          for pair in '1 one' '2 two' '3 three'; do set -- $pair; mv "$RUNNER_TEMP/vscode-test-results/vscode-test-partition-$2/mocha-result.json" "$RUNNER_TEMP/vscode-test-results/partition-$1/"; done
+          mv "$RUNNER_TEMP/vscode-test-results/vscode-test-multi-folder/mocha-result-multifolder.json" "$RUNNER_TEMP/vscode-test-results/multi-folder/"
+          node scripts/dev/verify-vscode-test-results.mjs "$GITHUB_WORKSPACE" "$RUNNER_TEMP/vscode-test-results"
+EOF
+)" || return 1
+}
+check_workflow "$workflow"
+# Each mutation must be rejected by the same checker, not a separate grep.
+reject_mutation() {
+  set +e
+  check_workflow "$1" >/dev/null 2>&1
+  local status=$?
+  set -e
+  test "$status" -ne 0
+}
+fixture=""
+mutated=$(mktemp)
+trap 'rm -f "$mutated"; rm -rf "$fixture"' EXIT
+sed '\|node scripts/dev/verify-vscode-test-results.mjs|d' "$workflow" >"$mutated"; reject_mutation "$mutated"
+sed 's/        if: env.RUN_EXT == '\''true'\''/        # if: env.RUN_EXT == '\''true'\''\n        if: true/' "$workflow" >"$mutated"; reject_mutation "$mutated"
+sed 's/          PARTITIONS: .*/          # PARTITIONS: expected mapping\n          PARTITIONS: success/' "$workflow" >"$mutated"; reject_mutation "$mutated"
+sed 's/\[ "$CHANNEL" != success \]/false/' "$workflow" >"$mutated"; reject_mutation "$mutated"
+sed 's/exit 1/true/' "$workflow" >"$mutated"; reject_mutation "$mutated"
+sed 's|          node scripts/dev/verify-vscode-test-results|          # node scripts/dev/verify-vscode-test-results|' "$workflow" >"$mutated"; reject_mutation "$mutated"
+sed '/      - name: Verify extension test exact-once metadata/i\      - name: Verify extension test exact-once metadata\n        if: true\n        run: true' "$workflow" >"$mutated"; reject_mutation "$mutated"
+rm -f "$mutated"
+echo "VS Code workflow lifecycle contract passed"
+grep -Fq 'check-vscode-test-partitions' "$root/Makefile"
+make_target_block() {
+  awk -v wanted="$1:" '$0 == wanted { in_target=1; found=1 } in_target && /^[^[:space:]#][^:]*:/ && $0 != wanted { exit } in_target { print } END { if (!found) exit 1 }' "$root/Makefile"
+}
+for target in test-ext-partition test-ext-multi-folder; do
+  target_block=$(make_target_block "$target")
+  test "$(grep -Fc 'cd "$(EXT_DIR)" && "$(NPM)" run copy-canonical && "$(NPM)" run bundle;' <<<"$target_block")" -eq 1 || {
+    echo "$target must copy canonical assets before bundling" >&2
+    exit 1
+  }
+done
+grep -Fq 'cd "$(EXT_DIR)" && xvfb-run -a node ./out/test/runTest.js;' "$root/Makefile"
+test "$(grep -Fc 'mocha.suite.beforeAll' "$root/editors/vscode/src/test/index.ts")" -eq 1
+test "$(grep -Fc 'mocha.suite.afterAll' "$root/editors/vscode/src/test/index.ts")" -eq 1
+test "$(grep -Ec '^(suiteSetup|suiteTeardown)\(' "$root/editors/vscode/src/test/serverHealth.test.ts")" -eq 0
+test "$(jq -r '.scripts.test' "$root/editors/vscode/package.json")" = 'node ./out/test/runTest.js'
+test "$(jq -r '.scripts.pretest' "$root/editors/vscode/package.json")" = 'npm run compile'
+test "$(grep -Fc 'editors/vscode/* | scripts/dev/json-no-duplicate-keys.mjs | scripts/dev/test-vscode-test-partitions.sh | scripts/dev/verify-vscode-test-partitions.mjs | scripts/dev/verify-vscode-test-results.mjs | rust/*' "$workflow")" -eq 1
+grep -Fq '"status": "hosted-duration-balanced"' "$manifest"
+grep -Fq '"measurement_field": "fileDurationsMs"' "$manifest"
+echo "VS Code partition gate call-chain contract passed"
+
+# Fresh-checkout proof: the verifier must use tracked TypeScript sources when
+# ignored compilation output is absent, and must fail on a source inventory
+# mutation rather than silently accepting a stale output tree.
+fixture=$(mktemp -d)
+mkdir -p "$fixture/editors/vscode"
+cp "$manifest" "$fixture/editors/vscode/test-partitions.json"
+cp -R "$root/editors/vscode/src" "$fixture/editors/vscode/src"
+node "$root/scripts/dev/verify-vscode-test-partitions.mjs" "$fixture" >/dev/null
+sed 's/  "version": 1,/  "version": 1,\n  "version": 1,/' "$fixture/editors/vscode/test-partitions.json" >"$mutated"
+mv "$mutated" "$fixture/editors/vscode/test-partitions.json"
+if node "$root/scripts/dev/verify-vscode-test-partitions.mjs" "$fixture" >/dev/null 2>&1; then
+  echo "duplicate manifest key unexpectedly passed" >&2
+  exit 1
+fi
+cp "$manifest" "$fixture/editors/vscode/test-partitions.json"
+rm "$fixture/editors/vscode/src/test/aliasTracking.test.ts"
+if node "$root/scripts/dev/verify-vscode-test-partitions.mjs" "$fixture" >/dev/null 2>&1; then
+  echo "source inventory mutation unexpectedly passed" >&2
+  exit 1
+fi
+echo "VS Code fresh source inventory contract passed"
+
+# Runner-shaped metadata proves the aggregate without extension dependencies.
+results="$fixture/results"
+mkdir -p "$results/partition-1" "$results/partition-2" "$results/partition-3" "$results/multi-folder"
+node - "$manifest" "$results" <<'NODE'
+const fs = require("node:fs");
+const path = require("node:path");
+const [manifestPath, results] = process.argv.slice(2);
+const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+let remaining = manifest.expected_tests.single_root.identities;
+for (const [partition, files] of Object.entries(manifest.partitions)) {
+  const isLast = partition === "3";
+  const count = isLast ? remaining : files.length;
+  remaining -= count;
+  const identities = files.map((file, index) => `${file}:synthetic ${index}`);
+  while (identities.length < count) identities.push(`${files[0]}:synthetic ${identities.length}`);
+  const pending = files.includes("specPackTorture.test.js") ? 1 : 0;
+  const durations = Object.fromEntries(files.map((file) => [file, 1]));
+  fs.writeFileSync(
+    path.join(results, `partition-${partition}`, "mocha-result.json"),
+    JSON.stringify({
+      failures: 0,
+      partition: { index: Number(partition), count: 3 },
+      files,
+      discoveredTestIdentities: identities,
+      testIdentities: identities,
+      fileDurationsMs: durations,
+      testsStarted: count,
+      testsCompleted: count,
+      testsPassed: count - pending,
+      testsPending: pending,
+    }),
+  );
+}
+const files = manifest.multi_folder_files;
+const count = manifest.expected_tests.multi_folder.identities;
+const identities = Array.from({ length: count }, (_, index) => `${files[0]}:synthetic ${index}`);
+fs.writeFileSync(
+  path.join(results, "multi-folder", "mocha-result-multifolder.json"),
+  JSON.stringify({
+    failures: 0,
+    files,
+    discoveredTestIdentities: identities,
+    testIdentities: identities,
+    fileDurationsMs: Object.fromEntries(files.map((file) => [file, 1])),
+    testsStarted: count,
+    testsCompleted: count,
+    testsPassed: count,
+    testsPending: 0,
+  }),
+);
+NODE
+node "$root/scripts/dev/verify-vscode-test-results.mjs" "$root" "$results" >/dev/null
+result="$results/partition-1/mocha-result.json"
+sed 's/{/{"failures":0,/' "$result" >"$mutated"
+mv "$mutated" "$result"
+if node "$root/scripts/dev/verify-vscode-test-results.mjs" "$root" "$results" >/dev/null 2>&1; then
+  echo "duplicate result key unexpectedly passed" >&2
+  exit 1
+fi
+echo "VS Code aggregate metadata contract passed"

--- a/scripts/dev/verify-vscode-test-partitions.mjs
+++ b/scripts/dev/verify-vscode-test-partitions.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import fs from "node:fs";
+import path from "node:path";
+import { parseJsonNoDuplicateKeys } from "./json-no-duplicate-keys.mjs";
+
+const root = path.resolve(process.argv[2] ?? ".");
+const extension = path.join(root, "editors", "vscode");
+const manifest = parseJsonNoDuplicateKeys(
+  fs.readFileSync(path.join(extension, "test-partitions.json"), "utf8"),
+  "VS Code test partition manifest",
+);
+if (manifest.version !== 1 || manifest.canonical_glob !== "**/*.test.js" || JSON.stringify(manifest.exclude) !== JSON.stringify(["multiFolder/**"])) {
+  throw new Error("unsupported VS Code test partition manifest schema");
+}
+if (JSON.stringify(Object.keys(manifest.partitions).sort()) !== JSON.stringify(["1", "2", "3"])) {
+  throw new Error("manifest must define exactly partitions 1, 2, and 3");
+}
+function listFiles(root, prefix = "") {
+  if (!fs.existsSync(root)) return [];
+  const files = [];
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    const relative = prefix ? `${prefix}/${entry.name}` : entry.name;
+    if (entry.isDirectory()) {
+      files.push(...listFiles(path.join(root, entry.name), relative));
+    } else if (entry.isFile()) {
+      files.push(relative);
+    }
+  }
+  return files;
+}
+const sourceRoot = path.join(extension, "src", "test");
+const compiledRoot = path.join(extension, "out", "test");
+const sourceCanonical = listFiles(sourceRoot)
+  .filter((file) => file.endsWith(".test.ts") && !file.startsWith("multiFolder/"))
+  .map((file) => file.replace(/\.ts$/, ".js"));
+const canonicalMulti = listFiles(path.join(sourceRoot, "multiFolder"))
+  .filter((file) => file.endsWith(".test.ts"))
+  .map((file) => file.replace(/\.ts$/, ".js"))
+  .sort();
+if (JSON.stringify(manifest.multi_folder_files) !== JSON.stringify(canonicalMulti)) {
+  throw new Error("manifest multi-folder inventory differs from tracked src/test inventory");
+}
+const compiledCanonical = listFiles(compiledRoot).filter(
+  (file) => file.endsWith(".test.js") && !file.startsWith("multiFolder/"),
+);
+const canonical = sourceCanonical.sort();
+if (compiledCanonical.length > 0 && JSON.stringify(compiledCanonical.sort()) !== JSON.stringify(canonical)) {
+  throw new Error("compiled out/test inventory differs from tracked src/test inventory");
+}
+const seen = new Map();
+for (const [partition, files] of Object.entries(manifest.partitions)) {
+  if (!Array.isArray(files) || files.length === 0) {
+    throw new Error(`partition ${partition} is empty`);
+  }
+  for (const file of files) {
+    if (!canonical.includes(file)) throw new Error(`non-canonical file: ${file}`);
+    if (seen.has(file)) throw new Error(`duplicate file ${file}`);
+    seen.set(file, partition);
+  }
+}
+if (seen.size !== canonical.length || canonical.some((file) => !seen.has(file))) {
+  throw new Error("partition manifest does not cover the canonical glob exactly once");
+}
+if (seen.get("serverHealth.test.js") !== "1") {
+  throw new Error("serverHealth.test.js must run exactly once in partition 1");
+}
+if (
+  manifest.expected_tests?.single_root?.identities !== 976 ||
+  manifest.expected_tests?.single_root?.passed !== 975 ||
+  manifest.expected_tests?.single_root?.pending !== 1 ||
+  manifest.expected_tests?.multi_folder?.identities !== 14 ||
+  manifest.expected_tests?.multi_folder?.passed !== 14 ||
+  manifest.expected_tests?.multi_folder?.pending !== 0
+) {
+  throw new Error("manifest expected test counts drifted");
+}
+console.log(JSON.stringify({
+  partitions: manifest.partitions,
+  files: canonical.length,
+  exact_once: true,
+}));

--- a/scripts/dev/verify-vscode-test-results.mjs
+++ b/scripts/dev/verify-vscode-test-results.mjs
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import fs from "node:fs";
+import path from "node:path";
+import { parseJsonNoDuplicateKeys } from "./json-no-duplicate-keys.mjs";
+
+const root = path.resolve(process.argv[2] ?? ".");
+const results = path.resolve(process.argv[3] ?? root);
+const manifest = parseJsonNoDuplicateKeys(
+  fs.readFileSync(path.join(root, "editors/vscode/test-partitions.json"), "utf8"),
+  "VS Code test partition manifest",
+);
+if (
+  manifest.version !== 1 ||
+  manifest.canonical_glob !== "**/*.test.js" ||
+  JSON.stringify(manifest.exclude) !== JSON.stringify(["multiFolder/**"]) ||
+  JSON.stringify(Object.keys(manifest.partitions).sort()) !== JSON.stringify(["1", "2", "3"])
+) {
+  throw new Error("unsupported VS Code test partition manifest schema");
+}
+const expected = new Set(Object.values(manifest.partitions).flat());
+if (
+  manifest.expected_tests?.single_root?.identities !== 976 ||
+  manifest.expected_tests?.single_root?.passed !== 975 ||
+  manifest.expected_tests?.single_root?.pending !== 1 ||
+  manifest.expected_tests?.multi_folder?.identities !== 14 ||
+  manifest.expected_tests?.multi_folder?.passed !== 14 ||
+  manifest.expected_tests?.multi_folder?.pending !== 0
+) {
+  throw new Error("manifest expected test counts drifted");
+}
+const files = new Set();
+const identities = new Set();
+let tests = 0;
+function validateIdentities(result, assigned, label) {
+  if (!Array.isArray(result.testIdentities) || result.testIdentities.length !== result.testsCompleted) {
+    throw new Error(`${label} test identity count does not match completed tests`);
+  }
+  const validate = (identity) => {
+    if (typeof identity !== "string" || !identity.includes(":")) {
+      throw new Error(`${label} has malformed test identity`);
+    }
+    const separator = identity.indexOf(":");
+    const file = identity.slice(0, separator);
+    const title = identity.slice(separator + 1);
+    if (!file || !title || !assigned.has(file)) {
+      throw new Error(`${label} has incomplete or wrong-file test identity: ${identity}`);
+    }
+    return identity;
+  };
+  for (const identity of result.testIdentities) validate(identity);
+  if (!Array.isArray(result.discoveredTestIdentities) || result.discoveredTestIdentities.length !== result.testIdentities.length) {
+    throw new Error(`${label} discovered test identity count does not match completed tests`);
+  }
+  for (const identity of result.discoveredTestIdentities) validate(identity);
+  const discovered = new Set(result.discoveredTestIdentities);
+  if (discovered.size !== result.discoveredTestIdentities.length || discovered.size !== result.testIdentities.length || [...discovered].some((identity) => !result.testIdentities.includes(identity))) {
+    throw new Error(`${label} discovered tests do not exactly match completed tests`);
+  }
+}
+function validateOutcomes(result, expected, label) {
+  for (const field of ["failures", "testsStarted", "testsCompleted", "testsPassed", "testsPending"]) {
+    if (!Number.isInteger(result[field]) || result[field] < 0) {
+      throw new Error(`${label} has invalid ${field}`);
+    }
+  }
+  if (
+    result.failures !== 0 ||
+    result.testsStarted !== result.testsCompleted ||
+    result.testsPassed + result.testsPending + result.failures !== result.testsCompleted
+  ) {
+    throw new Error(`${label} outcome counts drifted or did not complete`);
+  }
+  if (
+    expected &&
+    (result.testsCompleted !== expected.identities ||
+      result.testsPassed !== expected.passed ||
+      result.testsPending !== expected.pending)
+  ) {
+    throw new Error(`${label} expected outcome counts drifted`);
+  }
+}
+let testsPassed = 0;
+let testsPending = 0;
+for (const partition of Object.keys(manifest.partitions)) {
+  const file = path.join(results, `partition-${partition}`, "mocha-result.json");
+  const result = parseJsonNoDuplicateKeys(fs.readFileSync(file, "utf8"), `partition ${partition} result`);
+  validateOutcomes(result, undefined, `partition ${partition}`);
+  if (result.partition?.index !== Number(partition) || result.partition?.count !== Object.keys(manifest.partitions).length) {
+    throw new Error(`partition ${partition} metadata does not identify its declared index/count`);
+  }
+  const assigned = new Set(manifest.partitions[partition]);
+  const resultFiles = new Set(result.files);
+  if (resultFiles.size !== assigned.size || [...assigned].some((name) => !resultFiles.has(name))) {
+    throw new Error(`partition ${partition} result files do not match its manifest assignment`);
+  }
+  if (!result.fileDurationsMs || Object.entries(result.fileDurationsMs).some(([name, ms]) => !assigned.has(name) || !Number.isFinite(ms) || ms < 0)) {
+    throw new Error(`partition ${partition} file duration metadata is invalid`);
+  }
+  if (JSON.stringify(Object.keys(result.fileDurationsMs).sort()) !== JSON.stringify([...assigned].sort())) {
+    throw new Error(`partition ${partition} file duration metadata is incomplete`);
+  }
+  validateIdentities(result, assigned, `partition ${partition}`);
+  for (const identity of result.testIdentities) {
+    const separator = identity.indexOf(":");
+    const file = identity.slice(0, separator);
+    if (identities.has(identity)) throw new Error(`duplicate test identity: ${identity}`);
+    identities.add(identity);
+  }
+  for (const name of result.files) {
+    if (files.has(name)) throw new Error(`duplicate result file: ${name}`);
+    files.add(name);
+  }
+  tests += result.testsCompleted;
+  testsPassed += result.testsPassed;
+  testsPending += result.testsPending;
+}
+validateOutcomes(
+  {
+    failures: 0,
+    testsStarted: tests,
+    testsCompleted: tests,
+    testsPassed,
+    testsPending,
+  },
+  manifest.expected_tests.single_root,
+  "single-root aggregate",
+);
+const multiFile = path.join(results, "multi-folder", "mocha-result-multifolder.json");
+const multi = parseJsonNoDuplicateKeys(fs.readFileSync(multiFile, "utf8"), "multi-folder result");
+validateOutcomes(multi, manifest.expected_tests.multi_folder, "multi-folder suite");
+const multiExpectedFiles = new Set(manifest.multi_folder_files);
+if (!Array.isArray(multi.files) || multi.files.length !== multiExpectedFiles.size || JSON.stringify([...new Set(multi.files)].sort()) !== JSON.stringify([...multiExpectedFiles].sort())) {
+  throw new Error("multi-folder result files do not match manifest inventory");
+}
+validateIdentities(multi, multiExpectedFiles, "multi-folder");
+if (new Set(multi.testIdentities).size !== multi.testIdentities.length) throw new Error("duplicate multi-folder test identity");
+if (!multi.fileDurationsMs || Object.entries(multi.fileDurationsMs).some(([, ms]) => !Number.isFinite(ms) || ms < 0)) {
+  throw new Error("multi-folder file duration metadata is invalid");
+}
+if (JSON.stringify(Object.keys(multi.fileDurationsMs).sort()) !== JSON.stringify([...multiExpectedFiles].sort())) {
+  throw new Error("multi-folder file duration metadata is incomplete");
+}
+if (files.size !== expected.size || [...expected].some((name) => !files.has(name))) {
+  throw new Error("partition result files do not cover the manifest exactly once");
+}
+if (tests !== manifest.expected_tests.single_root.identities) {
+  throw new Error(`single-root identity count drifted: expected ${manifest.expected_tests.single_root.identities}, got ${tests}`);
+}
+console.log(JSON.stringify({
+  exact_once: true,
+  files: files.size,
+  single_root_identities: tests,
+  single_root_passed: manifest.expected_tests.single_root.passed,
+  single_root_pending: manifest.expected_tests.single_root.pending,
+  multi_folder_identities: multi.testsCompleted,
+  multi_folder_passed: multi.testsPassed,
+  multi_folder_pending: multi.testsPending,
+}));


### PR DESCRIPTION
## Summary

- run the 106 single-root test files in three isolated, whole-file VS Code extension-host jobs
- keep local `npm test` unpartitioned and retain the 14-test multi-folder host as a separate mandatory job
- upload file, duration, discovered/completed identity, pass, and pending metadata from every producer
- preserve the stable `test-ext` status as a fail-closed aggregate that proves exact coverage
- reject stale source inventories, duplicate JSON keys, duplicate workflow steps, skipped prerequisites, missing artifacts, and identity drift

The exact single-root contract is 976 identities: 975 passing tests plus the deliberately pending manual edit-storm test. The multi-folder contract is 14 identities, all passing.

## Hosted experiment

First hosted run `34320581260` at `a845d8552` produced three green single-root artifacts with exact global coverage: 106 files and 976 unique identities, with no omissions or duplicates. Measured test durations were:

- partition 1 / job `102366472957`: 28,817 ms
- partition 2 / job `102366472969`: 63,001 ms
- partition 3 / job `102366473057`: 94,948 ms

A deterministic longest-processing-time reassignment, retaining `serverHealth.test.js` in partition 1, projected 62,255 / 62,256 / 62,255 ms. The next hosted run measured 59,122 ms for partition 2 and 60,251 ms for partition 3; the same manifest measured 62,111 ms locally for partition 1. The three-way spread is 2,989 ms (4.8% of the slowest partition), while the prior critical path was 94,948 ms. The final exact-head hosted run is `34331570756`.

The first isolated multi-folder job exposed that `make compile` leaves raw `tsc` output at `out/extension.js`; unlike the former combined `npm test` path, it did not create the node esbuild bundle, so Node tried to execute imported Markdown. Each producer now performs the node bundle exactly once before launching its runner. The activation wait is unconditional to await an already-in-flight activation promise. Local multi-folder proof is 14/14 passing.

The next exact hosted run exposed a second incremental-build edge: CI's direct `tsc` step creates `out/extension.js`, allowing `make compile` to be considered current without staging the canonical Markdown files consumed by raw compiled test modules. Both isolated test targets now stage canonical assets explicitly before bundling, with a structural regression assertion. A clean-output reproduction proved the files absent after direct `tsc`; the corrected partition-1 target then passed 265 tests with the single deliberate pending test.

Review fixes move the root activation/final-server-state hooks into the common single-root runner so every isolated host is bracketed, and propagate a failed `channel` prerequisite even when `RUN_EXT` cannot be derived. A local partition without the named health suite passed 205/205 identities with the common hooks installed.

## Local proof at `33fd45685`

- `make rust-check` — passed
- `make prep-pr` — passed
- `bash scripts/dev/test-vscode-test-partitions.sh` — passed the inventory, workflow, dependency-free aggregate, duplicate-key, asset-staging, and adversarial mutation contracts
- current synthetic merge `028992672` onto `rust` — passed the same focused contract from a clean detached worktree
- native partition 1 from a missing canonical-output directory — 34 files, 266/266 identities, 265 passed, 1 deliberate pending, zero failures
- native partition 2 — 35 files, 205/205 identities, 205 passed, zero pending/failures
- multi-folder host — 14/14 passed

Closes #2010
