### PR TITLE
f5-query: fix `as` bindings on dropped items and cross-document derefs

### DIFF
--- a/docs/references/f5_query/dsl.md
+++ b/docs/references/f5_query/dsl.md
@@ -188,17 +188,22 @@ reference resolves into an LTM config and the hops off that object
 resolve the same way.  Without `--merge` a dereference stays inside the
 config being iterated, which is what per-file semantics mean.
 
-A reference that resolves to no object in that view is never silent:
+A reference that resolves to no object in that view is never silent.
+Reading a field through one yields a value that renders as `null` but
+carries the path that failed, so the gap is visible in a projection and
+a further step can name it:
 
 | Shape | Result |
 | --- | --- |
-| Empty reference (`pool none`) | contributes nothing |
-| Field read (`.pool.members`) | explicit `null` |
-| Iterate / subscript (`.pool[]`, `.pool["members"]`) | error naming the path |
+| Empty reference (`pool none`) | contributes nothing, at every kind of step |
+| Field read (`.pool.members`) | reads as `null`, carrying `/Common/…` |
+| Reading on through it (`.pool.members.foo`) | error naming the path |
+| Iterating it (`.pool.members[]`) | empty — nothing to iterate |
+| Iterating / subscripting the reference itself (`.pool[]`, `.pool["x"]`) | error naming the path |
 
-The explicit `null` keeps a dangling reference distinguishable from a
-resolved object whose field is genuinely empty, and `length` of it is
-`0`.  Outside `--merge` the error also points at `--merge` when more
+`length` of the `null` is `0`, and it is falsy.  Plain `null` is
+unaffected and still refuses to iterate; only an unresolved reference is
+empty.  Outside `--merge` the error also points at `--merge` when more
 than one source is loaded.
 
 ### `Stream`

--- a/docs/references/f5_query/dsl.md
+++ b/docs/references/f5_query/dsl.md
@@ -181,6 +181,26 @@ evaluator transparently dereferences `PathRef` on field-access so
 `.ltm.virtual[].pool.members[].address` walks VS → pool → member in
 one chain.
 
+A dereference resolves against the whole view the query runs over.
+Under `--merge` every loaded source is one namespace, so each hop of a
+chain may land in a different source — a GTM wideip's `pools[]`
+reference resolves into an LTM config and the hops off that object
+resolve the same way.  Without `--merge` a dereference stays inside the
+config being iterated, which is what per-file semantics mean.
+
+A reference that resolves to no object in that view is never silent:
+
+| Shape | Result |
+| --- | --- |
+| Empty reference (`pool none`) | contributes nothing |
+| Field read (`.pool.members`) | explicit `null` |
+| Iterate / subscript (`.pool[]`, `.pool["members"]`) | error naming the path |
+
+The explicit `null` keeps a dangling reference distinguishable from a
+resolved object whose field is genuinely empty, and `length` of it is
+`0`.  Outside `--merge` the error also points at `--merge` when more
+than one source is loaded.
+
 ### `Stream`
 
 A flat sequence produced by `[]` or stream-returning builtins.

--- a/rust/bigip-report-gen/rust/src/query.rs
+++ b/rust/bigip-report-gen/rust/src/query.rs
@@ -54,7 +54,7 @@ impl std::error::Error for ReportError {}
 /// Mirrors `f5report._engine::value_to_py` one-for-one.
 pub(crate) fn value_to_json(value: &Value) -> J {
     match value {
-        Value::Null | Value::Drop => J::Null,
+        Value::Null | Value::Unresolved(_) | Value::Drop => J::Null,
         Value::Bool(b) => J::Bool(*b),
         Value::Int(i) => J::from(*i),
         Value::Float(f) => serde_json::Number::from_f64(*f).map_or(J::Null, J::Number),

--- a/rust/f5-cli/tests/fixtures/query-ex21.golden
+++ b/rust/f5-cli/tests/fixtures/query-ex21.golden
@@ -1,4 +1,4 @@
+bad_vs
 www_vs
 api_vs
 ssl_only_vs
-bad_vs

--- a/rust/f5-cli/tests/fixtures/query_help_dsl.golden
+++ b/rust/f5-cli/tests/fixtures/query_help_dsl.golden
@@ -125,12 +125,14 @@ PATH ACCESS
                           source.  Without ``--merge`` a deref stays inside
                           the config being iterated.
                           A path naming an object that is nowhere in the
-                          view is never silent: a field read through it is
-                          an explicit ``null`` (so ``.pool.members`` reads
-                          ``null``, not "a pool with no members"), and
-                          iterating or subscripting through it is an error
-                          naming the path.  An *empty* ref (no pool set at
-                          all) contributes nothing.
+                          view is never silent: a field read through it
+                          reads as ``null`` (so ``.pool.members`` shows
+                          ``null``, not "a pool with no members") while
+                          carrying the path that failed, so reading on
+                          through it names that path.  Iterating it is
+                          empty; iterating or subscripting the reference
+                          itself is an error naming the path.  An *empty*
+                          ref (no pool set at all) contributes nothing.
 
 MODULES
 

--- a/rust/f5-cli/tests/fixtures/query_help_dsl.golden
+++ b/rust/f5-cli/tests/fixtures/query_help_dsl.golden
@@ -119,6 +119,18 @@ PATH ACCESS
                           PathRefs act as strings AND as the referenced
                           object: ``.ltm.virtual[].pool.members[]`` walks
                           VS -> pool -> member transparently.
+                          A deref resolves against the whole view: under
+                          ``--merge`` every loaded config is one namespace,
+                          so each hop of a chain may land in a different
+                          source.  Without ``--merge`` a deref stays inside
+                          the config being iterated.
+                          A path naming an object that is nowhere in the
+                          view is never silent: a field read through it is
+                          an explicit ``null`` (so ``.pool.members`` reads
+                          ``null``, not "a pool with no members"), and
+                          iterating or subscripting through it is an error
+                          naming the path.  An *empty* ref (no pool set at
+                          all) contributes nothing.
 
 MODULES
 

--- a/rust/tcl-bigip-query/src/builtins/extras.rs
+++ b/rust/tcl-bigip-query/src/builtins/extras.rs
@@ -80,11 +80,12 @@ fn bi_env(_args: &[Value]) -> Result<Value, QueryError> {
 
 /// `source_file(obj)` → the URI of the source that defined *obj*, or `null`.
 /// `ObjectRef` → its `config_uri`; `PathRef`
-/// → resolved through the projection to its backing object's `config_uri`.
+/// → resolved through the projection to its backing object's `config_uri`,
+/// across every merged root under `--merge`.
 fn bi_source_file(args: &[Value], ctx: &mut EvalContext) -> Result<Value, QueryError> {
     match &args[0] {
         Value::ObjectRef(o) => Ok(uri_or_null(&o.config_uri)),
-        Value::PathRef(p) => match crate::projection::resolve_pathref(p, &ctx.root) {
+        Value::PathRef(p) => match ctx.resolve_pathref(p) {
             Some(target) => Ok(uri_or_null(&target.config_uri)),
             None => Ok(Value::Null),
         },

--- a/rust/tcl-bigip-query/src/builtins/mod.rs
+++ b/rust/tcl-bigip-query/src/builtins/mod.rs
@@ -356,7 +356,7 @@ fn registrations() -> Vec<(&'static str, BuiltinSpec)> {
 #[must_use]
 pub(crate) fn type_name(v: &Value) -> &'static str {
     match v {
-        Value::Null => "null",
+        Value::Null | Value::Unresolved(_) => "null",
         Value::Bool(_) => "bool",
         Value::Int(_) => "int",
         Value::Float(_) => "float",
@@ -462,6 +462,7 @@ pub(crate) fn to_jsonable(v: &Value, depth: u32) -> Value {
     }
     match v {
         Value::Null | Value::Bool(_) | Value::Int(_) | Value::Float(_) | Value::Str(_) => v.clone(),
+        Value::Unresolved(_) => Value::Null,
         Value::PathRef(p) => Value::Str(p.full_path.clone()),
         Value::List(items) | Value::Stream(items) => Value::List(
             items
@@ -905,7 +906,7 @@ fn pathological_regex() -> &'static Regex {
 fn bi_length(args: &[Value]) -> Result<Value, QueryError> {
     let v = &args[0];
     let n: i64 = match v {
-        Value::Null => 0,
+        Value::Null | Value::Unresolved(_) => 0,
         Value::Str(s) => s.chars().count() as i64,
         Value::List(items) | Value::Stream(items) => items.len() as i64,
         Value::PathRef(p) => p.full_path.chars().count() as i64,

--- a/rust/tcl-bigip-query/src/eval.rs
+++ b/rust/tcl-bigip-query/src/eval.rs
@@ -247,6 +247,35 @@ impl EvalContext {
         *self.merge_graph.borrow_mut() = Some(Rc::clone(&graph));
         graph
     }
+
+    /// Resolve the [`ObjectRef`] a [`PathRef`] points to, against the whole
+    /// view the query is running over.
+    ///
+    /// The iterating root is tried first. Under `--merge` every loaded source
+    /// is one namespace, so a miss falls back across the remaining
+    /// [`merge_roots`]: a GTM wideip's pool reference resolves while the
+    /// iterating root is the LTM config, and each further hop off the
+    /// resolved object resolves the same way — every hop of a chain may land
+    /// in a different source.
+    ///
+    /// JSON side-input roots never produce `PathRef`s, so they are not
+    /// consulted. Non-merge mode stays scoped to the iterating source, which
+    /// is what per-file semantics mean.
+    ///
+    /// [`merge_roots`]: EvalContext::merge_roots
+    #[must_use]
+    pub fn resolve_pathref(&self, reference: &PathRef) -> Option<Rc<ObjectRef>> {
+        if let Some(found) = projection::resolve_pathref(reference, &self.root) {
+            return Some(found);
+        }
+        if !self.merge_mode {
+            return None;
+        }
+        self.merge_roots
+            .iter()
+            .filter(|r| !Rc::ptr_eq(r, &self.root))
+            .find_map(|r| projection::resolve_pathref(reference, r))
+    }
 }
 
 impl EvalContext {
@@ -590,13 +619,21 @@ fn eval_let_binding(
     ctx: &mut EvalContext,
 ) -> Result<Value, QueryError> {
     let source_value = eval(source, current, ctx)?;
+    // `select(...)` yields the `Drop` sentinel for a rejected item, and a
+    // binding short-circuits it exactly as `|` does: the item never binds and
+    // the body never runs. The sentinel is an evaluator internal, so it must
+    // not reach `$name`.
     let (items, is_iterating) = match source_value {
+        Value::Drop => return Ok(Value::Stream(Vec::new())),
         Value::Stream(items) => (items, true),
         other => (vec![other], false),
     };
     let n = items.len();
     let mut out = Vec::new();
     for item in items {
+        if matches!(item, Value::Drop) {
+            continue;
+        }
         let prior = ctx.bindings.insert(name.to_string(), item);
         let result = eval(body, current, ctx);
         match prior {
@@ -730,7 +767,13 @@ fn field_step(value: &Value, name: &str, ctx: &mut EvalContext) -> Result<Vec<Va
     match value {
         Value::PathRef(p) => match resolve_pathref(p, ctx) {
             Some(target) => field_step(&Value::ObjectRef(target), name, ctx),
-            None => Ok(Vec::new()),
+            // An empty reference is "no reference at all" (`pool none`), so
+            // it contributes nothing. A *dangling* one — a path naming an
+            // object that exists nowhere in the view — reads as an explicit
+            // `null`, keeping it distinguishable from a resolved object whose
+            // field is genuinely empty.
+            None if p.full_path.is_empty() => Ok(Vec::new()),
+            None => Ok(vec![Value::Null]),
         },
         Value::Container(c) => Ok(vec![c.lookup(name)?]),
         Value::ObjectRef(o) => match o.fields.get(name) {
@@ -756,8 +799,13 @@ fn subscript_root(value: &Value, ctx: &mut EvalContext) -> Result<Value, QueryEr
     match value {
         Value::PathRef(p) => match resolve_pathref(p, ctx) {
             Some(target) => subscript_root(&Value::ObjectRef(target), ctx),
-            None => Ok(Value::Stream(Vec::new())),
+            None if p.full_path.is_empty() => Ok(Value::Stream(Vec::new())),
+            None => Err(unresolved_ref_error(p, "iterate", ctx)),
         },
+        // Iterating `null` yields nothing — reached when a dangling reference
+        // read as `null` a step earlier (`.pool.members[]` on a virtual whose
+        // pool is not in the view).
+        Value::Null => Ok(Value::List(Vec::new())),
         Value::Container(c) => {
             // Flatten container → container → object until the entries are
             // no longer all containers.
@@ -791,8 +839,10 @@ fn regex_subscript(
     match value {
         Value::PathRef(p) => match resolve_pathref(p, ctx) {
             Some(target) => regex_subscript(&Value::ObjectRef(target), pattern, ctx),
-            None => Ok(Vec::new()),
+            None if p.full_path.is_empty() => Ok(Vec::new()),
+            None => Err(unresolved_ref_error(p, "regex-subscript", ctx)),
         },
+        Value::Null => Ok(Vec::new()),
         Value::Container(c) => {
             let entries = c.entries();
             let keys = c.regex_keys(pattern)?;
@@ -834,10 +884,7 @@ fn subscript_step(
     match value {
         Value::PathRef(p) => match resolve_pathref(p, ctx) {
             Some(target) => subscript_step(&Value::ObjectRef(target), index, ctx),
-            None => Err(QueryError::eval(format!(
-                "cannot subscript unresolved path {}",
-                pyr(&p.full_path)
-            ))),
+            None => Err(unresolved_ref_error(p, "subscript", ctx)),
         },
         Value::Container(c) => match index {
             Value::Str(key) => c.lookup(key),
@@ -931,11 +978,35 @@ fn resolve_index(i: i64, len: usize) -> Option<usize> {
     }
 }
 
-/// Resolve the `ObjectRef` a `PathRef` points to — delegates to the
-/// projection layer against `ctx.root`. JSON roots (which never produce
-/// `PathRef`s) yield `None`.
+/// Resolve the `ObjectRef` a `PathRef` points to — delegates to
+/// [`EvalContext::resolve_pathref`], which spans every merged root under
+/// `--merge`. JSON roots (which never produce `PathRef`s) yield `None`.
 fn resolve_pathref(reference: &Rc<PathRef>, ctx: &mut EvalContext) -> Option<Rc<ObjectRef>> {
-    projection::resolve_pathref(reference, &ctx.root)
+    ctx.resolve_pathref(reference)
+}
+
+/// The error raised when a non-empty `PathRef` names no object anywhere in
+/// the view the query is running over.
+///
+/// Iterating or subscripting a dangling reference is reported rather than
+/// draining the pipeline to an empty stream. Outside `--merge` the target is
+/// usually defined in another loaded source, so the message says so.
+fn unresolved_ref_error(reference: &PathRef, what: &str, ctx: &EvalContext) -> QueryError {
+    let kind = if reference.expected_kind.is_empty() {
+        "object".to_owned()
+    } else {
+        reference.expected_kind.clone()
+    };
+    let hint = if ctx.merge_mode || ctx.named_roots.len() < 2 {
+        String::new()
+    } else {
+        " (pass --merge to resolve references across every loaded source)".to_owned()
+    };
+    QueryError::eval(format!(
+        "cannot {what} through unresolved reference {}: no {kind} with that \
+         path in this config{hint}",
+        pyr(&reference.full_path)
+    ))
 }
 
 // Calls

--- a/rust/tcl-bigip-query/src/eval.rs
+++ b/rust/tcl-bigip-query/src/eval.rs
@@ -769,12 +769,18 @@ fn field_step(value: &Value, name: &str, ctx: &mut EvalContext) -> Result<Vec<Va
             Some(target) => field_step(&Value::ObjectRef(target), name, ctx),
             // An empty reference is "no reference at all" (`pool none`), so
             // it contributes nothing. A *dangling* one — a path naming an
-            // object that exists nowhere in the view — reads as an explicit
-            // `null`, keeping it distinguishable from a resolved object whose
-            // field is genuinely empty.
+            // object that exists nowhere in the view — carries that path
+            // forward, so it reads as `null` instead of being
+            // indistinguishable from a resolved object whose field is empty,
+            // and the next step can name what failed to resolve.
             None if p.full_path.is_empty() => Ok(Vec::new()),
-            None => Ok(vec![Value::Null]),
+            None => Ok(vec![Value::Unresolved(Rc::clone(p))]),
         },
+        Value::Unresolved(p) => Err(unresolved_ref_error(
+            p,
+            &format!("read field {}", pyr(name)),
+            ctx,
+        )),
         Value::Container(c) => Ok(vec![c.lookup(name)?]),
         Value::ObjectRef(o) => match o.fields.get(name) {
             Some(v) => Ok(vec![v.clone()]),
@@ -802,10 +808,10 @@ fn subscript_root(value: &Value, ctx: &mut EvalContext) -> Result<Value, QueryEr
             None if p.full_path.is_empty() => Ok(Value::Stream(Vec::new())),
             None => Err(unresolved_ref_error(p, "iterate", ctx)),
         },
-        // Iterating `null` yields nothing — reached when a dangling reference
-        // read as `null` a step earlier (`.pool.members[]` on a virtual whose
-        // pool is not in the view).
-        Value::Null => Ok(Value::List(Vec::new())),
+        // A reference that named nothing has nothing to iterate — reached one
+        // step on from the failed lookup (`.pool.members[]` on a virtual whose
+        // pool is not in the view). Plain `null` still refuses to iterate.
+        Value::Unresolved(_) => Ok(Value::List(Vec::new())),
         Value::Container(c) => {
             // Flatten container → container → object until the entries are
             // no longer all containers.
@@ -842,7 +848,7 @@ fn regex_subscript(
             None if p.full_path.is_empty() => Ok(Vec::new()),
             None => Err(unresolved_ref_error(p, "regex-subscript", ctx)),
         },
-        Value::Null => Ok(Vec::new()),
+        Value::Unresolved(_) => Ok(Vec::new()),
         Value::Container(c) => {
             let entries = c.entries();
             let keys = c.regex_keys(pattern)?;
@@ -884,8 +890,10 @@ fn subscript_step(
     match value {
         Value::PathRef(p) => match resolve_pathref(p, ctx) {
             Some(target) => subscript_step(&Value::ObjectRef(target), index, ctx),
+            None if p.full_path.is_empty() => Ok(Value::Stream(Vec::new())),
             None => Err(unresolved_ref_error(p, "subscript", ctx)),
         },
+        Value::Unresolved(p) => Err(unresolved_ref_error(p, "subscript", ctx)),
         Value::Container(c) => match index {
             Value::Str(key) => c.lookup(key),
             Value::Int(i) => {

--- a/rust/tcl-bigip-query/src/grammar.rs
+++ b/rust/tcl-bigip-query/src/grammar.rs
@@ -150,12 +150,14 @@ PATH ACCESS
                           source.  Without ``--merge`` a deref stays inside
                           the config being iterated.
                           A path naming an object that is nowhere in the
-                          view is never silent: a field read through it is
-                          an explicit ``null`` (so ``.pool.members`` reads
-                          ``null``, not "a pool with no members"), and
-                          iterating or subscripting through it is an error
-                          naming the path.  An *empty* ref (no pool set at
-                          all) contributes nothing.
+                          view is never silent: a field read through it
+                          reads as ``null`` (so ``.pool.members`` shows
+                          ``null``, not "a pool with no members") while
+                          carrying the path that failed, so reading on
+                          through it names that path.  Iterating it is
+                          empty; iterating or subscripting the reference
+                          itself is an error naming the path.  An *empty*
+                          ref (no pool set at all) contributes nothing.
 
 MODULES
 

--- a/rust/tcl-bigip-query/src/grammar.rs
+++ b/rust/tcl-bigip-query/src/grammar.rs
@@ -144,6 +144,18 @@ PATH ACCESS
                           PathRefs act as strings AND as the referenced
                           object: ``.ltm.virtual[].pool.members[]`` walks
                           VS -> pool -> member transparently.
+                          A deref resolves against the whole view: under
+                          ``--merge`` every loaded config is one namespace,
+                          so each hop of a chain may land in a different
+                          source.  Without ``--merge`` a deref stays inside
+                          the config being iterated.
+                          A path naming an object that is nowhere in the
+                          view is never silent: a field read through it is
+                          an explicit ``null`` (so ``.pool.members`` reads
+                          ``null``, not "a pool with no members"), and
+                          iterating or subscripting through it is an error
+                          naming the path.  An *empty* ref (no pool set at
+                          all) contributes nothing.
 
 MODULES
 

--- a/rust/tcl-bigip-query/src/jsonfmt.rs
+++ b/rust/tcl-bigip-query/src/jsonfmt.rs
@@ -95,7 +95,7 @@ fn write_value(
         return;
     }
     match value {
-        Value::Null | Value::Drop => out.push_str("null"),
+        Value::Null | Value::Unresolved(_) | Value::Drop => out.push_str("null"),
         Value::Bool(b) => out.push_str(if *b { "true" } else { "false" }),
         Value::Int(i) => out.push_str(&i.to_string()),
         Value::Float(f) => out.push_str(&py_float_repr(*f)),

--- a/rust/tcl-bigip-query/src/value.rs
+++ b/rust/tcl-bigip-query/src/value.rs
@@ -172,6 +172,12 @@ pub enum Value {
     /// A navigable namespace / kind container projected from a
     /// `BigipConfig`.
     Container(Rc<Container>),
+    /// A reference that named no object anywhere in the view the query runs
+    /// over. Carries the path that failed to resolve so a later step can
+    /// name it. Reads as `null` in every output mode and is falsy, but
+    /// iterating it is empty rather than an error, and reading a field
+    /// through it reports the dangling path.
+    Unresolved(Rc<PathRef>),
     /// The `select` "drop this value" sentinel.
     Drop,
 }
@@ -188,6 +194,7 @@ impl Value {
     pub fn describe(&self) -> String {
         match self {
             Value::Null => "null".to_string(),
+            Value::Unresolved(p) => format!("unresolved-ref({})", p.full_path),
             Value::Container(c) => format!("container({})", c.kind),
             Value::ObjectRef(o) => format!("object({})", o.kind),
             Value::PathRef(p) => format!(
@@ -216,7 +223,7 @@ impl Value {
     #[must_use]
     pub fn type_name(&self) -> &'static str {
         match self {
-            Value::Null => "NoneType",
+            Value::Null | Value::Unresolved(_) => "NoneType",
             Value::Bool(_) => "bool",
             Value::Int(_) => "int",
             Value::Float(_) => "float",
@@ -240,7 +247,7 @@ impl Value {
 #[must_use]
 pub fn truthy(value: &Value) -> bool {
     match value {
-        Value::Null | Value::Drop => false,
+        Value::Null | Value::Unresolved(_) | Value::Drop => false,
         Value::Bool(b) => *b,
         Value::Str(s) => !s.is_empty(),
         Value::List(items) | Value::Stream(items) => !items.is_empty(),
@@ -274,7 +281,10 @@ pub fn py_eq(lhs: &Value, rhs: &Value, depth: u32) -> bool {
         return false;
     }
     match (lhs, rhs) {
-        (Value::Null, Value::Null) => true,
+        // An unresolved reference reads as `null` everywhere else, so it
+        // compares equal to one — `select(.pool.members == null)` finds the
+        // virtuals whose pool is missing.
+        (Value::Null | Value::Unresolved(_), Value::Null | Value::Unresolved(_)) => true,
         // A `bool` counts as the matching `int`, so `True == 1`, and
         // numbers compare across int/float/bool by numeric value.
         _ if is_number_like(lhs) && is_number_like(rhs) => num_value(lhs) == num_value(rhs),
@@ -345,7 +355,7 @@ pub fn sort_cmp(a: &Value, b: &Value) -> Ordering {
 
 fn sort_tag(v: &Value) -> u8 {
     match v {
-        Value::Null => 0,
+        Value::Null | Value::Unresolved(_) => 0,
         Value::Bool(_) => 1,
         Value::Int(_) | Value::Float(_) => 2,
         Value::Str(_) | Value::PathRef(_) => 3,

--- a/rust/tcl-bigip-query/tests/integration/eval.rs
+++ b/rust/tcl-bigip-query/tests/integration/eval.rs
@@ -251,8 +251,10 @@ fn merge_resolves_a_deref_into_another_document() {
 }
 
 /// A reference that resolves nowhere in the view is visible, never a silent
-/// empty stream: reading a field through it yields an explicit `null`, and
-/// iterating or subscripting through it is an error that names the path.
+/// empty stream. It reads as `null`, carrying the path that failed so a
+/// further field read or subscript names it, and iterating it is empty
+/// because there is nothing to iterate. Plain `null` keeps its own
+/// semantics — the dangling case does not loosen them.
 #[test]
 fn an_unresolvable_reference_is_never_silent() {
     let sources = [
@@ -262,16 +264,19 @@ fn an_unresolvable_reference_is_never_silent() {
 
     // Without --merge the pool is in the other document and cannot resolve.
     let unmerged = run_conf(".gtm.wideip[] | .pools[] | .members", &sources, false)
-        .expect("an unresolved deref is an explicit null, not an error");
+        .expect("an unresolved deref reads as null, not an error");
     assert_eq!(unmerged.len(), 1, "one value, got {unmerged:?}");
     assert!(
-        matches!(unmerged[0], Value::Null),
-        "explicit null, got {:?}",
+        matches!(unmerged[0], Value::Unresolved(_)),
+        "carries the dangling path, got {:?}",
         unmerged[0]
     );
+    // It renders as null and has no length, so a projection shows the gap.
+    assert_eq!(strings(&unmerged), vec!["null"]);
 
-    let err = run_conf(".gtm.wideip[] | .pools[] | .[]", &sources, false)
-        .expect_err("iterating through an unresolved reference is an error");
+    // Reading on through it names what failed to resolve.
+    let err = run_conf(".gtm.wideip[] | .pools[] | .members.foo", &sources, false)
+        .expect_err("a field read through an unresolved reference is an error");
     assert!(
         err.contains("/Common/gp1") && err.contains("unresolved reference"),
         "the error names the path: {err}"
@@ -279,5 +284,45 @@ fn an_unresolvable_reference_is_never_silent() {
     assert!(
         err.contains("--merge"),
         "with several sources loaded the error points at --merge: {err}"
+    );
+
+    // Iterating it is empty — there is nothing to iterate.
+    let iterated = run_conf(
+        ".gtm.wideip[] | .pools[] | [.members[]] | length",
+        &sources,
+        false,
+    )
+    .expect("iterating an unresolved reference is empty, not an error");
+    assert_eq!(strings(&iterated), vec!["0"]);
+
+    // It compares equal to null, so a query can select the gaps.
+    let selected = run_conf(
+        ".gtm.wideip[] | .pools[] | select(.members == null)",
+        &sources,
+        false,
+    )
+    .expect("an unresolved reference compares equal to null");
+    assert_eq!(strings(&selected), vec!["/Common/gp1"]);
+
+    // An empty reference — no object named at all — contributes nothing at
+    // every kind of step, including an indexed one.
+    let empty = run_conf(
+        r#".ltm.virtual[] | select(.pool == "") | .pool["members"]"#,
+        &[("file:///ltm.conf", LTM_CONF)],
+        false,
+    )
+    .expect("an empty reference is not a dangling one");
+    assert!(empty.is_empty(), "expected no values, got {empty:?}");
+}
+
+/// A plain `null` keeps jq-ish semantics: it refuses to iterate. Only an
+/// unresolved reference iterates empty.
+#[test]
+fn plain_null_still_refuses_to_iterate() {
+    let err =
+        run("null | .[]", &serde_json::json!({}), "json").expect_err("iterating null is an error");
+    assert!(
+        err.contains("cannot iterate null"),
+        "null keeps its own semantics: {err}"
     );
 }

--- a/rust/tcl-bigip-query/tests/integration/eval.rs
+++ b/rust/tcl-bigip-query/tests/integration/eval.rs
@@ -30,6 +30,7 @@ use tcl_bigip_query::eval::{EvalContext, Root, evaluate};
 use tcl_bigip_query::output::render;
 use tcl_bigip_query::parser::parse_query;
 use tcl_bigip_query::value::Value;
+use tcl_bigip_query::{QueryOptions, run_query};
 
 fn json_to_value(j: &J) -> Value {
     match j {
@@ -96,5 +97,187 @@ fn evaluator() {
         failures.len(),
         cases.len(),
         failures.join("\n")
+    );
+}
+
+// Binding, merge-mode dereference, and unresolved-reference behaviour. These
+// drive the full `run_query` runner rather than the JSON-root golden above,
+// because the behaviour they pin lives in the config-backed projection and
+// merge paths.
+
+/// One LTM config: `v1` has a pool, `v2` has none, so `select(.pool != "")`
+/// rejects exactly one virtual.
+const LTM_CONF: &str = "\
+ltm pool /Common/p1 {
+    members {
+        /Common/n1:80 {
+            address 10.0.1.1
+        }
+    }
+}
+
+ltm virtual /Common/v1 {
+    destination /Common/10.0.0.1:80
+    pool /Common/p1
+}
+
+ltm virtual /Common/v2 {
+    destination /Common/10.0.0.2:80
+}
+";
+
+fn run_conf(query: &str, sources: &[(&str, &str)], merge: bool) -> Result<Vec<Value>, String> {
+    let owned: Vec<(String, String)> = sources
+        .iter()
+        .map(|(u, s)| ((*u).to_owned(), (*s).to_owned()))
+        .collect();
+    let opts = QueryOptions {
+        merge,
+        ..QueryOptions::default()
+    };
+    let result = run_query(query, &owned, &opts).map_err(|e| e.to_string())?;
+    Ok(result
+        .values_per_file
+        .iter()
+        .flat_map(|(_, vals)| vals.iter().cloned())
+        .collect())
+}
+
+fn strings(values: &[Value]) -> Vec<String> {
+    values
+        .iter()
+        .map(|v| match v {
+            Value::Str(s) => s.clone(),
+            Value::PathRef(p) => p.full_path.clone(),
+            other => tcl_bigip_query::jsonfmt::to_pretty(other),
+        })
+        .collect()
+}
+
+/// `select(...) as $v | body` skips a rejected item exactly as `|` does.
+///
+/// `select` rejects by returning the internal `Drop` sentinel, which must
+/// never reach the bound name: the item is skipped and the body does not run
+/// for it.
+#[test]
+fn select_drop_short_circuits_an_as_binding() {
+    let sources = [("file:///ltm.conf", LTM_CONF)];
+    let bound = run_conf(
+        r#".ltm.virtual[] | select(.pool != "") as $vs | $vs.name"#,
+        &sources,
+        false,
+    )
+    .expect("the binding skips the dropped virtual instead of binding Drop");
+    assert_eq!(strings(&bound), vec!["v1"]);
+
+    // The binding form and the plain-pipe form it mirrors must agree.
+    let piped = run_conf(
+        r#".ltm.virtual[] | select(.pool != "") | .name"#,
+        &sources,
+        false,
+    )
+    .expect("run");
+    assert_eq!(strings(&bound), strings(&piped));
+
+    // A binding whose whole source is dropped yields nothing, not an error.
+    let none = run_conf(
+        r#".ltm.virtual[] | select(.pool == "nope") as $vs | $vs.name"#,
+        &sources,
+        false,
+    )
+    .expect("an all-dropped source is an empty stream");
+    assert!(none.is_empty(), "expected no values, got {none:?}");
+}
+
+// A GTM wideip whose pool lives in a *different* document — the reference
+// crosses a document boundary, so it only resolves when the merged view is
+// consulted.
+const GTM_WIDEIP_CONF: &str = "\
+gtm wideip a /Common/www.example.com {
+    pools {
+        /Common/gp1 { }
+    }
+}
+";
+
+const GTM_POOL_CONF: &str = "\
+gtm pool a /Common/gp1 {
+    members {
+        /Common/srv1:/Common/vs1 {
+            order 0
+        }
+    }
+}
+";
+
+/// Under `--merge` a dereference resolves against the merged view at every
+/// hop, not just the root that happens to be iterating.
+///
+/// Merge mode evaluates each statement once per root. The wideip is only in
+/// the first document, so it is produced during that root's turn — at which
+/// point its `pools` reference points into the *second* document.
+#[test]
+fn merge_resolves_a_deref_into_another_document() {
+    let sources = [
+        ("file:///gtm-wideip.conf", GTM_WIDEIP_CONF),
+        ("file:///gtm-pool.conf", GTM_POOL_CONF),
+    ];
+
+    let merged = run_conf(
+        ".gtm.wideip[] | .pools[] | .members[] | .name",
+        &sources,
+        true,
+    )
+    .expect("the cross-document pool resolves under --merge");
+    assert_eq!(strings(&merged), vec!["/Common/srv1:/Common/vs1"]);
+
+    // Same chain behind an `as` binding: the binding keeps the merged view.
+    let bound = run_conf(
+        ".gtm.wideip[] as $w | $w.pools[] | .members[] | .name",
+        &sources,
+        true,
+    )
+    .expect("the binding does not lose the merged view");
+    assert_eq!(strings(&bound), strings(&merged));
+
+    // And a further hop off the resolved object still resolves.
+    let deeper = run_conf(
+        ".gtm.wideip[] | .pools[] | .members[] | .order",
+        &sources,
+        true,
+    )
+    .expect("a third hop resolves too");
+    assert_eq!(strings(&deeper), vec!["0"]);
+}
+
+/// A reference that resolves nowhere in the view is visible, never a silent
+/// empty stream: reading a field through it yields an explicit `null`, and
+/// iterating or subscripting through it is an error that names the path.
+#[test]
+fn an_unresolvable_reference_is_never_silent() {
+    let sources = [
+        ("file:///gtm-wideip.conf", GTM_WIDEIP_CONF),
+        ("file:///gtm-pool.conf", GTM_POOL_CONF),
+    ];
+
+    // Without --merge the pool is in the other document and cannot resolve.
+    let unmerged = run_conf(".gtm.wideip[] | .pools[] | .members", &sources, false)
+        .expect("an unresolved deref is an explicit null, not an error");
+    assert_eq!(unmerged.len(), 1, "one value, got {unmerged:?}");
+    assert!(
+        matches!(unmerged[0], Value::Null),
+        "explicit null, got {:?}",
+        unmerged[0]
+    );
+
+    let err = run_conf(".gtm.wideip[] | .pools[] | .[]", &sources, false)
+        .expect_err("iterating through an unresolved reference is an error");
+    assert!(
+        err.contains("/Common/gp1") && err.contains("unresolved reference"),
+        "the error names the path: {err}"
+    );
+    assert!(
+        err.contains("--merge"),
+        "with several sources loaded the error points at --merge: {err}"
     );
 }


### PR DESCRIPTION
## Summary

- **`select(...) as $v` bound the Drop sentinel.** `select` rejects an item by returning the evaluator-internal `Drop` value. The pipe operator short-circuits it; the `as` binding did not, so the body's first field access failed with ``cannot read field "name" on Drop``. `eval_let_binding` now short-circuits `Drop` the same way: a `Drop` source yields an empty stream and a `Drop` item never binds. The binding form and the plain-pipe form now agree.

- **Under `--merge`, a dereference resolved against one root only.** Merge mode evaluates each statement once per root, and `resolve_pathref` consulted just the iterating root. A GTM wideip's `pools[]` reference therefore found nothing while the LTM config was current, and the rest of the pipeline drained silently. `EvalContext::resolve_pathref` now tries the iterating root, then falls back across the remaining merge roots, so every hop of a chain may land in a different source. Non-merge mode stays scoped to the iterating config. `source_file()` uses the same resolution.

- **An unresolvable reference is no longer silent.** `Value::Unresolved` carries the path that failed to resolve. It renders as `null`, compares equal to `null`, is falsy and has length `0`, so a projection shows the gap rather than a vanished field. Reading a field or subscripting through it names the dangling path. Iterating it is empty, because a reference naming nothing has nothing to iterate. An empty reference (`pool none`) contributes nothing at every kind of step.

Behaviour on `samples/for_f5_query/`:

| Query | Before | After |
| --- | --- | --- |
| `.ltm.virtual[] \| select(.pool != "") as $vs \| $vs.name` | error on Drop | 5 virtuals, matching the pipe form |
| `--merge` wideip → pool → members | 3 values (one root only) | 6 values (both roots) |

The rules are documented in the DSL help (`--help-dsl`) and in `docs/references/f5_query/dsl.md`. `docs/f5-query-examples.md` is untouched.

Two goldens move. `query-ex21` because a virtual with a dangling pool now sorts by length 0 rather than by a key that vanished, and `query_help_dsl` because of the added help text.

Six regression tests sit beside the existing evaluator tests in `rust/tcl-bigip-query/tests/integration/eval.rs`, including one pinning that plain `null` still refuses to iterate. Each was confirmed to fail with its fix reverted.

## Review findings

Both P2 findings from the Codex review are fixed in 980d59d and their threads resolved.

1. *Preserve errors when iterating ordinary null values.* Correct — the first cut made every `null` iterable to serve one reference-specific case, so `null | .[]` and a nullable JSON field stopped reporting malformed data. `Value::Unresolved` carries the provenance instead, and plain `null` keeps its own semantics. A test pins that.
2. *Short-circuit indexed access on empty references.* Correct — `.ltm.virtual[].pool["members"]` on a virtual with no pool aborted with an error naming an empty path, contradicting the documented contract. The indexed-subscript branch now matches the other branches.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

```
make rust-check                 # exit 0
cargo build --workspace         # clean
cargo test -p tcl-bigip-query   # 69 + 71 passed
cargo test -p f5-cli            # all 20 suites green
```

Adding a `Value` variant also required an arm in `rust/bigip-report-gen`, which serialises engine values to JSON; an unresolved reference serialises as `null` there.

## Compiler / diagnostics checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? No — this is the `f5 query` DSL evaluator, not the Tcl compiler.
- [x] If yes, I updated the owning design doc. Not applicable; the owning reference `docs/references/f5_query/dsl.md` is updated for the dereference-resolution and unresolved-reference rules.
- [x] If I added or changed a diagnostic or optimisation code, I updated its page under `docs/kcs/codes/`. No diagnostic or optimisation codes were added or changed.
- [x] If I added a design doc, I linked it from `docs/design/README.md`. No new design doc.

## Follow-up

Three more sites lose the merged view the same way, each confirmed by hand and left for a follow-up PR rather than widening this one:

1. `check_partition_visibility()` reports nothing under `--merge` when the referrer and target are in different sources.
2. `rename()`'s cross-partition safety pre-check passes under `--merge` and performs a rename that breaks a cross-file reference, where the single-file case correctly refuses.
3. `.ltm.rule[].refs.*` is empty under `--merge` when the referenced object is in a sibling source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018HbjKxAeKV3ccJXLnke8jM