### PR TITLE
opt: a bracketed tail-call argument is one argument (O122)

### DIFF
--- a/docs/design/compiler/tail-call-recursion-optimisation.md
+++ b/docs/design/compiler/tail-call-recursion-optimisation.md
@@ -21,7 +21,11 @@ O122 subsumes O121 — when a proc is fully tail-recursive (all self-calls are i
 
 2. **O121 fires when** — for each self-call in tail position. `optimise_tail_calls` emits an O121 candidate at every tail-position self-call; these may later be suppressed when a higher-priority O122 covers the same range. The rewrite wraps the tail call with `tailcall`.
 
-3. **O122 fires when** — every self-call in the proc is in tail position, the proc has at least one parameter, every tail site passes exactly one argument per parameter as the pass reads it, and — for a proc with more than one parameter — the dialect has `lassign` (Tcl 8.5+). The entire proc body is rewritten to an iterative `while {1}` loop with parameter reassignment in place of each recursive call. A `return [f …]` site whose arguments contain a nested `[…]` substitution is not read as one argument per parameter, so such a proc gets O121 only (see the GCD example).
+3. **O122 fires when** — every self-call in the proc is in tail position, the proc has at least one parameter, every tail site passes exactly one argument per parameter, and — for a proc with more than one parameter — the dialect has `lassign` (Tcl 8.5+). The entire proc body is rewritten to an iterative `while {1}` loop with parameter reassignment in place of each recursive call.
+
+   Arguments are counted as Tcl words, so a bracketed argument such as `[expr {$n - 1}]` is **one** argument. A tail site that expands its arguments with `{*}`, or whose value holds more than one command, has no statically known arity and stands down to O121.
+
+   Tail position is judged across the whole body, conditions included: a self-call in an `if` / `while` / `for` condition or a `switch` subject is not in tail position, and the loop body would still evaluate it recursively, so it blocks the conversion.
 
 4. **O123 fires when** — exactly one non-tail self-call appears embedded in a return value (e.g. inside an `expr` or nested command substitution). This is a hint-only diagnostic; no source rewrite is produced. The hint indicates the recursion could be made tail-recursive by introducing an accumulator parameter. Doubly-recursive patterns (two or more self-calls in the same expression) are excluded.
 
@@ -31,7 +35,7 @@ O122 subsumes O121 — when a proc is fully tail-recursive (all self-calls are i
 
 ## Examples
 
-### GCD — `return [gcd …]` with a nested substitution (O121)
+### GCD — tail-recursive `if`/`else` (O122)
 
 **Before:**
 ```tcl
@@ -44,37 +48,39 @@ proc gcd {a b} {
 }
 ```
 
-**After (O121 rewrite):**
+**After (O122 rewrite):**
 ```tcl
 proc gcd {a b} {
-    if {$b == 0} {
-        return $a
-    } else {
-        tailcall gcd $b [expr {$a % $b}]
+    while {1} {
+        if {$b == 0} {
+            return $a
+        } else {
+            lassign [list $b [expr {$a % $b}]] a b
+        }
     }
 }
 ```
 
-### Two-parameter tail recursion — plain arguments (O122)
+### Factorial with accumulator — every argument bracketed (O122)
 
 **Before:**
 ```tcl
-proc g {a b} {
-    if {$b == 0} {
-        return $a
+proc fact {n acc} {
+    if {$n <= 1} {
+        return $acc
     }
-    return [g $b $a]
+    return [fact [expr {$n - 1}] [expr {$n * $acc}]]
 }
 ```
 
 **After (O122 rewrite):**
 ```tcl
-proc g {a b} {
+proc fact {n acc} {
     while {1} {
-        if {$b == 0} {
-            return $a
+        if {$n <= 1} {
+            return $acc
         }
-        lassign [list $b $a] a b
+        lassign [list [expr {$n - 1}] [expr {$n * $acc}]] n acc
     }
 }
 ```
@@ -110,7 +116,7 @@ proc factorial {n} {
 }
 ```
 
-O123 emits: *"Non-tail recursion in factorial could be eliminated by introducing an accumulator parameter and using tailcall."*
+O123 emits: *"Proc 'factorial' is a candidate for accumulator-style rewriting"* — the hint is that an accumulator parameter would put the recursive call in tail position, where O121 or O122 could take it.
 
 No source rewrite is produced (`hint_only: true`).
 

--- a/docs/kcs/codes/kcs-optimisation-o122-tail-recursion-to-while.md
+++ b/docs/kcs/codes/kcs-optimisation-o122-tail-recursion-to-while.md
@@ -43,8 +43,9 @@ with several parameters reassigns them together with `lassign`.
 
 ## Safety conditions
 
-- Skipped when the proc contains multiple recursive call sites or uses `uplevel`, `upvar`, or other stack-sensitive commands.
-- Skipped when a recursive call passes a different number of arguments than the proc declares.
+- Skipped when any self-call is **not** in tail position, including one in an `if` / `while` / `for` condition or a `switch` subject — the loop body would still evaluate that call recursively.
+- Skipped when a recursive call passes a different number of arguments than the proc declares. A bracketed argument such as `[expr {$n - 1}]` is one argument.
+- Skipped when a recursive call expands its arguments with `{*}`, whose word count is not known until runtime.
 - Skipped on Tcl 8.4 for a proc with more than one parameter, which has no `lassign` to reassign them.
 
 ## How to disable

--- a/docs/kcs/codes/kcs-optimisation-o122-tail-recursion-to-while.md
+++ b/docs/kcs/codes/kcs-optimisation-o122-tail-recursion-to-while.md
@@ -43,7 +43,7 @@ with several parameters reassigns them together with `lassign`.
 
 ## Safety conditions
 
-- Skipped when any self-call is **not** in tail position, including one in an `if` / `while` / `for` condition or a `switch` subject — the loop body would still evaluate that call recursively.
+- Skipped when any self-call is **not** in [tail position](../../GLOSSARY.md#tail-position), including one in an `if` / `while` / `for` condition or a `switch` subject — the loop body would still evaluate that call recursively.
 - Skipped when a recursive call passes a different number of arguments than the proc declares. A bracketed argument such as `[expr {$n - 1}]` is one argument.
 - Skipped when a recursive call expands its arguments with `{*}`, whose word count is not known until runtime.
 - Skipped on Tcl 8.4 for a proc with more than one parameter, which has no `lassign` to reassign them.

--- a/rust/tcl-compiler/src/optimiser/tail_call.rs
+++ b/rust/tcl-compiler/src/optimiser/tail_call.rs
@@ -25,10 +25,13 @@
 //!   - **bare call**: `proc f {…} { …; f $args }` — the
 //!     self-call is the final statement of the body.
 //!   - **return substitution**: `return [f $args]`.
-//! - **O122** (hint-only) — "Convert self-recursion to a
-//!   `while` loop". Fires when every self-call in the proc body
-//!   is in tail position (the total count of self-calls equals
-//!   the number of tail-position calls).
+//! - **O122** — "Convert self-recursion to a `while` loop". A
+//!   real source rewrite, not a hint: the whole proc is replaced
+//!   with a `while {1}` body whose recursive call becomes a
+//!   parameter reassignment. Fires when every self-call in the
+//!   proc body is in tail position (the total count of self-calls
+//!   equals the number of tail-position calls) and every one of
+//!   them passes exactly one argument per parameter.
 //! - **O123** (hint-only) — "Accumulator-eligible non-tail
 //!   self-recursion". Fires when there is at least one non-tail
 //!   self-call inside an expression body (e.g., `return [expr
@@ -89,7 +92,7 @@ pub fn run(ctx: &mut PassContext<'_>, cu: &CompilationUnit) {
         let mut sites: Vec<TailSite> = Vec::new();
         collect_tail_sites(ctx, &proc.body, &self_names, proc, &mut sites, emit_o121, 0);
 
-        let total_self_calls = count_self_calls_in_script(&proc.body, &self_names);
+        let total_self_calls = count_self_calls_in_script(ctx.source, &proc.body, &self_names);
         if !sites.is_empty() && sites.len() == total_self_calls {
             // O122: every self-call is in tail position. Emit a
             // real source rewrite — restructure the proc body as
@@ -127,8 +130,12 @@ pub fn run(ctx: &mut PassContext<'_>, cu: &CompilationUnit) {
 struct TailSite {
     /// Absolute source span of the tail-call statement.
     span: tcl_lexer::Span,
-    /// Raw argument texts passed to the recursive call.
-    args: Vec<String>,
+    /// The words passed to the recursive call, one entry per
+    /// argument. `None` when the arguments could not be split into
+    /// words with a fixed arity — a `{*}` expansion, or a value
+    /// holding more than one command — which makes the O122 loop
+    /// conversion unsafe.
+    args: Option<Vec<String>>,
 }
 
 /// Produce the replacement parameter reassignment for a tail
@@ -170,7 +177,11 @@ fn emit_loop_conversion(
     // Every tail-call site must pass exactly `params.len()` args
     // — otherwise the loop conversion would lose information.
     for site in sites {
-        if site.args.len() != proc.params.len() {
+        if site
+            .args
+            .as_ref()
+            .is_none_or(|args| args.len() != proc.params.len())
+        {
             return;
         }
     }
@@ -199,7 +210,10 @@ fn emit_loop_conversion(
         }
         let rel_start = site_range.start - body_start_abs;
         let rel_end = site_range.end - body_start_abs;
-        let reassign = make_reassignment(&proc.params, &site.args);
+        let Some(args) = &site.args else {
+            return;
+        };
+        let reassign = make_reassignment(&proc.params, args);
         modified.replace_range(rel_start..rel_end, &reassign);
     }
 
@@ -238,27 +252,56 @@ fn emit_loop_conversion(
     ));
 }
 
-/// Count every textual reference to a self-name across the
-/// script (tail, non-tail, inside conditions, inside argument
-/// substitutions). Uses the source-level argument text to catch
-/// `[self …]` substitutions the IR does not parse into a Call.
-fn count_self_calls_in_script(script: &Script, self_names: &HashSet<String>) -> usize {
+/// Count every textual reference to a self-name across the script — tail,
+/// non-tail, inside conditions, inside argument substitutions.  Reads the
+/// source-level argument text to catch `[self …]` substitutions the IR does
+/// not parse into a Call.
+///
+/// This is O122's safety gate: the loop conversion fires only when the count
+/// equals the number of tail-position sites, i.e. when nothing recurses
+/// outside a tail call.  A control-flow condition is not a tail position and
+/// the loop body would still evaluate it, so `if {[f $n]} …` counts.
+/// Conditions live in the IR as a parsed `ExprNode` rather than argument
+/// text, hence the count from their source slice.
+fn count_self_calls_in_script(
+    source: &str,
+    script: &Script,
+    self_names: &HashSet<String>,
+) -> usize {
     let mut count = 0;
-    count_self_calls_in_script_impl(script, self_names, &mut count);
+    count_self_calls_in_script_impl(source, script, self_names, &mut count);
     count
 }
 
 fn count_self_calls_in_script_impl(
+    source: &str,
     script: &Script,
     self_names: &HashSet<String>,
     count: &mut usize,
 ) {
     for stmt in &script.statements {
-        count_self_calls_in_stmt(stmt, self_names, count);
+        count_self_calls_in_stmt(source, stmt, self_names, count);
     }
 }
 
-fn count_self_calls_in_stmt(stmt: &Statement, self_names: &HashSet<String>, count: &mut usize) {
+/// Count self-calls in the source text covered by `span`, for the IR nodes
+/// — expression conditions — that keep no argument text.
+fn count_self_calls_in_span(
+    source: &str,
+    span: tcl_lexer::Span,
+    self_names: &HashSet<String>,
+) -> usize {
+    source
+        .get(span.as_range())
+        .map_or(0, |text| count_bracket_self_calls(text, self_names))
+}
+
+fn count_self_calls_in_stmt(
+    source: &str,
+    stmt: &Statement,
+    self_names: &HashSet<String>,
+    count: &mut usize,
+) {
     match stmt {
         Statement::Call { command, args, .. } => {
             if self_names.contains(command) {
@@ -282,23 +325,45 @@ fn count_self_calls_in_stmt(stmt: &Statement, self_names: &HashSet<String>, coun
             clauses, else_body, ..
         } => {
             for c in clauses {
-                count_self_calls_in_script_impl(&c.body, self_names, count);
+                *count += count_self_calls_in_span(source, c.condition_span, self_names);
+                count_self_calls_in_script_impl(source, &c.body, self_names, count);
             }
             if let Some(eb) = else_body {
-                count_self_calls_in_script_impl(eb, self_names, count);
+                count_self_calls_in_script_impl(source, eb, self_names, count);
             }
         }
         Statement::For {
-            init, next, body, ..
+            init,
+            next,
+            body,
+            condition_span,
+            ..
         } => {
-            count_self_calls_in_script_impl(init, self_names, count);
-            count_self_calls_in_script_impl(next, self_names, count);
-            count_self_calls_in_script_impl(body, self_names, count);
+            *count += count_self_calls_in_span(source, *condition_span, self_names);
+            count_self_calls_in_script_impl(source, init, self_names, count);
+            count_self_calls_in_script_impl(source, next, self_names, count);
+            count_self_calls_in_script_impl(source, body, self_names, count);
         }
-        Statement::While { body, .. }
-        | Statement::Catch { body, .. }
-        | Statement::Foreach { body, .. } => {
-            count_self_calls_in_script_impl(body, self_names, count);
+        Statement::While {
+            body,
+            condition_span,
+            ..
+        } => {
+            *count += count_self_calls_in_span(source, *condition_span, self_names);
+            count_self_calls_in_script_impl(source, body, self_names, count);
+        }
+        Statement::Foreach {
+            body, iterators, ..
+        } => {
+            for it in iterators {
+                if !it.list_braced {
+                    *count += count_bracket_self_calls(&it.list_arg, self_names);
+                }
+            }
+            count_self_calls_in_script_impl(source, body, self_names, count);
+        }
+        Statement::Catch { body, .. } => {
+            count_self_calls_in_script_impl(source, body, self_names, count);
         }
         Statement::Try {
             body,
@@ -306,24 +371,31 @@ fn count_self_calls_in_stmt(stmt: &Statement, self_names: &HashSet<String>, coun
             finally_body,
             ..
         } => {
-            count_self_calls_in_script_impl(body, self_names, count);
+            count_self_calls_in_script_impl(source, body, self_names, count);
             for h in handlers {
-                count_self_calls_in_script_impl(&h.body, self_names, count);
+                count_self_calls_in_script_impl(source, &h.body, self_names, count);
             }
             if let Some(fb) = finally_body {
-                count_self_calls_in_script_impl(fb, self_names, count);
+                count_self_calls_in_script_impl(source, fb, self_names, count);
             }
         }
         Statement::Switch {
-            arms, default_body, ..
+            arms,
+            default_body,
+            subject,
+            subject_braced,
+            ..
         } => {
+            if !*subject_braced {
+                *count += count_bracket_self_calls(subject, self_names);
+            }
             for a in arms {
                 if let Some(b) = &a.body {
-                    count_self_calls_in_script_impl(b, self_names, count);
+                    count_self_calls_in_script_impl(source, b, self_names, count);
                 }
             }
             if let Some(db) = default_body {
-                count_self_calls_in_script_impl(db, self_names, count);
+                count_self_calls_in_script_impl(source, db, self_names, count);
             }
         }
         _ => {}
@@ -561,7 +633,7 @@ fn collect_tail_sites(
             }
             sites.push(TailSite {
                 span: rewrite_span,
-                args: args.clone(),
+                args: (!args.iter().any(|a| a.starts_with("{*}"))).then(|| args.clone()),
             });
         }
         Statement::Return {
@@ -595,10 +667,13 @@ fn collect_tail_sites(
                         replacement,
                     ));
                 }
-                let split_args: Vec<String> = if call_args.is_empty() {
-                    Vec::new()
+                let split_args = if call_args.is_empty() {
+                    Some(Vec::new())
                 } else {
-                    call_args.split_whitespace().map(str::to_owned).collect()
+                    split_top_level_words(
+                        &call_args,
+                        tcl_lexer::LexerConfig::for_profile(ctx.dialect),
+                    )
                 };
                 sites.push(TailSite {
                     span: rewrite_span,
@@ -630,6 +705,49 @@ fn collect_tail_sites(
         }
         _ => {}
     }
+}
+
+/// Split a command's argument text into its top-level Tcl words.
+///
+/// One entry per argument, which is what O122's one-argument-per-parameter
+/// gate counts: `[expr {$n - 1}] [expr {$acc * $n}]` is two arguments, not
+/// eight.  Grouping the lexer's own tokens into words keeps a `{…}`, `[…]`
+/// or `"…"` word intact where splitting on whitespace would count its
+/// inner spaces.
+///
+/// `None` when the arity is not statically known — a `{*}` expansion, whose
+/// runtime word count is unbounded, or more than one command, from a
+/// newline inside the substitution.  The gate refuses a site it cannot
+/// count rather than rewrite it against a wrong arity.
+fn split_top_level_words(text: &str, config: tcl_lexer::LexerConfig) -> Option<Vec<String>> {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return Some(Vec::new());
+    }
+    let tokens = tcl_lexer::Lexer::with_config(trimmed, config)
+        .tokenise_all()
+        .ok()?;
+    let commands = tcl_lexer::group_commands(&tokens, trimmed, config);
+    let [command] = commands.as_slice() else {
+        return None;
+    };
+    if !command.expand_markers.is_empty() {
+        return None;
+    }
+    let sm = tcl_lexer::SourceMap::new(trimmed);
+    command
+        .words
+        .iter()
+        .map(|word| {
+            // The lexer's inner-end convention leaves a delimited word's
+            // closer outside the token span; `word_span` puts it back.
+            let last = *tokens.get(word.tokens.end.checked_sub(1)?)?;
+            let end = tcl_lexer::word_span(&sm, last).end().max(word.span.end());
+            trimmed
+                .get(word.span.start() as usize..end as usize)
+                .map(str::to_owned)
+        })
+        .collect()
 }
 
 /// Parse a `return` value's text looking for a `[cmd args…]`
@@ -717,12 +835,12 @@ mod tests {
     /// Regression coverage for issue #996: `collect_tail_sites` and the
     /// mutually-recursive `non_tail_self_call_in_expression`/
     /// `non_tail_in_stmt` pair recurse once per nested `if`/`for`/`while`/
-    /// `foreach`/`catch`/`try`/`switch` body, with no depth cap of their
-    /// own before this fix. Transitively bounded to `MAX_LOWER_NEST_DEPTH`
+    /// `foreach`/`catch`/`try`/`switch` body, and carry their own depth
+    /// cap. Transitively bounded to `MAX_LOWER_NEST_DEPTH`
     /// (256) by the lowering pass today, so this is defence-in-depth /
     /// consistency with every other full-tree walker in this crate, not a
     /// currently-reproducible crash. 1000 levels of source nesting is
-    /// comfortably past this new cap; the assertion is that `run_pass`
+    /// comfortably past that cap; the assertion is that `run_pass`
     /// returns at all, not what it returns. Spawns its own big-stack
     /// thread since the lexer/CST/segmenter stages upstream of the
     /// lowering cap still walk the full un-truncated source nesting before
@@ -977,7 +1095,7 @@ mod tests {
             .iter()
             .find(|o| o.code == DiagCode::O122)
             .expect("O122 should fire");
-        assert!(!opt.hint_only, "O122 should now be a real rewrite");
+        assert!(!opt.hint_only, "O122 is a real rewrite, not a hint");
         assert!(
             opt.replacement.contains("while {1}"),
             "expected while-loop replacement, got {:?}",
@@ -1006,6 +1124,107 @@ mod tests {
             "expected lassign for multi-param reassignment, got {:?}",
             opt.replacement,
         );
+    }
+
+    #[test]
+    fn o122_fires_when_return_subst_args_are_bracketed_words() {
+        // `return [fact [expr …] [expr …]]` passes two arguments, so the
+        // one-argument-per-parameter gate holds and the whole proc becomes
+        // a loop. Each bracketed word must survive the rewrite whole.
+        let opts = run_pass(
+            "proc fact {n acc} {\n    if {$n <= 1} { return $acc }\n    return [fact [expr {$n - 1}] [expr {$acc * $n}]]\n}",
+        );
+        let opt = opts
+            .iter()
+            .find(|o| o.code == DiagCode::O122)
+            .expect("O122 should fire for bracketed return-substitution args");
+        assert!(
+            opt.replacement
+                .contains("lassign [list [expr {$n - 1}] [expr {$acc * $n}]] n acc"),
+            "expected both bracketed words kept whole, got {:?}",
+            opt.replacement,
+        );
+    }
+
+    #[test]
+    fn o122_fires_for_gcd_shape_with_one_bracketed_arg() {
+        // Mixed plain / bracketed words — the design doc's GCD example.
+        let opts = run_pass(
+            "proc gcd {a b} {\n    if {$b == 0} {\n        return $a\n    } else {\n        return [gcd $b [expr {$a % $b}]]\n    }\n}",
+        );
+        let opt = opts
+            .iter()
+            .find(|o| o.code == DiagCode::O122)
+            .expect("O122 should fire for the GCD shape");
+        assert!(
+            opt.replacement
+                .contains("lassign [list $b [expr {$a % $b}]] a b"),
+            "expected two words for `$b [expr …]`, got {:?}",
+            opt.replacement,
+        );
+    }
+
+    #[test]
+    fn split_top_level_words_counts_bracketed_words_as_one() {
+        let config = tcl_lexer::LexerConfig::default();
+        assert_eq!(
+            split_top_level_words("[expr {$n - 1}] [expr {$acc * $n}]", config),
+            Some(vec![
+                "[expr {$n - 1}]".to_owned(),
+                "[expr {$acc * $n}]".to_owned(),
+            ]),
+        );
+        assert_eq!(
+            split_top_level_words("$b [expr {$a % $b}]", config),
+            Some(vec!["$b".to_owned(), "[expr {$a % $b}]".to_owned()]),
+        );
+        assert_eq!(
+            split_top_level_words("{a b} \"c d\" e", config),
+            Some(vec![
+                "{a b}".to_owned(),
+                "\"c d\"".to_owned(),
+                "e".to_owned(),
+            ]),
+        );
+        assert_eq!(split_top_level_words("   ", config), Some(Vec::new()));
+        // A `{*}` expansion has no statically known arity.
+        assert_eq!(split_top_level_words("{*}$args $b", config), None);
+    }
+
+    #[test]
+    fn o122_suppressed_when_tail_call_expands_its_args() {
+        // `{*}` makes the runtime word count unknown, so the loop
+        // conversion must stand down and leave O121 in place.
+        let opts = run_pass(
+            "proc f {a b} {\n    if {$a == 0} { return $b }\n    return [f {*}[list [expr {$a - 1}] $b]]\n}",
+        );
+        assert!(
+            opts.iter().all(|o| o.code != DiagCode::O122),
+            "O122 must not fire on a `{{*}}`-expanded tail call, got {opts:?}",
+        );
+        assert!(
+            opts.iter().any(|o| o.code == DiagCode::O121),
+            "O121 should still fire, got {opts:?}",
+        );
+    }
+
+    #[test]
+    fn o122_suppressed_when_a_self_call_sits_in_a_control_condition() {
+        // A condition is not a tail position: the loop body still
+        // evaluates it, so the recursion inside it would survive the
+        // conversion. Every one of these shapes must keep O122 out.
+        for src in [
+            "proc f {n} {\n    if {[f $n]} {\n        return [f [expr {$n - 1}]]\n    } else {\n        return $n\n    }\n}",
+            "proc f {n} {\n    while {[f $n]} {\n        return [f [expr {$n - 1}]]\n    }\n    return $n\n}",
+            "proc f {n} {\n    for {set i 0} {[f $n]} {incr i} {\n        return [f [expr {$n - 1}]]\n    }\n    return $n\n}",
+            "proc f {n} {\n    switch [f [expr {$n - 1}]] {\n        0 { return 0 }\n        default { return [f [expr {$n - 2}]] }\n    }\n}",
+        ] {
+            let opts = run_pass(src);
+            assert!(
+                opts.iter().all(|o| o.code != DiagCode::O122),
+                "O122 must not fire with a self-call in a control condition: {src}\ngot {opts:?}",
+            );
+        }
     }
 
     #[test]

--- a/rust/tcl-compiler/src/optimiser/tail_call.rs
+++ b/rust/tcl-compiler/src/optimiser/tail_call.rs
@@ -670,8 +670,8 @@ fn collect_tail_sites(
                 let split_args = if call_args.is_empty() {
                     Some(Vec::new())
                 } else {
-                    split_top_level_words(
-                        &call_args,
+                    split_call_arguments(
+                        &format!("{call_head} {call_args}"),
                         tcl_lexer::LexerConfig::for_profile(ctx.dialect),
                     )
                 };
@@ -707,19 +707,24 @@ fn collect_tail_sites(
     }
 }
 
-/// Split a command's argument text into its top-level Tcl words.
+/// Split a whole command's text into its top-level Tcl words, the command
+/// name first.
 ///
-/// One entry per argument, which is what O122's one-argument-per-parameter
-/// gate counts: `[expr {$n - 1}] [expr {$acc * $n}]` is two arguments, not
-/// eight.  Grouping the lexer's own tokens into words keeps a `{…}`, `[…]`
-/// or `"…"` word intact where splitting on whitespace would count its
+/// One entry per word, which is what O122's one-argument-per-parameter gate
+/// counts: `f [expr {$n - 1}] [expr {$acc * $n}]` is three words, not nine.
+/// Grouping the lexer's own tokens into words keeps a `{…}`, `[…]`, `"…"`
+/// or `${…}` word intact where splitting on whitespace would count its
 /// inner spaces.
+///
+/// The text must start at the command name, not at the first argument: a
+/// word is lexed according to its position, so an argument such as `#stop`
+/// is a comment at command position and an ordinary word after one.
 ///
 /// `None` when the arity is not statically known — a `{*}` expansion, whose
 /// runtime word count is unbounded, or more than one command, from a
 /// newline inside the substitution.  The gate refuses a site it cannot
 /// count rather than rewrite it against a wrong arity.
-fn split_top_level_words(text: &str, config: tcl_lexer::LexerConfig) -> Option<Vec<String>> {
+fn split_command_words(text: &str, config: tcl_lexer::LexerConfig) -> Option<Vec<String>> {
     let trimmed = text.trim();
     if trimmed.is_empty() {
         return Some(Vec::new());
@@ -734,20 +739,36 @@ fn split_top_level_words(text: &str, config: tcl_lexer::LexerConfig) -> Option<V
     if !command.expand_markers.is_empty() {
         return None;
     }
-    let sm = tcl_lexer::SourceMap::new(trimmed);
     command
         .words
         .iter()
         .map(|word| {
             // The lexer's inner-end convention leaves a delimited word's
-            // closer outside the token span; `word_span` puts it back.
-            let last = *tokens.get(word.tokens.end.checked_sub(1)?)?;
-            let end = tcl_lexer::word_span(&sm, last).end().max(word.span.end());
+            // closer outside the span. `word_span_at` puts it back for every
+            // delimited form, `${name}` included — its token-based sibling
+            // knows only `{`, `[` and `"` openers and would cut `${n}` back
+            // to `${n`.
+            let end = tcl_lexer::word_span_at(trimmed, word.span)
+                .end()
+                .max(word.span.end());
             trimmed
                 .get(word.span.start() as usize..end as usize)
                 .map(str::to_owned)
         })
         .collect()
+}
+
+/// The arguments of a self-call, one entry per argument, or `None` when
+/// their arity is not statically known. Splits the whole command so each
+/// word is lexed in the position it actually occupies, then drops the
+/// command name.
+fn split_call_arguments(command_text: &str, config: tcl_lexer::LexerConfig) -> Option<Vec<String>> {
+    let mut words = split_command_words(command_text, config)?;
+    if words.is_empty() {
+        return None;
+    }
+    words.remove(0);
+    Some(words)
 }
 
 /// Parse a `return` value's text looking for a `[cmd args…]`
@@ -1165,30 +1186,40 @@ mod tests {
     }
 
     #[test]
-    fn split_top_level_words_counts_bracketed_words_as_one() {
+    fn split_call_arguments_keeps_each_word_whole() {
         let config = tcl_lexer::LexerConfig::default();
+        let args = |text: &str| split_call_arguments(text, config);
         assert_eq!(
-            split_top_level_words("[expr {$n - 1}] [expr {$acc * $n}]", config),
+            args("f [expr {$n - 1}] [expr {$acc * $n}]"),
             Some(vec![
                 "[expr {$n - 1}]".to_owned(),
                 "[expr {$acc * $n}]".to_owned(),
             ]),
         );
         assert_eq!(
-            split_top_level_words("$b [expr {$a % $b}]", config),
+            args("f $b [expr {$a % $b}]"),
             Some(vec!["$b".to_owned(), "[expr {$a % $b}]".to_owned()]),
         );
         assert_eq!(
-            split_top_level_words("{a b} \"c d\" e", config),
+            args("f {a b} \"c d\" e"),
             Some(vec![
                 "{a b}".to_owned(),
                 "\"c d\"".to_owned(),
                 "e".to_owned(),
             ]),
         );
-        assert_eq!(split_top_level_words("   ", config), Some(Vec::new()));
+        // A braced variable reference keeps its closing brace: `${n}` sliced
+        // back to `${n` would make the reassignment unparseable.
+        assert_eq!(
+            args("f ${n} ${a b}"),
+            Some(vec!["${n}".to_owned(), "${a b}".to_owned()]),
+        );
+        // `#` is a comment only at command position; after the command name
+        // it is an ordinary word.
+        assert_eq!(args("f #stop"), Some(vec!["#stop".to_owned()]));
+        assert_eq!(args("f"), Some(Vec::new()));
         // A `{*}` expansion has no statically known arity.
-        assert_eq!(split_top_level_words("{*}$args $b", config), None);
+        assert_eq!(args("f {*}$args $b"), None);
     }
 
     #[test]
@@ -1225,6 +1256,40 @@ mod tests {
                 "O122 must not fire with a self-call in a control condition: {src}\ngot {opts:?}",
             );
         }
+    }
+
+    #[test]
+    fn o122_keeps_braced_variable_arguments_parseable() {
+        // `${n}` must reach the reassignment whole. Cut back to `${n` the
+        // rewritten proc no longer parses.
+        let opts = run_pass("proc f {n} {\n    if {$n <= 1} { return $n }\n    return [f ${n}]\n}");
+        let opt = opts
+            .iter()
+            .find(|o| o.code == DiagCode::O122)
+            .expect("O122 should fire");
+        assert!(
+            opt.replacement.contains("set n ${n}"),
+            "braced variable lost its closer: {:?}",
+            opt.replacement,
+        );
+    }
+
+    #[test]
+    fn o122_fires_when_an_argument_starts_with_hash() {
+        // `#stop` is a comment only at command position. Read as part of the
+        // whole call it is an ordinary argument, so the arity gate holds.
+        let opts = run_pass(
+            "proc h {tag} {\n    if {$tag eq \"stop\"} { return $tag }\n    return [h #stop]\n}",
+        );
+        let opt = opts
+            .iter()
+            .find(|o| o.code == DiagCode::O122)
+            .expect("O122 should fire for a `#`-leading argument");
+        assert!(
+            opt.replacement.contains("set tag #stop"),
+            "expected the argument kept, got {:?}",
+            opt.replacement,
+        );
     }
 
     #[test]

--- a/rust/tcl-compiler/tests/optimiser.rs
+++ b/rust/tcl-compiler/tests/optimiser.rs
@@ -1305,13 +1305,20 @@ fn tail_call_loop_conversion_o122() {
     // O122 rewrites tail recursion to a `while {1}` loop. tclsh proved factorial
     // and gcd loop-forms equal the recursive originals.
     let fac = "proc factorial {n acc} {\n    if {$n <= 1} {\n        return $acc\n    }\n    return [factorial [expr {$n - 1}] [expr {$n * $acc}]]\n}\n";
-    // The overlap selection prefers the per-site O121 `tailcall` rewrite for this
-    // body and emits O121, not the whole-proc O122 loop conversion. Both are
-    // semantically faithful (tclsh: tailcall factorial form == 120). Assert the
-    // applied rewrite is a sound tail-call form (tailcall OR while-loop).
+    // Both arguments are bracketed words, so the call passes one argument per
+    // parameter and O122 takes the whole proc; overlap selection prefers it
+    // over the per-site O121 `tailcall` covering the same range. tclsh proved
+    // the loop form equals the recursive original for n in 0..20.
     let fo = optimised(fac, TCL);
-    assert!(fo.contains("tailcall factorial") || fo.contains("while {1}"));
-    assert!(opt_fires(fac, TCL, "O121") || opt_fires(fac, TCL, "O122"));
+    assert!(
+        fo.contains("while {1}"),
+        "expected the loop conversion: {fo}"
+    );
+    assert!(
+        fo.contains("lassign [list [expr {$n - 1}] [expr {$n * $acc}]] n acc"),
+        "each bracketed argument must stay one word: {fo}",
+    );
+    assert!(opt_fires(fac, TCL, "O122"));
 
     // The bare self-call `loop` body DOES take the O122 loop conversion.
     let bare = "proc loop {items} {\n    if {[llength $items] == 0} {\n        return\n    }\n    puts [lindex $items 0]\n    loop [lrange $items 1 end]\n}\n";

--- a/samples/optimiser/README.md
+++ b/samples/optimiser/README.md
@@ -76,13 +76,12 @@ Adds dead-code elimination, code motion, and recursion transforms:
 - Dead stores removed (`set stale 1` before `set stale 2`)
 - Unreachable `if {0} { ... }` blocks removed
 - Unused variable assignments removed
-- Tail-recursive procs rewritten to `tailcall` (O121). **O122**'s loop
-  conversion accepts this shape too — `collect_tail_sites` parses an unbraced
-  `return [self …]` substitution and `emit_loop_conversion`'s parameter
-  reassignment preserves the recursive result — so the sample stops at
-  `tailcall` because *overlap selection* prefers the per-site rewrite over the
-  whole-proc one, not because O122 declined it. Both are faithful;
-  `tail_call_loop_conversion_o122` pins exactly this body and says so
+- Fully tail-recursive procs rewritten to an iterative `while {1}` loop
+  (O122), the recursive call becoming a `lassign` that reassigns the
+  parameters. *Overlap selection* prefers this whole-proc rewrite over the
+  per-site O121 `tailcall` covering the same range, which is why the sample
+  shows a loop and not `tailcall`; `tail_call_loop_conversion_o122` pins this
+  body
 - Loop-invariant code hoisted
 - Single-use variables inlined
 

--- a/samples/optimiser/input.tcl
+++ b/samples/optimiser/input.tcl
@@ -113,9 +113,10 @@ proc format_name {first last} {
 
 # --- Recursion transforms (O121, O122, O123) ---
 
-# O121 only: O122's loop conversion accepts this `return [factorial …]` shape
-# too, and overlap selection keeps the per-site `tailcall` rewrite instead.
-# Both are faithful; see README.md and `tail_call_loop_conversion_o122`.
+# O122: every self-call is in tail position and passes one argument per
+# parameter, so the whole proc becomes a `while {1}` loop. Overlap selection
+# prefers it over the per-site O121 `tailcall` rewrite covering the same
+# range. See README.md and `tail_call_loop_conversion_o122`.
 proc factorial {n {acc 1}} {
     if {$n <= 1} {
         return $acc

--- a/samples/optimiser/profile_aggressive.tcl
+++ b/samples/optimiser/profile_aggressive.tcl
@@ -105,14 +105,17 @@ proc format_name {first last} {
 
 # --- Recursion transforms (O121, O122, O123) ---
 
-# O121 only: O122's loop conversion accepts this `return [factorial …]` shape
-# too, and overlap selection keeps the per-site `tailcall` rewrite instead.
-# Both are faithful; see README.md and `tail_call_loop_conversion_o122`.
+# O122: every self-call is in tail position and passes one argument per
+# parameter, so the whole proc becomes a `while {1}` loop. Overlap selection
+# prefers it over the per-site O121 `tailcall` rewrite covering the same
+# range. See README.md and `tail_call_loop_conversion_o122`.
 proc factorial {n {acc 1}} {
-    if {$n <= 1} {
-        return $acc
+    while {1} {
+        if {$n <= 1} {
+            return $acc
+        }
+        lassign [list [expr {$n - 1}] [expr {$n * $acc}]] n acc
     }
-    tailcall factorial [expr {$n - 1}] [expr {$n * $acc}]
 }
 
 # O123: non-tail recursion hint (accumulator candidate)
@@ -125,7 +128,7 @@ proc sum_list {lst} {
 
 
 # -------------
-# optimised: 42 rewrite(s)
+# optimised: 45 rewrite(s)
 # O102  Forward literal load of 'count' from its single reaching definition
 # O114  Use incr instead of set/expr
 # O117  Simplify string length zero-check
@@ -148,7 +151,7 @@ proc sum_list {lst} {
 # O102  Forward literal load of 'rolling' from its single reaching definition
 # O109  Eliminate dead store
 # O102  Forward literal load of 'rolling' from its single reaching definition
-# O121  Use tailcall for self-recursion in proc 'factorial'
+# O122  Convert tail-recursive 'factorial' to iterative loop
 # O123  Proc 'sum_list' is a candidate for accumulator-style rewriting
 # O100  Inline the constant value of 'count' proved at this read
 # O115  Remove redundant nested expr
@@ -162,9 +165,12 @@ proc sum_list {lst} {
 # O116  Fold constant list command
 # O118  Fold constant lindex command
 # O100  Fold return of constant variable
+# O101  Fold constant expression
 # O123  Proc 'sum_list' is a candidate for accumulator-style rewriting
 # O108  Eliminate transitively dead code
 # O109  Eliminate dead store
 # O126  Remove unused variable assignment
+# O101  Fold constant expression
 # O123  Proc 'sum_list' is a candidate for accumulator-style rewriting
+# O101  Fold constant expression
 # O123  Proc 'sum_list' is a candidate for accumulator-style rewriting

--- a/samples/optimiser/profile_full.tcl
+++ b/samples/optimiser/profile_full.tcl
@@ -106,14 +106,17 @@ proc format_name {first last} {
 
 # --- Recursion transforms (O121, O122, O123) ---
 
-# O121 only: O122's loop conversion accepts this `return [factorial …]` shape
-# too, and overlap selection keeps the per-site `tailcall` rewrite instead.
-# Both are faithful; see README.md and `tail_call_loop_conversion_o122`.
+# O122: every self-call is in tail position and passes one argument per
+# parameter, so the whole proc becomes a `while {1}` loop. Overlap selection
+# prefers it over the per-site O121 `tailcall` rewrite covering the same
+# range. See README.md and `tail_call_loop_conversion_o122`.
 proc factorial {n {acc 1}} {
-    if {$n <= 1} {
-        return $acc
+    while {1} {
+        if {$n <= 1} {
+            return $acc
+        }
+        lassign [list [expr {$n - 1}] [expr {$n * $acc}]] n acc
     }
-    tailcall factorial [expr {$n - 1}] [expr {$n * $acc}]
 }
 
 # O123: non-tail recursion hint (accumulator candidate)
@@ -149,5 +152,5 @@ proc sum_list {lst} {
 # O102  Forward literal load of 'rolling' from its single reaching definition
 # O109  Eliminate dead store
 # O102  Forward literal load of 'rolling' from its single reaching definition
-# O121  Use tailcall for self-recursion in proc 'factorial'
+# O122  Convert tail-recursive 'factorial' to iterative loop
 # O123  Proc 'sum_list' is a candidate for accumulator-style rewriting

--- a/samples/optimiser/profile_readability.tcl
+++ b/samples/optimiser/profile_readability.tcl
@@ -113,9 +113,10 @@ proc format_name {first last} {
 
 # --- Recursion transforms (O121, O122, O123) ---
 
-# O121 only: O122's loop conversion accepts this `return [factorial …]` shape
-# too, and overlap selection keeps the per-site `tailcall` rewrite instead.
-# Both are faithful; see README.md and `tail_call_loop_conversion_o122`.
+# O122: every self-call is in tail position and passes one argument per
+# parameter, so the whole proc becomes a `while {1}` loop. Overlap selection
+# prefers it over the per-site O121 `tailcall` rewrite covering the same
+# range. See README.md and `tail_call_loop_conversion_o122`.
 proc factorial {n {acc 1}} {
     if {$n <= 1} {
         return $acc

--- a/samples/optimiser/profile_standard.tcl
+++ b/samples/optimiser/profile_standard.tcl
@@ -109,9 +109,10 @@ proc format_name {first last} {
 
 # --- Recursion transforms (O121, O122, O123) ---
 
-# O121 only: O122's loop conversion accepts this `return [factorial …]` shape
-# too, and overlap selection keeps the per-site `tailcall` rewrite instead.
-# Both are faithful; see README.md and `tail_call_loop_conversion_o122`.
+# O122: every self-call is in tail position and passes one argument per
+# parameter, so the whole proc becomes a `while {1}` loop. Overlap selection
+# prefers it over the per-site O121 `tailcall` rewrite covering the same
+# range. See README.md and `tail_call_loop_conversion_o122`.
 proc factorial {n {acc 1}} {
     if {$n <= 1} {
         return $acc


### PR DESCRIPTION
## Summary

- A self-recursive tail call written as a return substitution had its arguments split on whitespace, so `return [fact [expr {$n - 1}] [expr {$acc * $n}]]` counted as eight arguments rather than two. O122's one-argument-per-parameter gate then refused every accumulator shape, and `fact` and `gcd` were reported as O121 tail calls without ever reaching the recursion-to-loop rewrite.
- The call's argument text is now split into Tcl words using the lexer's own grouping, so `[...]`, `{...}` and `"..."` words stay whole. A `{*}` expansion has no statically known arity, and neither does a value holding more than one command, so both stand down to O121 rather than rewrite against a word count they cannot determine.
- Fixing the count exposed a second gap the arity mismatch had been masking. The "every self-call is in tail position" gate never counted self-calls in an `if` / `while` / `for` condition or a `switch` subject, which live in the IR as a parsed expression rather than argument text. A condition is not a tail position, so the loop body would still have recursed there. They are now counted from their source slice and block the conversion. `tail_call_loop_conversion_o122` already pinned these shapes and was passing for the wrong reason.
- The four `samples/optimiser/profile_*.tcl` goldens are regenerated. Only the `factorial` stanza changes shape, from the per-site `tailcall` to the whole-proc loop.

On the design doc's own example:

```tcl
proc fact {n acc} {
    if {$n <= 1} { return $acc }
    return [fact [expr {$n - 1}] [expr {$acc * $n}]]
}
```

```tcl
proc fact {n acc} {
    while {1} {
        if {$n <= 1} { return $acc }
        lassign [list [expr {$n - 1}] [expr {$acc * $n}]] n acc
    }
}
```

### Docs described the gap as the contract

Worth a second look from a reviewer, since this reverses recent doc changes rather than adding to them.

The design doc stated that a `return [f …]` site whose arguments contain a nested `[…]` substitution "is not read as one argument per parameter, so such a proc gets O121 only", and its GCD and accumulator examples had been swapped for shapes that avoided the bug. Both examples are restored, and all three before/after pairs in that file were diffed against the built binary and match byte for byte.

The O122 KCS page listed two safety conditions the pass does not implement, in place of the ones it does:

| Documented | Actual |
|---|---|
| Skipped when the proc uses `uplevel` / `upvar` | Not checked; a proc using `upvar` is rewritten |
| Skipped when the proc has multiple recursive call sites | Multiple tail sites convert fine, each becoming its own reassignment |

Both were replaced with the conditions the code enforces: a self-call outside tail position, an argument-count mismatch, a `{*}` expansion, and the Tcl 8.4 multi-parameter case that has no `lassign`.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

```
make rust-check
cargo test -p tcl-compiler --lib optimiser
cargo test -p tcl-compiler --test optimiser --test optimiser_coverage --test optimiser_depth
```

All pass. Five new tests cover the bracketed-argument arity, the GCD shape, the word splitter directly, the `{*}` stand-down, and the four control-condition shapes.

Behaviour was checked against real tclsh 9.0 rather than assumed. `fact`, `gcd`, the sample's `factorial`, and a two-site `if`/`elseif` body each produce identical results in recursive and loop form across their input ranges. Every documented safety condition and every before/after example in both docs was executed against the built binary.

## Compiler / diagnostics checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? Yes. O122 now fires on return-substitution tail calls whose arguments are bracketed, and no longer fires when a self-call sits in a control-flow condition.
- [x] If yes, I updated the owning design doc under `docs/design/compiler/` or `docs/design/contracts/`. `docs/design/compiler/tail-call-recursion-optimisation.md` states the arity gate, the `{*}` stand-down and the condition rule, and its examples match shipped output.
- [x] If I added or changed a diagnostic or optimisation code, I updated its page under `docs/kcs/codes/` and linked it from `docs/kcs/codes/README.md`. `kcs-optimisation-o122-tail-recursion-to-while.md` has corrected safety conditions. It was already indexed.
- [x] If I added a design doc, I linked it from `docs/design/README.md`. No new design doc.

## Follow-up

The O121 rewrite for a **bare** tail call drops every argument: `h [expr {$a - 1}]` becomes `tailcall h`. It predates this change and is unrelated to argument counting, but is more severe, since `tcl opt` writes that source and the LSP offers it as a code action. It stays hidden whenever O122 supersedes O121, which this change makes more common but does not repair. It gets its own PR rather than widening this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KqCwTY1tXwYmJctaPYgzHm

---
_Generated by [Claude Code](https://claude.ai/code/session_01KqCwTY1tXwYmJctaPYgzHm)_