### PR TITLE
fix(tclvm): expand command-head words

### DIFF
--- a/docs/design/compiler/lexing-segmentation.md
+++ b/docs/design/compiler/lexing-segmentation.md
@@ -127,6 +127,13 @@ is populated from the active dialect's `LexerGrammar`
   a braced literal `{*}` concatenated with `$x`.  `GRAMMAR_F5_TCL` is also
   the grammar that treats `}{` as a word separator.
 
+Bytecode emission consumes those flags in argv order through one expanded-word
+path. Position zero is not special: an expanded command word is substituted,
+split as a list, and contributes the command plus any leading arguments before
+the ordinary argument tail is emitted. Expanding an empty command-word list is
+a successful empty invocation, while a malformed list preserves the shared
+list owner's structured `TCL VALUE LIST ...` error code.
+
 Arity checks at both the analyser (user-proc call sites) and the IR layer
 (`check_simple_arity` in
 `rust/tcl-compiler/src/analyser/diagnostics/validity.rs`, which takes the

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -7325,7 +7325,7 @@ impl Interp {
                     Ok(e) => e,
                     Err(e) => {
                         release_all(&argv);
-                        return self.error(e.message());
+                        return self.error_with_code(e.message(), e.error_code());
                     }
                 };
                 // For a `{*}` of a *literal* word, each element keeps its source
@@ -7359,6 +7359,10 @@ impl Interp {
         }
 
         if argv.is_empty() {
+            // TclEvalObjvInternal's empty expanded argv is a successful empty
+            // command. It still resets the prior interpreter result, just as
+            // the ordinary dispatch boundary below does.
+            self.set_result_bytes(b"");
             return Code::Ok;
         }
 

--- a/runtime/rust/tests/expanded_invoke_semantics.rs
+++ b/runtime/rust/tests/expanded_invoke_semantics.rs
@@ -47,9 +47,12 @@ fn standalone_and_tcl_9_0_4_share_command_head_expansion_semantics() {
     assert_eq!(code, Code::Ok, "standalone fixture failed: {result}");
     assert_eq!(result, EXPECTED);
 
-    let tree = locate_source_tree(&repository_root(), TclVersion::V9_0, None)
+    let Some(tree) = locate_source_tree(&repository_root(), TclVersion::V9_0, None)
         .expect("locate Tcl 9.0.4 source tree")
-        .expect("Tcl 9.0.4 source tree is installed");
+    else {
+        eprintln!("skipping oracle: Tcl 9.0.4 source tree is not installed");
+        return;
+    };
     assert_eq!(tree.patchlevel, "9.0.4", "exact Tcl oracle pin");
     let oracle_source = format!("{source}\nputs -nonewline [set ::out]\n");
     let oracle = run_script_from_source_tree(&tree, TclVersion::V9_0, oracle_source.as_bytes())

--- a/runtime/rust/tests/expanded_invoke_semantics.rs
+++ b/runtime/rust/tests/expanded_invoke_semantics.rs
@@ -1,0 +1,60 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Standalone-runtime coverage for the shared Tcl 9 command-head matrix.
+
+use std::path::{Path, PathBuf};
+
+use tcl_dialect::TclVersion;
+use tcl_runtime::interp::{Code, Interp};
+use tcl_test_support::{locate_source_tree, run_script_from_source_tree};
+
+const EXPECTED: &str = "statement 2 \
+head-ordinary-expanded {head ordinary tail1 tail2} empty {} multi {a b} \
+substitutions seed value {value position} malformed 1 \
+{unmatched open brace in list} {TCL VALUE LIST BRACE}";
+
+fn repository_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+#[test]
+fn standalone_and_tcl_9_0_4_share_command_head_expansion_semantics() {
+    let source = std::fs::read_to_string(
+        repository_root().join("tests/fixtures/tcl9/expanded-command-head.tcl"),
+    )
+    .expect("read expanded-command-head fixture");
+
+    let mut interp = Interp::new();
+    interp.set_runtime_version(TclVersion::V9_0);
+    let code = interp.eval_str(source.as_bytes());
+    let result = String::from_utf8(interp.result_bytes()).expect("runtime result is UTF-8");
+    assert_eq!(code, Code::Ok, "standalone fixture failed: {result}");
+    assert_eq!(result, EXPECTED);
+
+    let tree = locate_source_tree(&repository_root(), TclVersion::V9_0, None)
+        .expect("locate Tcl 9.0.4 source tree")
+        .expect("Tcl 9.0.4 source tree is installed");
+    assert_eq!(tree.patchlevel, "9.0.4", "exact Tcl oracle pin");
+    let oracle_source = format!("{source}\nputs -nonewline [set ::out]\n");
+    let oracle = run_script_from_source_tree(&tree, TclVersion::V9_0, oracle_source.as_bytes())
+        .expect("run Tcl 9.0.4 oracle")
+        .strict_text()
+        .expect("Tcl 9.0.4 oracle succeeds");
+    assert_eq!(result, oracle);
+}

--- a/runtime/rust/tests/expanded_invoke_semantics.rs
+++ b/runtime/rust/tests/expanded_invoke_semantics.rs
@@ -54,6 +54,10 @@ fn standalone_and_tcl_9_0_4_share_command_head_expansion_semantics() {
         return;
     };
     assert_eq!(tree.patchlevel, "9.0.4", "exact Tcl oracle pin");
+    if !tree.root.join("unix/tclsh").is_file() {
+        eprintln!("skipping oracle: Tcl 9.0.4 source tree has no built unix/tclsh");
+        return;
+    }
     let oracle_source = format!("{source}\nputs -nonewline [set ::out]\n");
     let oracle = run_script_from_source_tree(&tree, TclVersion::V9_0, oracle_source.as_bytes())
         .expect("run Tcl 9.0.4 oracle")

--- a/rust/tcl-compiler/src/codegen/cmd_subst.rs
+++ b/rust/tcl-compiler/src/codegen/cmd_subst.rs
@@ -1975,6 +1975,42 @@ mod tests {
         assert!(ops.contains(&Op::IRULE_CONTAINS), "{ops:?}");
     }
 
+    /// Public codegen consumers may supply a profile-projected registry
+    /// without separately setting the optional module dialect. Nested source
+    /// must still follow that registry's grammar rather than ambient Tcl.
+    #[test]
+    fn inline_cmd_subst_expansion_uses_the_profiled_registry_grammar() {
+        let f5_registry = tcl_registry::model::ingress::static_context_for_profile(
+            tcl_dialect::DialectProfile::irules(),
+        )
+        .commands();
+        let mut f5 = CodegenCtx::new(true, &["head"], f5_registry);
+        assert!(f5.dialect.is_none());
+        f5.emit_inline_cmd_subst("[{*}$head ordinary]");
+        let f5_ops: Vec<Op> = f5
+            .instructions
+            .iter()
+            .map(|instruction| instruction.op)
+            .collect();
+        assert!(!f5_ops.contains(&Op::EXPAND_STKTOP), "{f5_ops:?}");
+        assert!(!f5_ops.contains(&Op::INVOKE_EXPANDED), "{f5_ops:?}");
+
+        let modern_profile =
+            tcl_registry::model::ingress::resolve_environment("tcl8.5").analyser_profile();
+        let modern_registry =
+            tcl_registry::model::ingress::static_context_for_profile(modern_profile).commands();
+        let mut modern = CodegenCtx::new(true, &["head"], modern_registry);
+        assert!(modern.dialect.is_none());
+        modern.emit_inline_cmd_subst("[{*}$head ordinary]");
+        let modern_ops: Vec<Op> = modern
+            .instructions
+            .iter()
+            .map(|instruction| instruction.op)
+            .collect();
+        assert!(modern_ops.contains(&Op::EXPAND_STKTOP), "{modern_ops:?}");
+        assert!(modern_ops.contains(&Op::INVOKE_EXPANDED), "{modern_ops:?}");
+    }
+
     /// The same site's release axis: an operator the target release lacks is
     /// not specialised at all, so the VM raises the interpreter's own
     /// diagnostic instead of executing an opcode 8.4 has no grammar for.

--- a/rust/tcl-compiler/src/codegen/cmd_subst.rs
+++ b/rust/tcl-compiler/src/codegen/cmd_subst.rs
@@ -1201,7 +1201,7 @@ impl CodegenCtx<'_> {
         // A `{*}`-expanded command substitution in value position compiles to the
         // `expandStart … expandStkTop N; invokeExpanded` form (tclsh's), leaving
         // the result on the stack (no trailing `pop`, unlike the statement form).
-        if text.contains("{*}") {
+        if self.recognises_expand_syntax() && text.contains("{*}") {
             let parts = parse_cmd_parts_expand(text);
             if parts.iter().any(|(_, _, expand)| *expand) {
                 self.emit_expanded_cmd_subst(&parts);

--- a/rust/tcl-compiler/src/codegen/cmd_subst.rs
+++ b/rust/tcl-compiler/src/codegen/cmd_subst.rs
@@ -739,6 +739,34 @@ impl CodegenCtx<'_> {
         }
     }
 
+    /// Emit the ordered words of one `{*}` invocation.
+    ///
+    /// The command head and argument tail deliberately share this loop: Tcl's
+    /// expansion marker belongs to a *word position*, including position zero,
+    /// and every position must finish its substitutions before that value is
+    /// split as a list.  Callers supply words as `(text, braced, expanded)`;
+    /// [`Self::emit_cmd_word`] remains the single value-emission path for both
+    /// statement and command-substitution invocations.
+    pub(crate) fn emit_expanded_words<'w>(
+        &mut self,
+        words: impl IntoIterator<Item = (&'w str, bool, bool)>,
+        comment: &str,
+    ) {
+        self.emit_comment(Op::EXPAND_START, vec![], comment);
+        for (index, (word, braced, expanded)) in words.into_iter().enumerate() {
+            self.emit_cmd_word(word, braced);
+            if expanded {
+                self.emit(
+                    Op::EXPAND_STKTOP,
+                    vec![Operand::Imm(
+                        i32::try_from(index + 1).expect("word count fits in i32"),
+                    )],
+                );
+            }
+        }
+        self.emit_comment(Op::INVOKE_EXPANDED, vec![], comment);
+    }
+
     /// Inline compile `[list {*}$a {*}$b]` as `load a; load b; listConcat`.
     ///
     /// Only matches the exact two-argument form — `[list {*}$x]` (one
@@ -1268,27 +1296,12 @@ impl CodegenCtx<'_> {
     /// trailing `pop`.
     pub(super) fn emit_expanded_cmd_subst(&mut self, parts: &[(String, bool, bool)]) {
         self.used_inline_cmd_subst = true;
-        self.emit_comment(Op::EXPAND_START, vec![], "(expanded)");
-        let mut word_count: u32 = 0;
-        for (part, braced, expand) in parts {
-            if *braced {
-                // A braced expanded word splits its *list* elements without
-                // substitution, so push it verbatim.
-                self.push_lit_verbatim(part);
-            } else {
-                self.emit_cmd_subst_arg(part, false);
-            }
-            word_count += 1;
-            if *expand {
-                self.emit(
-                    Op::EXPAND_STKTOP,
-                    vec![Operand::Imm(
-                        i32::try_from(word_count).expect("word count fits in i32"),
-                    )],
-                );
-            }
-        }
-        self.emit_comment(Op::INVOKE_EXPANDED, vec![], "");
+        self.emit_expanded_words(
+            parts
+                .iter()
+                .map(|(word, braced, expanded)| (word.as_str(), *braced, *expanded)),
+            "(expanded)",
+        );
     }
 
     // -- Private inline helpers for emit_inline_cmd_subst --

--- a/rust/tcl-compiler/src/codegen/control_flow.rs
+++ b/rust/tcl-compiler/src/codegen/control_flow.rs
@@ -956,10 +956,7 @@ impl CodegenCtx<'_> {
         // `parse_cmd_parts` would split adjacent `{*}$args` into the literal
         // `*` and `$args`, changing the callee's argv (notably Tcltest's
         // `catch {Configure {*}$args}`).
-        let expand_syntax = self
-            .dialect
-            .is_none_or(|profile| profile.grammar.expand_syntax);
-        if expand_syntax && body.contains("{*}") {
+        if self.recognises_expand_syntax() && body.contains("{*}") {
             let expanded = parse_cmd_parts_expand(body);
             if expanded.iter().any(|(_, _, expand)| *expand) {
                 self.emit_expanded_cmd_subst(&expanded);

--- a/rust/tcl-compiler/src/codegen/mod.rs
+++ b/rust/tcl-compiler/src/codegen/mod.rs
@@ -376,16 +376,15 @@ impl<'r> CodegenCtx<'r> {
     /// rather than the default grammar.
     #[must_use]
     pub fn lexer_config(&self) -> tcl_lexer::LexerConfig {
-        tcl_lexer::LexerConfig::for_profile(self.registry.profile())
+        tcl_lexer::LexerConfig::for_profile(self.dialect.or_else(|| self.registry.profile()))
     }
 
     /// Whether nested source reparsed by codegen recognises TIP 157 argument
-    /// expansion. A named compile follows its resolved grammar; a dialect-less
-    /// compile retains the ambient, permissive Tcl grammar.
+    /// expansion. This delegates to the compile's central re-lex configuration
+    /// so module-profile and profile-projected-registry consumers agree.
     #[must_use]
     pub(crate) fn recognises_expand_syntax(&self) -> bool {
-        self.dialect
-            .is_none_or(|profile| profile.grammar.expand_syntax)
+        self.lexer_config().expand_syntax
     }
 
     /// Set the rooted constructed command-resolution namespace for direct

--- a/rust/tcl-compiler/src/codegen/mod.rs
+++ b/rust/tcl-compiler/src/codegen/mod.rs
@@ -379,6 +379,15 @@ impl<'r> CodegenCtx<'r> {
         tcl_lexer::LexerConfig::for_profile(self.registry.profile())
     }
 
+    /// Whether nested source reparsed by codegen recognises TIP 157 argument
+    /// expansion. A named compile follows its resolved grammar; a dialect-less
+    /// compile retains the ambient, permissive Tcl grammar.
+    #[must_use]
+    pub(crate) fn recognises_expand_syntax(&self) -> bool {
+        self.dialect
+            .is_none_or(|profile| profile.grammar.expand_syntax)
+    }
+
     /// Set the rooted constructed command-resolution namespace for direct
     /// codegen specialisations in this function.
     pub(crate) fn set_resolution_namespace(&mut self, namespace: &str) {

--- a/rust/tcl-compiler/src/codegen/statements.rs
+++ b/rust/tcl-compiler/src/codegen/statements.rs
@@ -913,32 +913,22 @@ impl CodegenCtx<'_> {
         expand_word: &[bool],
         tokens: Option<&crate::ir::CommandTokens>,
     ) {
-        self.emit_comment(Op::EXPAND_START, vec![], &format!("{cmd} (expanded)"));
-        // Build full word list: [cmd, *args]
-        self.emit_value_interpolated(cmd);
-        let mut word_count: u32 = 1;
-        for (i, arg) in args.iter().enumerate() {
-            // A braced single-token word stays verbatim even when expanded: the
-            // `{*}` splits its *list* elements without substituting them, so a
-            // `[…]`/`$…` inside `{*}{… [x] …}` is literal data (matches C, which
-            // expands the parsed list elements, not a re-substituted string).
-            let braced = tokens.is_some_and(|t| {
-                t.argv_kinds.get(i + 1) == Some(&tcl_lexer::TokenType::Str)
-                    && t.single_token_word.get(i + 1).copied().unwrap_or(false)
+        let words = std::iter::once(cmd)
+            .chain(args.iter().map(String::as_str))
+            .enumerate()
+            .map(|(index, word)| {
+                // A braced single-token word stays verbatim even when
+                // expanded: the split operates on its list value without
+                // substituting `[…]` / `$…` inside it. This applies equally to
+                // the command head (index zero) and to every argument.
+                let braced = tokens.is_some_and(|t| {
+                    t.argv_kinds.get(index) == Some(&tcl_lexer::TokenType::Str)
+                        && t.single_token_word.get(index).copied().unwrap_or(false)
+                });
+                let expanded = expand_word.get(index).copied().unwrap_or(false);
+                (word, braced, expanded)
             });
-            self.emit_word(arg, braced);
-            word_count += 1;
-            // expand_word[0] is the command itself, args start at [1]
-            if expand_word.get(i + 1).copied().unwrap_or(false) {
-                self.emit(
-                    Op::EXPAND_STKTOP,
-                    vec![Operand::Imm(
-                        i32::try_from(word_count).expect("word_count fits in i32"),
-                    )],
-                );
-            }
-        }
-        self.emit_comment(Op::INVOKE_EXPANDED, vec![], cmd);
+        self.emit_expanded_words(words, &format!("{cmd} (expanded)"));
         self.emit(Op::POP, vec![]);
     }
 
@@ -1448,10 +1438,26 @@ mod tests {
     fn emit_expanded_call_basic() {
         let registry = CommandRegistry::build_default();
         let mut ctx = CodegenCtx::new(false, &[], &registry);
-        ctx.emit_expanded_call("puts", &["hello".into()], &[false, true], None);
+        ctx.emit_expanded_call(
+            "list head",
+            &["ordinary".into(), "tail one tail two".into()],
+            &[true, false, true],
+            None,
+        );
         let ops = opcodes(&ctx);
-        assert!(ops.contains(&Op::EXPAND_START));
-        assert!(ops.contains(&Op::EXPAND_STKTOP));
-        assert!(ops.contains(&Op::INVOKE_EXPANDED));
+        assert_eq!(
+            ops,
+            vec![
+                Op::EXPAND_START,
+                Op::PUSH1,
+                Op::EXPAND_STKTOP,
+                Op::PUSH1,
+                Op::PUSH1,
+                Op::EXPAND_STKTOP,
+                Op::INVOKE_EXPANDED,
+                Op::POP,
+            ],
+            "head and tail words must use one ordered expansion path",
+        );
     }
 }

--- a/rust/tcl-compiler/tests/fixtures/codegen/matching/set-inline-expand.golden
+++ b/rust/tcl-compiler/tests/fixtures/codegen/matching/set-inline-expand.golden
@@ -27,6 +27,6 @@ ByteCode ::f, 9 instructions, 18 bytes, 3 literals, 2 variables
     (5) loadScalar1 %v0	# var "args"
     (7) expandStkTop 3
     (12) push1 2	# "b"
-    (14) invokeExpanded
+    (14) invokeExpanded	# (expanded)
     (15) storeScalar1 %v1	# var "x"
     (17) done

--- a/rust/tcl-vm/src/exec.rs
+++ b/rust/tcl-vm/src/exec.rs
@@ -4099,7 +4099,9 @@ impl Vm {
                 };
                 match list_v.as_list() {
                     Ok(items) => f.stack.extend(items.iter().cloned()),
-                    Err(e) => return Tick::Return(err(e.message)),
+                    Err(e) => {
+                        return Tick::Return(crate::command::completion_from_tcl_error(e));
+                    }
                 }
             }
             // `expandDrop` abandons the innermost expansion: pop its marker and
@@ -4119,23 +4121,26 @@ impl Vm {
                 }
                 let words = f.stack.split_off(marker);
                 if words.is_empty() {
-                    return Tick::Return(command_lookup_error(""));
-                }
-                let entered = f.take_entered_command();
-                match self.dispatch_words_with_entered(f, &words, entered.as_ref()) {
-                    Ok(Some(call)) => return call,
-                    Ok(None) => {}
-                    Err(c) => {
-                        let cmd_text = instr.source_cmd_text.clone();
-                        let msg = c.result.to_str().to_string();
-                        let line = instr.source_line;
-                        self.log_command_info_with_context(
-                            &cmd_text,
-                            Value::list(words),
-                            &msg,
-                            line,
-                        );
+                    if let Err(c) = Self::deliver_sync(f, ok(Value::empty())) {
                         return Tick::Return(c);
+                    }
+                } else {
+                    let entered = f.take_entered_command();
+                    match self.dispatch_words_with_entered(f, &words, entered.as_ref()) {
+                        Ok(Some(call)) => return call,
+                        Ok(None) => {}
+                        Err(c) => {
+                            let cmd_text = instr.source_cmd_text.clone();
+                            let msg = c.result.to_str().to_string();
+                            let line = instr.source_line;
+                            self.log_command_info_with_context(
+                                &cmd_text,
+                                Value::list(words),
+                                &msg,
+                                line,
+                            );
+                            return Tick::Return(c);
+                        }
                     }
                 }
             }

--- a/rust/tcl-vm/tests/cross_version_command_surface_e2e.rs
+++ b/rust/tcl-vm/tests/cross_version_command_surface_e2e.rs
@@ -734,13 +734,14 @@ fn profile_mutation_recompiles_cached_bodies_and_rejects_live_continuations() {
         )
         .expect("8.6 coroutine setup compiles");
     assert!(newer_setup.code.is_ok(), "{}", newer_setup.result.to_str());
-    // This source is lexically accepted on 8.5+ (its eventual runtime
-    // command error is immaterial); retaining its compiled module exercises
-    // the lexer-sensitive eval cache that 8.4 must discard and re-lex.
+    // This source is accepted and expanded on 8.5+; retaining its compiled
+    // module exercises the lexer-sensitive eval cache that 8.4 must discard
+    // and re-lex.
     let lexer_86 = vm
         .eval_source("{*}[list set ::profile_mutation_lexer 1]")
         .expect("8.5 lexer source compiles");
-    assert_eq!(lexer_86.code, Code::Error);
+    assert_eq!(lexer_86.code, Code::Ok);
+    assert_eq!(lexer_86.result.to_str().as_ref(), "1");
 
     assert!(vm.set_child_dialect_profile("child", v84));
     vm.set_dialect_profile(v84);
@@ -771,7 +772,7 @@ fn profile_mutation_recompiles_cached_bodies_and_rejects_live_continuations() {
         Code::Error
     );
     assert!(
-        vm.eval_source("{*}[list set ::profile_mutation_lexer 2]")
+        vm.eval_source("{*}[list set ::profile_mutation_lexer 1]")
             .is_err()
     );
 

--- a/rust/tcl-vm/tests/expanded_invoke_e2e.rs
+++ b/rust/tcl-vm/tests/expanded_invoke_e2e.rs
@@ -1,0 +1,124 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Tcl 9.0.4-pinned coverage for `{*}` expansion at command-word position.
+
+use std::path::{Path, PathBuf};
+
+use tcl_compiler::compile_service::BytecodeCompileService;
+use tcl_dialect::TclVersion;
+use tcl_test_support::{locate_source_tree, run_script_from_source_tree};
+use tcl_vm::{CompileService, Vm};
+
+const EXPECTED: &str = "statement 2 \
+head-ordinary-expanded {head ordinary tail1 tail2} empty {} multi {a b} \
+substitutions seed value {value position} malformed 1 \
+{unmatched open brace in list} {TCL VALUE LIST BRACE}";
+
+fn repository_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+fn fixture() -> String {
+    std::fs::read_to_string(repository_root().join("tests/fixtures/tcl9/expanded-command-head.tcl"))
+        .expect("read expanded-command-head fixture")
+}
+
+fn compile_for(release: &str, source: &str) -> tcl_bytecode::ModuleAsm {
+    let profile = tcl_registry::model::ingress::resolve_environment(release).analyser_profile();
+    BytecodeCompileService::for_profile(profile)
+        .compile(source)
+        .unwrap_or_else(|error| panic!("compile for {release}: {}", error.0))
+}
+
+fn run_compiled(release: &str, source: &str) -> String {
+    let profile = tcl_registry::model::ingress::resolve_environment(release).analyser_profile();
+    let asm = compile_for(release, source);
+    let mut vm = Vm::new();
+    vm.set_dialect_profile(profile);
+    vm.set_compiler(Box::new(BytecodeCompileService::for_profile(profile)));
+    let completion = vm.run_module(&asm);
+    assert!(
+        completion.code.is_ok(),
+        "compiled fixture failed: {}",
+        completion.result.to_str()
+    );
+    completion.result.to_str().to_string()
+}
+
+#[test]
+fn command_head_expansion_matrix_matches_exact_tcl_9_0_4() {
+    let source = fixture();
+    let tree = locate_source_tree(&repository_root(), TclVersion::V9_0, None)
+        .expect("locate Tcl 9.0.4 source tree")
+        .expect("Tcl 9.0.4 source tree is installed");
+    assert_eq!(tree.patchlevel, "9.0.4", "exact Tcl oracle pin");
+    let oracle_source = format!("{source}\nputs -nonewline [set ::out]\n");
+    let oracle = run_script_from_source_tree(&tree, TclVersion::V9_0, oracle_source.as_bytes())
+        .expect("run Tcl 9.0.4 oracle")
+        .strict_text()
+        .expect("Tcl 9.0.4 oracle succeeds");
+    assert_eq!(oracle, EXPECTED, "unexpected Tcl 9.0.4 oracle result");
+    assert_eq!(run_compiled("tcl9.0", &source), oracle);
+}
+
+#[test]
+fn expansion_opcodes_follow_the_resolved_document_grammar() {
+    let source = "set head {list ok}\n{*}$head";
+    let release = "tcl8.4";
+    let profile = tcl_registry::model::ingress::resolve_environment(release).analyser_profile();
+    let failure = match BytecodeCompileService::for_profile(profile).compile(source) {
+        Ok(_) => panic!("{release} must not recognise Tcl 8.5 expansion syntax"),
+        Err(error) => error.0,
+    };
+    assert_eq!(
+        failure, "extra characters after close-brace",
+        "{release} must retain its resolved pre-8.5 word grammar",
+    );
+
+    // F5's Tcl 8.4-derived grammar has its own word-boundary rules, so this
+    // shape remains compilable there, but `{*}` is still ordinary text rather
+    // than an expansion marker.
+    let f5 = compile_for("f5-irules", source);
+    let f5_ops = f5
+        .top_level
+        .instructions
+        .iter()
+        .map(|instruction| instruction.op)
+        .collect::<Vec<_>>();
+    assert!(!f5_ops.contains(&tcl_bytecode::Op::EXPAND_STKTOP));
+    assert!(!f5_ops.contains(&tcl_bytecode::Op::INVOKE_EXPANDED));
+
+    for release in ["tcl8.5", "tcl8.6", "tcl9.0"] {
+        let asm = compile_for(release, source);
+        let ops = asm
+            .top_level
+            .instructions
+            .iter()
+            .map(|instruction| instruction.op)
+            .collect::<Vec<_>>();
+        assert!(
+            ops.contains(&tcl_bytecode::Op::EXPAND_STKTOP),
+            "{release} expansion grammar: {ops:?}",
+        );
+        assert!(
+            ops.contains(&tcl_bytecode::Op::INVOKE_EXPANDED),
+            "{release} invocation grammar: {ops:?}",
+        );
+    }
+}

--- a/rust/tcl-vm/tests/expanded_invoke_e2e.rs
+++ b/rust/tcl-vm/tests/expanded_invoke_e2e.rs
@@ -79,46 +79,50 @@ fn command_head_expansion_matrix_matches_exact_tcl_9_0_4() {
 
 #[test]
 fn expansion_opcodes_follow_the_resolved_document_grammar() {
-    let source = "set head {list ok}\n{*}$head";
-    let release = "tcl8.4";
-    let profile = tcl_registry::model::ingress::resolve_environment(release).analyser_profile();
-    let failure = match BytecodeCompileService::for_profile(profile).compile(source) {
-        Ok(_) => panic!("{release} must not recognise Tcl 8.5 expansion syntax"),
-        Err(error) => error.0,
-    };
-    assert_eq!(
-        failure, "extra characters after close-brace",
-        "{release} must retain its resolved pre-8.5 word grammar",
-    );
+    for source in [
+        "set head {list ok}\n{*}$head",
+        "set head {list ok}\nset x [{*}$head ordinary]\nset x",
+    ] {
+        let release = "tcl8.4";
+        let profile = tcl_registry::model::ingress::resolve_environment(release).analyser_profile();
+        let failure = match BytecodeCompileService::for_profile(profile).compile(source) {
+            Ok(_) => panic!("{release} must not recognise Tcl 8.5 expansion syntax in {source:?}"),
+            Err(error) => error.0,
+        };
+        assert_eq!(
+            failure, "extra characters after close-brace",
+            "{release} must retain its resolved pre-8.5 word grammar for {source:?}",
+        );
 
-    // F5's Tcl 8.4-derived grammar has its own word-boundary rules, so this
-    // shape remains compilable there, but `{*}` is still ordinary text rather
-    // than an expansion marker.
-    let f5 = compile_for("f5-irules", source);
-    let f5_ops = f5
-        .top_level
-        .instructions
-        .iter()
-        .map(|instruction| instruction.op)
-        .collect::<Vec<_>>();
-    assert!(!f5_ops.contains(&tcl_bytecode::Op::EXPAND_STKTOP));
-    assert!(!f5_ops.contains(&tcl_bytecode::Op::INVOKE_EXPANDED));
-
-    for release in ["tcl8.5", "tcl8.6", "tcl9.0"] {
-        let asm = compile_for(release, source);
-        let ops = asm
+        // F5's Tcl 8.4-derived grammar has its own word-boundary rules, so
+        // these shapes remain compilable there, but `{*}` is still ordinary
+        // text rather than an expansion marker.
+        let f5 = compile_for("f5-irules", source);
+        let f5_ops = f5
             .top_level
             .instructions
             .iter()
             .map(|instruction| instruction.op)
             .collect::<Vec<_>>();
-        assert!(
-            ops.contains(&tcl_bytecode::Op::EXPAND_STKTOP),
-            "{release} expansion grammar: {ops:?}",
-        );
-        assert!(
-            ops.contains(&tcl_bytecode::Op::INVOKE_EXPANDED),
-            "{release} invocation grammar: {ops:?}",
-        );
+        assert!(!f5_ops.contains(&tcl_bytecode::Op::EXPAND_STKTOP));
+        assert!(!f5_ops.contains(&tcl_bytecode::Op::INVOKE_EXPANDED));
+
+        for release in ["tcl8.5", "tcl8.6", "tcl9.0"] {
+            let asm = compile_for(release, source);
+            let ops = asm
+                .top_level
+                .instructions
+                .iter()
+                .map(|instruction| instruction.op)
+                .collect::<Vec<_>>();
+            assert!(
+                ops.contains(&tcl_bytecode::Op::EXPAND_STKTOP),
+                "{release} expansion grammar for {source:?}: {ops:?}",
+            );
+            assert!(
+                ops.contains(&tcl_bytecode::Op::INVOKE_EXPANDED),
+                "{release} invocation grammar for {source:?}: {ops:?}",
+            );
+        }
     }
 }

--- a/rust/tcl-vm/tests/opcode_c_parity.rs
+++ b/rust/tcl-vm/tests/opcode_c_parity.rs
@@ -833,7 +833,33 @@ fn const_blocks_later_writes() {
     assert_eq!(err_str(&c), "can't set \"k\": variable is a constant");
 }
 
-// -- expandDrop ------------------------------------------------------
+// -- argument expansion ---------------------------------------------
+
+/// Expanding an empty command-head list leaves no argv. C Tcl treats that as
+/// an empty successful command rather than looking up the empty command name.
+#[test]
+fn invoke_expanded_with_no_words_returns_empty_success() {
+    let mut a = Asm::new();
+    a.op(Op::EXPAND_START, &[])
+        .push("")
+        .op(Op::EXPAND_STKTOP, &[1])
+        .op(Op::INVOKE_EXPANDED, &[]);
+    let (_, c) = run_fresh(a);
+    assert_eq!(ok_str(&c), "");
+}
+
+/// `Tcl_ListObjGetElements` supplies the structured list error code. The
+/// opcode boundary must preserve it when the expanded word is malformed.
+#[test]
+fn expand_stktop_preserves_list_error_code() {
+    let mut a = Asm::new();
+    a.op(Op::EXPAND_START, &[])
+        .push("list {")
+        .op(Op::EXPAND_STKTOP, &[1]);
+    let (_, c) = run_fresh(a);
+    assert_eq!(err_str(&c), "unmatched open brace in list");
+    assert_eq!(err_code(&c), "TCL VALUE LIST BRACE");
+}
 
 /// `expandDrop` abandons the innermost expansion, truncating the stack back to
 /// the depth its `expandStart` recorded (C `INST_EXPAND_DROP`).

--- a/scripts/dev/rust-test-binary-shards.tsv
+++ b/scripts/dev/rust-test-binary-shards.tsv
@@ -82,6 +82,7 @@
 2	tcl-vm::cross_version_expr_surface_e2e	test	tcl-vm	cross_version_expr_surface_e2e
 2	tcl-vm::cross_version_numerals_e2e	test	tcl-vm	cross_version_numerals_e2e
 2	tcl-vm::element_recovery_traces_e2e	test	tcl-vm	element_recovery_traces_e2e
+2	tcl-vm::expanded_invoke_e2e	test	tcl-vm	expanded_invoke_e2e
 2	tcl-vm::expr_surface_e2e	test	tcl-vm	expr_surface_e2e
 2	tcl-vm::namespace_colon_runs_e2e	test	tcl-vm	namespace_colon_runs_e2e
 2	tcl-vm::numeric_tower_e2e	test	tcl-vm	numeric_tower_e2e

--- a/tests/fixtures/tcl9/expanded-command-head.tcl
+++ b/tests/fixtures/tcl9/expanded-command-head.tcl
@@ -1,0 +1,22 @@
+set ::out {}
+
+{*}{set statement 2}
+lappend ::out statement $statement
+
+lappend ::out head-ordinary-expanded \
+    [{*}{list head} ordinary {*}{tail1 tail2}]
+lappend ::out empty [{*}{}]
+lappend ::out multi [{*}{list a b}]
+
+set prefix l
+set suffix {ist seed}
+lappend ::out substitutions [{*}$prefix$suffix]
+
+set value [{*}{list value} position]
+lappend ::out value $value
+
+set bad "list {"
+set code [catch {{*}$bad} message options]
+lappend ::out malformed $code $message [dict get $options -errorcode]
+
+set ::out


### PR DESCRIPTION
## Summary

- lower Tcl 8.5+ `{*}` command-head expansion through one ordered compiler word-emission path
- source expansion recognition from the effective dialect lexer configuration, including registry-projected profiles and Tcl 8.4/F5 grammar
- make VM and standalone fallback handling agree on empty expansions, structured list errors, and left-to-right side effects
- schedule the Tcl 9.0.4 expanded-invoke oracle in CI

## Verification

- `make rust-check`
- `make test-spectcl-compat`
- `make prep-pr` (30/30 smoke tests)
- Tcl 9.0.4 expanded-invoke oracle and dialect/profile matrix

Closes #1779