### PR TITLE
Derive Docker Tcl patchlevel from the reference-toolchain manifest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4523,6 +4523,7 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "tar",
+ "tcl-dialect",
  "tcl-lexer",
  "tcl-registry",
  "tcl-sandbox",

--- a/docs/design/contracts/development-environment.md
+++ b/docs/design/contracts/development-environment.md
@@ -54,7 +54,7 @@ upstream than `tcl.tk` / SourceForge on every cold session. The hook exports
 |---|---|
 | Rust channel | `rust-toolchain.toml`; `Cargo.toml` `rust-version` |
 | Node.js minimum | `.github/workflows/ci.yml` `node-version`; `NODE_MIN_MAJOR` in `ensure-test-deps.sh` |
-| Tcl / Tk patchlevels and source tags | `rust/tcl-dialect/data/reference-toolchains.tsv` (the fetch skill and host installer consume it) |
+| Tcl / Tk patchlevels and source tags | `rust/tcl-dialect/data/reference-toolchains.tsv` (the fetch skill, host installer, and `tcl docker` source-build layers consume it) |
 | Wasmtime, Binaryen, wasi-sdk, tcllib (remote) | variables at the top of `.claude/hooks/session-start.sh` |
 | Wasmtime, wasi-sdk, tcllib (laptop) | variables near the top of `scripts/dev/ensure-test-deps.sh` |
 

--- a/docs/design/contracts/shared-utility-contracts-rust.md
+++ b/docs/design/contracts/shared-utility-contracts-rust.md
@@ -80,7 +80,9 @@ entry point, or gate moves without this contract being updated.
   facts from it at build time; `tcl-test-support` reuses those APIs for oracle
   provenance, while the POSIX shell adapter under `scripts/dev` supplies the
   same rows to ensure-test-deps, the source-fetch skill, and remote-session
-  bootstrap.
+  bootstrap. `tcl-pkg` reads the same pins for the source-build layers of a
+  generated Dockerfile, so a pin bump reaches user-facing output and not only
+  test oracles and dev-host bootstrap.
 - Default/PATH oracle resolution requires the exact pinned patchlevel and
   records the interpreter's reported value as provenance. An explicitly
   paired source-tree interpreter may name another patchlevel on the same

--- a/docs/kcs/features/kcs-feature-tcl-docker.md
+++ b/docs/kcs/features/kcs-feature-tcl-docker.md
@@ -37,6 +37,10 @@ downloads the `tcl` binary built for the image's architecture, checks it
 against the release's `SHA256SUMS`, and runs `tcl pkg install --frozen` when a
 `tclpkg.lock` is present. No Python interpreter is installed or needed.
 
+A source build fetches the exact patchlevel this project pins for that release
+line. An 8.6 image installs the base image's own Tcl package, so its patchlevel
+is whatever that distribution ships.
+
 ### Choosing the release
 
 The Dockerfile pins the release as a build argument, defaulting to the one the

--- a/editors/sublime-text/SUBMITTING.md
+++ b/editors/sublime-text/SUBMITTING.md
@@ -44,10 +44,6 @@ order:
 }
 ```
 
-The first release eligible for this entry is v2.2.2. v2.2.1 carries the
-previous `TclLsp.sublime-package` shape and remains useful only as the tested
-baseline.
-
 ## Pre-submission checks
 
 1. Confirm the stable GitHub release carries `LSP-Tcl.sublime-package`.

--- a/rust/tcl-pkg/Cargo.toml
+++ b/rust/tcl-pkg/Cargo.toml
@@ -28,6 +28,7 @@ repository.workspace = true
 authors.workspace = true
 
 [dependencies]
+tcl-dialect = { path = "../tcl-dialect" }
 tcl-lexer = { path = "../tcl-lexer" }
 tcl-syntax = { path = "../tcl-syntax" }
 tcl-sandbox = { path = "../tcl-sandbox" }

--- a/rust/tcl-pkg/src/docker.rs
+++ b/rust/tcl-pkg/src/docker.rs
@@ -28,6 +28,8 @@
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
+use tcl_dialect::TclVersion;
+
 use crate::errors::TclPkgError;
 
 pub const SUPPORTED_TCL_VERSIONS: [&str; 4] = ["8.4", "8.5", "8.6", "9.0"];
@@ -85,14 +87,30 @@ fn docker_error(message: impl Into<String>) -> TclPkgError {
     TclPkgError::new(message)
 }
 
-fn recipe(family: &str, version: &str) -> Option<&'static str> {
+/// The placeholder a source-build recipe carries where the pinned reference
+/// patchlevel goes, so the tarball name is never a second literal to drift.
+const PATCHLEVEL_PLACEHOLDER: &str = "@PATCHLEVEL@";
+
+/// The exact upstream patchlevel this project pins for `version`'s release
+/// line, from the `tcl-dialect` reference-toolchain manifest that the test
+/// harness, the session bootstrap, and the engines all read.
+fn pinned_patchlevel(version: &str) -> Option<&'static str> {
+    TclVersion::from_version_string(version).map(TclVersion::patchlevel)
+}
+
+fn recipe(family: &str, version: &str) -> Option<String> {
     let table: &[(&str, &str)] = match family {
         "debian" => DEBIAN_RECIPES,
         "alpine" => ALPINE_RECIPES,
         "redhat" => REDHAT_RECIPES,
         _ => return None,
     };
-    table.iter().find(|(v, _)| *v == version).map(|(_, r)| *r)
+    let template = table.iter().find(|(v, _)| *v == version).map(|(_, r)| *r)?;
+    if !template.contains(PATCHLEVEL_PLACEHOLDER) {
+        return Some(template.to_string());
+    }
+    let patchlevel = pinned_patchlevel(version)?;
+    Some(template.replace(PATCHLEVEL_PLACEHOLDER, patchlevel))
 }
 
 fn family_versions(family: &str) -> Option<&'static [(&'static str, &'static str)]> {
@@ -155,16 +173,14 @@ pub fn tcl_install_recipe(image: &str, tcl_version: &str) -> Result<String, TclP
             "no install recipe for image family: {family}"
         )));
     };
-    recipe(&family, tcl_version)
-        .map(ToString::to_string)
-        .ok_or_else(|| {
-            let mut available: Vec<&str> = versions.iter().map(|(v, _)| *v).collect();
-            available.sort_unstable();
-            docker_error(format!(
-                "no recipe for Tcl {tcl_version} on {family} (available: {})",
-                available.join(", ")
-            ))
-        })
+    recipe(&family, tcl_version).ok_or_else(|| {
+        let mut available: Vec<&str> = versions.iter().map(|(v, _)| *v).collect();
+        available.sort_unstable();
+        docker_error(format!(
+            "no recipe for Tcl {tcl_version} on {family} (available: {})",
+            available.join(", ")
+        ))
+    })
 }
 
 /// Return the Dockerfile snippet that installs what fetching and verifying the
@@ -473,11 +489,11 @@ pub fn write_dockerfile(
 const DEBIAN_RECIPES: &[(&str, &str)] = &[
     (
         "8.4",
-        "RUN apt-get update && apt-get install -y --no-install-recommends \\\n        build-essential curl ca-certificates && \\\n    curl -fSL \"https://prdownloads.sourceforge.net/tcl/tcl8.4.20-src.tar.gz\" \\\n        -o /tmp/tcl.tar.gz && \\\n    tar -xzf /tmp/tcl.tar.gz -C /tmp && \\\n    cd /tmp/tcl8.4.20/unix && \\\n    ./configure --prefix=/usr/local && make -j\"$(nproc)\" && make install && \\\n    ln -sf /usr/local/bin/tclsh8.4 /usr/local/bin/tclsh && \\\n    rm -rf /tmp/tcl* && \\\n    apt-get purge -y --auto-remove build-essential && \\\n    rm -rf /var/lib/apt/lists/*",
+        "RUN apt-get update && apt-get install -y --no-install-recommends \\\n        build-essential curl ca-certificates && \\\n    curl -fSL \"https://prdownloads.sourceforge.net/tcl/tcl@PATCHLEVEL@-src.tar.gz\" \\\n        -o /tmp/tcl.tar.gz && \\\n    tar -xzf /tmp/tcl.tar.gz -C /tmp && \\\n    cd /tmp/tcl@PATCHLEVEL@/unix && \\\n    ./configure --prefix=/usr/local && make -j\"$(nproc)\" && make install && \\\n    ln -sf /usr/local/bin/tclsh8.4 /usr/local/bin/tclsh && \\\n    rm -rf /tmp/tcl* && \\\n    apt-get purge -y --auto-remove build-essential && \\\n    rm -rf /var/lib/apt/lists/*",
     ),
     (
         "8.5",
-        "RUN apt-get update && apt-get install -y --no-install-recommends \\\n        build-essential curl ca-certificates && \\\n    curl -fSL \"https://prdownloads.sourceforge.net/tcl/tcl8.5.19-src.tar.gz\" \\\n        -o /tmp/tcl.tar.gz && \\\n    tar -xzf /tmp/tcl.tar.gz -C /tmp && \\\n    cd /tmp/tcl8.5.19/unix && \\\n    ./configure --prefix=/usr/local && make -j\"$(nproc)\" && make install && \\\n    ln -sf /usr/local/bin/tclsh8.5 /usr/local/bin/tclsh && \\\n    rm -rf /tmp/tcl* && \\\n    apt-get purge -y --auto-remove build-essential && \\\n    rm -rf /var/lib/apt/lists/*",
+        "RUN apt-get update && apt-get install -y --no-install-recommends \\\n        build-essential curl ca-certificates && \\\n    curl -fSL \"https://prdownloads.sourceforge.net/tcl/tcl@PATCHLEVEL@-src.tar.gz\" \\\n        -o /tmp/tcl.tar.gz && \\\n    tar -xzf /tmp/tcl.tar.gz -C /tmp && \\\n    cd /tmp/tcl@PATCHLEVEL@/unix && \\\n    ./configure --prefix=/usr/local && make -j\"$(nproc)\" && make install && \\\n    ln -sf /usr/local/bin/tclsh8.5 /usr/local/bin/tclsh && \\\n    rm -rf /tmp/tcl* && \\\n    apt-get purge -y --auto-remove build-essential && \\\n    rm -rf /var/lib/apt/lists/*",
     ),
     (
         "8.6",
@@ -485,39 +501,39 @@ const DEBIAN_RECIPES: &[(&str, &str)] = &[
     ),
     (
         "9.0",
-        "RUN apt-get update && apt-get install -y --no-install-recommends \\\n        build-essential curl ca-certificates zlib1g-dev && \\\n    curl -fSL \"https://prdownloads.sourceforge.net/tcl/tcl9.0.1-src.tar.gz\" \\\n        -o /tmp/tcl.tar.gz && \\\n    tar -xzf /tmp/tcl.tar.gz -C /tmp && \\\n    cd /tmp/tcl9.0.1/unix && \\\n    ./configure --prefix=/usr/local && make -j\"$(nproc)\" && make install && \\\n    ln -sf /usr/local/bin/tclsh9.0 /usr/local/bin/tclsh && \\\n    rm -rf /tmp/tcl* && \\\n    apt-get purge -y --auto-remove build-essential zlib1g-dev && \\\n    rm -rf /var/lib/apt/lists/*",
+        "RUN apt-get update && apt-get install -y --no-install-recommends \\\n        build-essential curl ca-certificates zlib1g-dev && \\\n    curl -fSL \"https://prdownloads.sourceforge.net/tcl/tcl@PATCHLEVEL@-src.tar.gz\" \\\n        -o /tmp/tcl.tar.gz && \\\n    tar -xzf /tmp/tcl.tar.gz -C /tmp && \\\n    cd /tmp/tcl@PATCHLEVEL@/unix && \\\n    ./configure --prefix=/usr/local && make -j\"$(nproc)\" && make install && \\\n    ln -sf /usr/local/bin/tclsh9.0 /usr/local/bin/tclsh && \\\n    rm -rf /tmp/tcl* && \\\n    apt-get purge -y --auto-remove build-essential zlib1g-dev && \\\n    rm -rf /var/lib/apt/lists/*",
     ),
 ];
 
 const ALPINE_RECIPES: &[(&str, &str)] = &[
     (
         "8.4",
-        "RUN apk add --no-cache build-base curl && \\\n    curl -fSL \"https://prdownloads.sourceforge.net/tcl/tcl8.4.20-src.tar.gz\" \\\n        -o /tmp/tcl.tar.gz && \\\n    tar -xzf /tmp/tcl.tar.gz -C /tmp && \\\n    cd /tmp/tcl8.4.20/unix && \\\n    ./configure --prefix=/usr/local && make -j\"$(nproc)\" && make install && \\\n    ln -sf /usr/local/bin/tclsh8.4 /usr/local/bin/tclsh && \\\n    rm -rf /tmp/tcl* && \\\n    apk del build-base",
+        "RUN apk add --no-cache build-base curl && \\\n    curl -fSL \"https://prdownloads.sourceforge.net/tcl/tcl@PATCHLEVEL@-src.tar.gz\" \\\n        -o /tmp/tcl.tar.gz && \\\n    tar -xzf /tmp/tcl.tar.gz -C /tmp && \\\n    cd /tmp/tcl@PATCHLEVEL@/unix && \\\n    ./configure --prefix=/usr/local && make -j\"$(nproc)\" && make install && \\\n    ln -sf /usr/local/bin/tclsh8.4 /usr/local/bin/tclsh && \\\n    rm -rf /tmp/tcl* && \\\n    apk del build-base",
     ),
     (
         "8.5",
-        "RUN apk add --no-cache build-base curl && \\\n    curl -fSL \"https://prdownloads.sourceforge.net/tcl/tcl8.5.19-src.tar.gz\" \\\n        -o /tmp/tcl.tar.gz && \\\n    tar -xzf /tmp/tcl.tar.gz -C /tmp && \\\n    cd /tmp/tcl8.5.19/unix && \\\n    ./configure --prefix=/usr/local && make -j\"$(nproc)\" && make install && \\\n    ln -sf /usr/local/bin/tclsh8.5 /usr/local/bin/tclsh && \\\n    rm -rf /tmp/tcl* && \\\n    apk del build-base",
+        "RUN apk add --no-cache build-base curl && \\\n    curl -fSL \"https://prdownloads.sourceforge.net/tcl/tcl@PATCHLEVEL@-src.tar.gz\" \\\n        -o /tmp/tcl.tar.gz && \\\n    tar -xzf /tmp/tcl.tar.gz -C /tmp && \\\n    cd /tmp/tcl@PATCHLEVEL@/unix && \\\n    ./configure --prefix=/usr/local && make -j\"$(nproc)\" && make install && \\\n    ln -sf /usr/local/bin/tclsh8.5 /usr/local/bin/tclsh && \\\n    rm -rf /tmp/tcl* && \\\n    apk del build-base",
     ),
     ("8.6", "RUN apk add --no-cache tcl"),
     (
         "9.0",
-        "RUN apk add --no-cache build-base curl zlib-dev && \\\n    curl -fSL \"https://prdownloads.sourceforge.net/tcl/tcl9.0.1-src.tar.gz\" \\\n        -o /tmp/tcl.tar.gz && \\\n    tar -xzf /tmp/tcl.tar.gz -C /tmp && \\\n    cd /tmp/tcl9.0.1/unix && \\\n    ./configure --prefix=/usr/local && make -j\"$(nproc)\" && make install && \\\n    ln -sf /usr/local/bin/tclsh9.0 /usr/local/bin/tclsh && \\\n    rm -rf /tmp/tcl* && \\\n    apk del build-base zlib-dev",
+        "RUN apk add --no-cache build-base curl zlib-dev && \\\n    curl -fSL \"https://prdownloads.sourceforge.net/tcl/tcl@PATCHLEVEL@-src.tar.gz\" \\\n        -o /tmp/tcl.tar.gz && \\\n    tar -xzf /tmp/tcl.tar.gz -C /tmp && \\\n    cd /tmp/tcl@PATCHLEVEL@/unix && \\\n    ./configure --prefix=/usr/local && make -j\"$(nproc)\" && make install && \\\n    ln -sf /usr/local/bin/tclsh9.0 /usr/local/bin/tclsh && \\\n    rm -rf /tmp/tcl* && \\\n    apk del build-base zlib-dev",
     ),
 ];
 
 const REDHAT_RECIPES: &[(&str, &str)] = &[
     (
         "8.4",
-        "RUN dnf install -y gcc make curl && \\\n    curl -fSL \"https://prdownloads.sourceforge.net/tcl/tcl8.4.20-src.tar.gz\" \\\n        -o /tmp/tcl.tar.gz && \\\n    tar -xzf /tmp/tcl.tar.gz -C /tmp && \\\n    cd /tmp/tcl8.4.20/unix && \\\n    ./configure --prefix=/usr/local && make -j\"$(nproc)\" && make install && \\\n    ln -sf /usr/local/bin/tclsh8.4 /usr/local/bin/tclsh && \\\n    rm -rf /tmp/tcl* && \\\n    dnf remove -y gcc make && dnf clean all",
+        "RUN dnf install -y gcc make curl && \\\n    curl -fSL \"https://prdownloads.sourceforge.net/tcl/tcl@PATCHLEVEL@-src.tar.gz\" \\\n        -o /tmp/tcl.tar.gz && \\\n    tar -xzf /tmp/tcl.tar.gz -C /tmp && \\\n    cd /tmp/tcl@PATCHLEVEL@/unix && \\\n    ./configure --prefix=/usr/local && make -j\"$(nproc)\" && make install && \\\n    ln -sf /usr/local/bin/tclsh8.4 /usr/local/bin/tclsh && \\\n    rm -rf /tmp/tcl* && \\\n    dnf remove -y gcc make && dnf clean all",
     ),
     (
         "8.5",
-        "RUN dnf install -y gcc make curl && \\\n    curl -fSL \"https://prdownloads.sourceforge.net/tcl/tcl8.5.19-src.tar.gz\" \\\n        -o /tmp/tcl.tar.gz && \\\n    tar -xzf /tmp/tcl.tar.gz -C /tmp && \\\n    cd /tmp/tcl8.5.19/unix && \\\n    ./configure --prefix=/usr/local && make -j\"$(nproc)\" && make install && \\\n    ln -sf /usr/local/bin/tclsh8.5 /usr/local/bin/tclsh && \\\n    rm -rf /tmp/tcl* && \\\n    dnf remove -y gcc make && dnf clean all",
+        "RUN dnf install -y gcc make curl && \\\n    curl -fSL \"https://prdownloads.sourceforge.net/tcl/tcl@PATCHLEVEL@-src.tar.gz\" \\\n        -o /tmp/tcl.tar.gz && \\\n    tar -xzf /tmp/tcl.tar.gz -C /tmp && \\\n    cd /tmp/tcl@PATCHLEVEL@/unix && \\\n    ./configure --prefix=/usr/local && make -j\"$(nproc)\" && make install && \\\n    ln -sf /usr/local/bin/tclsh8.5 /usr/local/bin/tclsh && \\\n    rm -rf /tmp/tcl* && \\\n    dnf remove -y gcc make && dnf clean all",
     ),
     ("8.6", "RUN dnf install -y tcl && dnf clean all"),
     (
         "9.0",
-        "RUN dnf install -y gcc make curl zlib-devel && \\\n    curl -fSL \"https://prdownloads.sourceforge.net/tcl/tcl9.0.1-src.tar.gz\" \\\n        -o /tmp/tcl.tar.gz && \\\n    tar -xzf /tmp/tcl.tar.gz -C /tmp && \\\n    cd /tmp/tcl9.0.1/unix && \\\n    ./configure --prefix=/usr/local && make -j\"$(nproc)\" && make install && \\\n    ln -sf /usr/local/bin/tclsh9.0 /usr/local/bin/tclsh && \\\n    rm -rf /tmp/tcl* && \\\n    dnf remove -y gcc make zlib-devel && dnf clean all",
+        "RUN dnf install -y gcc make curl zlib-devel && \\\n    curl -fSL \"https://prdownloads.sourceforge.net/tcl/tcl@PATCHLEVEL@-src.tar.gz\" \\\n        -o /tmp/tcl.tar.gz && \\\n    tar -xzf /tmp/tcl.tar.gz -C /tmp && \\\n    cd /tmp/tcl@PATCHLEVEL@/unix && \\\n    ./configure --prefix=/usr/local && make -j\"$(nproc)\" && make install && \\\n    ln -sf /usr/local/bin/tclsh9.0 /usr/local/bin/tclsh && \\\n    rm -rf /tmp/tcl* && \\\n    dnf remove -y gcc make zlib-devel && dnf clean all",
     ),
 ];
 
@@ -543,6 +559,28 @@ mod tests {
         let r = tcl_install_recipe("alpine:3.19", "8.6").unwrap();
         assert_eq!(r, "RUN apk add --no-cache tcl");
         assert!(tcl_install_recipe("alpine:3.19", "7.0").is_err());
+    }
+
+    /// Every source build fetches the patchlevel the reference-toolchain
+    /// manifest pins, and leaves no placeholder behind for a shell to choke on.
+    #[test]
+    fn source_recipes_track_the_pinned_patchlevel() {
+        for image in ["debian:bookworm-slim", "alpine:3.19", "fedora:39"] {
+            for version in ["8.4", "8.5", "9.0"] {
+                let recipe = tcl_install_recipe(image, version).expect("recipe");
+                let patchlevel = pinned_patchlevel(version).expect("pinned patchlevel");
+                assert!(
+                    recipe.contains(&format!("tcl{patchlevel}-src.tar.gz")),
+                    "{image} Tcl {version} fetches an unpinned tarball: {recipe}"
+                );
+                assert!(
+                    recipe.contains(&format!("/tmp/tcl{patchlevel}/unix")),
+                    "{image} Tcl {version} builds an unpinned tree: {recipe}"
+                );
+                assert!(!recipe.contains(PATCHLEVEL_PLACEHOLDER));
+            }
+        }
+        assert_eq!(pinned_patchlevel("9.0"), Some("9.0.4"));
     }
 
     #[test]

--- a/rust/tcl-pkg/src/docker.rs
+++ b/rust/tcl-pkg/src/docker.rs
@@ -91,26 +91,11 @@ fn docker_error(message: impl Into<String>) -> TclPkgError {
 /// patchlevel goes, so the tarball name is never a second literal to drift.
 const PATCHLEVEL_PLACEHOLDER: &str = "@PATCHLEVEL@";
 
-/// The exact upstream patchlevel this project pins for `version`'s release
-/// line, from the `tcl-dialect` reference-toolchain manifest that the test
-/// harness, the session bootstrap, and the engines all read.
-fn pinned_patchlevel(version: &str) -> Option<&'static str> {
-    TclVersion::from_version_string(version).map(TclVersion::patchlevel)
-}
-
-fn recipe(family: &str, version: &str) -> Option<String> {
-    let table: &[(&str, &str)] = match family {
-        "debian" => DEBIAN_RECIPES,
-        "alpine" => ALPINE_RECIPES,
-        "redhat" => REDHAT_RECIPES,
-        _ => return None,
-    };
-    let template = table.iter().find(|(v, _)| *v == version).map(|(_, r)| *r)?;
-    if !template.contains(PATCHLEVEL_PLACEHOLDER) {
-        return Some(template.to_string());
-    }
-    let patchlevel = pinned_patchlevel(version)?;
-    Some(template.replace(PATCHLEVEL_PLACEHOLDER, patchlevel))
+fn recipe_template(family: &str, version: &str) -> Option<&'static str> {
+    family_versions(family)?
+        .iter()
+        .find(|(candidate, _)| *candidate == version)
+        .map(|(_, template)| *template)
 }
 
 fn family_versions(family: &str) -> Option<&'static [(&'static str, &'static str)]> {
@@ -173,14 +158,27 @@ pub fn tcl_install_recipe(image: &str, tcl_version: &str) -> Result<String, TclP
             "no install recipe for image family: {family}"
         )));
     };
-    recipe(&family, tcl_version).ok_or_else(|| {
+    let template = recipe_template(&family, tcl_version).ok_or_else(|| {
         let mut available: Vec<&str> = versions.iter().map(|(v, _)| *v).collect();
         available.sort_unstable();
         docker_error(format!(
             "no recipe for Tcl {tcl_version} on {family} (available: {})",
             available.join(", ")
         ))
-    })
+    })?;
+    // Only a source build names a tarball, so only a source build needs the
+    // pinned patchlevel; a distro-package recipe is complete as written.
+    if !template.contains(PATCHLEVEL_PLACEHOLDER) {
+        return Ok(template.to_string());
+    }
+    let patchlevel = TclVersion::from_version_string(tcl_version)
+        .ok_or_else(|| {
+            docker_error(format!(
+                "Tcl {tcl_version} has no pinned patchlevel in the reference-toolchain manifest"
+            ))
+        })?
+        .patchlevel();
+    Ok(template.replace(PATCHLEVEL_PLACEHOLDER, patchlevel))
 }
 
 /// Return the Dockerfile snippet that installs what fetching and verifying the
@@ -561,14 +559,24 @@ mod tests {
         assert!(tcl_install_recipe("alpine:3.19", "7.0").is_err());
     }
 
-    /// Every source build fetches the patchlevel the reference-toolchain
-    /// manifest pins, and leaves no placeholder behind for a shell to choke on.
+    /// Every supported release either installs a distro package or builds the
+    /// exact patchlevel the reference-toolchain manifest pins, and no recipe
+    /// ever reaches a shell with the placeholder still in it.
     #[test]
-    fn source_recipes_track_the_pinned_patchlevel() {
+    fn recipes_install_a_distro_package_or_the_pinned_patchlevel() {
         for image in ["debian:bookworm-slim", "alpine:3.19", "fedora:39"] {
-            for version in ["8.4", "8.5", "9.0"] {
+            for version in SUPPORTED_TCL_VERSIONS {
                 let recipe = tcl_install_recipe(image, version).expect("recipe");
-                let patchlevel = pinned_patchlevel(version).expect("pinned patchlevel");
+                assert!(
+                    !recipe.contains(PATCHLEVEL_PLACEHOLDER),
+                    "{image} Tcl {version} leaks the patchlevel placeholder: {recipe}"
+                );
+                if !recipe.contains("-src.tar.gz") {
+                    continue;
+                }
+                let patchlevel = TclVersion::from_version_string(version)
+                    .expect("a supported release is on the dialect ladder")
+                    .patchlevel();
                 assert!(
                     recipe.contains(&format!("tcl{patchlevel}-src.tar.gz")),
                     "{image} Tcl {version} fetches an unpinned tarball: {recipe}"
@@ -577,10 +585,8 @@ mod tests {
                     recipe.contains(&format!("/tmp/tcl{patchlevel}/unix")),
                     "{image} Tcl {version} builds an unpinned tree: {recipe}"
                 );
-                assert!(!recipe.contains(PATCHLEVEL_PLACEHOLDER));
             }
         }
-        assert_eq!(pinned_patchlevel("9.0"), Some("9.0.4"));
     }
 
     #[test]

--- a/scripts/release/test-sign-and-upload-action.sh
+++ b/scripts/release/test-sign-and-upload-action.sh
@@ -21,7 +21,7 @@ mkdir -p "$fixture/build"
 
 zip=$fixture/build/tcl-lsp-claude-skills-2.2.0.zip
 vsix=$fixture/build/tcl-lsp-vscode-2.2.0-universal.vsix
-sublime=$fixture/build/TclLsp.sublime-package
+sublime=$fixture/build/LSP-Tcl.sublime-package
 : > "$zip"
 : > "$vsix"
 : > "$sublime"
@@ -38,7 +38,7 @@ assert_resolves() {
 # Representative glob shapes from the shared action's real callers.
 assert_resolves "$fixture/build/tcl-lsp-claude-skills-*.zip" "$zip"
 assert_resolves "$fixture/build/tcl-lsp-vscode-*-universal.vsix" "$vsix"
-assert_resolves "$fixture/build/TclLsp*.sublime-package" "$sublime"
+assert_resolves "$fixture/build/LSP-Tcl*.sublime-package" "$sublime"
 
 if $RESOLVER "$fixture/build/missing-*.zip" >/dev/null 2>&1; then
     echo "resolver accepted a zero-match release glob" >&2


### PR DESCRIPTION
## Summary

- `tcl docker` source-build recipes fetched `tcl9.0.1-src.tar.gz` while `rust/tcl-dialect/data/reference-toolchains.tsv` pins 9.0.4, so a generated image built a different Tcl from every other tool in the tree. The recipes now carry a patchlevel placeholder that `recipe` fills from `TclVersion::patchlevel`, reading the same manifest the test harness, session bootstrap, and engines read. 8.4 and 8.5 move to the same mechanism so they cannot drift out of their pins either.
- A new `tcl-pkg` test asserts every source recipe fetches and builds the manifest's patchlevel and leaves no placeholder in the shell text.
- `scripts/release/test-sign-and-upload-action.sh` fixtured the retired `TclLsp*.sublime-package` asset name. CI and the Makefile publish `LSP-Tcl.sublime-package`, and the shared action resolves it with `build/LSP-Tcl*.sublime-package`, so the test exercised a shape no caller uses. Fixture the real name and glob.
- `editors/sublime-text/SUBMITTING.md` drops a paragraph about the asset rename; the pre-submission checks already state what a stable release carries.

`tcl-pkg` gains a direct `tcl-dialect` dependency, which it already had transitively through `tcl-lexer`.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

```
cargo test -p tcl-pkg                      # 86 passed
bash scripts/release/test-sign-and-upload-action.sh
make rust-check                            # exit 0
make prep-pr                               # exit 0
tcl docker recipe debian:bookworm-slim --tcl-version 9.0   # emits tcl9.0.4-src.tar.gz
```

All three source tarball names resolve upstream (HTTP 200 for `tcl9.0.4`, `tcl8.4.20`, `tcl8.5.19`).

## Compiler / diagnostics checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [ ] Did this change alter a compiler fact contract? No — packaging and release tooling only.
- [ ] If yes, I updated the owning design doc under `docs/design/compiler/` or
      `docs/design/contracts/`.
- [ ] If I added or changed a diagnostic or optimisation code, I updated its
      page under `docs/kcs/codes/` and linked it from `docs/kcs/codes/README.md`.
- [ ] If I added a design doc, I linked it from `docs/design/README.md`
      (`cargo xtask kcs-index-links` enforces this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YKdc6J7NnbEV9ecYNgozVz

---
_Generated by [Claude Code](https://claude.ai/code/session_01YKdc6J7NnbEV9ecYNgozVz)_