### PR TITLE
Fix lsp-client --help crash and drop the dead python backend

### DIFF
--- a/.claude/skills/lsp-client/SKILL.md
+++ b/.claude/skills/lsp-client/SKILL.md
@@ -30,7 +30,7 @@ subcommand. All line/col arguments are **0-based**.
 | `diagnostics` | `<file>` | `SEVERITY CODE l:c-l:c message`; optimiser O-codes are INFO with quick-fix actions |
 | `format` | `<file>` | the edits the formatter would apply |
 | `hover` / `completion` / `definition` / `references` | `<file> <line> <col>` | the feature at a position |
-| `code-lens` | `<file>` | reference-count lenses, each resolved via `codeLens/resolve` as an editor would; `[inert — empty command id]` marks the clickable-broken shape (#724 / #956) |
+| `code-lens` | `<file>` | reference-count lenses, each resolved via `codeLens/resolve` as an editor would; `[inert — empty command id]` marks a lens whose command id is empty, so an editor cannot click it |
 | `code-actions` | `<file> <l> <c> <el> <ec>` | code actions in a range |
 | `optimize` | `<file>` | each rewrite and the full optimised source |
 | `symbols` | `<file>` | the document symbol hierarchy (events, procs, namespaces, variables) |
@@ -54,6 +54,14 @@ results race the scan. A new cross-file check must call
 python3 .claude/skills/lsp-client/lsp_client.py --also-open lib.tcl definition consumer.tcl 3 10
 ```
 
+The scan covers the workspace root — the current directory, or `--server-dir`.
+Scanning the whole repository exceeds the default timeout on a debug build, so
+point `--server-dir` at the directory holding the files under test:
+
+```bash
+python3 .claude/skills/lsp-client/lsp_client.py --server-dir editors/vscode/testFixture diagnostics editors/vscode/testFixture/diagnostics.tcl
+```
+
 ## When to use
 
 After changing tokens, diagnostics, the formatter, or the optimiser; to check
@@ -62,9 +70,9 @@ a position-dependent feature at a cursor; `all` as a smoke test; `bench` and
 
 ```bash
 python3 .claude/skills/lsp-client/lsp_client.py semantic-tokens samples/for_screenshots/03-completions.tcl
-python3 .claude/skills/lsp-client/lsp_client.py diagnostics editors/vscode/testFixture/diagnostics.tcl
+python3 .claude/skills/lsp-client/lsp_client.py --server-dir editors/vscode/testFixture diagnostics editors/vscode/testFixture/diagnostics.tcl
 python3 .claude/skills/lsp-client/lsp_client.py hover editors/vscode/testFixture/procs.tcl 1 6
-python3 .claude/skills/lsp-client/lsp_client.py code-lens editors/vscode/testFixture/objMethodDispatch.tcl
+python3 .claude/skills/lsp-client/lsp_client.py --server-dir editors/vscode/testFixture code-lens editors/vscode/testFixture/objMethodDispatch.tcl
 python3 .claude/skills/lsp-client/lsp_client.py diagram samples/for_screenshots/ai-scene.irul
 python3 .claude/skills/lsp-client/lsp_client.py event-info HTTP_REQUEST
 python3 .claude/skills/lsp-client/lsp_client.py bench samples/tcl/09_long_code.tcl --iterations 3

--- a/.claude/skills/lsp-client/lsp_client.py
+++ b/.claude/skills/lsp-client/lsp_client.py
@@ -242,9 +242,12 @@ class LspClient:
     """Manages a language server subprocess and JSON-RPC communication."""
 
     def __init__(self, server_dir: str, launch_cmd: list[str]) -> None:
-        self.server_dir = server_dir
+        #: Workspace root, resolved absolute because it becomes ``rootUri``:
+        #: a relative path there names a URI authority rather than a
+        #: directory, so the server would scan somewhere else entirely.
+        self.server_dir = str(Path(server_dir).resolve())
         #: argv used to spawn the server — the native ``tcl-lsp-server``
-        #: binary.  ``server_dir`` is only the workspace root (``rootUri``).
+        #: binary.
         self._launch_cmd = list(launch_cmd)
         self.process: subprocess.Popen | None = None
         self._request_id = 0
@@ -659,7 +662,7 @@ def initialize(client: LspClient) -> dict:
         "initialize",
         {
             "processId": os.getpid(),
-            "rootUri": f"file://{client.server_dir}",
+            "rootUri": Path(client.server_dir).as_uri(),
             "capabilities": {
                 "textDocument": {
                     "semanticTokens": {

--- a/.claude/skills/lsp-client/lsp_client.py
+++ b/.claude/skills/lsp-client/lsp_client.py
@@ -254,20 +254,11 @@ SYMBOL_KIND = {
 class LspClient:
     """Manages a language server subprocess and JSON-RPC communication."""
 
-    def __init__(self, server_dir: str, launch_cmd: list[str] | None = None) -> None:
+    def __init__(self, server_dir: str, launch_cmd: list[str]) -> None:
         self.server_dir = server_dir
-        #: argv used to spawn the server.  Defaults to the Python server via
-        #: ``uv``; ``launch_cmd`` overrides it (e.g. the native Rust binary).
-        self._launch_cmd = launch_cmd or [
-            "uv",
-            "run",
-            "--directory",
-            server_dir,
-            "--no-dev",
-            "python",
-            "-m",
-            "lsp",
-        ]
+        #: argv used to spawn the server — the native ``tcl-lsp-server``
+        #: binary.  ``server_dir`` is only the workspace root (``rootUri``).
+        self._launch_cmd = list(launch_cmd)
         self.process: subprocess.Popen | None = None
         self._request_id = 0
         self._pending: dict[int, dict] = {}  # id -> {"event": Event, "result": ...}
@@ -660,7 +651,7 @@ class LspClient:
 
 
 def find_native_server(override: str | None = None) -> str:
-    """Locate the native Rust ``tcl-lsp-server`` binary (serverKind=rust).
+    """Locate the native ``tcl-lsp-server`` binary.
 
     Honours ``override`` / ``TCL_LSP_SERVER_BIN`` first, then probes
     ``target/{release,debug}/`` under the project root.
@@ -679,35 +670,6 @@ def find_native_server(override: str | None = None) -> str:
     raise FileNotFoundError(
         "No native tcl-lsp-server binary found — build it with "
         "`cargo build -p tcl-lsp-server` (or `make rust-server`), or pass --server-bin."
-    )
-
-
-def find_server_dir(override: str | None = None) -> str:
-    """Locate the tcl-lsp server directory."""
-    if override:
-        p = Path(override).resolve()
-        if (p / "lsp" / "__main__.py").exists():
-            return str(p)
-        raise FileNotFoundError(f"No server found at {p}")
-
-    # Walk up from script location: .claude/skills/lsp-client/lsp_client.py
-    script_dir = Path(__file__).resolve().parent
-    # Try: script_dir -> .claude/skills/lsp-client
-    #      project root -> script_dir / ../../..
-    #      server -> project_root / tcl-lsp
-    project_root = script_dir.parent.parent.parent
-    server_dir = project_root / "tcl-lsp"
-    if (server_dir / "lsp" / "__main__.py").exists():
-        return str(server_dir)
-
-    # Also try: maybe we're already inside tcl-lsp
-    cwd = Path.cwd()
-    if (cwd / "lsp" / "__main__.py").exists():
-        return str(cwd)
-
-    raise FileNotFoundError(
-        f"Cannot find tcl-lsp server. Tried {server_dir} and cwd={cwd}. "
-        "Use --server-dir to specify the path."
     )
 
 
@@ -1778,17 +1740,12 @@ examples:
 """,
     )
     parser.add_argument(
-        "--server-dir", help="Path to tcl-lsp directory (auto-detected by default)"
-    )
-    parser.add_argument(
-        "--server",
-        choices=["python", "rust"],
-        default=os.environ.get("TCL_LSP_SERVER_KIND", "rust"),
-        help="Which LSP backend to drive: the native Rust binary (default) or the Python server.",
+        "--server-dir",
+        help="Workspace root sent as rootUri (defaults to the current directory)",
     )
     parser.add_argument(
         "--server-bin",
-        help="Path to the native tcl-lsp-server binary (for --server rust; else auto-detected).",
+        help="Path to the native tcl-lsp-server binary (auto-detected by default).",
     )
     parser.add_argument(
         "--scan-timeout",
@@ -1803,7 +1760,7 @@ examples:
             "WORKSPACE_SCAN_FILE_CAP (2000 files) took ~12.3s unloaded / "
             "~15.2s under 4-way CPU contention on a 4-core box in a *debug* "
             "build (a `--release` build did the same scan in ~1.9s), so the "
-            "old 15.0s default left under 20% headroom over the unloaded "
+            "old 15.0s default left under 20%% headroom over the unloaded "
             "debug-build worst case and none at all once loaded. 30.0 keeps "
             "roughly 2x headroom over the worst measured case and matches "
             "the Rust e2e harness's own `DEFAULT_TIMEOUT`."
@@ -1937,20 +1894,15 @@ examples:
 
     args = parser.parse_args()
 
-    # Find server (Python dir or native Rust binary)
-    server_kind = (args.server or "python").strip().lower()
-    launch_cmd: list[str] | None = None
+    # Find the native server binary.
     try:
-        if server_kind == "rust":
-            native = find_native_server(args.server_bin)
-            # rootUri only needs a directory; the binary doesn't need a bundle.
-            server_dir = args.server_dir or str(Path.cwd())
-            launch_cmd = [native]
-        else:
-            server_dir = find_server_dir(args.server_dir)
+        launch_cmd = [find_native_server(args.server_bin)]
     except FileNotFoundError as e:
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)
+
+    # rootUri only needs a directory; the binary doesn't need a bundle.
+    server_dir = args.server_dir or str(Path.cwd())
 
     # Create client and run
     client = LspClient(server_dir, launch_cmd=launch_cmd)

--- a/.claude/skills/lsp-client/lsp_client.py
+++ b/.claude/skills/lsp-client/lsp_client.py
@@ -26,19 +26,17 @@ Cross-file assertions (definition/references/diagnostics/code-actions/
 context/all/completion/code-lens touching more than one file's worth of
 state — workspace variables, package tiers, sibling-file completions,
 workspace-wide lens counts) wait out the server's background workspace scan
-first via `LspClient.wait_for_workspace_scan()` (bounded by --scan-timeout,
-default 30s — measured/tuned per issue #1111) rather than racing it — see
-issue #1094 and that method's
-docstring for the exact server-side signal it waits on. Single-file
-subcommands (semantic-tokens, hover, format, ...) are unaffected and
-don't wait.
+first via `LspClient.wait_for_workspace_scan()`, bounded by --scan-timeout,
+rather than racing it; that method's docstring names the exact server-side
+signal it waits on. Single-file subcommands (semantic-tokens, hover,
+format, ...) are unaffected and don't wait.
 
 Pass `--also-open FILE` (repeatable) to open one or more companion files
-before the main <file> argument — the first-class "open two files and
-assert" helper (issue #1111) for a cross-file check (a definition/reference
-in <file> resolving into FILE, a sibling-file completion, a workspace-wide
-lens count). Companion files are opened *after* the workspace-scan wait
-above and *before* <file>, so whichever subcommand you run sees them.
+before the main <file> argument, for a cross-file check: a
+definition/reference in <file> resolving into FILE, a sibling-file
+completion, a workspace-wide lens count. Companion files are opened *after*
+the workspace-scan wait above and *before* <file>, so whichever subcommand
+you run sees them.
 
 Usage:
     python3 lsp_client.py semantic-tokens <file.tcl>
@@ -143,16 +141,13 @@ LSP_SEVERITY = {1: "ERROR", 2: "WARNING", 3: "INFO", 4: "HINT"}
 # rust/tcl-lsp-server/src/lib.rs). It fires exactly once, after
 # `package_resolver` / `workspace_index` have been (re)built from disk —
 # unconditionally, even for a zero-root / single-file session — via a
-# `window/logMessage` notification (MessageType::LOG). The server's own doc
-# comment on that call site says explicitly: "a client (or a test) that
-# needs to know the autoload / cross-file workspace state is current rather
-# than racing this scan should wait on this line instead of an unrelated
-# per-document signal (issue #1003)". See issue #1094.
+# `window/logMessage` notification (MessageType::LOG). It is the line a
+# client that needs the autoload / cross-file workspace state to be current
+# should wait on.
 #
 # NOT the same marker as `[timing] workspace_state.update`, which is a
-# *per-document* diagnostics-publish timing line (fires once per open
-# document, unrelated to workspace-scan completion) — waiting on that one
-# instead is the exact confusion issue #1094 warns against.
+# *per-document* diagnostics-publish timing line: it fires once per open
+# document and says nothing about workspace-scan completion.
 WORKSPACE_SCAN_SIGNAL = "[timing] workspace_folders_scan"
 
 COMPLETION_KIND = {
@@ -184,8 +179,8 @@ COMPLETION_KIND = {
 }
 
 # Subcommands whose results can depend on cross-file workspace state
-# (workspace variables, package tiers — issue #1094): `definition` and
-# `references` query `workspace_index` directly per-request, so waiting
+# (workspace variables, package tiers). `definition` and `references` query
+# `workspace_index` directly per-request, so waiting
 # right before the request (see `cmd_definition`/`cmd_references`) is
 # sufficient. `diagnostics`, `code-actions`, `context`, and `all` are
 # different: diagnostics are *pushed* once, right after `didOpen`, and only
@@ -199,14 +194,6 @@ COMPLETION_KIND = {
 # (completion enumerates sibling-file procedures; lenses count
 # workspace-wide references), so they wait too — before `didOpen` via
 # `main()`, which is also sufficient for their per-request reads.
-#
-# Verified live (issue #1111) against a real `tcl-lsp-server` build (this
-# reasoning previously rested on code inspection only — no binary was
-# buildable in the sandbox that filed the issue): `--also-open` + `definition`
-# resolving a companion file's symbol on the *first* request of 20/20 freshly
-# spawned server processes, with no `--scan-timeout` override, confirms
-# waiting before `didOpen` sidesteps the race the comment above describes
-# rather than merely happening not to trigger it.
 CROSS_FILE_COMMANDS = {
     "definition",
     "references",
@@ -315,16 +302,13 @@ class LspClient:
 
         Writes through a raw, `select()`-bounded loop on the stdin file
         descriptor rather than the buffered file object's blocking
-        `write()`/`flush()`. That blocking write had no timeout at all: a
-        server that stops draining stdin (wedged, or mid-crash, or the
-        intermittent #1399 hang — a client stuck in `write()` opposite a
-        server idle in `read()`) blocked here forever, and `REQUEST_TIMEOUT_S`
-        in `send_request` never even got a chance to fire because the
-        request was never fully sent. `select()` reports writability before
-        each chunk, so a stalled peer surfaces as a `TimeoutError` a caller
-        can catch (as `Bench.check`/`Bench.request` in `bench.py` already
-        do for the read side) instead of a wedged process indistinguishable
-        from real work.
+        `write()`/`flush()`, which has no timeout: against a server that
+        stops draining stdin (wedged, mid-crash, or idle in `read()` while
+        the client is stuck in `write()`) it blocks forever, and
+        `send_request`'s response timeout never fires because the request
+        was never fully sent. `select()` reports writability before each
+        chunk, so a stalled peer surfaces as a `TimeoutError` a caller can
+        catch instead of a wedged process indistinguishable from real work.
 
         `os.write` is used directly on the fd (set non-blocking in `start()`)
         rather than mixed with the buffered `Popen.stdin` object, so every
@@ -348,8 +332,7 @@ class LspClient:
                 raise TimeoutError(
                     f"write() to server stdin blocked for >{timeout}s "
                     f"({len(payload) - len(view)}/{len(payload)} bytes sent) "
-                    "— the server appears to have stopped draining stdin "
-                    "(see issue #1399)"
+                    "— the server appears to have stopped draining stdin"
                 )
             try:
                 _, writable, _ = select.select([], [fd], [], remaining)
@@ -445,11 +428,8 @@ class LspClient:
     def send_request(self, method: str, params: dict, timeout: float = 30.0) -> Any:
         """Send a request and wait for the response.
 
-        `timeout` now bounds *both* halves of the round-trip: getting the
-        request onto the wire (the `_send` write, previously unbounded — see
-        `_send`'s docstring) and waiting for the reply. A caller that passed
-        a generous `timeout` for a slow server got that generosity on the
-        write before too; it just also now has a ceiling.
+        `timeout` bounds *both* halves of the round-trip: getting the
+        request onto the wire (the `_send` write) and waiting for the reply.
         """
         self._request_id += 1
         rid = self._request_id
@@ -582,8 +562,8 @@ class LspClient:
         `Backend::scan_workspace_folders` populates in the background —
         kicked off from the `initialized` handler, running concurrently
         with whatever `didOpen` the client sends next. Asserting before
-        that scan lands is issue #1094: results flip between "resolved"
-        and "unresolved" depending on scan timing.
+        that scan lands is racy: results flip between "resolved" and
+        "unresolved" depending on scan timing.
 
         Waits for the `[timing] workspace_folders_scan` `window/logMessage`
         line (see `WORKSPACE_SCAN_SIGNAL` above) — the scan's one
@@ -594,8 +574,8 @@ class LspClient:
         the signal has already arrived returns immediately (cheap to call
         defensively from multiple places).
 
-        Raises TimeoutError with a pointer back to the server-side signal
-        and this issue if the line never arrives within *timeout* seconds.
+        Raises TimeoutError, pointing back at the server-side signal, if
+        the line never arrives within *timeout* seconds.
         """
         deadline = time.monotonic() + timeout
         while True:
@@ -615,8 +595,8 @@ class LspClient:
             f"Timed out after {timeout}s waiting for the server's workspace "
             f"scan to complete — no {WORKSPACE_SCAN_SIGNAL!r} window/logMessage "
             "was seen. Cross-file navigation/diagnostics results read here "
-            "would be racy (issue #1094). If this is a legitimately large "
-            "workspace, pass a higher --scan-timeout; otherwise check that "
+            "would be racy. If this is a legitimately large workspace, pass "
+            "a higher --scan-timeout; otherwise check that "
             "the server actually reached `scan_workspace_folders` (see "
             "rust/tcl-lsp-server/src/lib.rs) — e.g. it never got past "
             "`initialized` because a server-to-client request went "
@@ -1210,10 +1190,9 @@ def cmd_completion(client: LspClient, uri: str, line: int, col: int) -> None:
 def cmd_definition(client: LspClient, uri: str, line: int, col: int) -> None:
     """Request and display definitions.
 
-    A "navigation request" per issue #1094: waits out the background
-    workspace scan first (idempotent/cheap if `main()` already did) so a
-    cross-file definition isn't raced. Belt-and-suspenders for callers that
-    invoke this directly rather than through `main()`.
+    Waits out the background workspace scan first (idempotent and cheap if
+    `main()` already did) so a cross-file definition isn't raced — callers
+    may invoke this directly rather than through `main()`.
     """
     client.wait_for_workspace_scan()
     result = client.send_request(
@@ -1231,10 +1210,9 @@ def cmd_definition(client: LspClient, uri: str, line: int, col: int) -> None:
 def cmd_references(client: LspClient, uri: str, line: int, col: int) -> None:
     """Request and display references.
 
-    A "navigation request" per issue #1094: waits out the background
-    workspace scan first (idempotent/cheap if `main()` already did) so
-    cross-file references aren't raced. Belt-and-suspenders for callers
-    that invoke this directly rather than through `main()`.
+    Waits out the background workspace scan first (idempotent and cheap if
+    `main()` already did) so cross-file references aren't raced — callers
+    may invoke this directly rather than through `main()`.
     """
     client.wait_for_workspace_scan()
     result = client.send_request(
@@ -1734,7 +1712,7 @@ def main() -> None:
         epilog="""\
 examples:
   %(prog)s semantic-tokens samples/for_screenshots/03-completions.tcl
-  %(prog)s diagnostics editors/vscode/testFixture/diagnostics.tcl
+  %(prog)s --server-dir editors/vscode/testFixture diagnostics editors/vscode/testFixture/diagnostics.tcl
   %(prog)s hover editors/vscode/testFixture/procs.tcl 1 6
   %(prog)s all samples/for_screenshots/03-completions.tcl
 """,
@@ -1754,16 +1732,12 @@ examples:
         help=(
             "Seconds to wait for the background workspace scan to complete "
             "before cross-file subcommands (definition, references, "
-            "diagnostics, code-actions, context, all) proceed. See "
-            "issue #1094. Default: 30.0 — tuned against a measured "
-            "worst-case scan (issue #1111): a workspace at "
-            "WORKSPACE_SCAN_FILE_CAP (2000 files) took ~12.3s unloaded / "
-            "~15.2s under 4-way CPU contention on a 4-core box in a *debug* "
-            "build (a `--release` build did the same scan in ~1.9s), so the "
-            "old 15.0s default left under 20%% headroom over the unloaded "
-            "debug-build worst case and none at all once loaded. 30.0 keeps "
-            "roughly 2x headroom over the worst measured case and matches "
-            "the Rust e2e harness's own `DEFAULT_TIMEOUT`."
+            "diagnostics, code-actions, context, all) proceed. The default "
+            "keeps roughly 2x headroom over a worst-case scan — a workspace "
+            "at WORKSPACE_SCAN_FILE_CAP in a debug build under CPU "
+            "contention — and matches the Rust e2e harness's DEFAULT_TIMEOUT. "
+            "Raise it for a larger workspace or a slower machine. "
+            "Default: 30.0"
         ),
     )
     parser.add_argument(
@@ -1779,7 +1753,7 @@ examples:
             "after the workspace-scan wait (for a cross-file subcommand) and "
             "before <file>, in the order given, so the request the "
             "subcommand issues against <file> already sees every one of "
-            "them. See issue #1111."
+            "them."
         ),
     )
 
@@ -1959,15 +1933,14 @@ examples:
             # workspace scan *before* opening the document, so the doc's
             # one diagnostics publish (and any definition/references
             # request issued below) already sees the fully-populated
-            # workspace_index / package_resolver instead of racing the
-            # scan (issue #1094).
+            # workspace_index / package_resolver instead of racing the scan.
             if args.command in CROSS_FILE_COMMANDS:
                 client.wait_for_workspace_scan(timeout=args.scan_timeout)
 
-            # `--also-open FILE` (repeatable): the multi-file helper (issue
-            # #1111) — open every companion file *before* the main one, in
-            # the order given, after the scan wait above so a cross-file
-            # subcommand's request against `args.file` already sees them.
+            # `--also-open FILE` (repeatable): open every companion file
+            # *before* the main one, in the order given, after the scan wait
+            # above so a cross-file subcommand's request against `args.file`
+            # already sees them.
             # Each open gets the same post-didOpen settle main() gives the
             # primary file below, so a companion file's own diagnostics
             # publish (which can itself touch workspace state a sibling-file

--- a/.claude/skills/lsp-client/test_lsp_client.py
+++ b/.claude/skills/lsp-client/test_lsp_client.py
@@ -1,0 +1,89 @@
+# tcl-lsp — a language server and toolchain for Tcl
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Tests for the standalone LSP client's CLI surface.
+
+These cover the argument parser and helpers only; driving a real
+`tcl-lsp-server` is the job of the native e2e suite.
+"""
+
+from __future__ import annotations
+
+import inspect
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+CLIENT = Path(__file__).resolve().parent / "lsp_client.py"
+sys.path.insert(0, str(CLIENT.parent))
+
+from lsp_client import LspClient
+
+
+def run_cli(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(CLIENT), *args],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+
+
+def test_help_renders():
+    """argparse %-expands every help string, so a literal % in one crashes."""
+    result = run_cli("--help")
+    assert result.returncode == 0, result.stderr
+    assert "--scan-timeout" in result.stdout
+
+
+SUBCOMMANDS = [
+    "semantic-tokens",
+    "diagnostics",
+    "format",
+    "hover",
+    "completion",
+    "definition",
+    "references",
+    "code-lens",
+    "code-actions",
+    "optimize",
+    "symbols",
+    "diagram",
+    "event-info",
+    "command-info",
+    "context",
+    "all",
+    "bench",
+    "logs",
+]
+
+
+@pytest.mark.parametrize("subcommand", SUBCOMMANDS)
+def test_subcommand_help_renders(subcommand: str):
+    result = run_cli(subcommand, "--help")
+    assert result.returncode == 0, result.stderr
+
+
+def test_every_subcommand_is_covered():
+    """Keeps SUBCOMMANDS honest against the parser it is meant to exercise."""
+    usage = run_cli("--help").stdout
+    declared = usage[usage.index("{") + 1 : usage.index("}")].split(",")
+    assert sorted(declared) == sorted(SUBCOMMANDS)
+
+
+def test_no_python_backend_option():
+    """The client drives the native server only; there is no backend choice."""
+    result = run_cli("--server", "python", "semantic-tokens", "x.tcl")
+    assert result.returncode != 0
+    assert "{python,rust}" not in run_cli("--help").stdout
+
+
+def test_launch_cmd_is_required():
+    """LspClient spawns what it is given, with no implicit fallback server."""
+    launch_cmd = inspect.signature(LspClient.__init__).parameters["launch_cmd"]
+    assert launch_cmd.default is inspect.Parameter.empty
+
+    client = LspClient("/tmp", launch_cmd=["/nonexistent/tcl-lsp-server"])
+    assert client._launch_cmd == ["/nonexistent/tcl-lsp-server"]

--- a/.claude/skills/lsp-client/test_lsp_client.py
+++ b/.claude/skills/lsp-client/test_lsp_client.py
@@ -80,6 +80,17 @@ def test_no_python_backend_option():
     assert "{python,rust}" not in run_cli("--help").stdout
 
 
+def test_workspace_root_is_absolute(tmp_path, monkeypatch):
+    """A relative rootUri names a URI authority, not a directory."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "fixture").mkdir()
+
+    client = LspClient("fixture", launch_cmd=["/nonexistent/tcl-lsp-server"])
+
+    assert client.server_dir == str(tmp_path / "fixture")
+    assert Path(client.server_dir).as_uri().startswith("file:///")
+
+
 def test_launch_cmd_is_required():
     """LspClient spawns what it is given, with no implicit fallback server."""
     launch_cmd = inspect.signature(LspClient.__init__).parameters["launch_cmd"]


### PR DESCRIPTION
## Summary

- **Fix the `--help` crash.** The `--scan-timeout` help text contained a literal `20%`. argparse `%`-expands every help string against its params dict, so `% h` + `e` parsed as a space-flagged float conversion and any `--help` invocation died with `TypeError: must be real number, not dict`. The help text is reworded and no longer carries a bare `%`.
- **Remove the `python` backend.** `--server` still offered a `python` choice for a backend that no longer exists — the repository is Rust-only. Gone with it: `find_server_dir()`, which probed for an `lsp/__main__.py` bundle; `LspClient.__init__`'s `uv run … -m lsp` fallback launch command, so `launch_cmd` is now required (`scripts/perf/bench.py`, the only external caller, already passed it); and the `server_kind` branch in `main()`. `--server-dir` survives as the `rootUri` override it had already become, with help text that says so.
- **Resolve the workspace root before sending it as `rootUri`.** A relative `--server-dir` was interpolated straight into `file://…`, where the first path segment becomes the URI *authority* — `editors/vscode/testFixture` reached the server as the path `/vscode/testFixture`. The scan indexed the wrong directory and cross-file results came back silently empty. `LspClient` now resolves `server_dir`, so every caller gets an absolute root, and `initialize()` builds the URI with `Path.as_uri()` rather than concatenation, so a root containing spaces or other reserved characters is encoded. Found by Codex review on this PR; without it the documented recipe below would have been broken.
- **Describe current behaviour in the docs and comments.** The comments and help text in this skill narrated their own change history — which default a value replaced, what a docstring's reasoning used to rest on, which issue a since-fixed hang came from. That belongs in git history, so they now state what the code does and why.
- **Add a pytest module** for the CLI surface: the `--help` regression, the help string of every subcommand, a check that keeps that subcommand list honest against the parser, the absolute-root invariant, and the absence of an implicit fallback server.
- **Document the workspace-root scoping.** The scan covers the workspace root (cwd, or `--server-dir`); scanning the whole repository exceeds the default scan timeout on a debug build, so the cross-file examples now scope `--server-dir` at the fixture directory. The previous `diagnostics editors/vscode/testFixture/diagnostics.tcl` example, run from the repo root as written, timed out.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

```bash
make prep-pr          # exit 0, no drift
make lint-py          # ruff format --check + ruff check: 36 files, all passed
make typecheck-py     # ty + pyright: all checks passed, 0 errors
pytest .claude/skills/lsp-client/test_lsp_client.py   # 23 passed
```

Against `target/debug/tcl-lsp-server` built from this branch, as the skill documents:

| Check | Result |
|---|---|
| `--help` | prints; previously crashed |
| `semantic-tokens samples/for_screenshots/03-completions.tcl` | 5 tokens, exit 0 |
| `hover editors/vscode/testFixture/procs.tcl 1 6` | `proc ::fib {n}`, exit 0 |
| `symbols` with explicit `--server-bin` | 3 symbols, exit 0 |
| `--server-dir … diagnostics …` | 15 diagnostics, exit 0 — exercises the cross-file scan wait |
| `--server-dir … code-lens …` | 2 resolved lenses, exit 0 |
| `event-info HTTP_REQUEST` | known, 800 valid commands, exit 0 |
| `--server python` | rejected, exit 2 |

Both bugs were reproduced before being fixed, not just observed passing afterwards:

- the `--help` test fails against the pre-fix help string;
- the `rootUri` fix was demonstrated with a two-file fixture (`lib.tcl` defining a proc, `consumer.tcl` calling it), requesting the definition without opening `lib.tcl` so only the workspace scan can resolve it. Relative `--server-dir` returned **0 locations** and absolute returned **1**; after the fix both return 1.

## Compiler / diagnostics checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

Not applicable — this changes an agent skill's Python client only. No compiler fact contract, diagnostic code, optimisation code, or design doc is touched. `ai/claude/skills/` carries no copy of this client, so there is no second tree to sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E3i6Kqq5ierpRZz3vA6rQL