### PR TITLE
fix(refactor): classify proc-refactoring variables at the frame boundary

### DIFF
--- a/docs/kcs/features/kcs-feature-refactor-extract-proc.md
+++ b/docs/kcs/features/kcs-feature-refactor-extract-proc.md
@@ -69,6 +69,12 @@ counted, in either direction: what it writes and what it reads are that
 frame's variables, not the selection's, so a nested proc's parameter never
 becomes a parameter of the extracted one.
 
+Nor does a name that only *looks* like a reference. A braced word substitutes
+nothing, so the `$notavar` of `set msg {$notavar}` and the `$a` of an `apply`
+lambda handed to `lsort -command` are literal text rather than variables the
+caller has to supply. A braced word that carries script or an expression is
+still read as such.
+
 ## Example
 
 Selecting the middle two lines of the first example extracts to:

--- a/docs/kcs/features/kcs-feature-refactor-extract-proc.md
+++ b/docs/kcs/features/kcs-feature-refactor-extract-proc.md
@@ -65,7 +65,9 @@ puts $total
 extracts to a proc that takes `total` by name, not one that takes it by value
 and drops the sum. A body that opens its own variable frame — a nested `proc`,
 `namespace eval`, `uplevel`, or an `apply` lambda — is deliberately not
-counted: what it writes is that frame's variable, not the selection's.
+counted, in either direction: what it writes and what it reads are that
+frame's variables, not the selection's, so a nested proc's parameter never
+becomes a parameter of the extracted one.
 
 ## Example
 
@@ -109,17 +111,22 @@ described in the registry rather than by being named inside the refactoring.
 ## Operational context
 
 Implemented in `rust/tcl-lsp-core/src/refactor/extract_proc.rs`. The selection
-is snapped to whole segmented commands; the "is this variable read after the
-selection?" question is asked over the innermost enclosing script region
-(a proc body, an `if` branch, a `foreach` body, or the file), found by
-descending registry-resolved `ArgRole::Body` arguments.
+is snapped to whole segmented commands; the "is this variable read again?"
+question is asked over the frame the selection runs in, which ends at the
+nearest body that opens a variable frame of its own (a proc body, a
+`namespace eval`, an `apply` lambda) or at the file. An `if` or `foreach` body
+is not such a boundary, so a selection made inside a loop is still classified
+against the code that owns the variable. Each enclosing same-frame body counts
+in full rather than only the part after the selection, because a loop runs
+again and reads on its next pass what the previous one assigned.
 
-Both the selection's own classification and that after-the-selection question
-walk the statement tree through `nested_dispatch_regions`, the shared
-same-frame walker Find All References and the caller-frame scan use. It is
+Both the selection's own classification and that read-again question walk the
+statement tree through `nested_dispatch_regions`, the shared same-frame walker
+Find All References and the caller-frame scan use, and find the frame
+boundaries through its complement, `frame_shifted_dispatch_regions`. It is
 registry-driven throughout: `Plain` body arguments, `switch`-style clause arms
 via the registry's own `CaseListSpec`, and `[…]` command substitutions are
-descended, while `Structural` bodies and `apply` lambdas are not.
+descended, while `Structural` bodies and `apply` lambdas end the walk.
 
 ## Failure modes
 

--- a/docs/kcs/features/kcs-feature-refactor-extract-proc.md
+++ b/docs/kcs/features/kcs-feature-refactor-extract-proc.md
@@ -73,7 +73,8 @@ Nor does a name that only *looks* like a reference. A braced word substitutes
 nothing, so the `$notavar` of `set msg {$notavar}` and the `$a` of an `apply`
 lambda handed to `lsort -command` are literal text rather than variables the
 caller has to supply. A braced word that carries script or an expression is
-still read as such.
+still read as such, and so is every word of a command that performs Tcl
+substitution itself: `subst {hello $name}` does read `name`.
 
 ## Example
 

--- a/docs/kcs/features/kcs-feature-refactor-extract-proc.md
+++ b/docs/kcs/features/kcs-feature-refactor-extract-proc.md
@@ -126,7 +126,9 @@ Find All References and the caller-frame scan use, and find the frame
 boundaries through its complement, `frame_shifted_dispatch_regions`. It is
 registry-driven throughout: `Plain` body arguments, `switch`-style clause arms
 via the registry's own `CaseListSpec`, and `[…]` command substitutions are
-descended, while `Structural` bodies and `apply` lambdas end the walk.
+descended, the ones inside a braced expression argument through the expression
+parser's own script bridge, while `Structural` bodies and `apply` lambdas end
+the walk.
 
 ## Failure modes
 

--- a/docs/kcs/features/kcs-feature-refactor-inline-proc.md
+++ b/docs/kcs/features/kcs-feature-refactor-inline-proc.md
@@ -67,9 +67,17 @@ them. Splicing the written word into the body changes the value the body sees.
 | A parameter used in an `expr` operand is bound to a non-number | `expr {abc * 2}` reads `abc` as a function name, not as the string. |
 | A parameter used more than once is bound to a run-time value | `f [next]` with the body reading the parameter twice would call `next` twice. |
 
+Each of those questions is asked of the body's whole statement tree, not just
+its outermost command. A one-command body can still carry a script — `if {…}
+{set total 0}`, `foreach n … {…}`, `catch {…}` — and a write, a loop binding,
+or a frame-sensitive command inside one of those bodies moves into the caller's
+frame exactly as a top-level one would. The same goes for expression operands:
+`puts [expr {$n eq "abc"}]` holds its operand one level down.
+
 The frame-sensitive command list is the command registry's own, so a command
 gains this protection by being described in the registry — not by being added
-to a list inside the refactoring.
+to a list inside the refactoring. A loop's own binding is the registry's
+`LoopVarList` role rather than a write, and is refused for the same reason.
 
 ## Operational context
 

--- a/rust/tcl-lsp-core/src/refactor/extract_proc.rs
+++ b/rust/tcl-lsp-core/src/refactor/extract_proc.rs
@@ -233,31 +233,30 @@ fn plan_extraction(
         .get(block_start as usize..block_end as usize)
         .ok_or_else(|| "the selected range is unreadable".to_string())?;
 
-    // A written variable that is read again after the selection must keep
-    // reaching the caller's frame; one that is not becomes a proc local.
-    let tail = source
-        .get(block_end as usize..scope.end as usize)
-        .unwrap_or("");
-    // Segmented at its real offset so the same-frame walk below can address
-    // the tail's nested bodies in `source`'s own coordinates.
-    let tail_commands: Vec<SegmentedCommand> =
-        segment_commands_with_offset_and_config(tail, block_end, config)
-            .into_iter()
-            .filter(|command| !command.name().is_empty())
-            .collect();
-    let mut used_after: BTreeSet<String> = variable_references(tail, style);
+    // A written variable that is read again by the frame the selection runs
+    // in must keep reaching the caller; one that is not becomes a proc local.
+    let mut used_after: BTreeSet<String> = BTreeSet::new();
     let mut nested_tail = Vec::new();
-    for command in &tail_commands {
-        used_after.extend(role_named_variables(command, registry));
-        // A read after the selection decides `upvar` versus proc local, so a
-        // role-named read nested in a control-flow body has to count exactly
-        // as a top-level one does: `if {$ok} {incr total}` carries no
-        // `$total` for the text scan to find, and missing it would turn the
-        // selection's write into a proc local and lose the caller's value.
-        nested_tail.clear();
-        nested_same_frame_commands(source, command, &walk, 0, &mut nested_tail);
-        for inner in &nested_tail {
-            used_after.extend(role_named_variables(inner, registry));
+    for (start, end) in observing_regions(source, &walk, block_start, block_end) {
+        let text = source.get(start as usize..end as usize).unwrap_or_default();
+        used_after.extend(variable_references(text, style));
+        // Segmented at its real offset so the same-frame walk below can
+        // address nested bodies in `source`'s own coordinates.
+        for command in segment_commands_with_offset_and_config(text, start, config) {
+            if command.name().is_empty() {
+                continue;
+            }
+            used_after.extend(role_named_variables(&command, registry));
+            // A read decides `upvar` versus proc local, so a role-named read
+            // nested in a control-flow body has to count exactly as a
+            // top-level one does: `if {$ok} {incr total}` carries no `$total`
+            // for the text scan to find, and missing it would turn the
+            // selection's write into a proc local and lose the caller's value.
+            nested_tail.clear();
+            nested_same_frame_commands(source, &command, &walk, 0, &mut nested_tail);
+            for inner in &nested_tail {
+                used_after.extend(role_named_variables(inner, registry));
+            }
         }
     }
 
@@ -307,6 +306,91 @@ fn plan_extraction(
                 new_text: call,
             },
         ],
+    })
+}
+
+/// The byte ranges that can still observe what the selection writes.
+///
+/// A variable the selection assigns has to keep reaching the caller's frame
+/// whenever anything in that frame reads it again, so the question runs to the
+/// nearest boundary that opens a variable frame of its own — a `proc` body, a
+/// `namespace eval`, an `apply` lambda — or the end of the file.  An `if` or
+/// `foreach` body is *not* such a boundary: it shares the caller's variables,
+/// and stopping the scan at it classifies a selection made inside a loop as
+/// writing a proc local, dropping every value the loop accumulates.
+///
+/// Each enclosing same-frame body counts in full rather than only after the
+/// selection, because such a body can run again and read on its next pass what
+/// this one assigned.
+fn observing_regions(
+    source: &str,
+    walk: &FrameWalk,
+    block_start: u32,
+    block_end: u32,
+) -> Vec<(u32, u32)> {
+    let mut frame = (0, u32::try_from(source.len()).unwrap_or(u32::MAX));
+    let mut enclosing: Vec<(u32, u32)> = Vec::new();
+    let mut search = frame;
+    let mut depth = 0;
+    while !crate::references::MAX_DISPATCH_SCAN_DEPTH.exceeded(depth) {
+        let Some((region, opens_frame)) = containing_region(source, walk, search, block_start)
+        else {
+            break;
+        };
+        // Every step has to narrow the window, or a region that reports itself
+        // would spin here.
+        if region.0 <= search.0 && region.1 >= search.1 {
+            break;
+        }
+        if opens_frame {
+            frame = region;
+            enclosing.clear();
+        } else {
+            enclosing.push(region);
+        }
+        search = region;
+        depth += 1;
+    }
+    let mut regions = vec![(block_end, frame.1)];
+    regions.extend(enclosing.into_iter().map(|(start, _)| (start, block_start)));
+    regions
+}
+
+/// The innermost region of `search` containing `offset`, and whether it opens
+/// a variable frame of its own.
+fn containing_region(
+    source: &str,
+    walk: &FrameWalk,
+    search: (u32, u32),
+    offset: u32,
+) -> Option<((u32, u32), bool)> {
+    let text = source.get(search.0 as usize..search.1 as usize)?;
+    for command in segment_commands_with_offset_and_config(text, search.0, walk.config) {
+        if command.name().is_empty() {
+            continue;
+        }
+        if let Some(region) = region_containing(
+            &crate::references::frame_shifted_dispatch_regions(source, walk.dialect, &command),
+            offset,
+        ) {
+            return Some((region, true));
+        }
+        if let Some(region) =
+            region_containing(&same_frame_regions(source, &command, walk), offset)
+        {
+            return Some((region, false));
+        }
+    }
+    None
+}
+
+/// The first of `regions` that contains `offset`.
+fn region_containing(regions: &[(usize, usize)], offset: u32) -> Option<(u32, u32)> {
+    regions.iter().copied().find_map(|(start, end)| {
+        let (Ok(start), Ok(end)) = (u32::try_from(start), u32::try_from(end)) else {
+            return None;
+        };
+        (offset >= start && offset < end).then_some((start, end))
     })
 }
 
@@ -467,6 +551,69 @@ fn nested_same_frame_commands(
     }
 }
 
+/// Every region inside `command` that runs in a variable frame of its own,
+/// appended to `out`.
+///
+/// The frame-opening bodies are [`crate::references::frame_shifted_dispatch_regions`]'s
+/// answer — the exact complement of the same-frame set
+/// [`nested_same_frame_commands`] walks — asked of `command` and of every
+/// same-frame command beneath it, so a `proc` nested in an `if` branch is
+/// found as readily as one at the selection's top level.
+fn frame_shifted_regions_within(
+    source: &str,
+    command: &SegmentedCommand,
+    walk: &FrameWalk,
+    out: &mut Vec<(u32, u32)>,
+) {
+    let mut push = |regions: Vec<(usize, usize)>| {
+        for (start, end) in regions {
+            let (Ok(start), Ok(end)) = (u32::try_from(start), u32::try_from(end)) else {
+                continue;
+            };
+            out.push((start, end));
+        }
+    };
+    push(crate::references::frame_shifted_dispatch_regions(
+        source,
+        walk.dialect,
+        command,
+    ));
+    let mut nested = Vec::new();
+    nested_same_frame_commands(source, command, walk, 0, &mut nested);
+    for inner in &nested {
+        push(crate::references::frame_shifted_dispatch_regions(
+            source,
+            walk.dialect,
+            inner,
+        ));
+    }
+}
+
+/// `start..end` with every range in `holes` cut out of it.
+fn same_frame_slices(start: u32, end: u32, holes: &[(u32, u32)]) -> Vec<(u32, u32)> {
+    let mut cuts: Vec<(u32, u32)> = holes
+        .iter()
+        .copied()
+        .filter(|(from, to)| *to > start && *from < end && from < to)
+        .collect();
+    cuts.sort_unstable();
+    let mut slices = Vec::new();
+    let mut cursor = start;
+    for (from, to) in cuts {
+        if from > cursor {
+            slices.push((cursor, from.min(end)));
+        }
+        cursor = cursor.max(to);
+        if cursor >= end {
+            break;
+        }
+    }
+    if cursor < end {
+        slices.push((cursor, end));
+    }
+    slices
+}
+
 /// Classify the selection's variable use from the registry's argument roles
 /// plus the `$name` references in its text.
 ///
@@ -496,18 +643,26 @@ fn classify_variables(
         written: BTreeMap::new(),
     };
     let mut nested = Vec::new();
+    let mut frames = Vec::new();
     for command in selected {
-        // One text scan per selected command already covers the `$name` reads
-        // of its whole subtree, nested bodies included.
+        // One text scan per selected command covers the `$name` reads of its
+        // whole subtree, minus the bodies that open a variable frame of their
+        // own: a `$name` in a nested proc body or an `apply` lambda names that
+        // frame's variable, so making it a parameter would ask the caller for
+        // a variable it does not have.
         let (start, end) = command_span_offsets(source, command);
-        let text = source.get(start as usize..end as usize).unwrap_or("");
-        for (name, at, _) in super::variable_reference_spans(text, style) {
-            let at = start.saturating_add(u32::try_from(at).unwrap_or(0));
-            roles
-                .read
-                .entry(name)
-                .and_modify(|first| *first = (*first).min(at))
-                .or_insert(at);
+        frames.clear();
+        frame_shifted_regions_within(source, command, walk, &mut frames);
+        for (from, to) in same_frame_slices(start, end, &frames) {
+            let text = source.get(from as usize..to as usize).unwrap_or("");
+            for (name, at, _) in super::variable_reference_spans(text, style) {
+                let at = from.saturating_add(u32::try_from(at).unwrap_or(0));
+                roles
+                    .read
+                    .entry(name)
+                    .and_modify(|first| *first = (*first).min(at))
+                    .or_insert(at);
+            }
         }
         classify_command(source, command, registry, &mut roles)?;
         nested.clear();
@@ -1163,6 +1318,62 @@ mod tests {
             "the expression's substitution writes the caller's variable: {result}"
         );
         assert!(result.contains("extracted_proc x\n"), "{result}");
+    }
+
+    /// A selection made *inside* a loop body still writes the caller's
+    /// variable: a control-flow body shares the frame it sits in, so the
+    /// "read after the selection?" question runs past the body's closing
+    /// brace to the frame that owns the variable.
+    ///
+    /// Oracle (tclsh 8.6.18 and 9.0.4 alike): original and extraction both
+    /// print `6`.  Classifying `total` as a proc local prints `0`.
+    #[test]
+    fn tp_a_write_inside_a_loop_body_reaches_the_caller() {
+        let src = "set total 0\nforeach n {1 2 3} {\n    incr total $n\n}\nputs $total\n";
+        let result = outcome(src, "incr total $n").unwrap();
+        assert!(
+            result.contains("proc extracted_proc {n totalName} {\n    upvar 1 $totalName total\n"),
+            "the loop body's write is the caller's write: {result}"
+        );
+        assert!(result.contains("extracted_proc $n total\n"), "{result}");
+    }
+
+    /// The enclosing body counts in full, not only the part after the
+    /// selection: a loop runs again, so a read *above* the selection reads
+    /// what the previous iteration assigned.
+    ///
+    /// Oracle: the original prints `0`, `1`, `3`; so does the extraction.
+    #[test]
+    fn tp_a_loop_carried_read_above_the_selection_keeps_the_upvar() {
+        let src = "set total 0\nforeach n {1 2 3} {\n    puts $total\n    incr total $n\n}\n";
+        let result = outcome(src, "incr total $n").unwrap();
+        assert!(
+            result.contains("upvar 1 $totalName total"),
+            "the next iteration reads what this one wrote: {result}"
+        );
+        assert!(result.contains("extracted_proc $n total\n"), "{result}");
+    }
+
+    /// A `$name` inside a body that opens its own variable frame names *that*
+    /// frame's variable, so it is neither a parameter of the extracted proc
+    /// nor an argument at the call site — the caller has no such variable to
+    /// pass.
+    ///
+    /// Oracle: the original defines `helper` and prints `done`; so does the
+    /// extraction.  Asking the caller for `$name` dies with
+    /// `can't read "name": no such variable`.
+    #[test]
+    fn tp_a_read_inside_a_nested_procs_body_is_not_a_parameter() {
+        let src = "proc helper {name} {\n    puts \"hello $name\"\n}\nputs done\n";
+        let result = outcome(src, "proc helper {name} {\n    puts \"hello $name\"\n}").unwrap();
+        assert!(
+            result.contains("proc extracted_proc {} {"),
+            "the nested proc's parameter is nobody else's: {result}"
+        );
+        assert!(
+            !result.contains("extracted_proc $name"),
+            "the caller has no `name` to pass: {result}"
+        );
     }
 
     /// A write nested in a control-flow body is still the caller's write.

--- a/rust/tcl-lsp-core/src/refactor/extract_proc.rs
+++ b/rust/tcl-lsp-core/src/refactor/extract_proc.rs
@@ -407,6 +407,59 @@ struct VariableRoles {
     written: BTreeMap<String, u32>,
 }
 
+/// The braced word interiors of `command` that substitute nothing, appended to
+/// `out`.
+///
+/// A braced word is a literal: `set msg {$notavar}` reads no variable at all,
+/// and scanning its text for `$name` would put a name in the generated
+/// parameter list that the caller need not have — the extraction then rewrites
+/// a working file into one that dies on `can't read`.
+///
+/// Three kinds of braced word are *not* such a literal and stay scanned: an
+/// [`ArgRole::Expr`] word, whose `$name`s `expr` substitutes; any word a
+/// same-frame or frame-opening region overlaps, which is script rather than
+/// data; and every word of a command the registry does not know, where nothing
+/// says the word is data.
+fn literal_word_holes(
+    source: &str,
+    command: &SegmentedCommand,
+    registry: &CommandRegistry,
+    walk: &super::FrameWalk,
+    out: &mut Vec<(u32, u32)>,
+) {
+    let head = command.name();
+    if registry.get(head).is_none() {
+        return;
+    }
+    let args: Vec<&str> = command.args().iter().map(String::as_str).collect();
+    let evaluated: Vec<usize> = registry.arg_indices_for_role(head, &args, ArgRole::Expr);
+    let mut scripts = walk.same_frame_regions(source, command);
+    scripts.extend(walk.frame_shifted_regions(source, command));
+    for (index, token) in command.argv.iter().enumerate().skip(1) {
+        if evaluated.contains(&(index - 1)) {
+            continue;
+        }
+        if token.kind != tcl_lexer::TokenType::Str
+            || token.content_offset != 1
+            || source.as_bytes().get(token.span.start() as usize) != Some(&b'{')
+        {
+            continue;
+        }
+        let start = token.span.start() + u32::from(token.content_offset);
+        let end = token.span.end();
+        if start >= end {
+            continue;
+        }
+        let overlaps_script = scripts.iter().any(|(from, to)| {
+            u32::try_from(*to).is_ok_and(|to| to > start)
+                && u32::try_from(*from).is_ok_and(|from| from < end)
+        });
+        if !overlaps_script {
+            out.push((start, end));
+        }
+    }
+}
+
 /// `start..end` with every range in `holes` cut out of it.
 fn same_frame_slices(start: u32, end: u32, holes: &[(u32, u32)]) -> Vec<(u32, u32)> {
     let mut cuts: Vec<(u32, u32)> = holes
@@ -461,17 +514,22 @@ fn classify_variables(
         written: BTreeMap::new(),
     };
     let mut nested = Vec::new();
-    let mut frames = Vec::new();
+    let mut holes = Vec::new();
     for command in selected {
         // One text scan per selected command covers the `$name` reads of its
-        // whole subtree, minus the bodies that open a variable frame of their
-        // own: a `$name` in a nested proc body or an `apply` lambda names that
-        // frame's variable, so making it a parameter would ask the caller for
-        // a variable it does not have.
+        // whole subtree, minus the parts of it that read nothing the caller
+        // owns: a body that opens a variable frame of its own, and a braced
+        // word that substitutes nothing.  Either one would ask the caller for
+        // a variable that need not exist there.
         let (start, end) = command_span_offsets(source, command);
-        frames.clear();
-        walk.frame_shifted_regions_within(source, command, &mut frames);
-        for (from, to) in same_frame_slices(start, end, &frames) {
+        nested.clear();
+        walk.nested_same_frame_commands(source, command, &mut nested);
+        holes.clear();
+        walk.frame_shifted_regions_within(source, command, &mut holes);
+        for inner in std::iter::once(*command).chain(nested.iter()) {
+            literal_word_holes(source, inner, registry, walk, &mut holes);
+        }
+        for (from, to) in same_frame_slices(start, end, &holes) {
             let text = source.get(from as usize..to as usize).unwrap_or("");
             for (name, at, _) in super::variable_reference_spans(text, style) {
                 let at = from.saturating_add(u32::try_from(at).unwrap_or(0));
@@ -483,8 +541,6 @@ fn classify_variables(
             }
         }
         classify_command(source, command, registry, &mut roles)?;
-        nested.clear();
-        walk.nested_same_frame_commands(source, command, &mut nested);
         for inner in &nested {
             classify_command(source, inner, registry, &mut roles)?;
         }
@@ -1088,6 +1144,43 @@ mod tests {
     }
 
     // -- TP: caller-frame writes survive via upvar -------------------------
+    /// A braced word substitutes nothing, so the `$name` spelled inside one
+    /// is not a variable the caller has to supply.
+    ///
+    /// Oracle (tclsh 8.6.18 and 9.0.4 alike): the original prints the four
+    /// characters `$notavar`; so does the extraction.  A `notavar` parameter
+    /// makes the rewritten call die with `can't read "notavar"`.
+    #[test]
+    fn tp_a_braced_literal_is_not_a_variable_read() {
+        let src = "set msg {$notavar}\nputs $msg\n";
+        let result = outcome(src, "set msg {$notavar}").unwrap();
+        assert!(
+            result.contains("proc extracted_proc {msgName} {"),
+            "a braced word reads nothing: {result}"
+        );
+        assert!(result.contains("extracted_proc msg\n"), "{result}");
+    }
+
+    /// The same rule reaches a lambda inside a callback word. `lsort`'s
+    /// `-command` value is data to the script lexer, so the lambda's own
+    /// parameters are neither the selection's reads nor the caller's to pass.
+    ///
+    /// Oracle: the original prints `1 2 3`; so does the extraction.
+    #[test]
+    fn tp_a_lambda_in_a_callback_word_is_not_a_parameter() {
+        let src = "set items {3 1 2}\nset sorted [lsort -command {apply {{a b} {expr {$a - $b}}}} $items]\nputs $sorted\n";
+        let result = outcome(
+            src,
+            "set sorted [lsort -command {apply {{a b} {expr {$a - $b}}}} $items]",
+        )
+        .unwrap();
+        assert!(
+            result.contains("proc extracted_proc {items sortedName} {"),
+            "only the list is the caller's: {result}"
+        );
+        assert!(result.contains("extracted_proc $items sorted"), "{result}");
+    }
+
     /// A name the selection reads *before* it writes is still an input. The
     /// list word of `foreach x $x` is evaluated before the loop binds `x`, so
     /// the caller has to hand that list over.

--- a/rust/tcl-lsp-core/src/refactor/extract_proc.rs
+++ b/rust/tcl-lsp-core/src/refactor/extract_proc.rs
@@ -415,11 +415,12 @@ struct VariableRoles {
 /// parameter list that the caller need not have — the extraction then rewrites
 /// a working file into one that dies on `can't read`.
 ///
-/// Three kinds of braced word are *not* such a literal and stay scanned: an
+/// Four kinds of braced word are *not* such a literal and stay scanned: an
 /// [`ArgRole::Expr`] word, whose `$name`s `expr` substitutes; any word a
 /// same-frame or frame-opening region overlaps, which is script rather than
-/// data; and every word of a command the registry does not know, where nothing
-/// says the word is data.
+/// data; every word of a command that performs Tcl substitution, which reads
+/// through its own arguments; and every word of a command the registry does
+/// not know, where nothing says the word is data.
 fn literal_word_holes(
     source: &str,
     command: &SegmentedCommand,
@@ -428,7 +429,17 @@ fn literal_word_holes(
     out: &mut Vec<(u32, u32)>,
 ) {
     let head = command.name();
-    if registry.get(head).is_none() {
+    let Some(spec) = registry.get(head) else {
+        return;
+    };
+    // `subst {hello $name}` substitutes `$name` out of a braced word, so a
+    // command carrying the registry's own substitution trait has no inert
+    // words at all.  The trait is the whole test, exactly as the compiler's
+    // dynamic-name barrier reads it — this module names no command.
+    if spec
+        .traits
+        .contains(tcl_registry::Traits::PERFORMS_SUBSTITUTION)
+    {
         return;
     }
     let args: Vec<&str> = command.args().iter().map(String::as_str).collect();
@@ -1144,6 +1155,24 @@ mod tests {
     }
 
     // -- TP: caller-frame writes survive via upvar -------------------------
+    /// A command that performs Tcl substitution reads through its own braced
+    /// argument, so that word is not the inert literal a braced word usually
+    /// is: `subst {hello $name}` substitutes `$name`.
+    ///
+    /// Oracle (tclsh 8.6.18 and 9.0.4 alike): the original prints
+    /// `hello world`; so does the extraction.  Dropping the `name` parameter
+    /// makes the rewritten call die with `can't read "name"`.
+    #[test]
+    fn tp_a_substituting_command_reads_through_its_braced_word() {
+        let src = "set name world\nset msg [subst {hello $name}]\nputs $msg\n";
+        let result = outcome(src, "set msg [subst {hello $name}]").unwrap();
+        assert!(
+            result.contains("proc extracted_proc {name msgName} {"),
+            "the substituted name is the caller's: {result}"
+        );
+        assert!(result.contains("extracted_proc $name msg"), "{result}");
+    }
+
     /// A braced word substitutes nothing, so the `$name` spelled inside one
     /// is not a variable the caller has to supply.
     ///

--- a/rust/tcl-lsp-core/src/refactor/extract_proc.rs
+++ b/rust/tcl-lsp-core/src/refactor/extract_proc.rs
@@ -369,11 +369,13 @@ fn containing_region(
         if command.name().is_empty() {
             continue;
         }
-        if let Some(region) = region_containing(&walk.frame_shifted_regions(source, &command), offset)
+        if let Some(region) =
+            region_containing(&walk.frame_shifted_regions(source, &command), offset)
         {
             return Some((region, true));
         }
-        if let Some(region) = region_containing(&walk.same_frame_regions(source, &command), offset) {
+        if let Some(region) = region_containing(&walk.same_frame_regions(source, &command), offset)
+        {
             return Some((region, false));
         }
     }

--- a/rust/tcl-lsp-core/src/refactor/extract_proc.rs
+++ b/rust/tcl-lsp-core/src/refactor/extract_proc.rs
@@ -375,8 +375,7 @@ fn containing_region(
         ) {
             return Some((region, true));
         }
-        if let Some(region) =
-            region_containing(&same_frame_regions(source, &command, walk), offset)
+        if let Some(region) = region_containing(&same_frame_regions(source, &command, walk), offset)
         {
             return Some((region, false));
         }

--- a/rust/tcl-lsp-core/src/refactor/extract_proc.rs
+++ b/rust/tcl-lsp-core/src/refactor/extract_proc.rs
@@ -223,7 +223,7 @@ fn plan_extraction(
     // the wrong release's rule produces a proc built for a variable that
     // does not exist (issue #1605).
     let style = super::braced_var_style(analysis);
-    let walk = FrameWalk::new(source, analysis);
+    let walk = super::FrameWalk::new(source, analysis);
     let roles = classify_variables(source, selected, registry, &walk, style)?;
 
     // The selection's own byte range, snapped to the commands it covers.
@@ -253,7 +253,7 @@ fn plan_extraction(
             // for the text scan to find, and missing it would turn the
             // selection's write into a proc local and lose the caller's value.
             nested_tail.clear();
-            nested_same_frame_commands(source, &command, &walk, 0, &mut nested_tail);
+            walk.nested_same_frame_commands(source, &command, &mut nested_tail);
             for inner in &nested_tail {
                 used_after.extend(role_named_variables(inner, registry));
             }
@@ -324,7 +324,7 @@ fn plan_extraction(
 /// this one assigned.
 fn observing_regions(
     source: &str,
-    walk: &FrameWalk,
+    walk: &super::FrameWalk,
     block_start: u32,
     block_end: u32,
 ) -> Vec<(u32, u32)> {
@@ -360,23 +360,20 @@ fn observing_regions(
 /// a variable frame of its own.
 fn containing_region(
     source: &str,
-    walk: &FrameWalk,
+    walk: &super::FrameWalk,
     search: (u32, u32),
     offset: u32,
 ) -> Option<((u32, u32), bool)> {
     let text = source.get(search.0 as usize..search.1 as usize)?;
-    for command in segment_commands_with_offset_and_config(text, search.0, walk.config) {
+    for command in walk.segment(text, search.0) {
         if command.name().is_empty() {
             continue;
         }
-        if let Some(region) = region_containing(
-            &crate::references::frame_shifted_dispatch_regions(source, walk.dialect, &command),
-            offset,
-        ) {
+        if let Some(region) = region_containing(&walk.frame_shifted_regions(source, &command), offset)
+        {
             return Some((region, true));
         }
-        if let Some(region) = region_containing(&same_frame_regions(source, &command, walk), offset)
-        {
+        if let Some(region) = region_containing(&walk.same_frame_regions(source, &command), offset) {
             return Some((region, false));
         }
     }
@@ -406,186 +403,6 @@ struct VariableRoles {
     /// the end of the assigning command, or the start of a loop body for the
     /// name that loop binds.
     written: BTreeMap<String, u32>,
-}
-
-/// The document facts a same-frame statement walk needs, built once per
-/// extraction.
-///
-/// `nesting` is deliberately the **document's own** registry rather than the
-/// caller's: which nested words are same-frame scripts is a question
-/// [`crate::references::nested_dispatch_regions`] answers from the dialect
-/// profile's registry (a `switch` clause list reaches its arm bodies only
-/// through that registry's `CaseListSpec`), whereas the argument roles this
-/// module classifies stay the caller's to decide.
-struct FrameWalk {
-    dialect: &'static tcl_dialect::DialectProfile,
-    nesting: &'static CommandRegistry,
-    identities: tcl_compiler::realm::CommandBindingRealm,
-    config: LexerConfig,
-    expr_surface: tcl_registry::expr_surface::RuntimeExprSurface,
-}
-
-impl FrameWalk {
-    fn new(source: &str, analysis: &AnalysisResult) -> Self {
-        let dialect = crate::profile_for_dialect(&analysis.dialect);
-        let nesting = crate::registry_for_dialect_profile(dialect);
-        Self {
-            dialect,
-            nesting,
-            identities: tcl_compiler::realm::document_realm_bindings(source, dialect, nesting),
-            config: LexerConfig::from_grammar(dialect.grammar),
-            expr_surface: tcl_registry::expr_surface::RuntimeExprSurface::for_profile(dialect),
-        }
-    }
-}
-
-/// The regions of `command` that run in `command`'s own variable frame.
-///
-/// [`crate::references::nested_dispatch_regions`] owns the script ones. It
-/// cannot see inside a *braced* expression argument, which the script lexer
-/// treats as one opaque word and `expr` substitutes itself, so `if {[set x 1]}
-/// …` would hide a write to the caller's `x`.  Those spans come from
-/// [`tcl_syntax::expr::substitution::command_substitution_spans`], the
-/// expression owner's own script bridge, gated on the dialect's runtime
-/// expression surface: an expression the release would reject at run time
-/// substitutes nothing.
-fn same_frame_regions(
-    source: &str,
-    command: &SegmentedCommand,
-    walk: &FrameWalk,
-) -> Vec<(usize, usize)> {
-    let mut regions = crate::references::nested_dispatch_regions_with_identities(
-        source,
-        walk.dialect,
-        walk.nesting,
-        &walk.identities,
-        command,
-    );
-    let head = command.name();
-    let args: Vec<&str> = command.args().iter().map(String::as_str).collect();
-    for index in walk
-        .nesting
-        .arg_indices_for_role(head, &args, ArgRole::Expr)
-    {
-        let Some(token) = command.argv.get(index + 1) else {
-            continue;
-        };
-        // An unbraced or quoted expression word is substituted by the script
-        // lexer before `expr` ever parses it, so its `[…]` are already among
-        // the dispatch regions above; only a braced one needs the expression
-        // parser to find them.
-        if source.as_bytes().get(token.span.start() as usize) != Some(&b'{')
-            || token.content_offset != 1
-        {
-            continue;
-        }
-        let start = token.span.start() as usize + token.content_offset as usize;
-        let end = token.span.end() as usize;
-        let Some(expression) = source.get(start..end) else {
-            continue;
-        };
-        for span in tcl_syntax::expr::substitution::command_substitution_spans(
-            expression,
-            walk.dialect,
-            walk.config,
-            |parsed| walk.expr_surface.validate(parsed).is_ok(),
-        ) {
-            // The span carries the `[` and `]`; the script inside them is what
-            // runs.
-            let (Some(inner_start), Some(inner_end)) = (
-                start.checked_add(span.start() as usize + 1),
-                start
-                    .checked_add(span.end() as usize)
-                    .and_then(|e| e.checked_sub(1)),
-            ) else {
-                continue;
-            };
-            if inner_start < inner_end {
-                regions.push((inner_start, inner_end));
-            }
-        }
-    }
-    regions
-}
-
-/// Every command nested inside `command` that still runs in `command`'s own
-/// variable frame, appended to `out` innermost-first.
-///
-/// The nesting itself is [`crate::references::nested_dispatch_regions`]'s
-/// answer — the same walker Find-References and the caller-frame scan use for
-/// "which nested scripts run in this frame": an [`ArgRole::Body`] argument
-/// with a `Plain` body kind (`if`, `while`, `foreach`, `try`, `catch`, …), a
-/// `switch`-style clause list flattened through the registry's own
-/// `CaseListSpec`, and every `[…]` command substitution.  A `Structural`
-/// body — `proc`, `namespace eval`, `uplevel`, `oo::define` — and `apply`'s
-/// lambda are deliberately *not* descended: a `set` inside one writes that
-/// frame's variable, not the selection's, so classifying it here would put a
-/// stranger's name in the generated parameter list or, worse, an `upvar`
-/// against a variable the moved code never touches.
-fn nested_same_frame_commands(
-    source: &str,
-    command: &SegmentedCommand,
-    walk: &FrameWalk,
-    depth: u32,
-    out: &mut Vec<SegmentedCommand>,
-) {
-    if crate::references::MAX_DISPATCH_SCAN_DEPTH.exceeded(depth) {
-        return;
-    }
-    for (start, end) in same_frame_regions(source, command, walk) {
-        let Some(text) = source.get(start..end) else {
-            continue;
-        };
-        for nested in segment_commands_with_offset_and_config(
-            text,
-            u32::try_from(start).unwrap_or(0),
-            walk.config,
-        ) {
-            if nested.name().is_empty() {
-                continue;
-            }
-            nested_same_frame_commands(source, &nested, walk, depth + 1, out);
-            out.push(nested);
-        }
-    }
-}
-
-/// Every region inside `command` that runs in a variable frame of its own,
-/// appended to `out`.
-///
-/// The frame-opening bodies are [`crate::references::frame_shifted_dispatch_regions`]'s
-/// answer — the exact complement of the same-frame set
-/// [`nested_same_frame_commands`] walks — asked of `command` and of every
-/// same-frame command beneath it, so a `proc` nested in an `if` branch is
-/// found as readily as one at the selection's top level.
-fn frame_shifted_regions_within(
-    source: &str,
-    command: &SegmentedCommand,
-    walk: &FrameWalk,
-    out: &mut Vec<(u32, u32)>,
-) {
-    let mut push = |regions: Vec<(usize, usize)>| {
-        for (start, end) in regions {
-            let (Ok(start), Ok(end)) = (u32::try_from(start), u32::try_from(end)) else {
-                continue;
-            };
-            out.push((start, end));
-        }
-    };
-    push(crate::references::frame_shifted_dispatch_regions(
-        source,
-        walk.dialect,
-        command,
-    ));
-    let mut nested = Vec::new();
-    nested_same_frame_commands(source, command, walk, 0, &mut nested);
-    for inner in &nested {
-        push(crate::references::frame_shifted_dispatch_regions(
-            source,
-            walk.dialect,
-            inner,
-        ));
-    }
 }
 
 /// `start..end` with every range in `holes` cut out of it.
@@ -634,7 +451,7 @@ fn classify_variables(
     source: &str,
     selected: &[&SegmentedCommand],
     registry: &CommandRegistry,
-    walk: &FrameWalk,
+    walk: &super::FrameWalk,
     style: BracedVarStyle,
 ) -> Result<VariableRoles, String> {
     let mut roles = VariableRoles {
@@ -651,7 +468,7 @@ fn classify_variables(
         // a variable it does not have.
         let (start, end) = command_span_offsets(source, command);
         frames.clear();
-        frame_shifted_regions_within(source, command, walk, &mut frames);
+        walk.frame_shifted_regions_within(source, command, &mut frames);
         for (from, to) in same_frame_slices(start, end, &frames) {
             let text = source.get(from as usize..to as usize).unwrap_or("");
             for (name, at, _) in super::variable_reference_spans(text, style) {
@@ -665,7 +482,7 @@ fn classify_variables(
         }
         classify_command(source, command, registry, &mut roles)?;
         nested.clear();
-        nested_same_frame_commands(source, command, walk, 0, &mut nested);
+        walk.nested_same_frame_commands(source, command, &mut nested);
         for inner in &nested {
             classify_command(source, inner, registry, &mut roles)?;
         }

--- a/rust/tcl-lsp-core/src/refactor/inline_proc.rs
+++ b/rust/tcl-lsp-core/src/refactor/inline_proc.rs
@@ -144,23 +144,7 @@ pub fn inline_proc_in_program(
     let title = format!("Inline proc '{}'", proc_def.name);
     let (call_start, call_end) = command_span_offsets(source, &call);
 
-    // The numeric-literal grammar of the dialect this document was analysed
-    // under — whether a substituted value reads as a number in an `expr`
-    // operand is release-dependent (`0o17` from 8.5, `0d99` and `1_000` from
-    // 9.0).  `AnalysisResult::dialect` carries the name the host passed to
-    // `Analyser::analyse`; an empty (default-constructed) one resolves to the
-    // permissive `plain_tcl` profile, i.e. modern rules.
-    let numbers = crate::profile_for_dialect(&analysis.dialect)
-        .grammar
-        .numbers;
-    // …and its `${…}` close rule, for the same reason: which bytes are the
-    // variable's name is release-dependent, and this transform rewrites the
-    // reference's own span (issue #1605).
-    let style = super::braced_var_style(analysis);
-
-    match plan_inline(
-        source, &call, proc_def, analysis, registry, numbers, style, config,
-    ) {
+    match plan_inline(source, &call, proc_def, analysis, registry, config) {
         Ok(new_text) => Some(Refactoring {
             title,
             edits: vec![RefactorEdit {
@@ -189,10 +173,21 @@ fn plan_inline(
     proc_def: &tcl_compiler::analyser::ProcDef,
     analysis: &AnalysisResult,
     registry: &CommandRegistry,
-    numbers: NumberSyntax,
-    style: BracedVarStyle,
     config: LexerConfig,
 ) -> Result<String, String> {
+    // The numeric-literal grammar of the dialect this document was analysed
+    // under — whether a substituted value reads as a number in an `expr`
+    // operand is release-dependent (`0o17` from 8.5, `0d99` and `1_000` from
+    // 9.0).  `AnalysisResult::dialect` carries the name the host passed to
+    // `Analyser::analyse`; an empty (default-constructed) one resolves to the
+    // permissive `plain_tcl` profile, i.e. modern rules.
+    let numbers: NumberSyntax = crate::profile_for_dialect(&analysis.dialect)
+        .grammar
+        .numbers;
+    // …and its `${…}` close rule, for the same reason: which bytes are the
+    // variable's name is release-dependent, and this transform rewrites the
+    // reference's own span (issue #1605).
+    let style: BracedVarStyle = super::braced_var_style(analysis);
     if proc_def.params_computed {
         return Err(
             "the proc's parameter list is computed at run time, so its formals are unknown"

--- a/rust/tcl-lsp-core/src/refactor/inline_proc.rs
+++ b/rust/tcl-lsp-core/src/refactor/inline_proc.rs
@@ -158,7 +158,9 @@ pub fn inline_proc_in_program(
     // reference's own span (issue #1605).
     let style = super::braced_var_style(analysis);
 
-    match plan_inline(source, &call, proc_def, registry, numbers, style, config) {
+    match plan_inline(
+        source, &call, proc_def, analysis, registry, numbers, style, config,
+    ) {
         Ok(new_text) => Some(Refactoring {
             title,
             edits: vec![RefactorEdit {
@@ -185,6 +187,7 @@ fn plan_inline(
     source: &str,
     call: &tcl_compiler::segmenter::SegmentedCommand,
     proc_def: &tcl_compiler::analyser::ProcDef,
+    analysis: &AnalysisResult,
     registry: &CommandRegistry,
     numbers: NumberSyntax,
     style: BracedVarStyle,
@@ -198,10 +201,19 @@ fn plan_inline(
     }
     let body = single_command_body(source, proc_def, config)?;
     let bindings = bind_arguments(source, call, proc_def)?;
-    reject_frame_sensitive_body(&body, registry)?;
-    reject_body_variable_writes(&body, registry)?;
+    // The body is one command, but that command carries a whole script: `if`,
+    // `foreach`, `catch`, and `switch` each hold theirs in a body argument.
+    // Every guard below asks its question of that statement tree, because a
+    // `set` or a `return` one level down moves into the caller's frame just as
+    // surely as one at the body's top level.  Spans are relative to
+    // `body.text`, which is what the substitution rewrites.
+    let walk = super::FrameWalk::new(&body.text, analysis);
+    let mut nested = Vec::new();
+    walk.nested_same_frame_commands(&body.text, &body.command, &mut nested);
+    reject_frame_sensitive_body(&body, &nested, registry)?;
+    reject_body_variable_writes(&body, &nested, registry)?;
     reject_args_reference(&body, proc_def, style)?;
-    substitute_bindings(&body, &bindings, registry, numbers, style)
+    substitute_bindings(&body, &nested, &bindings, registry, numbers, style)
 }
 
 /// One command's worth of proc body, re-segmented so its argument roles and
@@ -385,28 +397,31 @@ fn argument_value(source: &str, token: Token) -> Result<(String, bool), String> 
 /// caller's caller instead of the caller.
 fn reject_frame_sensitive_body(
     body: &BodyCommand,
+    nested: &[tcl_compiler::segmenter::SegmentedCommand],
     registry: &CommandRegistry,
 ) -> Result<(), String> {
     let unsafe_heads = registry.frame_sensitive_commands();
-    let head = body.command.name();
-    if unsafe_heads.contains(&head) {
-        return Err(format!(
-            "the body calls '{head}', which acts on the call frame — running it \
-             in the caller's frame would change what it returns from, breaks out \
-             of, or binds against"
-        ));
-    }
-    // A frame-sensitive command nested in a `[…]` substitution inside an
-    // argument is just as frame-bound as one at the head.
-    for text in body.command.args() {
-        if let Some(inner) = nested_command_head(text)
-            && unsafe_heads.contains(&inner)
-        {
+    for command in std::iter::once(&body.command).chain(nested) {
+        let head = command.name();
+        if unsafe_heads.contains(&head) {
             return Err(format!(
-                "the body evaluates '{inner}', which acts on the call frame — \
-                 running it in the caller's frame would change what it binds \
-                 against"
+                "the body calls '{head}', which acts on the call frame — running it \
+                 in the caller's frame would change what it returns from, breaks out \
+                 of, or binds against"
             ));
+        }
+        // A frame-sensitive command nested in a `[…]` substitution inside an
+        // argument is just as frame-bound as one at the head.
+        for text in command.args() {
+            if let Some(inner) = nested_command_head(text)
+                && unsafe_heads.contains(&inner)
+            {
+                return Err(format!(
+                    "the body evaluates '{inner}', which acts on the call frame — \
+                     running it in the caller's frame would change what it binds \
+                     against"
+                ));
+            }
         }
     }
     Ok(())
@@ -432,24 +447,47 @@ fn nested_command_head(text: &str) -> Option<&str> {
 /// variables, and anything else a spec declares, without listing any of them.
 fn reject_body_variable_writes(
     body: &BodyCommand,
+    nested: &[tcl_compiler::segmenter::SegmentedCommand],
     registry: &CommandRegistry,
 ) -> Result<(), String> {
-    let args: Vec<&str> = body.command.args().iter().map(String::as_str).collect();
-    let writes = registry.arg_indices_for_role(body.command.name(), &args, ArgRole::VarWrite);
-    if writes.is_empty() {
-        return Ok(());
-    }
-    Err(format!(
-        "the body assigns a variable ('{}' writes to '{}'), which would leak \
-         into — and could overwrite — a variable of the same name in the caller",
-        body.command.name(),
-        writes
+    for command in std::iter::once(&body.command).chain(nested) {
+        let head = command.name();
+        let args: Vec<&str> = command.args().iter().map(String::as_str).collect();
+        let writes: Vec<&str> = registry
+            .arg_indices_for_role(head, &args, ArgRole::VarWrite)
             .iter()
             .filter_map(|index| args.get(*index))
             .copied()
-            .collect::<Vec<_>>()
-            .join("', '")
-    ))
+            .collect();
+        if !writes.is_empty() {
+            return Err(format!(
+                "the body assigns a variable ('{head}' writes to '{}'), which would \
+                 leak into — and could overwrite — a variable of the same name in \
+                 the caller",
+                writes.join("', '")
+            ));
+        }
+        // A loop's own binding leaks exactly as an assignment does, and it is
+        // a `LoopVarList` word rather than a `VarWrite` one: `foreach n {1 2 3}
+        // {…}` leaves `n` behind in whatever frame runs it.
+        for index in registry.arg_indices_for_role(head, &args, ArgRole::LoopVarList) {
+            let Some(word) = args.get(index) else {
+                continue;
+            };
+            let Ok(names) = tcl_syntax::list::split_list(word) else {
+                continue;
+            };
+            if !names.is_empty() {
+                return Err(format!(
+                    "the body binds '{}' on every iteration of its '{head}', which \
+                     would leak into — and could overwrite — a variable of the same \
+                     name in the caller",
+                    names.join("', '")
+                ));
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Refuse a body that reads the variadic `args` list.
@@ -486,13 +524,21 @@ fn reject_args_reference(
 /// changing what it means.
 fn substitute_bindings(
     body: &BodyCommand,
+    nested: &[tcl_compiler::segmenter::SegmentedCommand],
     bindings: &[Binding],
     registry: &CommandRegistry,
     numbers: NumberSyntax,
     style: BracedVarStyle,
 ) -> Result<String, String> {
     let references = variable_references(&body.text, style);
-    let expr_ranges = expr_argument_ranges(&body.command, registry);
+    // The occurrences come from the whole body text, so the expression
+    // positions have to as well: `puts [expr {$n eq "abc"}]` puts its operand
+    // one level below the body's own command, and substituting a bareword
+    // there would make `expr` read it as a function name.
+    let expr_ranges: Vec<(usize, usize)> = std::iter::once(&body.command)
+        .chain(nested)
+        .flat_map(|command| expr_argument_ranges(command, registry))
+        .collect();
     let mut replacements: Vec<(usize, usize, String)> = Vec::new();
     for binding in bindings {
         let occurrences: Vec<&(String, usize, usize)> = references
@@ -665,6 +711,55 @@ mod tests {
             needle,
             tcl_registry::model::ingress::resolve_environment("tcl9.0").analyser_profile(),
         )
+    }
+
+    // -- FP: a body's nested statements are guarded like its top level ----
+
+    /// The body is one command, but that command carries a script. A `set`
+    /// inside it lands in the caller's frame just as a top-level one would.
+    ///
+    /// Oracle (tclsh 8.6.18 and 9.0.4 alike): `total` is 99 after the call in
+    /// the original and 0 if the body is inlined, so the extraction is refused.
+    #[test]
+    fn fp_refuses_a_write_nested_in_a_body() {
+        let src =
+            "proc reset {} {\n    if {1} {\n        set total 0\n    }\n}\nset total 99\nreset\n";
+        let reason = outcome(src, "reset\n").unwrap_err();
+        assert!(reason.contains("assigns a variable"), "{reason}");
+    }
+
+    /// A loop's own binding leaks exactly as an assignment does, and it is a
+    /// `LoopVarList` word rather than a `VarWrite` one.
+    ///
+    /// Oracle: `n` keeps its old value after the call and holds 3 if the body
+    /// is inlined.
+    #[test]
+    fn fp_refuses_a_loop_binding_in_the_body() {
+        let src = "proc show {} {\n    foreach n {1 2 3} {\n        puts $n\n    }\n}\nshow\n";
+        let reason = outcome(src, "show\n").unwrap_err();
+        assert!(reason.contains("on every iteration"), "{reason}");
+    }
+
+    /// A frame-sensitive command one level down is still frame-bound: a
+    /// `return` inside an `if` body would return from the *caller* once
+    /// inlined.
+    #[test]
+    fn fp_refuses_a_frame_sensitive_command_nested_in_a_body() {
+        let src = "proc grab {} {\n    if {1} {\n        global config\n    }\n}\ngrab\n";
+        let reason = outcome(src, "grab\n").unwrap_err();
+        assert!(reason.contains("acts on the call frame"), "{reason}");
+    }
+
+    /// An expression operand one level below the body's own command is still
+    /// an expression operand.
+    ///
+    /// Oracle: `check abc` prints 1, while `puts [expr {abc eq "abc"}]` fails
+    /// with `invalid bareword "abc"` on tclsh 8.6.18 and 9.0.4.
+    #[test]
+    fn fp_refuses_a_bareword_bound_to_a_nested_expression_operand() {
+        let src = "proc check {n} {\n    puts [expr {$n eq \"abc\"}]\n}\ncheck abc\n";
+        let reason = outcome(src, "check abc").unwrap_err();
+        assert!(reason.contains("expression operand"), "{reason}");
     }
 
     // -- TP: binding is performed and the result is correct ---------------

--- a/rust/tcl-lsp-core/src/refactor/mod.rs
+++ b/rust/tcl-lsp-core/src/refactor/mod.rs
@@ -402,7 +402,10 @@ impl FrameWalk {
     ) {
         let head = command.name();
         let args: Vec<&str> = command.args().iter().map(String::as_str).collect();
-        for index in self.nesting.arg_indices_for_role(head, &args, ArgRole::Expr) {
+        for index in self
+            .nesting
+            .arg_indices_for_role(head, &args, ArgRole::Expr)
+        {
             let Some(token) = command.argv.get(index + 1) else {
                 continue;
             };

--- a/rust/tcl-lsp-core/src/refactor/mod.rs
+++ b/rust/tcl-lsp-core/src/refactor/mod.rs
@@ -278,6 +278,209 @@ pub fn token_end_offset(source: &str, tok: Token) -> u32 {
     }
 }
 
+/// The document facts a same-frame statement walk needs, built once per
+/// refactoring.
+///
+/// `nesting` is deliberately the **document's own** registry rather than the
+/// caller's: which nested words are same-frame scripts is a question
+/// [`crate::references::nested_dispatch_regions`] answers from the dialect
+/// profile's registry (a `switch` clause list reaches its arm bodies only
+/// through that registry's `CaseListSpec`), whereas the argument roles a
+/// refactoring classifies stay its own to decide.
+///
+/// `source` is whatever text the walk will address — a whole document for a
+/// transform that works in document coordinates, a proc body for one that has
+/// re-segmented that body on its own.
+pub(crate) struct FrameWalk {
+    dialect: &'static tcl_dialect::DialectProfile,
+    nesting: &'static CommandRegistry,
+    identities: tcl_compiler::realm::CommandBindingRealm,
+    config: LexerConfig,
+    expr_surface: tcl_registry::expr_surface::RuntimeExprSurface,
+}
+
+impl FrameWalk {
+    pub(crate) fn new(source: &str, analysis: &tcl_compiler::analyser::AnalysisResult) -> Self {
+        let dialect = crate::profile_for_dialect(&analysis.dialect);
+        let nesting = crate::registry_for_dialect_profile(dialect);
+        Self {
+            dialect,
+            nesting,
+            identities: tcl_compiler::realm::document_realm_bindings(source, dialect, nesting),
+            config: LexerConfig::from_grammar(dialect.grammar),
+            expr_surface: tcl_registry::expr_surface::RuntimeExprSurface::for_profile(dialect),
+        }
+    }
+
+    /// Every command nested inside `command` that still runs in `command`'s
+    /// own variable frame, appended to `out` innermost-first.
+    ///
+    /// The nesting is [`crate::references::nested_dispatch_regions`]'s answer
+    /// — the same walker Find All References and the caller-frame scan use for
+    /// "which nested scripts run in this frame": an [`ArgRole::Body`] argument
+    /// with a `Plain` body kind (`if`, `while`, `foreach`, `try`, `catch`, …),
+    /// a `switch`-style clause list flattened through the registry's own
+    /// `CaseListSpec`, and every `[…]` command substitution.  A `Structural`
+    /// body — `proc`, `namespace eval`, `uplevel`, `oo::define` — and `apply`'s
+    /// lambda are deliberately *not* descended: what they read and write are
+    /// their own frame's variables, so counting them would put a stranger's
+    /// name in a generated parameter list or an `upvar` against a variable the
+    /// moved code never touches.
+    pub(crate) fn nested_same_frame_commands(
+        &self,
+        source: &str,
+        command: &SegmentedCommand,
+        out: &mut Vec<SegmentedCommand>,
+    ) {
+        self.walk_same_frame(source, command, 0, out);
+    }
+
+    fn walk_same_frame(
+        &self,
+        source: &str,
+        command: &SegmentedCommand,
+        depth: u32,
+        out: &mut Vec<SegmentedCommand>,
+    ) {
+        if crate::references::MAX_DISPATCH_SCAN_DEPTH.exceeded(depth) {
+            return;
+        }
+        for (start, end) in self.same_frame_regions(source, command) {
+            let Some(text) = source.get(start..end) else {
+                continue;
+            };
+            for nested in segment_commands_with_offset_and_config(
+                text,
+                u32::try_from(start).unwrap_or(0),
+                self.config,
+            ) {
+                if nested.name().is_empty() {
+                    continue;
+                }
+                self.walk_same_frame(source, &nested, depth + 1, out);
+                out.push(nested);
+            }
+        }
+    }
+
+    /// `text`, segmented at its real offset in the walked source.
+    pub(crate) fn segment(&self, text: &str, offset: u32) -> Vec<SegmentedCommand> {
+        segment_commands_with_offset_and_config(text, offset, self.config)
+    }
+
+    /// The regions of `command` that run in `command`'s own variable frame.
+    ///
+    /// [`crate::references::nested_dispatch_regions`] owns the script ones. It
+    /// cannot see inside a *braced* expression argument, which the script
+    /// lexer treats as one opaque word and `expr` substitutes itself, so
+    /// `if {[set x 1]} …` would hide a write to the caller's `x`.  Those spans
+    /// come from [`tcl_syntax::expr::substitution::command_substitution_spans`],
+    /// the expression owner's own script bridge, gated on the dialect's
+    /// runtime expression surface: an expression the release would reject at
+    /// run time substitutes nothing.
+    pub(crate) fn same_frame_regions(
+        &self,
+        source: &str,
+        command: &SegmentedCommand,
+    ) -> Vec<(usize, usize)> {
+        let mut regions = crate::references::nested_dispatch_regions_with_identities(
+            source,
+            self.dialect,
+            self.nesting,
+            &self.identities,
+            command,
+        );
+        self.push_expression_substitutions(source, command, &mut regions);
+        regions
+    }
+
+    fn push_expression_substitutions(
+        &self,
+        source: &str,
+        command: &SegmentedCommand,
+        out: &mut Vec<(usize, usize)>,
+    ) {
+        let head = command.name();
+        let args: Vec<&str> = command.args().iter().map(String::as_str).collect();
+        for index in self.nesting.arg_indices_for_role(head, &args, ArgRole::Expr) {
+            let Some(token) = command.argv.get(index + 1) else {
+                continue;
+            };
+            // An unbraced or quoted expression word is substituted by the
+            // script lexer before `expr` ever parses it, so its `[…]` are
+            // already among the dispatch regions; only a braced one needs the
+            // expression parser to find them.
+            if source.as_bytes().get(token.span.start() as usize) != Some(&b'{')
+                || token.content_offset != 1
+            {
+                continue;
+            }
+            let start = token.span.start() as usize + token.content_offset as usize;
+            let end = token.span.end() as usize;
+            let Some(expression) = source.get(start..end) else {
+                continue;
+            };
+            for span in tcl_syntax::expr::substitution::command_substitution_spans(
+                expression,
+                self.dialect,
+                self.config,
+                |parsed| self.expr_surface.validate(parsed).is_ok(),
+            ) {
+                // The span carries the `[` and `]`; the script inside them is
+                // what runs.
+                let (Some(inner_start), Some(inner_end)) = (
+                    start.checked_add(span.start() as usize + 1),
+                    start
+                        .checked_add(span.end() as usize)
+                        .and_then(|end| end.checked_sub(1)),
+                ) else {
+                    continue;
+                };
+                if inner_start < inner_end {
+                    out.push((inner_start, inner_end));
+                }
+            }
+        }
+    }
+
+    /// The regions of `command` that open a variable frame of their own — the
+    /// exact complement of [`Self::same_frame_regions`].
+    pub(crate) fn frame_shifted_regions(
+        &self,
+        source: &str,
+        command: &SegmentedCommand,
+    ) -> Vec<(usize, usize)> {
+        crate::references::frame_shifted_dispatch_regions(source, self.dialect, command)
+    }
+
+    /// Every region inside `command`, at any same-frame depth, that runs in a
+    /// variable frame of its own, appended to `out`.
+    ///
+    /// A `proc` nested in an `if` branch is found as readily as one at
+    /// `command`'s own top level.
+    pub(crate) fn frame_shifted_regions_within(
+        &self,
+        source: &str,
+        command: &SegmentedCommand,
+        out: &mut Vec<(u32, u32)>,
+    ) {
+        let mut push = |regions: Vec<(usize, usize)>| {
+            for (start, end) in regions {
+                let (Ok(start), Ok(end)) = (u32::try_from(start), u32::try_from(end)) else {
+                    continue;
+                };
+                out.push((start, end));
+            }
+        };
+        push(self.frame_shifted_regions(source, command));
+        let mut nested = Vec::new();
+        self.nested_same_frame_commands(source, command, &mut nested);
+        for inner in &nested {
+            push(self.frame_shifted_regions(source, inner));
+        }
+    }
+}
+
 fn byte_len(source: &str) -> u32 {
     u32::try_from(source.len()).unwrap_or(u32::MAX)
 }


### PR DESCRIPTION
## Summary

Six shapes where the two proc refactorings answered a variable question over
the wrong region and rewrote a working file into a broken one. Each was
reproduced first, and each has a regression test carrying its tclsh 8.6.18 /
9.0.4 oracle.

**Extract into proc**

- The live-out question stopped at the innermost script region. Selecting
  `incr total $n` inside a `foreach` body classified `total` against that body
  alone, so it became a proc local and the caller's total stayed `0` instead of
  reaching `6`. A control-flow body is not a frame boundary, so the question now
  runs to the nearest body that opens a variable frame of its own, and counts
  each enclosing same-frame body in full — a loop reads on its next pass what
  the previous one assigned.
- The read scan stopped at no boundary at all. A `$name` inside a nested `proc`
  body or an `apply` lambda names that frame's variable, and making it a
  parameter asked the caller for something it does not have: extracting
  `proc helper {name} {puts "hello $name"}` emitted a call `extracted_proc $name`
  that dies with `can't read "name"`.
- A braced word substitutes nothing, so `set msg {$notavar}` and the `apply`
  lambda handed to `lsort -command` were inventing parameters the same way. The
  scan now cuts those word interiors, keeping expression words, script bodies,
  the words of a command that performs Tcl substitution itself (`subst {hello
  $name}` does read `name`), and the arguments of a command the registry does
  not know.

**Inline proc**

- A one-command body still carries a script, so every guard saw only its
  outermost command. `proc reset {} {if {1} {set total 0}}` inlined its write
  into the caller, and `foreach n {1 2 3} {…}` leaked `n` the same way — a loop
  binding is the registry's `LoopVarList` role rather than a write. A
  frame-sensitive command one level down was equally invisible, so
  `if {1} {global config}` inlined a frame-bound command into the caller.
  Each guard now asks its question of the body's whole statement tree.
- Expression operands come from that tree too. A parameter bound to a bareword
  and used in a nested `expr` produced `puts [expr {abc eq "abc"}]`, which reads
  `abc` as a function name.

The same-frame walk both refactorings need now lives on one `FrameWalk` in the
refactor module rather than being copied into the second consumer.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

```
make rust-check                 # passed
cargo test -p tcl-lsp-core      # passed
make prep-pr                    # passed
```

Ten regression tests were added: a write inside a loop body, a loop-carried
read above the selection, a read inside a nested proc body, a braced literal, a
lambda in a callback word, a substituting command's braced word, a nested
write, a nested loop binding, a nested frame-sensitive command, and a bareword
bound to a nested expression operand.

Both feature notes document the frame boundary, the literal rule, and the
statement-tree guards.

## Compiler / diagnostics checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? No — it consumes the
      existing registry roles and traits and the existing same-frame and
      frame-shifted dispatch-region walkers.
- [x] If yes, I updated the owning design doc. Not applicable.
- [x] If I added or changed a diagnostic or optimisation code, I updated its
      page. Not applicable — no diagnostic or optimisation code changed.
- [x] If I added a design doc, I linked it from `docs/design/README.md`. No new
      design doc; both feature notes were already indexed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016enFS3du4TM3VbySM3izf8