### PR TITLE
ci: cover Python engine dependency closure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,8 @@ jobs:
   #                    event (fail-safe: detection failure, a >300-file
   #                    compare, or a tag ref → everything counts as changed),
   #                    so jobs whose input surface didn't change stop
-  #                    re-testing it on every PR.
+  #                    re-testing it on every PR. Python includes the complete
+  #                    locked local dependency closure of its native engine.
   #   lsp_wasm_changed — a wasm LSP transport (browser or WASI) or one of the
   #                    transitive local dependencies they share changed.  This
   #                    keeps the two expensive real wasm builds and their
@@ -233,6 +234,8 @@ jobs:
             if [[ "$ok" == "true" ]]; then
               for path in \
                 scripts/dev/changed-paths.sh \
+                scripts/dev/python-ci-path.sh \
+                scripts/dev/python-engine-package-paths.txt \
                 scripts/dev/rust-tests-path.sh \
                 scripts/dev/rust-tests-package-paths.txt \
                 scripts/dev/rust-tests-input-paths.txt \
@@ -246,16 +249,19 @@ jobs:
               done
             fi
             if [[ "$ok" == "true" ]]; then
-              chmod +x "$trusted/changed-paths.sh" "$trusted/rust-tests-path.sh" "$trusted/lsp-e2e-path.sh"
+              chmod +x "$trusted/changed-paths.sh" "$trusted/python-ci-path.sh" "$trusted/rust-tests-path.sh" "$trusted/lsp-e2e-path.sh"
               changed_paths="$trusted/changed-paths.sh"
+              python_ci_path="$trusted/python-ci-path.sh"
               rust_tests_path="$trusted/rust-tests-path.sh"
               lsp_e2e_path="$trusted/lsp-e2e-path.sh"
+              export TCL_LSP_PYTHON_ENGINE_PACKAGE_MANIFEST="$trusted/python-engine-package-paths.txt"
               export TCL_LSP_RUST_TESTS_PACKAGE_MANIFEST="$trusted/rust-tests-package-paths.txt"
               export TCL_LSP_RUST_TESTS_INPUT_MANIFEST="$trusted/rust-tests-input-paths.txt"
               export TCL_LSP_E2E_PACKAGE_MANIFEST="$trusted/lsp-e2e-package-paths.txt"
               export TCL_LSP_E2E_INPUT_MANIFEST="$trusted/lsp-e2e-input-paths.txt"
             fi
           fi
+          python_ci_path=${python_ci_path:-scripts/dev/python-ci-path.sh}
           if [[ "$ok" == "true" ]] && files="$("$changed_paths" "$GITHUB_EVENT_NAME" "$GITHUB_REPOSITORY" "$PR_NUMBER" "$BEFORE" "$GITHUB_SHA" "$GITHUB_REF")"; then
             :
           else
@@ -275,10 +281,15 @@ jobs:
           docs_only=true
           if [ "$ok" = "true" ]; then
             while IFS= read -r f; do
-              case "$f" in
-                *.py | *.pyi | typings/* | rust/bigip-report-gen/python/* | ruff.toml | pyrightconfig.json | Makefile | .github/workflows/ci.yml)
-                  python_changed=true ;;
-              esac
+              if "$python_ci_path" "$f"; then
+                python_changed=true
+              else
+                status=$?
+                if [ "$status" -ne 1 ]; then
+                  ok=false
+                  break
+                fi
+              fi
               case "$f" in
                 editors/vscode/* | scripts/dev/json-no-duplicate-keys.mjs | scripts/dev/test-vscode-test-partitions.sh | scripts/dev/verify-vscode-test-partitions.mjs | scripts/dev/verify-vscode-test-results.mjs | rust/* | grammars/* | ai/* | Cargo.toml | Cargo.lock | rust-toolchain.toml | Makefile | .github/workflows/ci.yml)
                   ext_changed=true ;;
@@ -2527,14 +2538,17 @@ jobs:
       - name: Compute venv cache key
         if: env.RUN_PY == 'true'
         id: pykey
-        run: echo "pyver=$(python3 -V | tr ' ' '-')" >> "$GITHUB_OUTPUT"
+        run: |
+          echo "pyver=$(python3 -V | tr ' ' '-')" >> "$GITHUB_OUTPUT"
+          engine=$(make --no-print-directory python-engine-source-hash)
+          echo "engine=$engine" >> "$GITHUB_OUTPUT"
 
       - name: Cache typecheck venv
         if: env.RUN_PY == 'true'
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .venv-typecheck
-          key: ${{ runner.os }}-venv-typecheck-${{ steps.pykey.outputs.pyver }}-${{ hashFiles('rust/bigip-report-gen/python/**') }}
+          key: ${{ runner.os }}-venv-typecheck-${{ steps.pykey.outputs.pyver }}-${{ steps.pykey.outputs.engine }}
 
       # Pinned installer rather than a floating action, so the uv that resolves
       # the pinned tool versions is itself pinned.  The installer is fetched to
@@ -2569,6 +2583,10 @@ jobs:
       - name: ty + pyright
         if: env.RUN_PY == 'true'
         run: make typecheck-py
+
+      - name: Native engine binding tests
+        if: env.RUN_PY == 'true'
+        run: make test-py-engine
 
   # The two npm roots that are NOT `editors/vscode`.  Nothing on a pull
   # request used to install them: every `npm ci` in this workflow is in

--- a/Makefile
+++ b/Makefile
@@ -210,7 +210,7 @@ TS_SRCS  := $(shell find $(EXT_DIR)/src -name '*.ts' 2>/dev/null)
 # Tests
 .PHONY: test test-ext test-ext-partition test-ext-multi-folder test-emacs test-jetbrains test-rust rust-server rust-tcl rust-f5 rust-mcp rust-clis ensure-server-cross-deps server-cross-build server-cross-build-all mcp-cross-build-all cli-cross-build-all server-cross-test server-cross-test-build print-server-targets-all print-server-targets-jetbrains
 .PHONY: xtask-check xtask-editor-extensions xtask-kcs-index-links xtask-diag-tables xtask-diag-emission-check xtask-gen-editor-catalogs xtask-gen-bundled-environments xtask-gen-editor-dialects xtask-gen-irule-test-data xtask-gen-zed-queries xtask-gen-editor-settings xtask-gen-vscode-package xtask-gen-jetbrains-catalog xtask-gen-ai-diagnostics xtask-owner-resolution xtask-command-backing xtask-audit-option-dialects xtask-registry-oracle xtask-sslictcl-data xtask-runtime-stdlib tcltest-sweep tcltest-sweep-check xtask-f5query-builtins-doc xtask-bigip-data-schema xtask-c-api-ownership check-c-api-ownership
-.PHONY: xtask-workflow-sync xtask-resolution-drift xtask-retired-api-gate xtask-pack-goldens xtask-number-drift xtask-gen-tmlanguage-keywords xtask-option-registry-drift xtask-callback-inventory check-tcl-reference-toolchains check-spectcl-compat-paths check-runtime-rust-paths check-rust-tests-runner check-persistent-cargo-target check-rust-tests-paths check-lsp-e2e-paths check-lsp-e2e-partitions check-lsp-wasi-lto check-vscode-test-partitions check-already-green check-monitoring-triggers check-smoke-targets check-wasm-cc-env check-homebrew-ci check-sign-and-upload check-release-dependency-graph xtask-dialect-drift xtask-segmentation-drift
+.PHONY: xtask-workflow-sync xtask-resolution-drift xtask-retired-api-gate xtask-pack-goldens xtask-number-drift xtask-gen-tmlanguage-keywords xtask-option-registry-drift xtask-callback-inventory check-tcl-reference-toolchains check-spectcl-compat-paths check-runtime-rust-paths check-python-ci-paths check-rust-tests-runner check-persistent-cargo-target check-rust-tests-paths check-lsp-e2e-paths check-lsp-e2e-partitions check-lsp-wasi-lto check-vscode-test-partitions check-already-green check-monitoring-triggers check-smoke-targets check-wasm-cc-env check-homebrew-ci check-sign-and-upload check-release-dependency-graph xtask-dialect-drift xtask-segmentation-drift
 # Lint / format / typecheck
 .PHONY: lint format lint-ts format-ts typecheck-ts check-rust check-rust-pr _check-rust-pr rust-deny
 .PHONY: build-report-assets build-report-pyz lint-report-ts typecheck-report-ts check-report-assets lint-spec-studio-ts typecheck-spec-studio-ts
@@ -644,7 +644,7 @@ PY_VENV := $(ROOT).venv-typecheck
 # gate uses, and it skips build outputs, the venv, and untracked scratch files.
 PY_FILES = $(shell git -C $(ROOT) ls-files '*.py')
 
-.PHONY: lint-py format-py typecheck-py py-venv
+.PHONY: lint-py format-py typecheck-py test-py-engine py-venv python-engine-source-hash
 
 lint-py: ## Lint + format-check every tracked Python file (ruff)
 	@echo "==> Linting Python (ruff format --check + ruff check)"
@@ -663,11 +663,11 @@ py-venv: ## Build the typecheck venv (f5report + native _engine + pytest)
 	@# The reinstall maturin-compiles the native `_engine` in release mode
 	@# (~4 min), so gate it on a content hash of the package tree: ty/pyright
 	@# read the committed `_engine.pyi` stub, never the compiled module, so the
-	@# venv only needs a rebuild when the Python package itself changes.
+	@# venv needs a rebuild when the Python package or any local Rust input
+	@# compiled into its native extension changes.
 	@cd $(ROOT) && \
 	  stamp="$(PY_VENV)/.f5report-src-hash"; \
-	  files=$$(git ls-files -- rust/bigip-report-gen/python | LC_ALL=C sort); \
-	  hash=$$( { printf '%s\n' "$$files"; printf '%s\n' "$$files" | xargs git hash-object; printf '%s\n' "pytest=$(PYTEST_VERSION)"; } | git hash-object --stdin ); \
+	  hash=$$($(MAKE) --no-print-directory python-engine-source-hash); \
 	  if [ ! -f "$$stamp" ] || [ "$$(cat "$$stamp")" != "$$hash" ]; then \
 	    uv pip install --python $(PY_VENV) --quiet \
 	        --reinstall-package f5report ./rust/bigip-report-gen/python pytest==$(PYTEST_VERSION) || exit; \
@@ -676,6 +676,14 @@ py-venv: ## Build the typecheck venv (f5report + native _engine + pytest)
 	    echo "    f5report source unchanged — venv already current"; \
 	  fi
 
+python-engine-source-hash: ## Hash every source/build input compiled into the f5report Python engine
+	@cd $(ROOT) && \
+	  files=$$(scripts/dev/python-engine-source-files.sh) && \
+	  { printf '%s\n' "$$files"; \
+	    printf '%s\n' "$$files" | git hash-object --stdin-paths; \
+	    printf '%s\n' "pytest=$(PYTEST_VERSION)"; \
+	  } | git hash-object --stdin
+
 typecheck-py: py-venv ## Type-check every tracked Python file (ty + pyright)
 	@echo "==> Type-checking Python (ty)"
 	@cd $(ROOT) && uvx ty@$(TY_VERSION) check \
@@ -683,6 +691,10 @@ typecheck-py: py-venv ## Type-check every tracked Python file (ty + pyright)
 	    --extra-search-path .claude/skills/lsp-client $(PY_FILES)
 	@echo "==> Type-checking Python (pyright)"
 	@cd $(ROOT) && uvx pyright@$(PYRIGHT_VERSION)
+
+test-py-engine: py-venv ## Test the native f5report query-engine binding
+	@echo "==> Testing the native Python query-engine binding"
+	@cd $(ROOT) && $(PY_VENV)/bin/pytest -q rust/bigip-report-gen/python/tests/test_engine.py
 
 # The lsp_e2e suite is native: rust/tcl-lsp-server/tests/*_e2e.rs, run by
 # `cargo test` (see test-rust). tclpkg is the `tcl-pkg` Rust crate, exercised by
@@ -857,7 +869,7 @@ coverage-ext: compile $(NPM_STAMP) ensure-vscode-test-deps ## Run VS Code extens
 # --- Native (cargo xtask) check gates.  These need the Rust toolchain, so CI
 # runs them in the rust-tests-shard matrix and its stable rust-tests aggregate
 # (ci.yml). `xtask-check` is the CI aggregate.
-xtask-check: check-tcl-reference-toolchains check-spectcl-compat-paths check-runtime-rust-paths check-rust-tests-runner check-persistent-cargo-target check-rust-tests-paths check-lsp-e2e-paths check-lsp-e2e-partitions check-lsp-wasi-lto check-already-green check-monitoring-triggers check-smoke-targets check-wasm-cc-env check-homebrew-ci check-sign-and-upload check-release-dependency-graph check-vsix-web-assets-contract xtask-workflow-sync xtask-kcs-index-links xtask-diag-tables xtask-diag-emission-check xtask-gen-editor-catalogs xtask-gen-bundled-environments xtask-gen-editor-dialects xtask-gen-irule-test-data xtask-gen-zed-queries xtask-gen-tmlanguage-keywords xtask-gen-editor-settings xtask-gen-vscode-package xtask-gen-jetbrains-catalog xtask-gen-ai-diagnostics xtask-owner-resolution xtask-resolution-drift xtask-retired-api-gate xtask-pack-goldens xtask-number-drift xtask-segmentation-drift xtask-command-backing xtask-callback-inventory xtask-option-registry-drift xtask-sslictcl-data xtask-runtime-stdlib xtask-editor-extensions xtask-f5query-builtins-doc xtask-bigip-data-schema xtask-c-api-ownership ## Rust-side check gates (docs index coverage + generated-table/catalog drift) xtask-dialect-drift
+xtask-check: check-tcl-reference-toolchains check-spectcl-compat-paths check-runtime-rust-paths check-python-ci-paths check-rust-tests-runner check-persistent-cargo-target check-rust-tests-paths check-lsp-e2e-paths check-lsp-e2e-partitions check-lsp-wasi-lto check-already-green check-monitoring-triggers check-smoke-targets check-wasm-cc-env check-homebrew-ci check-sign-and-upload check-release-dependency-graph check-vsix-web-assets-contract xtask-workflow-sync xtask-kcs-index-links xtask-diag-tables xtask-diag-emission-check xtask-gen-editor-catalogs xtask-gen-bundled-environments xtask-gen-editor-dialects xtask-gen-irule-test-data xtask-gen-zed-queries xtask-gen-tmlanguage-keywords xtask-gen-editor-settings xtask-gen-vscode-package xtask-gen-jetbrains-catalog xtask-gen-ai-diagnostics xtask-owner-resolution xtask-resolution-drift xtask-retired-api-gate xtask-pack-goldens xtask-number-drift xtask-segmentation-drift xtask-command-backing xtask-callback-inventory xtask-option-registry-drift xtask-sslictcl-data xtask-runtime-stdlib xtask-editor-extensions xtask-f5query-builtins-doc xtask-bigip-data-schema xtask-c-api-ownership ## Rust-side check gates (docs index coverage + generated-table/catalog drift) xtask-dialect-drift
 
 check-lsp-wasi-lto: ## Verify functional WASI uses thin LTO and tags retain fat LTO
 	@bash scripts/dev/test-lsp-wasi-lto.sh
@@ -874,6 +886,10 @@ check-spectcl-compat-paths: ## Verify CI's SpecTcl dependency closure and centra
 check-runtime-rust-paths: ## Verify CI's standalone-runtime dependency closure and job wiring (#1768)
 	@echo "==> Checking standalone runtime CI path ownership"
 	@bash scripts/dev/test-runtime-rust-paths.sh
+
+check-python-ci-paths: ## Verify Python CI's native-engine dependency closure, cache key, and wiring
+	@echo "==> Checking Python CI path and cache ownership"
+	@bash scripts/dev/test-python-ci-paths.sh
 
 check-rust-tests-paths: ## Verify CI's root Rust test dependency closure and classifier wiring
 	@echo "==> Checking root Rust test path ownership"

--- a/docs/design/contracts/test-tiers-and-ci-gates.md
+++ b/docs/design/contracts/test-tiers-and-ci-gates.md
@@ -9,7 +9,7 @@ behind it.
 | Tier | Runs | What |
 |---|---|---|
 | **smoke** — `make smoke`, `make smoke-p P=<crate>` | locally after every compile; inside `make prep-pr` | the fail-closed smoke-named function/module and effective Cargo-target subset owned by `scripts/dev/smoke-targets.tsv`, one sanity check per crate, seconds warm. Reuses the dev-profile default-features build (never `--all-features`), so it never forces a recompile. |
-| **deep** — CI jobs `rust-tests-shard` and `rust-tests-doctest` plus their stable `rust-tests` aggregate, `rust-tests-heavy`, `runtime-rust-tests`, `lsp-e2e`, `test-ext`, `test-ext-web`, `cargo-deny`, `python`, `spectcl-compat`, `web-frontends` | every PR and every push to `rust` | the full workspace suite (native `lsp_e2e` included), the VM-sim heavies, the standalone `runtime/rust` unit suite, the VS Code extension on desktop and in a browser host, supply-chain audit, Python lint/typecheck of `rust/bigip-report-gen/python`, and an `npm ci` of the two npm roots that are not `editors/vscode`. Skips only what demonstrably did not change (below). |
+| **deep** — CI jobs `rust-tests-shard` and `rust-tests-doctest` plus their stable `rust-tests` aggregate, `rust-tests-heavy`, `runtime-rust-tests`, `lsp-e2e`, `test-ext`, `test-ext-web`, `cargo-deny`, `python`, `spectcl-compat`, `web-frontends` | every PR and every push to `rust` | the full workspace suite (native `lsp_e2e` included), the VM-sim heavies, the standalone `runtime/rust` unit suite, the VS Code extension on desktop and in a browser host, supply-chain audit, Python lint/typecheck plus native-engine build and binding tests for `rust/bigip-report-gen/python`, and an `npm ci` of the two npm roots that are not `editors/vscode`. Skips only what demonstrably did not change (below). |
 | **exhaustive** — `make test-exhaustive`, `make fuzz`, `make tcltest-sweep[-check]` | only when a human invokes it by name | every `#[ignore]`d corpus sweep over `tmp/tcl*` and tcllib, differential-fuzz gates, privileged bpf/kernel tests, fuzz campaigns. **Never** wired into `prep-pr`, `test`, `check-all`, or CI. |
 
 The native `lsp-e2e` surface is produced once as a nextest 0.9.143 archive,
@@ -210,6 +210,13 @@ CI skips only what demonstrably did not change. The rules live in
 - **Docs-only** changes skip the cargo test steps; `python`, `test-ext`, and
   `test-ext-web` run only when their input paths changed (`test-ext-web` on
   `ext_changed` or `lsp_wasm_changed`, since it consumes both).
+- The `python` job's input surface includes every tracked Python/stub file and
+  the native f5report engine's locked local Cargo dependency closure. The
+  classifier and package manifest come from the PR base and fail closed;
+  `make check-python-ci-paths` re-derives the closure from the engine lockfile.
+  The restored venv is keyed and stamped with the content of that same native
+  source closure, so a transitive Rust edit both schedules the job and forces
+  maturin to rebuild the extension.
 - The root `rust-tests-shard` matrix produces five binary-aware legs when the
   Rust suite is required, while the concurrent hosted
   `rust-tests-doctest` job runs `cargo test --workspace --all-features --doc

--- a/rust/bigip-report-gen/python/src/lib.rs
+++ b/rust/bigip-report-gen/python/src/lib.rs
@@ -65,10 +65,10 @@ create_exception!(
 /// * `Stream`   → `list` (top-level streams are flattened by [`query`]);
 /// * `ObjectRef`→ `{"kind", "full-path", "fields": {…}}`;
 /// * `Container`→ `"container(<kind>)"` (matching the JSON fallback);
-/// * `Drop`/`Null` → `None`.
+/// * `Drop`/`Null`/`Unresolved` → `None`.
 fn value_to_py(py: Python<'_>, value: &Value) -> PyResult<Py<PyAny>> {
     let obj = match value {
-        Value::Null | Value::Drop => py.None(),
+        Value::Null | Value::Unresolved(_) | Value::Drop => py.None(),
         Value::Bool(b) => pyo3::types::PyBool::new(py, *b)
             .to_owned()
             .into_any()

--- a/rust/bigip-report-gen/python/tests/test_engine.py
+++ b/rust/bigip-report-gen/python/tests/test_engine.py
@@ -112,6 +112,17 @@ def test_merge_refuses_colliding_identities():
         f5report.query(".ltm.pool[]", [a, b], merge=True)
 
 
+def test_unresolved_reference_is_none():
+    sources = [
+        (
+            "virtual.conf",
+            "ltm virtual /Common/app { pool /Common/missing_pool }\n",
+        )
+    ]
+    rows = f5report.query(".ltm.virtual[] | .pool | .members", sources)
+    assert rows == [None]
+
+
 def test_bad_query_raises_queryerror():
     sources = f5report.load_paths([UCS1])
     with pytest.raises(f5report._engine.QueryError):

--- a/scripts/dev/python-ci-path.sh
+++ b/scripts/dev/python-ci-path.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+# tcl-lsp — a language server and toolchain for Tcl
+# Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+# Exit 0 when a repository-relative path can change Python lint/typecheck or
+# the native f5report engine it compiles, 1 when it cannot, and 2 when the
+# request or committed dependency closure is unusable. CI fails closed on 2.
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+REPO_ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/../.." && pwd)
+PACKAGE_MANIFEST=${TCL_LSP_PYTHON_ENGINE_PACKAGE_MANIFEST:-$REPO_ROOT/scripts/dev/python-engine-package-paths.txt}
+
+if [ "$#" -ne 1 ] || [ -z "$1" ]; then
+    echo "usage: scripts/dev/python-ci-path.sh REPOSITORY_PATH" >&2
+    exit 2
+fi
+if [ ! -r "$PACKAGE_MANIFEST" ]; then
+    echo "cannot read Python engine package closure: $PACKAGE_MANIFEST" >&2
+    exit 2
+fi
+awk '
+    /^[[:space:]]*#/ || /^[[:space:]]*$/ { next }
+    $0 ~ /^[[:space:]]/ || $0 ~ /[[:space:]]$/ || $0 ~ /^\// || $0 ~ /\/$/ || $0 ~ /[*?]/ || index($0, "[") || index($0, "\\") || index($0, "//") || $0 ~ /(^|\/)(\.\.?)(\/|$)/ || seen[$0]++ {
+        printf "python-ci-path: invalid row %d in %s: %s\n", NR, FILENAME, $0 > "/dev/stderr"; bad=1
+    }
+    { count++ }
+    END { if (count == 0) { print "python-ci-path: empty manifest " FILENAME > "/dev/stderr"; bad=1 } exit bad }
+' "$PACKAGE_MANIFEST" || exit 2
+
+PATH_TO_CLASSIFY=$1
+
+case "$PATH_TO_CLASSIFY" in
+    *.py | *.pyi | typings/* | ruff.toml | pyrightconfig.json)
+        exit 0
+        ;;
+    .cargo/config.toml | Cargo.toml | rust-toolchain.toml | Makefile | \
+    .github/workflows/ci.yml | scripts/dev/python-*)
+        exit 0
+        ;;
+esac
+
+while IFS= read -r package_root || [ -n "$package_root" ]; do
+    case "$package_root" in '' | \#*) continue ;; esac
+    case "$PATH_TO_CLASSIFY" in
+        "$package_root" | "$package_root"/*) exit 0 ;;
+    esac
+done < "$PACKAGE_MANIFEST"
+
+exit 1

--- a/scripts/dev/python-engine-package-paths.txt
+++ b/scripts/dev/python-engine-package-paths.txt
@@ -1,0 +1,25 @@
+# Local package source roots in the locked bigip-report-gen-py dependency
+# closure. The report root deliberately covers its Rust/Python packages and
+# the templates, generated front-end, and WASM assets embedded by the Rust
+# report library. scripts/dev/test-python-ci-paths.sh derives the package
+# closure from rust/bigip-report-gen/python/Cargo.lock and rejects drift.
+rust/bigip-report-gen
+rust/tcl-bigip
+rust/tcl-bigip-io
+rust/tcl-bigip-query
+rust/tcl-bytecode
+rust/tcl-cmd-core
+rust/tcl-compiler
+rust/tcl-core-types
+rust/tcl-diagram
+rust/tcl-dialect
+rust/tcl-f5mku
+rust/tcl-irules
+rust/tcl-lexer
+rust/tcl-platform
+rust/tcl-regex
+rust/tcl-registry
+rust/tcl-runtime-api
+rust/tcl-sslictcl
+rust/tcl-syntax
+rust/tcl-version

--- a/scripts/dev/python-engine-source-files.sh
+++ b/scripts/dev/python-engine-source-files.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+# tcl-lsp — a language server and toolchain for Tcl
+# Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+# Print the tracked source/build inputs that determine the native f5report
+# wheel. This is shared by the local venv stamp and GitHub Actions cache key.
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+REPO_ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/../.." && pwd)
+PACKAGE_MANIFEST=${TCL_LSP_PYTHON_ENGINE_PACKAGE_MANIFEST:-$REPO_ROOT/scripts/dev/python-engine-package-paths.txt}
+
+if [ ! -r "$PACKAGE_MANIFEST" ]; then
+    echo "cannot read Python engine package closure: $PACKAGE_MANIFEST" >&2
+    exit 2
+fi
+awk '
+    /^[[:space:]]*#/ || /^[[:space:]]*$/ { next }
+    $0 ~ /^[[:space:]]/ || $0 ~ /[[:space:]]$/ || $0 ~ /^\// || $0 ~ /\/$/ || $0 ~ /[*?]/ || index($0, "[") || index($0, "\\") || index($0, "//") || $0 ~ /(^|\/)(\.\.?)(\/|$)/ || seen[$0]++ {
+        printf "python-engine-source-files: invalid row %d in %s: %s\n", NR, FILENAME, $0 > "/dev/stderr"; bad=1
+    }
+    { count++ }
+    END { if (count == 0) { print "python-engine-source-files: empty manifest " FILENAME > "/dev/stderr"; bad=1 } exit bad }
+' "$PACKAGE_MANIFEST" || exit 2
+
+paths=$(mktemp)
+trap 'rm -f "$paths"' EXIT HUP INT TERM
+
+while IFS= read -r package_root || [ -n "$package_root" ]; do
+    case "$package_root" in '' | \#*) continue ;; esac
+    if [ ! -d "$REPO_ROOT/$package_root" ]; then
+        echo "missing Python engine package root: $package_root" >&2
+        exit 2
+    fi
+    git -C "$REPO_ROOT" ls-files -- "$package_root" >> "$paths"
+done < "$PACKAGE_MANIFEST"
+git -C "$REPO_ROOT" ls-files -- \
+    .cargo/config.toml Cargo.toml Makefile rust-toolchain.toml \
+    scripts/dev/python-ci-path.sh \
+    scripts/dev/python-engine-package-paths.txt \
+    scripts/dev/python-engine-source-files.sh >> "$paths"
+
+LC_ALL=C sort -u "$paths"

--- a/scripts/dev/test-python-ci-paths.sh
+++ b/scripts/dev/test-python-ci-paths.sh
@@ -1,0 +1,164 @@
+#!/bin/sh
+# tcl-lsp — a language server and toolchain for Tcl
+# Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+# Contract tests for the Python lane's native-engine dependency closure,
+# source-content cache identity, and fail-closed CI wiring.
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+REPO_ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/../.." && pwd)
+CLASSIFIER=$SCRIPT_DIR/python-ci-path.sh
+SOURCE_FILES=$SCRIPT_DIR/python-engine-source-files.sh
+LOCKFILE=$REPO_ROOT/rust/bigip-report-gen/python/Cargo.lock
+WORKFLOW=$REPO_ROOT/.github/workflows/ci.yml
+
+fail() {
+    echo "$1" >&2
+    exit 1
+}
+
+expect_relevant() {
+    "$CLASSIFIER" "$1" || fail "expected Python-relevant path: $1"
+}
+
+expect_unrelated() {
+    if "$CLASSIFIER" "$1"; then
+        fail "expected Python-unrelated path: $1"
+    else
+        status=$?
+        [ "$status" -eq 1 ] || fail "classifier failed for $1 with status $status"
+    fi
+}
+
+[ -r "$LOCKFILE" ] || fail "cannot read $LOCKFILE"
+
+local_packages=$(
+    awk '
+        /^\[\[package\]\]/ { name = ""; source = "" }
+        /^name = / { name = $3; gsub(/"/, "", name) }
+        /^source = / { source = $3 }
+        /^$/ { if (name != "" && source == "") print name; name = "" }
+        END { if (name != "" && source == "") print name }
+    ' "$LOCKFILE" | sort -u
+)
+[ -n "$local_packages" ] || fail "Python engine lockfile has no local packages"
+
+closure_dirs=''
+expected_roots=''
+for package in $local_packages; do
+    case "$package" in
+        bigip-report-gen-py)
+            directory=rust/bigip-report-gen/python
+            package_root=rust/bigip-report-gen
+            ;;
+        bigip-report-gen-rust)
+            directory=rust/bigip-report-gen/rust
+            package_root=rust/bigip-report-gen
+            ;;
+        *)
+            directory=rust/$package
+            package_root=$directory
+            ;;
+    esac
+    [ -f "$REPO_ROOT/$directory/Cargo.toml" ] \
+        || fail "local package $package maps to missing $directory/Cargo.toml"
+    closure_dirs="$closure_dirs $directory"
+    expected_roots="$expected_roots
+$package_root"
+    expect_relevant "$directory/Cargo.toml"
+    expect_relevant "$directory/src/lib.rs"
+done
+
+expected_roots=$(printf '%s\n' "$expected_roots" | sed '/^$/d' | LC_ALL=C sort -u)
+manifest_roots=$(sed '/^[[:space:]]*#/d; /^[[:space:]]*$/d' \
+    "$SCRIPT_DIR/python-engine-package-paths.txt" | LC_ALL=C sort -u)
+if [ "$manifest_roots" != "$expected_roots" ]; then
+    echo "Python engine package closure differs from its lockfile:" >&2
+    printf 'expected:\n%s\nactual:\n%s\n' "$expected_roots" "$manifest_roots" >&2
+    exit 1
+fi
+
+for manifest in "$REPO_ROOT"/rust/*/Cargo.toml; do
+    directory=rust/$(basename "$(dirname "$manifest")")
+    in_closure=no
+    for known in $closure_dirs; do
+        [ "$known" = "$directory" ] && in_closure=yes
+    done
+    [ "$in_closure" = yes ] && continue
+    expect_unrelated "$directory/src/lib.rs"
+done
+
+expect_relevant rust/bigip-report-gen/frontend/dist/report.js
+expect_relevant editors/sublime/plugin.py
+expect_relevant typings/sublime.pyi
+expect_relevant Cargo.toml
+expect_relevant rust-toolchain.toml
+expect_relevant Makefile
+expect_relevant .github/workflows/ci.yml
+expect_relevant scripts/dev/python-engine-package-paths.txt
+expect_unrelated README.md
+expect_unrelated editors/vscode/src/extension.ts
+
+if "$CLASSIFIER" '' 2>/dev/null; then
+    fail "empty path unexpectedly classified relevant"
+else
+    status=$?
+    [ "$status" -eq 2 ] || fail "empty path returned $status, expected 2"
+fi
+
+listed_file=$(mktemp)
+manifest_probe=$(mktemp)
+trap 'rm -f "$listed_file" "$manifest_probe"' EXIT HUP INT TERM
+$SOURCE_FILES > "$listed_file"
+for required in \
+    rust/bigip-report-gen/python/src/lib.rs \
+    rust/bigip-report-gen/frontend/dist/report.js \
+    rust/tcl-bigip-query/src/value.rs \
+    Cargo.toml Makefile rust-toolchain.toml \
+    scripts/dev/python-engine-package-paths.txt; do
+    grep -Fxq "$required" "$listed_file" \
+        || fail "native-engine source identity omits $required"
+done
+if grep -Fxq editors/vscode/src/extension.ts "$listed_file"; then
+    fail "native-engine source identity includes unrelated VS Code source"
+fi
+
+printf '%s\n' '../outside' > "$manifest_probe"
+if TCL_LSP_PYTHON_ENGINE_PACKAGE_MANIFEST=$manifest_probe \
+    "$CLASSIFIER" README.md >/dev/null 2>&1; then
+    fail "malformed Python path closure unexpectedly classified a path"
+else
+    status=$?
+    [ "$status" -eq 2 ] || fail "malformed path closure returned $status, expected 2"
+fi
+if TCL_LSP_PYTHON_ENGINE_PACKAGE_MANIFEST=$manifest_probe \
+    "$SOURCE_FILES" >/dev/null 2>&1; then
+    fail "malformed native-engine source closure unexpectedly succeeded"
+else
+    status=$?
+    [ "$status" -eq 2 ] || fail "malformed source closure returned $status, expected 2"
+fi
+
+hash_one=$(make -s -C "$REPO_ROOT" python-engine-source-hash)
+hash_two=$(make -s -C "$REPO_ROOT" python-engine-source-hash)
+[ "$hash_one" = "$hash_two" ] || fail "native-engine source hash is unstable"
+[ "${#hash_one}" -eq 40 ] || fail "native-engine source hash has wrong length: $hash_one"
+case "$hash_one" in *[!0-9a-f]*) fail "native-engine source hash is malformed: $hash_one" ;; esac
+
+grep -Fq 'scripts/dev/python-ci-path.sh' "$WORKFLOW" \
+    || fail "CI does not use the Python path classifier"
+grep -Fq 'TCL_LSP_PYTHON_ENGINE_PACKAGE_MANIFEST="$trusted/python-engine-package-paths.txt"' "$WORKFLOW" \
+    || fail "trusted PR classification does not use the base package closure"
+grep -Fq "engine=\$(make --no-print-directory python-engine-source-hash)" "$WORKFLOW" \
+    || fail "CI cache key does not use the native-engine source identity"
+grep -Fq 'hash=$$($(MAKE) --no-print-directory python-engine-source-hash)' "$REPO_ROOT/Makefile" \
+    || fail "local venv stamp does not use the native-engine source identity"
+grep -Fq 'run: make test-py-engine' "$WORKFLOW" \
+    || fail "Python CI does not run the native-engine binding tests"
+
+count=$(printf '%s\n' "$local_packages" | wc -l | tr -d ' ')
+echo "Python CI path and cache contracts passed ($count local packages)"


### PR DESCRIPTION
## Summary

- map unresolved BIG-IP references to Python `None`, matching every other output mode
- schedule the Python lane for the native engine's exact locked local Cargo dependency closure
- key both the restored venv and local stamp from that same source closure
- enforce the classifier, cache identity, and base-trusted PR wiring with a fail-closed contract

This fixes the latent regression introduced by #2023 and unblocks #2037 and #2038.

## Experimental proof

Before the fix, `make typecheck-py` failed in maturin with Rust E0004 because `Value::Unresolved(_)` was not covered. With the fix, the identical target passes both ty and pyright. A content-only edit to `rust/tcl-bigip-query/src/value.rs` changed the engine source identity from `1f57966601ef7488dfd94f47585061a0607e7fb8` to `b8eb3066ba8a52da87fc5f18a6430aa7a87c86ec`; after restoration, an unchanged rerun took the fast `f5report source unchanged` path.

## Verification

- `make rust-check`
- `make prep-pr` (30/30 smoke)
- `make lint-py`
- `make typecheck-py`
- `.venv-typecheck/bin/pytest -q rust/bigip-report-gen/python/tests/test_engine.py` (13 passed)
- `bash scripts/dev/test-python-ci-paths.sh` (21-package exact closure)