### PR TITLE
opt: read a tail call's arguments from source, not the IR (O121/O122)

### DIFF
--- a/docs/design/compiler/tail-call-recursion-optimisation.md
+++ b/docs/design/compiler/tail-call-recursion-optimisation.md
@@ -19,7 +19,7 @@ O122 subsumes O121 — when a proc is fully tail-recursive (all self-calls are i
 
 1. **Tail position** — a self-call is in tail position if it is the last statement in the proc body, or the last statement in every branch of an `if`/`elseif`/`else` or `switch` at the end of the body. Calls inside `expr`, `catch`, `try`, loops, or nested command substitutions are never in tail position.
 
-2. **O121 fires when** — for each self-call in tail position. `optimise_tail_calls` emits an O121 candidate at every tail-position self-call; these may later be suppressed when a higher-priority O122 covers the same range. The rewrite wraps the tail call with `tailcall`.
+2. **O121 fires when** — for each self-call in tail position, on a dialect that has `tailcall` (Tcl 8.6+, TIP 327). `optimise_tail_calls` emits an O121 candidate at every tail-position self-call; these may later be suppressed when a higher-priority O122 covers the same range. The rewrite prefixes the call as written with `tailcall`, so braced, quoted, and `{*}`-expanded words reach the rewrite unaltered.
 
 3. **O122 fires when** — every self-call in the proc is in tail position, the proc has at least one parameter, every tail site passes exactly one argument per parameter, and — for a proc with more than one parameter — the dialect has `lassign` (Tcl 8.5+). The entire proc body is rewritten to an iterative `while {1}` loop with parameter reassignment in place of each recursive call.
 
@@ -135,6 +135,8 @@ Neither O121 nor O122 fires because neither call is in tail position. O123 does 
 
 - **Single parameter**: `set param $newval`
 - **Multiple parameters**: `lassign [list $arg1 $arg2 ...] param1 param2 ...` — avoids evaluation-order bugs where reassigning `a` before reading the old `a` for `b` would corrupt the value.
+
+Both rewrites take the arguments from the source text of the call, not from the IR. The IR holds each word's *value* with its delimiters stripped, so `f {x y} "q r" $c` would come back as five words rather than three, and `[list …]` would hand `lassign` the wrong element per parameter. Reading the source keeps one list element per argument and preserves `{*}`.
 
 ## File-path anchors
 

--- a/docs/kcs/codes/kcs-optimisation-o121-tailcall-rewrite.md
+++ b/docs/kcs/codes/kcs-optimisation-o121-tailcall-rewrite.md
@@ -22,25 +22,34 @@ What does O121 rewrite, and when does it fire?
 ## Before
 
 ```tcl
-proc fact {n acc} {
-  if {$n <= 1} { return $acc }
-  return [fact [expr {$n-1}] [expr {$n*$acc}]]
+proc walk {node acc} {
+  if {$node eq ""} { return $acc }
+  set acc [combine $acc [walk [left $node] {}]]
+  return [walk [right $node] $acc]
 }
 ```
 
 ## After
 
 ```tcl
-proc fact {n acc} {
-  if {$n <= 1} { return $acc }
-  tailcall fact [expr {$n-1}] [expr {$n*$acc}]
+proc walk {node acc} {
+  if {$node eq ""} { return $acc }
+  set acc [combine $acc [walk [left $node] {}]]
+  tailcall walk [right $node] $acc
 }
 ```
+
+The call is rewritten as written, so its arguments — including braced,
+quoted, and `{*}`-expanded words — reach the `tailcall` unchanged. The first,
+non-tail `walk` is left alone, and it is what keeps [O122](kcs-optimisation-o122-tail-recursion-to-while.md)
+away: were every self-call in tail position, O122 would convert the whole proc
+to a loop and supersede this rewrite.
 
 ## Safety conditions
 
 - Skipped when the recursive call is not in [tail position](../../GLOSSARY.md#tail-position).
 - Skipped when the call is wrapped in a `catch` or `try` block.
+- Skipped before Tcl 8.6, which has no `tailcall` (TIP 327). The O122 loop conversion still applies there.
 
 ## How to disable
 

--- a/rust/tcl-compiler/src/optimiser/tail_call.rs
+++ b/rust/tcl-compiler/src/optimiser/tail_call.rs
@@ -590,6 +590,92 @@ fn self_name_variants(qname: &str) -> HashSet<String> {
     names
 }
 
+/// Record the tail site for a bare self-call, `f $args`, and report its
+/// O121 rewrite.
+///
+/// The rewrite prefixes the call as written: `full_rewrite_span` only
+/// extends the statement span through trailing closers, so its text is the
+/// call verbatim, with braces, quotes, `{*}` markers and spacing intact.
+/// The IR's `args` hold each word's *value* with its delimiters stripped,
+/// which cannot be reassembled into the source that produced it, so both
+/// the `tailcall` text and the loop conversion's arguments read the source.
+fn collect_bare_call_site(
+    ctx: &mut PassContext<'_>,
+    span: tcl_lexer::Span,
+    command: &str,
+    proc: &Procedure,
+    sites: &mut Vec<TailSite>,
+    emit_o121: bool,
+) {
+    let rewrite_span = full_rewrite_span(ctx.source, span);
+    let call_text = ctx.source.get(rewrite_span.as_range());
+    if emit_o121 {
+        let replacement = match call_text {
+            Some(text) => format!("tailcall {text}"),
+            None => format!("tailcall {command}"),
+        };
+        ctx.report(Optimisation::new(
+            DiagCode::O121,
+            format!("Use tailcall for self-recursion in proc '{}'", proc.name),
+            rewrite_span,
+            replacement,
+        ));
+    }
+    // `[list …]` must receive the words as written, so a braced or quoted
+    // argument stays one element.
+    let args = call_text.and_then(|text| {
+        split_call_arguments(text, tcl_lexer::LexerConfig::for_profile(ctx.dialect))
+    });
+    sites.push(TailSite {
+        span: rewrite_span,
+        args,
+    });
+}
+
+/// Record the tail site for a return substitution, `return [f $args]`, and
+/// report its O121 rewrite. Does nothing when `value` is not a single
+/// command substitution of a self-name.
+fn collect_return_subst_site(
+    ctx: &mut PassContext<'_>,
+    span: tcl_lexer::Span,
+    value: &str,
+    self_names: &HashSet<String>,
+    proc: &Procedure,
+    sites: &mut Vec<TailSite>,
+    emit_o121: bool,
+) {
+    let config = tcl_lexer::LexerConfig::for_profile(ctx.dialect);
+    let Some((call_head, call_args)) = parse_return_subst(value, config) else {
+        return;
+    };
+    if !self_names.contains(&call_head) {
+        return;
+    }
+    let rewrite_span = full_rewrite_span(ctx.source, span);
+    if emit_o121 {
+        let replacement = if call_args.is_empty() {
+            format!("tailcall {call_head}")
+        } else {
+            format!("tailcall {call_head} {call_args}")
+        };
+        ctx.report(Optimisation::new(
+            DiagCode::O121,
+            format!("Use tailcall for self-recursion in proc '{}'", proc.name),
+            rewrite_span,
+            replacement,
+        ));
+    }
+    let args = if call_args.is_empty() {
+        Some(Vec::new())
+    } else {
+        split_call_arguments(&format!("{call_head} {call_args}"), config)
+    };
+    sites.push(TailSite {
+        span: rewrite_span,
+        args,
+    });
+}
+
 /// Recursively walk `script` collecting self-calls in tail
 /// position. Only the last statement of each script (and the
 /// tail position of each `if` / `switch` branch) is considered.
@@ -616,25 +702,8 @@ fn collect_tail_sites(
         return;
     };
     match last {
-        Statement::Call {
-            span,
-            command,
-            args,
-            ..
-        } if self_names.contains(command) => {
-            let rewrite_span = full_rewrite_span(ctx.source, *span);
-            if emit_o121 {
-                ctx.report(Optimisation::new(
-                    DiagCode::O121,
-                    format!("Use tailcall for self-recursion in proc '{}'", proc.name),
-                    rewrite_span,
-                    format!("tailcall {command}"),
-                ));
-            }
-            sites.push(TailSite {
-                span: rewrite_span,
-                args: (!args.iter().any(|a| a.starts_with("{*}"))).then(|| args.clone()),
-            });
+        Statement::Call { span, command, .. } if self_names.contains(command) => {
+            collect_bare_call_site(ctx, *span, command, proc, sites, emit_o121);
         }
         Statement::Return {
             span,
@@ -642,43 +711,11 @@ fn collect_tail_sites(
             braced,
             ..
         } => {
-            // `return {[f $n]}` is a braced literal — the
-            // substitution is never executed — so neither O121
-            // (tailcall rewrite) nor the site count toward O122
-            // (loop conversion) should fire.
-            if *braced {
-                return;
-            }
-            if let Some((call_head, call_args)) =
-                parse_return_subst(v, tcl_lexer::LexerConfig::for_profile(ctx.dialect))
-                && self_names.contains(&call_head)
-            {
-                let rewrite_span = full_rewrite_span(ctx.source, *span);
-                if emit_o121 {
-                    let replacement = if call_args.is_empty() {
-                        format!("tailcall {call_head}")
-                    } else {
-                        format!("tailcall {call_head} {call_args}")
-                    };
-                    ctx.report(Optimisation::new(
-                        DiagCode::O121,
-                        format!("Use tailcall for self-recursion in proc '{}'", proc.name),
-                        rewrite_span,
-                        replacement,
-                    ));
-                }
-                let split_args = if call_args.is_empty() {
-                    Some(Vec::new())
-                } else {
-                    split_call_arguments(
-                        &format!("{call_head} {call_args}"),
-                        tcl_lexer::LexerConfig::for_profile(ctx.dialect),
-                    )
-                };
-                sites.push(TailSite {
-                    span: rewrite_span,
-                    args: split_args,
-                });
+            // `return {[f $n]}` is a braced literal — the substitution is
+            // never executed — so neither O121 nor the site count toward
+            // O122 should fire.
+            if !*braced {
+                collect_return_subst_site(ctx, *span, v, self_names, proc, sites, emit_o121);
             }
         }
         Statement::If {
@@ -1290,6 +1327,81 @@ mod tests {
             "expected the argument kept, got {:?}",
             opt.replacement,
         );
+    }
+
+    #[test]
+    fn o121_bare_call_keeps_its_arguments() {
+        // The bare-call rewrite prefixes the call, so every argument
+        // survives. An arity mismatch keeps O122 away and leaves O121 as
+        // the applied rewrite.
+        let opts =
+            run_pass("proc h {a b} {\n    if {$a == 0} { return $b }\n    h [expr {$a - 1}]\n}");
+        let opt = opts
+            .iter()
+            .find(|o| o.code == DiagCode::O121)
+            .expect("O121 should fire for a bare self-call");
+        assert_eq!(opt.replacement, "tailcall h [expr {$a - 1}]");
+    }
+
+    #[test]
+    fn o121_bare_call_keeps_delimiters_and_expansion() {
+        // Braces, quotes and `{*}` are part of the call as written and must
+        // reach the rewrite unaltered.
+        let opts = run_pass(
+            "proc f {a b c} {\n    if {$a == 0} { return $b }\n    f {x y} \"q r\" {*}$rest\n}",
+        );
+        let opt = opts
+            .iter()
+            .find(|o| o.code == DiagCode::O121)
+            .expect("O121 should fire");
+        assert_eq!(opt.replacement, "tailcall f {x y} \"q r\" {*}$rest");
+    }
+
+    #[test]
+    fn o122_bare_call_reassigns_words_as_written() {
+        // `[list …]` receives the words as written, so a braced or quoted
+        // argument stays one element. Rebuilding from the IR's delimiter-
+        // stripped values would make `{x y} "q r" $c` five elements and
+        // `lassign` would distribute them across the wrong parameters.
+        let opts =
+            run_pass("proc f {a b c} {\n    if {$a == 0} { return $b }\n    f {x y} \"q r\" $c\n}");
+        let opt = opts
+            .iter()
+            .find(|o| o.code == DiagCode::O122)
+            .expect("O122 should fire");
+        assert!(
+            opt.replacement
+                .contains("lassign [list {x y} \"q r\" $c] a b c"),
+            "expected three list elements, got {:?}",
+            opt.replacement,
+        );
+    }
+
+    #[test]
+    fn bare_and_return_subst_tail_calls_reassign_alike() {
+        // The two variants read the same call text, so they must produce the
+        // same loop body for the same arguments.
+        let body = "    if {$a == 0} { return $b }\n";
+        let bare = run_pass(&format!(
+            "proc f {{a b c}} {{\n{body}    f {{x y}} \"q r\" $c\n}}"
+        ));
+        let subst = run_pass(&format!(
+            "proc f {{a b c}} {{\n{body}    return [f {{x y}} \"q r\" $c]\n}}"
+        ));
+        let reassignment = |opts: &[Optimisation]| {
+            opts.iter()
+                .find(|o| o.code == DiagCode::O122)
+                .map(|o| {
+                    o.replacement
+                        .lines()
+                        .find(|l| l.contains("lassign"))
+                        .unwrap_or_default()
+                        .trim()
+                        .to_owned()
+                })
+                .expect("O122 should fire")
+        };
+        assert_eq!(reassignment(&bare), reassignment(&subst));
     }
 
     #[test]


### PR DESCRIPTION
Follows #2030, now merged. This PR carries a single commit against `rust`.

## Summary

Both tail-call rewrites rebuilt the recursive call from the IR's `args`, which hold each word's *value* with its delimiters stripped. Neither could reconstruct the source that produced them. Two separate miscompiles followed.

**O121's bare-call rewrite dropped its arguments outright**, because it only ever formatted the command name:

```tcl
proc h {a b} {
    if {$a == 0} { return $b }
    h [expr {$a - 1}]
}
```

became `tailcall h`. The rewritten proc calls itself with no arguments. `tcl opt` writes that source and the LSP offers it as a code action, so accepting the suggestion breaks working code.

**O122's bare-call loop conversion mis-split delimited arguments.** For `f {x y} "q r" $c` it emitted:

```tcl
lassign [list x y q r ${c}] a b c
```

a five-element list distributed across three parameters, so the loop ran with `a` = x and `c` = q. Under tclsh 9.0 the rewritten proc fails with a type error where the original returns cleanly. The return-substitution variant of the same call was already correct, which is what made the divergence easy to miss.

Both now read the call from the source text. `full_rewrite_span` extends the statement span only through trailing closers, so its slice is the call verbatim; O121 prefixes it rather than rebuilding it, and O122 splits that slice into words and drops the command. A braced or quoted argument stays one list element, and `{*}` survives. The two variants now produce the same reassignment for the same arguments, which a test pins directly.

Splitting the two call arms out of `collect_tail_sites` keeps it under the line limit without a new `#[allow]`.

## Docs

The O121 KCS page's before/after example took O122 rather than the rewrite it documents, so it now uses a proc with one non-tail self-call, which is what holds O122 off. Its dialect floor was also missing: O121 needs Tcl 8.6 for `tailcall`, verified by running the same proc under `--dialect tcl8.5` and `--dialect tcl9.0`.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

```
make rust-check
cargo test -p tcl-compiler --lib optimiser
cargo test -p tcl-compiler --test optimiser --test optimiser_coverage --test optimiser_depth
```

All pass. Four new tests cover the bare-call arguments surviving, delimiters and `{*}` surviving, the corrected `lassign` element count, and the two variants agreeing.

Behaviour was checked against real tclsh 9.0: the corrected loop form matches the recursive original across its input range, the previous form raises a type error on the same input, and both `tailcall` shapes (plain arguments and `{*}` expansion) run correctly. Every before/after example in the design doc and both KCS pages was diffed against the built binary and matches byte for byte. The optimiser sample goldens are unchanged, since the sample's recursion uses the return-substitution path that was already correct.

## Compiler / diagnostics checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? Yes. O121's bare-call rewrite keeps its arguments, and O122's bare-call reassignment keeps one list element per argument.
- [x] If yes, I updated the owning design doc under `docs/design/compiler/` or `docs/design/contracts/`. `docs/design/compiler/tail-call-recursion-optimisation.md` records that both rewrites read the call from source and why the IR cannot serve.
- [x] If I added or changed a diagnostic or optimisation code, I updated its page under `docs/kcs/codes/` and linked it from `docs/kcs/codes/README.md`. `kcs-optimisation-o121-tailcall-rewrite.md` has a shipped-accurate example and the Tcl 8.6 floor. It was already indexed.
- [x] If I added a design doc, I linked it from `docs/design/README.md`. No new design doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KqCwTY1tXwYmJctaPYgzHm