### PR TITLE
fix: gate report WASM feature graph

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -142,6 +142,7 @@ jobs:
         with:
           workspaces: |
             rust/bigip-report-gen/python
+            rust/bigip-report-gen/wasm
             rust/tcl-explorer-wasm
             rust/tcl-spec-studio-wasm
             rust/tcl-lsp-server-wasm
@@ -288,6 +289,13 @@ jobs:
           # installed for the Studio boot check.
           NODE_PATH="$PWD/rust/tcl-spec-studio/web/node_modules" \
             node rust/tcl-cli/gui/test/pages-boot.mjs site
+
+          # Exercise the in-browser report generator as Pages serves it. This
+          # loads the inlined report WASM, generates and downloads a report from
+          # a checked-in config, and inspects its contents. That catches broken
+          # glue, target-only traps, or a feature graph that only works natively.
+          NODE_PATH="$PWD/rust/tcl-spec-studio/web/node_modules" \
+            node rust/bigip-report-gen/wasm/test/pages-boot.mjs site
 
           # Root landing page linking both apps (the shared Pages root).
           cat > site/index.html <<'HTML'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,6 +332,7 @@ dependencies = [
  "base64 0.23.1",
  "chrono",
  "ipnet",
+ "js-sys",
  "md-5",
  "minijinja",
  "pulldown-cmark",

--- a/Makefile
+++ b/Makefile
@@ -1402,6 +1402,9 @@ _check-rust-pr:
 	cd $(ROOT); \
 	cargo fmt --all --check; \
 	cargo clippy --workspace --all-targets -- -D warnings; \
+	echo "==> Checking tcl-bigip-query's offline x509 feature set (clippy + test)"; \
+	cargo clippy -p tcl-bigip-query --no-default-features --features x509 --all-targets -- -D warnings; \
+	cargo test -p tcl-bigip-query --no-default-features --features x509 --test x509_only; \
 	if [ -f "$(RUNTIME_RUST_DIR)/Cargo.toml" ]; then \
 		echo "==> Checking runtime/rust (fmt + clippy)"; \
 		$(MAKE) --no-print-directory -C $(ROOT) runtime-rust-lint; \

--- a/docs/design/contracts/development-environment.md
+++ b/docs/design/contracts/development-environment.md
@@ -76,7 +76,7 @@ sharing `CARGO_HOME` is fine are in
 
 | Target | Purpose |
 |---|---|
-| `make rust-check` | Rust PR gate: fmt + clippy + xtask drift gates (mirrors CI `pr-gate`) |
+| `make rust-check` | Rust PR gate: fmt + Clippy/test for the workspace/default graph and the report-WASM `tcl-bigip-query` x509-only graph, plus xtask drift gates (mirrors CI `pr-gate`) |
 | `make prep-pr` | pre-push gate: format + codegen + lint/typecheck + smoke |
 | `make check-all` | lint + typecheck across TypeScript, Rust, Python |
 | `make smoke`, `make smoke-p P=<crate>` | the smoke tier |

--- a/docs/design/contracts/test-tiers-and-ci-gates.md
+++ b/docs/design/contracts/test-tiers-and-ci-gates.md
@@ -109,10 +109,14 @@ until the map assigns it.
    make prep-pr        # format + codegen + lint/typecheck + smoke
    ```
 
-   `rust-check` is the minimum for Rust-only changes. `check-all` (lint +
-   typecheck across TypeScript, Rust, Python) is the surface to run alone
-   after touching TypeScript or Python. Failures are fixed, not skipped;
-   tooling-missing skips are deliberate (`SKIP_CHECK_RUST=1`, …). Commit
+   `rust-check` is the minimum for Rust-only changes. Alongside the workspace
+   default-feature pass, it checks and executes the focused x509-only contract
+   test for `tcl-bigip-query` because the report WASM uses that socket-free
+   graph and the default `probes` build cannot expose feature-gating errors
+   there.
+   `check-all` (lint + typecheck across TypeScript, Rust, Python) is the surface
+   to run alone after touching TypeScript or Python. Failures are fixed, not
+   skipped; tooling-missing skips are deliberate (`SKIP_CHECK_RUST=1`, …). Commit
    whatever formatting `prep-pr` applies, then re-run the gate — a
    `cargo fmt` after the commit is not a pass. Every "pr-gate bounced on a
    trivial lint" on this repo was a push that skipped this step.

--- a/rust/bigip-report-gen/python/Cargo.lock
+++ b/rust/bigip-report-gen/python/Cargo.lock
@@ -147,6 +147,7 @@ dependencies = [
  "base64",
  "chrono",
  "ipnet",
+ "js-sys",
  "md-5",
  "minijinja",
  "pulldown-cmark",

--- a/rust/bigip-report-gen/python/deploy/github-pages.yml
+++ b/rust/bigip-report-gen/python/deploy/github-pages.yml
@@ -142,6 +142,7 @@ jobs:
         with:
           workspaces: |
             rust/bigip-report-gen/python
+            rust/bigip-report-gen/wasm
             rust/tcl-explorer-wasm
             rust/tcl-spec-studio-wasm
             rust/tcl-lsp-server-wasm
@@ -288,6 +289,13 @@ jobs:
           # installed for the Studio boot check.
           NODE_PATH="$PWD/rust/tcl-spec-studio/web/node_modules" \
             node rust/tcl-cli/gui/test/pages-boot.mjs site
+
+          # Exercise the in-browser report generator as Pages serves it. This
+          # loads the inlined report WASM, generates and downloads a report from
+          # a checked-in config, and inspects its contents. That catches broken
+          # glue, target-only traps, or a feature graph that only works natively.
+          NODE_PATH="$PWD/rust/tcl-spec-studio/web/node_modules" \
+            node rust/bigip-report-gen/wasm/test/pages-boot.mjs site
 
           # Root landing page linking both apps (the shared Pages root).
           cat > site/index.html <<'HTML'

--- a/rust/bigip-report-gen/rust/Cargo.toml
+++ b/rust/bigip-report-gen/rust/Cargo.toml
@@ -100,6 +100,9 @@ cli = ["dep:tcl-bigip-io", "chrono/clock"]
 # validated against the same inputs.
 tcl-bigip-io = { path = "../../tcl-bigip-io" }
 
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
+js-sys = "0.3"
+
 # The native CLI generator: `cargo run -p bigip-report-gen-rust --features cli
 # --bin bigip-report-gen -- device.ucs -o report.html`. Requires `cli` (which
 # pulls the UCS reader + a real clock); a plain `cargo build` skips it.

--- a/rust/bigip-report-gen/rust/src/clock.rs
+++ b/rust/bigip-report-gen/rust/src/clock.rs
@@ -1,0 +1,36 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+pub(crate) fn now_epoch_seconds() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()
+        .and_then(|duration| i64::try_from(duration.as_secs()).ok())
+        .unwrap_or(0)
+}
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+pub(crate) fn now_epoch_seconds() -> i64 {
+    let milliseconds = js_sys::Date::now();
+    if milliseconds.is_finite() && milliseconds >= 0.0 {
+        (milliseconds / 1_000.0).floor() as i64
+    } else {
+        0
+    }
+}

--- a/rust/bigip-report-gen/rust/src/lib.rs
+++ b/rust/bigip-report-gen/rust/src/lib.rs
@@ -42,6 +42,7 @@
 
 mod apm;
 mod certs;
+mod clock;
 mod crypt;
 pub mod enrich;
 mod forensics;

--- a/rust/bigip-report-gen/rust/src/lifecycle.rs
+++ b/rust/bigip-report-gen/rust/src/lifecycle.rs
@@ -10,8 +10,6 @@
 //! date visible in the output: operators can immediately tell when they should
 //! re-check K5903 for a newer schedule.
 
-use std::time::{SystemTime, UNIX_EPOCH};
-
 use chrono::{DateTime, NaiveDate, Utc};
 use serde_json::{Map, Value as J};
 
@@ -117,11 +115,7 @@ fn parse_date(value: &str) -> NaiveDate {
 }
 
 fn today_utc() -> NaiveDate {
-    let seconds = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs();
-    DateTime::<Utc>::from_timestamp(i64::try_from(seconds).unwrap_or(i64::MAX), 0)
+    DateTime::<Utc>::from_timestamp(crate::clock::now_epoch_seconds(), 0)
         .expect("current time is representable")
         .date_naive()
 }

--- a/rust/bigip-report-gen/rust/src/model.rs
+++ b/rust/bigip-report-gen/rust/src/model.rs
@@ -2214,11 +2214,7 @@ pub fn collect_model_full(
     files: &HashMap<String, Vec<J>>,
     manifest: Option<&str>,
 ) -> J {
-    let analysis_time = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .ok()
-        .and_then(|duration| i64::try_from(duration.as_secs()).ok())
-        .unwrap_or(0);
+    let analysis_time = crate::clock::now_epoch_seconds();
     let empty_pems = HashMap::new();
     let empty_files: Vec<J> = Vec::new();
     let devices: Vec<J> = sources

--- a/rust/bigip-report-gen/wasm/Cargo.lock
+++ b/rust/bigip-report-gen/wasm/Cargo.lock
@@ -107,6 +107,7 @@ dependencies = [
  "base64",
  "chrono",
  "ipnet",
+ "js-sys",
  "md-5",
  "minijinja",
  "pulldown-cmark",

--- a/rust/bigip-report-gen/wasm/README.md
+++ b/rust/bigip-report-gen/wasm/README.md
@@ -44,7 +44,10 @@ engine as a **library** (PyO3), while this crate is the same generator
 
 The page (styles + upload controller) is the shared builder front-end
 (`rust/bigip-report-gen/frontend/src/pages/input.ts`); `build-wasm.sh` inlines the
-generator wasm behind it.
+generator wasm behind it. Browser builds obtain their epoch time from
+`Date.now()` through the shared report crate; native and WASI builds retain
+`SystemTime`. Calling `SystemTime::now()` directly on `wasm32-unknown-unknown`
+traps at run time even though the module compiles.
 
 ## Building
 
@@ -55,10 +58,17 @@ pinned `wasm-bindgen` crate version), and `python3`:
 bash build-wasm.sh          # → dist/index.html (WASM + glue inlined, one file)
 ```
 
+The script honours `CARGO_TARGET_DIR` and packages the module from that same
+directory. This is required in parallel worktrees: packaging a hard-coded
+crate-local target can silently reuse an older module after Cargo built the
+current checkout elsewhere.
+
 `dist/index.html` is fully self-contained — host it on any static server, or
 just open it from disk. `target/` and `dist/` are build outputs (gitignored);
 CI (the `github-pages` workflow) builds and publishes it to
-`/bigip-report-generator/`.
+`/bigip-report-generator/`. Its browser regression uploads a checked-in SCF,
+generates the report, waits for the download, and checks the downloaded HTML
+for fixture content.
 
 > `wasm-opt` is deliberately not run: on modern rustc layouts binaryen rebinds
 > the `__wbindgen_externrefs` export onto the fixed-size funcref table, which

--- a/rust/bigip-report-gen/wasm/build-wasm.sh
+++ b/rust/bigip-report-gen/wasm/build-wasm.sh
@@ -38,7 +38,16 @@ mkdir -p "$dist"
 wasm_cc_prepare
 echo "==> cargo build --target wasm32-unknown-unknown --release"
 ( cd "$here" && cargo build --target wasm32-unknown-unknown --release )
-wasm="$here/target/wasm32-unknown-unknown/release/bigip_report_wasm.wasm"
+cargo_target_dir=${CARGO_TARGET_DIR:-$here/target}
+case "$cargo_target_dir" in
+    /*) ;;
+    *) cargo_target_dir="$here/$cargo_target_dir" ;;
+esac
+wasm="$cargo_target_dir/wasm32-unknown-unknown/release/bigip_report_wasm.wasm"
+test -f "$wasm" || {
+    echo "built report WASM is missing from Cargo target directory: $wasm" >&2
+    exit 1
+}
 
 echo "==> wasm-bindgen (no-modules)"
 wasm-bindgen "$wasm" --out-dir "$out" --target no-modules --no-typescript

--- a/rust/bigip-report-gen/wasm/src/lib.rs
+++ b/rust/bigip-report-gen/wasm/src/lib.rs
@@ -27,8 +27,9 @@
 //! compiled in.
 //!
 //! The network-probe builtins are compiled out (`bigip-report-gen-rust` →
-//! `tcl-bigip-query` with `default-features = false`), so this binary has no
-//! socket / TLS / x509 dependency.
+//! `tcl-bigip-query` with `default-features = false`); the report retains the
+//! pure-Rust `x509` surface for its certificate inventory, but has no socket /
+//! TLS dependency.
 
 use wasm_bindgen::prelude::*;
 

--- a/rust/bigip-report-gen/wasm/test/pages-boot.mjs
+++ b/rust/bigip-report-gen/wasm/test/pages-boot.mjs
@@ -1,0 +1,131 @@
+// BIG-IP report-generator browser contract for the GitHub Pages deployment.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { createServer } from "node:http";
+import { readFile } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { dirname, extname, join, normalize, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const site = resolve(
+  process.argv[2] ?? join(here, "..", "..", "..", "..", "site"),
+);
+const fixture = resolve(
+  process.argv[3] ??
+    join(here, "..", "..", "..", "tcl-bigip", "tests", "fixtures", "bigip.conf"),
+);
+const types = {
+  ".html": "text/html; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".json": "application/json",
+  ".wasm": "application/wasm",
+};
+
+function serve() {
+  const server = createServer((request, response) => {
+    const url = new URL(request.url ?? "/", "http://localhost");
+    const relative = normalize(decodeURIComponent(url.pathname)).replace(
+      /^(?:\.\.[/\\])+/,
+      "",
+    );
+    const path = join(
+      site,
+      relative === "/" ? "index.html" : relative.replace(/\/$/, "/index.html"),
+    );
+    if (!path.startsWith(site)) return response.writeHead(403).end("no");
+    readFile(path).then(
+      (body) => {
+        response.writeHead(200, {
+          "content-type": types[extname(path)] ?? "application/octet-stream",
+        });
+        response.end(body);
+      },
+      () => response.writeHead(404).end("not found"),
+    );
+  });
+  return new Promise((resolveServer) =>
+    server.listen(0, "127.0.0.1", () => resolveServer(server)),
+  );
+}
+
+let chromium;
+try {
+  ({ chromium } = createRequire(import.meta.url)("playwright"));
+} catch {
+  console.log(
+    "playwright not installed — skipping BIG-IP report Pages boot check",
+  );
+  process.exit(0);
+}
+
+const server = await serve();
+const { port } = server.address();
+const browser = await chromium.launch();
+const page = await browser.newPage({ acceptDownloads: true });
+const problems = [];
+page.on("pageerror", (error) => problems.push(`page error: ${error.message}`));
+page.on("console", (message) => {
+  if (message.type() === "error")
+    problems.push(`console error: ${message.text()}`);
+});
+page.on("requestfailed", (request) =>
+  problems.push(
+    `request failed: ${request.url()} (${request.failure()?.errorText ?? "?"})`,
+  ),
+);
+
+try {
+  await page.goto(
+    `http://127.0.0.1:${port}/bigip-report-generator/?pages-test=1`,
+    {
+      waitUntil: "load",
+    },
+  );
+  await page.waitForFunction(
+    () => document.querySelector("#status")?.classList.contains("ok"),
+    undefined,
+    { timeout: 120_000 },
+  );
+  const version = (await page.textContent("#ver"))?.trim();
+  if (!version || !version.startsWith("engine v"))
+    throw new Error("the report WASM engine did not expose its version");
+
+  await page.setInputFiles("#picker", fixture);
+  await page.waitForFunction(
+    () =>
+      !(document.querySelector("#go") instanceof HTMLButtonElement) ||
+      !document.querySelector("#go").disabled,
+    undefined,
+    { timeout: 30_000 },
+  );
+  const downloadPromise = page.waitForEvent("download", { timeout: 120_000 });
+  await page.click("#go");
+  const download = await downloadPromise;
+  await page.waitForFunction(
+    () =>
+      document.querySelector("#status")?.textContent?.startsWith("done —") &&
+      document.querySelector("#result")?.classList.contains("show"),
+    undefined,
+    { timeout: 120_000 },
+  );
+  if (!download.suggestedFilename().endsWith(".html"))
+    throw new Error(`unexpected report filename: ${download.suggestedFilename()}`);
+  const reportPath = await download.path();
+  if (!reportPath) throw new Error("generated report download has no local path");
+  const report = await readFile(reportPath, "utf8");
+  if (!report.includes("www_vs"))
+    throw new Error("generated report does not contain the fixture's virtual server");
+  if (problems.length > 0) throw new Error(problems.join("\n"));
+  console.log(
+    `BIG-IP report generator generated ${download.suggestedFilename()} from a config fixture (${version})`,
+  );
+} catch (error) {
+  if (problems.length > 0) console.error(problems.join("\n"));
+  throw error;
+} finally {
+  await page.close();
+  await browser.close();
+  await new Promise((done) => server.close(done));
+}

--- a/rust/tcl-bigip-query/Cargo.toml
+++ b/rust/tcl-bigip-query/Cargo.toml
@@ -85,5 +85,10 @@ probes = [
 [dev-dependencies]
 temp-env = "0.3"
 
+[[test]]
+name = "x509_only"
+path = "tests/x509_only.rs"
+required-features = ["x509"]
+
 [lints]
 workspace = true

--- a/rust/tcl-bigip-query/src/builtins/inputs_load.rs
+++ b/rust/tcl-bigip-query/src/builtins/inputs_load.rs
@@ -17,19 +17,20 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 //! File-loading builtins: `json_load` / `jsonl_load` / `csv_load` /
-//! `f5log_load` / `cert_load`.
+//! `f5log_load`, plus the no-x509 fallback for `cert_load`.
 //!
 //! Each reads a file path argument and returns the parsed value, reusing
 //! the parsers in [`crate::inputs`] so a query can mix CLI-loaded
 //! side-inputs and in-query loads from the same code path.
 //!
 //! Notes:
-//! - All five honour `~` tilde expansion and report `file not found:` /
+//! - The file loaders honour `~` tilde expansion and report `file not found:` /
 //!   `cannot read` / format-specific parse errors with the exact
 //!   wording.
-//! - `cert_load` is **unsupported**: it reads the file and validates its
-//!   shape, then raises a clear error for the X.509 parse rather than
-//!   returning a half-shaped dict.
+//! - Without either certificate feature, `cert_load` is an explicit fallback:
+//!   it reads the file and validates its shape, then raises a clear unsupported
+//!   error rather than returning a half-shaped dict. The x509 feature replaces
+//!   that one registration with the real parser.
 
 use crate::builtins::{BuiltinSpec, as_str, plain, type_name};
 use crate::errors::QueryError;
@@ -37,13 +38,22 @@ use crate::inputs::{parse_csv, parse_f5log, parse_jsonl};
 use crate::value::Value;
 
 pub(super) fn registrations() -> Vec<(&'static str, BuiltinSpec)> {
-    vec![
+    let registrations = vec![
         plain("json_load", "value", 1, Some(1), false, bi_json_load),
         plain("jsonl_load", "value", 1, Some(1), false, bi_jsonl_load),
         plain("csv_load", "value", 1, Some(2), false, bi_csv_load),
         plain("f5log_load", "value", 1, Some(1), false, bi_f5log_load),
-        plain("cert_load", "value", 1, Some(2), false, bi_cert_load),
-    ]
+    ];
+    #[cfg(not(any(feature = "x509", feature = "probes")))]
+    {
+        let mut registrations = registrations;
+        registrations.push(plain("cert_load", "value", 1, Some(2), false, bi_cert_load));
+        registrations
+    }
+    #[cfg(any(feature = "x509", feature = "probes"))]
+    {
+        registrations
+    }
 }
 
 /// Tilde (`~` / `~user`) expansion of the path head, for the `~` / `~/...`
@@ -155,6 +165,7 @@ fn bi_f5log_load(args: &[Value]) -> Result<Value, QueryError> {
 
 /// `cert_load` — unsupported. Reads the file and validates the argument
 /// shapes, then raises a clear error for the X.509 parse.
+#[cfg(not(any(feature = "x509", feature = "probes")))]
 fn bi_cert_load(args: &[Value]) -> Result<Value, QueryError> {
     let p = as_str(&args[0], "cert_load", 1)?;
     let expanded = expanduser(&p);

--- a/rust/tcl-bigip-query/src/builtins/mod.rs
+++ b/rust/tcl-bigip-query/src/builtins/mod.rs
@@ -305,6 +305,7 @@ pub(crate) fn special(
 
 /// Attach an implementation caveat to a registration, so the catalogue and
 /// `--help-builtins` say what the builtin actually does.
+#[cfg(feature = "probes")]
 pub(crate) fn with_note(
     entry: (&'static str, BuiltinSpec),
     note: &'static str,
@@ -317,7 +318,10 @@ pub(crate) fn with_note(
 fn build_registry() -> HashMap<&'static str, BuiltinSpec> {
     let mut m = HashMap::new();
     for (name, spec) in registrations() {
-        m.insert(name, spec);
+        assert!(
+            m.insert(name, spec).is_none(),
+            "duplicate builtin registration: {name}"
+        );
     }
     m
 }
@@ -374,6 +378,8 @@ fn registrations() -> Vec<(&'static str, BuiltinSpec)> {
     r.extend(extras::registrations());
     r.extend(f5profile::registrations());
     r.extend(files::registrations());
+    #[cfg(any(feature = "x509", feature = "probes"))]
+    r.extend(crate::probes::x509_registrations());
     #[cfg(feature = "probes")]
     r.extend(crate::probes::registrations());
     r.extend(crate::special::registrations());

--- a/rust/tcl-bigip-query/src/probes.rs
+++ b/rust/tcl-bigip-query/src/probes.rs
@@ -416,7 +416,7 @@ fn spki_to_pem(spki_der: &[u8]) -> String {
 // x509_eq / x509_from_config — deterministic projections
 
 /// Structural equality of two parsed x509 dicts.
-#[cfg(feature = "probes")]
+#[cfg(any(feature = "x509", feature = "probes"))]
 pub(crate) fn x509_eq(left: &Value, right: &Value) -> bool {
     let (Value::Object(l), Value::Object(r)) = (as_dict(left), as_dict(right)) else {
         return crate::value::py_eq(left, right, 0);
@@ -431,7 +431,7 @@ pub(crate) fn x509_eq(left: &Value, right: &Value) -> bool {
         && dict_str(&l, "serial").eq_ignore_ascii_case(&dict_str(&r, "serial"))
 }
 
-#[cfg(feature = "probes")]
+#[cfg(any(feature = "x509", feature = "probes"))]
 fn as_dict(v: &Value) -> Value {
     match v {
         Value::ObjectRef(o) => Value::Object(o.fields.clone()),
@@ -439,7 +439,7 @@ fn as_dict(v: &Value) -> Value {
     }
 }
 
-#[cfg(feature = "probes")]
+#[cfg(any(feature = "x509", feature = "probes"))]
 fn dict_str(map: &IndexMap<String, Value>, key: &str) -> String {
     match map.get(key) {
         Some(Value::Str(s)) => s.clone(),
@@ -450,7 +450,7 @@ fn dict_str(map: &IndexMap<String, Value>, key: &str) -> String {
 
 /// Map BIG-IP `key-type` tokens to the `key_alg` strings the x509 parse
 /// uses.
-#[cfg(feature = "probes")]
+#[cfg(any(feature = "x509", feature = "probes"))]
 fn key_type_to_key_alg(key_type: &str) -> Option<&'static str> {
     Some(match key_type {
         "rsa-public" | "rsa-private" => "RSAPublicKey",
@@ -464,7 +464,7 @@ fn key_type_to_key_alg(key_type: &str) -> Option<&'static str> {
 
 /// Project a BIG-IP config-object cert into the `x509_parse` shape. `cert`
 /// is an `ObjectRef` (or dict) carrying the BIG-IP cert metadata fields.
-#[cfg(feature = "probes")]
+#[cfg(any(feature = "x509", feature = "probes"))]
 pub(crate) fn x509_from_config(cert: &Value) -> Result<Value, QueryError> {
     if matches!(cert, Value::Null) {
         return Err(QueryError::builtin("x509_from_config: cannot project None"));
@@ -556,7 +556,7 @@ pub(crate) fn x509_from_config(cert: &Value) -> Result<Value, QueryError> {
 
 /// Read a config field — accept attribute / dict-key / `ObjectRef`
 /// field form, with both `_`-and-`-` spellings, stripping surrounding quotes.
-#[cfg(feature = "probes")]
+#[cfg(any(feature = "x509", feature = "probes"))]
 fn field_get(cert: &Value, name: &str) -> String {
     let tmsh_name = name.replace('_', "-");
     let lookup = |fields: &IndexMap<String, Value>| -> String {
@@ -582,7 +582,7 @@ fn field_get(cert: &Value, name: &str) -> String {
     }
 }
 
-#[cfg(feature = "probes")]
+#[cfg(any(feature = "x509", feature = "probes"))]
 fn scalar_str(v: &Value) -> String {
     match v {
         Value::Str(s) => s.clone(),
@@ -596,7 +596,7 @@ fn scalar_str(v: &Value) -> String {
 }
 
 /// Parse a TMSH `expiration-string` → ISO-8601 UTC.
-#[cfg(feature = "probes")]
+#[cfg(any(feature = "x509", feature = "probes"))]
 fn parse_x509_date(text: &str) -> Option<String> {
     use chrono::{NaiveDateTime, TimeZone as _, Utc};
     if text.is_empty() {
@@ -635,7 +635,7 @@ fn parse_x509_date(text: &str) -> Option<String> {
 /// byte-identically to `x509_parse`. A single cert returns the dict; multiple
 /// return a list in file order. PKCS#12 (`.pfx` / `.p12`) is unsupported and
 /// returns a clear `BuiltinError` (PKCS#12 decoding is not supported).
-#[cfg(feature = "probes")]
+#[cfg(any(feature = "x509", feature = "probes"))]
 pub(crate) fn cert_load(path: &str, _password: Option<&str>) -> Result<Value, QueryError> {
     let expanded = expanduser(path);
     let raw = match std::fs::read(&expanded) {
@@ -697,7 +697,7 @@ pub(crate) fn cert_load(path: &str, _password: Option<&str>) -> Result<Value, Qu
 }
 
 /// Tilde expansion of a leading `~` / `~/` in the path.
-#[cfg(feature = "probes")]
+#[cfg(any(feature = "x509", feature = "probes"))]
 fn expanduser(path: &str) -> String {
     if (path == "~" || path.starts_with("~/"))
         && let Some(home) = std::env::var_os("HOME")
@@ -714,7 +714,7 @@ fn expanduser(path: &str) -> String {
 
 /// Split into one PEM string per `CERTIFICATE` block, in file order
 /// (key / other block types skipped).
-#[cfg(feature = "probes")]
+#[cfg(any(feature = "x509", feature = "probes"))]
 fn split_pem_blocks(text: &str) -> Vec<String> {
     let mut blocks: Vec<String> = Vec::new();
     let mut in_cert = false;
@@ -1042,9 +1042,11 @@ mod tls;
 
 // Registry wiring
 
+#[cfg(any(feature = "x509", feature = "probes"))]
+use crate::builtins::{BuiltinSpec, as_str, ctx, plain};
 #[cfg(feature = "probes")]
-use crate::builtins::{BuiltinSpec, as_int, as_str, ctx, plain, with_note};
-#[cfg(feature = "probes")]
+use crate::builtins::{as_int, with_note};
+#[cfg(any(feature = "x509", feature = "probes"))]
 use crate::eval::EvalContext;
 
 /// Optional positional-string arg with a default, matching the
@@ -1182,22 +1184,22 @@ fn bi_url_post(a: &[Value], c: &mut EvalContext) -> Result<Value, QueryError> {
 
 // --- ungated pure x509 surface (plain; not probe-gated) ---
 
-#[cfg(feature = "probes")]
+#[cfg(any(feature = "x509", feature = "probes"))]
 fn bi_x509_parse(args: &[Value]) -> Result<Value, QueryError> {
     x509_parse(&as_str(&args[0], "x509_parse", 1)?)
 }
 
-#[cfg(feature = "probes")]
+#[cfg(any(feature = "x509", feature = "probes"))]
 fn bi_x509_from_config(args: &[Value]) -> Result<Value, QueryError> {
     x509_from_config(&args[0])
 }
 
-#[cfg(feature = "probes")]
+#[cfg(any(feature = "x509", feature = "probes"))]
 fn bi_x509_eq(args: &[Value]) -> Result<Value, QueryError> {
     Ok(Value::Bool(x509_eq(&args[0], &args[1])))
 }
 
-#[cfg(feature = "probes")]
+#[cfg(any(feature = "x509", feature = "probes"))]
 fn bi_cert_load(args: &[Value]) -> Result<Value, QueryError> {
     let path = as_str(&args[0], "cert_load", 1)?;
     let password = match args.get(1) {
@@ -1207,7 +1209,7 @@ fn bi_cert_load(args: &[Value]) -> Result<Value, QueryError> {
     cert_load(&path, password.as_deref())
 }
 
-#[cfg(feature = "probes")]
+#[cfg(any(feature = "x509", feature = "probes"))]
 fn bi_ucs_cert(args: &[Value], ctx: &mut EvalContext) -> Result<Value, QueryError> {
     let Value::ObjectRef(obj) = &args[0] else {
         return Err(QueryError::builtin(
@@ -1268,8 +1270,28 @@ fn bi_ucs_cert(args: &[Value], ctx: &mut EvalContext) -> Result<Value, QueryErro
 const URL_NOT_LIVE: &str = "not implemented: returns the result shape with an `error` field, \
                             makes no request";
 
-/// Probe builtin registrations — folded into the global registry by
-/// [`crate::builtins`].
+/// Pure x509 builtin registrations — folded into the global registry by
+/// [`crate::builtins`] whenever the x509 surface is enabled.
+#[cfg(any(feature = "x509", feature = "probes"))]
+pub(crate) fn x509_registrations() -> Vec<(&'static str, BuiltinSpec)> {
+    vec![
+        ctx("ucs_cert", "net", 1, Some(1), bi_ucs_cert),
+        plain("x509_parse", "net", 1, Some(1), false, bi_x509_parse),
+        plain(
+            "x509_from_config",
+            "net",
+            1,
+            Some(1),
+            false,
+            bi_x509_from_config,
+        ),
+        plain("x509_eq", "net", 2, Some(2), false, bi_x509_eq),
+        plain("cert_load", "value", 1, Some(2), false, bi_cert_load),
+    ]
+}
+
+/// Network-probe builtin registrations — folded into the global registry by
+/// [`crate::builtins`] whenever the `probes` feature is enabled.
 #[cfg(feature = "probes")]
 pub(crate) fn registrations() -> Vec<(&'static str, BuiltinSpec)> {
     vec![
@@ -1299,18 +1321,5 @@ pub(crate) fn registrations() -> Vec<(&'static str, BuiltinSpec)> {
             ctx("url_post", "net", 1, Some(3), bi_url_post),
             URL_NOT_LIVE,
         ),
-        ctx("ucs_cert", "net", 1, Some(1), bi_ucs_cert),
-        // Pure x509 surface — ungated (plain, deterministic here).
-        plain("x509_parse", "net", 1, Some(1), false, bi_x509_parse),
-        plain(
-            "x509_from_config",
-            "net",
-            1,
-            Some(1),
-            false,
-            bi_x509_from_config,
-        ),
-        plain("x509_eq", "net", 2, Some(2), false, bi_x509_eq),
-        plain("cert_load", "value", 1, Some(2), false, bi_cert_load),
     ]
 }

--- a/rust/tcl-bigip-query/tests/x509_only.rs
+++ b/rust/tcl-bigip-query/tests/x509_only.rs
@@ -1,0 +1,112 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Contract tests for the report's socket-free x509 feature graph.
+
+use tcl_bigip_query::Value;
+use tcl_bigip_query::builtins::lookup;
+use tcl_bigip_query::eval::{EvalContext, Root, evaluate};
+use tcl_bigip_query::parser::parse_query;
+
+fn evaluate_query(query: &str) -> Result<Vec<tcl_bigip_query::Value>, String> {
+    let root = Root::json("x509-only.json", tcl_bigip_query::Value::Null);
+    let mut context = EvalContext::new(root);
+    let program = parse_query(query).map_err(|error| error.to_string())?;
+    evaluate(&program, &mut context).map_err(|error| error.to_string())
+}
+
+#[test]
+fn pure_x509_builtins_are_registered_without_network_probes() {
+    for name in [
+        "ucs_cert",
+        "x509_parse",
+        "x509_from_config",
+        "x509_eq",
+        "cert_load",
+    ] {
+        assert!(lookup(name).is_some(), "{name} must be available with x509");
+    }
+    #[cfg(not(feature = "probes"))]
+    for name in [
+        "dns",
+        "rev_dns",
+        "ping",
+        "portping",
+        "traceroute",
+        "socket_get",
+        "tls_handshake",
+        "url_get",
+        "url_head",
+        "url_options",
+        "url_post",
+    ] {
+        assert!(
+            lookup(name).is_none(),
+            "{name} must be absent without probes"
+        );
+    }
+}
+
+#[test]
+fn cert_load_dispatches_to_the_real_x509_implementation() {
+    let fixture = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/fixtures/x509_example.pem"
+    );
+    let query = format!(
+        "cert_load({})",
+        serde_json::to_string(fixture).expect("fixture path is JSON-encodable")
+    );
+    let values = evaluate_query(&query).expect("valid PEM must load with x509 only");
+    let Some(Value::Object(certificate)) = values.first() else {
+        panic!("cert_load must return one certificate object: {values:?}");
+    };
+    let Some(Value::Str(subject)) = certificate.get("subject") else {
+        panic!("cert_load subject is missing or not a string: {certificate:?}");
+    };
+    assert_eq!(subject, "CN=example.test,O=Example Corp,C=US");
+    let Some(Value::Str(fingerprint)) = certificate.get("fingerprint_sha256") else {
+        panic!("cert_load fingerprint is missing or not a string: {certificate:?}");
+    };
+    assert_eq!(
+        fingerprint,
+        "051B08743FE24044500609876DC3F008773FD0B91EDADD94A63DB5482D1FD8FE"
+    );
+}
+
+#[test]
+fn x509_parse_dispatches_through_the_x509_only_registry() {
+    let error = evaluate_query("x509_parse(\"not a certificate\")")
+        .expect_err("invalid PEM must be rejected by x509_parse");
+    assert!(
+        error.starts_with("x509_parse: not a PEM certificate ("),
+        "unexpected x509_parse error: {error}"
+    );
+}
+
+#[test]
+fn x509_projection_and_equality_dispatch_without_probes() {
+    let values = evaluate_query(
+        "x509_eq(\
+            x509_from_config({fingerprint: \"AA:BB\", subject: \"CN=leaf\", issuer: \"CN=root\"}), \
+            {fingerprint_sha256: \"AABB\"})",
+    )
+    .expect("x509 projection/equality must be available");
+    assert_eq!(values.len(), 1);
+    assert!(matches!(values.first(), Some(Value::Bool(true))));
+}

--- a/scripts/dev/rust-test-binary-shards.tsv
+++ b/scripts/dev/rust-test-binary-shards.tsv
@@ -264,6 +264,7 @@
 5	bpf-tcl::socket_filter	test	bpf-tcl	socket_filter
 5	bpf-tcl::xdp	test	bpf-tcl	xdp
 5	tcl-bigip-query::integration	test	tcl-bigip-query	integration
+5	tcl-bigip-query::x509_only	test	tcl-bigip-query	x509_only
 5	tcl-cli::explorer_gui	test	tcl-cli	explorer_gui
 5	tcl-cli::pkg_verbs	test	tcl-cli	pkg_verbs
 5	tcl-cli::spec_verbs	test	tcl-cli	spec_verbs


### PR DESCRIPTION
## Summary

- make the report WASM x509-only graph register and test the complete offline certificate surface while excluding every network probe
- add that graph to the merge-blocking Rust gate and exact binary-shard census
- use a browser-compatible clock instead of trapping in `SystemTime::now()` on `wasm32-unknown-unknown`
- package the module from the effective `CARGO_TARGET_DIR` and fail if that exact build output is absent
- exercise the assembled Pages report generator in Chromium through upload, generation, download, and report-content verification
- cache the standalone report-WASM workspace in Pages builds
- keep the independently locked Python report graph consistent with the new direct `js-sys` dependency

## Root cause

The Pages-only feature graph was checked only indirectly: default workspace Clippy kept probe helpers live, the x509-only graph did not register its certificate builtins, and no browser test invoked report generation. Once the Rust compile issue was fixed, the browser path still trapped while reading `SystemTime`, while the build script could package a stale crate-local module whenever the required per-worktree `CARGO_TARGET_DIR` redirected Cargo output elsewhere. The first corrected CI run then proved the Python report lockfile had not recorded the new direct `js-sys` dependency, so `cargo-deny --locked` correctly rejected it.

## Experimental proof

At the pre-fix `rust` commit `5244bdda4`, the exact report-WASM graph failed under `RUSTFLAGS=-D warnings` on the probe-only helper. The corrected graph has four focused x509-only tests that verify builtin registration, complete network-probe absence, invalid-PEM dispatch, projection/equality, and a real certificate fixture with exact subject and fingerprint.

On exact rebased head `be6496f876e2436654ccbf13381ac04de9e3c5de`:

- `make prep-pr` — passed; 30 smoke tests
- `make rust-check` — passed, including 4/4 x509-only tests and the exact Rust shard manifest
- `scripts/dev/cargo-deny-all.sh` — passed across every locked workspace
- `make report-wasm` — passed, including wasm-bindgen and externref-growability validation
- the assembled Pages browser smoke generated `bigip-report-20260909-151540.html`, downloaded it, and verified the fixture virtual server `www_vs`
- default-feature query tests and Clippy remained green
- canonical and deployed Pages workflow copies are byte-identical

Failed Pages runs reproduced: `34332534178` and `34330278866`. The stale-lock failure was reproduced in CI job `102527469606` and is fixed by the committed Python lockfile dependency edge.
