### PR TITLE
Size the lsp-client scan ceiling by build profile, and never answer with another file's diagnostics

### DIFF
--- a/.claude/skills/lsp-client/SKILL.md
+++ b/.claude/skills/lsp-client/SKILL.md
@@ -45,7 +45,7 @@ subcommand. All line/col arguments are **0-based**.
 
 `definition`, `references`, `diagnostics`, `code-actions`, `context`, `all`,
 `completion`, and `code-lens` wait for the background workspace scan
-(`--scan-timeout`, default 30 s) before proceeding; otherwise cross-file
+(`--scan-timeout`) before proceeding; otherwise cross-file
 results race the scan. A new cross-file check must call
 `client.wait_for_workspace_scan()` *before* `didOpen`. `--also-open FILE`
 (repeatable) opens companion files after that wait and before `<file>`:
@@ -55,8 +55,10 @@ python3 .claude/skills/lsp-client/lsp_client.py --also-open lib.tcl definition c
 ```
 
 The scan covers the workspace root — the current directory, or `--server-dir`.
-Scanning the whole repository exceeds the default timeout on a debug build, so
-point `--server-dir` at the directory holding the files under test:
+It is the slow part: this repository is ~540 indexed files, which a `--release`
+server scans in ~9 s and a `debug` one in ~65 s, so `--scan-timeout` defaults to
+30 s and 180 s respectively. Point `--server-dir` at the directory holding the
+files under test to scan less and finish sooner:
 
 ```bash
 python3 .claude/skills/lsp-client/lsp_client.py --server-dir editors/vscode/testFixture diagnostics editors/vscode/testFixture/diagnostics.tcl
@@ -70,9 +72,9 @@ a position-dependent feature at a cursor; `all` as a smoke test; `bench` and
 
 ```bash
 python3 .claude/skills/lsp-client/lsp_client.py semantic-tokens samples/for_screenshots/03-completions.tcl
-python3 .claude/skills/lsp-client/lsp_client.py --server-dir editors/vscode/testFixture diagnostics editors/vscode/testFixture/diagnostics.tcl
+python3 .claude/skills/lsp-client/lsp_client.py diagnostics editors/vscode/testFixture/diagnostics.tcl
 python3 .claude/skills/lsp-client/lsp_client.py hover editors/vscode/testFixture/procs.tcl 1 6
-python3 .claude/skills/lsp-client/lsp_client.py --server-dir editors/vscode/testFixture code-lens editors/vscode/testFixture/objMethodDispatch.tcl
+python3 .claude/skills/lsp-client/lsp_client.py code-lens editors/vscode/testFixture/objMethodDispatch.tcl
 python3 .claude/skills/lsp-client/lsp_client.py diagram samples/for_screenshots/ai-scene.irul
 python3 .claude/skills/lsp-client/lsp_client.py event-info HTTP_REQUEST
 python3 .claude/skills/lsp-client/lsp_client.py bench samples/tcl/09_long_code.tcl --iterations 3

--- a/.claude/skills/lsp-client/lsp_client.py
+++ b/.claude/skills/lsp-client/lsp_client.py
@@ -70,6 +70,7 @@ import threading
 import time
 from pathlib import Path
 from typing import Any
+from urllib.parse import unquote
 
 #: Default budget for one write to the server's stdin (see `_send`). Not the
 #: same knob as a request's response timeout (`send_request(timeout=...)`
@@ -676,11 +677,12 @@ class LspClient:
 def default_scan_timeout(server_bin: str) -> float:
     """Pick the workspace-scan ceiling for the server binary at *server_bin*.
 
-    Cargo puts the profile in the path (`target/release/`, `target/debug/`),
-    which is the only profile signal a client has.
+    Cargo names the directory holding the binary after the profile
+    (`target/release/`, `target/debug/`), which is the only profile signal a
+    client has. Only that directory counts: an ancestor named `release` is
+    someone's build root, not a statement about this binary.
     """
-    parts = {part.lower() for part in Path(server_bin).parts}
-    if "release" in parts:
+    if Path(server_bin).parent.name.lower() == "release":
         return SCAN_TIMEOUT_RELEASE_S
     return SCAN_TIMEOUT_DEBUG_S
 
@@ -735,6 +737,17 @@ def initialize(client: LspClient) -> dict:
     return result
 
 
+def document_uri(path: str) -> str:
+    """The `file:` URI for *path*, spelled as the server spells it.
+
+    The server percent-encodes the URIs it stores and republishes, so a
+    client that concatenates the raw path instead never matches its own
+    document's publish — the reserved characters, a space or non-ASCII byte
+    among them, differ on the two sides.
+    """
+    return Path(path).as_uri()
+
+
 def open_document(client: LspClient, file_path: str) -> tuple[str, str]:
     """Read a file, send textDocument/didOpen, return (uri, content)."""
     abs_path = os.path.abspath(file_path)
@@ -742,7 +755,7 @@ def open_document(client: LspClient, file_path: str) -> tuple[str, str]:
         raise FileNotFoundError(f"File not found: {abs_path}")
     with open(abs_path) as f:
         content = f.read()
-    uri = f"file://{abs_path}"
+    uri = document_uri(abs_path)
     client.send_notification(
         "textDocument/didOpen",
         {
@@ -945,7 +958,7 @@ def print_locations(locations: list[dict] | None, label: str) -> None:
         uri = loc.get("uri", "")
         # Shorten the URI for display
         if uri.startswith("file://"):
-            path = uri[7:]
+            path = unquote(uri[7:])
             # Show just the filename
             short = os.path.basename(path)
         else:
@@ -1442,7 +1455,7 @@ def cmd_context(client: LspClient, uri: str, content: str) -> None:
 
     Mirrors the context enrichment from the VS Code extension's contextPack.ts.
     """
-    file_path = uri.replace("file://", "")
+    file_path = unquote(uri.replace("file://", ""))
     basename = os.path.basename(file_path)
     line_count = len(content.split("\n"))
 

--- a/.claude/skills/lsp-client/lsp_client.py
+++ b/.claude/skills/lsp-client/lsp_client.py
@@ -150,6 +150,18 @@ LSP_SEVERITY = {1: "ERROR", 2: "WARNING", 3: "INFO", 4: "HINT"}
 # document and says nothing about workspace-scan completion.
 WORKSPACE_SCAN_SIGNAL = "[timing] workspace_folders_scan"
 
+# Ceilings for the workspace-scan wait, by the build profile of the server
+# binary. The wait returns as soon as the scan signals, so a ceiling costs
+# nothing when the scan completes — it only bounds how long a wedged or
+# never-started scan is tolerated before the caller is told. An unoptimised
+# build analyses the workspace several times more slowly than a release one,
+# far enough apart that one ceiling cannot serve both: sized for release it
+# fails a healthy debug scan, sized for debug it makes a wedged release server
+# look merely slow. A binary from neither profile gets the larger ceiling,
+# since waiting too long beats reporting a scan that was still running.
+SCAN_TIMEOUT_RELEASE_S = 30.0
+SCAN_TIMEOUT_DEBUG_S = 180.0
+
 COMPLETION_KIND = {
     1: "Text",
     2: "Method",
@@ -509,6 +521,32 @@ class LspClient:
         with self._lock:
             return [n for n in self._notifications if n.get("method") == method]
 
+    def wait_for_diagnostics(self, uri: str, timeout: float = 10.0) -> dict | None:
+        """Wait for the diagnostics the server publishes for *uri*.
+
+        The workspace scan publishes for other documents too, so waiting for
+        *any* `publishDiagnostics` can return while this document's own
+        publish is still in flight — only one carrying this `uri` answers
+        the question the caller asked. Returns the newest matching params
+        (the server republishes as workspace state settles, and the latest
+        supersedes rather than adds to the earlier ones), or None when the
+        server published nothing for *uri* within *timeout*.
+        """
+        deadline = time.monotonic() + timeout
+        while True:
+            with self._lock:
+                matching = [
+                    n["params"]
+                    for n in self._notifications
+                    if n.get("method") == "textDocument/publishDiagnostics"
+                    and n.get("params", {}).get("uri") == uri
+                ]
+            if matching:
+                return matching[-1]
+            if time.monotonic() >= deadline:
+                return None
+            time.sleep(0.05)
+
     def _stderr_loop(self) -> None:
         """Background thread: capture server stderr lines."""
         assert self.process and self.process.stderr
@@ -555,7 +593,7 @@ class LspClient:
                 messages.append(params.get("message", ""))
         return messages
 
-    def wait_for_workspace_scan(self, timeout: float = 30.0) -> str:
+    def wait_for_workspace_scan(self, timeout: float = SCAN_TIMEOUT_DEBUG_S) -> str:
         """Block until the server's initial background workspace scan completes.
 
         Cross-file navigation (`textDocument/definition`,
@@ -598,8 +636,10 @@ class LspClient:
             f"Timed out after {timeout}s waiting for the server's workspace "
             f"scan to complete — no {WORKSPACE_SCAN_SIGNAL!r} window/logMessage "
             "was seen. Cross-file navigation/diagnostics results read here "
-            "would be racy. If this is a legitimately large workspace, pass "
-            "a higher --scan-timeout; otherwise check that "
+            "would be racy. The scan covers the whole workspace root, so "
+            "scoping --server-dir to the directory holding the files under "
+            "test is usually faster than raising --scan-timeout; otherwise "
+            "check that "
             "the server actually reached `scan_workspace_folders` (see "
             "rust/tcl-lsp-server/src/lib.rs) — e.g. it never got past "
             "`initialized` because a server-to-client request went "
@@ -631,6 +671,18 @@ class LspClient:
 
 
 # LSP lifecycle helpers
+
+
+def default_scan_timeout(server_bin: str) -> float:
+    """Pick the workspace-scan ceiling for the server binary at *server_bin*.
+
+    Cargo puts the profile in the path (`target/release/`, `target/debug/`),
+    which is the only profile signal a client has.
+    """
+    parts = {part.lower() for part in Path(server_bin).parts}
+    if "release" in parts:
+        return SCAN_TIMEOUT_RELEASE_S
+    return SCAN_TIMEOUT_DEBUG_S
 
 
 def find_native_server(override: str | None = None) -> str:
@@ -1145,13 +1197,12 @@ def cmd_semantic_tokens(client: LspClient, uri: str, content: str) -> None:
 
 
 def cmd_diagnostics(client: LspClient, uri: str) -> None:
-    """Collect and display pushed diagnostics."""
-    notifs = client.collect_notifications("textDocument/publishDiagnostics")
-    matching = [n["params"] for n in notifs if n.get("params", {}).get("uri") == uri]
-    if not matching:
-        # Try with all notifications (some servers may not match URI exactly)
-        matching = [n["params"] for n in notifs]
-    print_diagnostics(matching)
+    """Display the diagnostics the server pushed for this document."""
+    params = client.wait_for_diagnostics(uri)
+    if params is None:
+        print(f"=== Diagnostics ===\n  (no publishDiagnostics for {uri})")
+        return
+    print_diagnostics([params])
 
 
 def cmd_format(client: LspClient, uri: str, content: str) -> None:
@@ -1406,12 +1457,8 @@ def cmd_context(client: LspClient, uri: str, content: str) -> None:
 
     # Diagnostics
     print()
-    notifs = client.collect_notifications("textDocument/publishDiagnostics")
-    matching = [n["params"] for n in notifs if n.get("params", {}).get("uri") == uri]
-    if not matching:
-        matching = [n["params"] for n in notifs]
-
-    all_diags = [d for params in matching for d in params.get("diagnostics", [])]
+    params = client.wait_for_diagnostics(uri)
+    all_diags = params.get("diagnostics", []) if params else []
 
     # Filter to actionable (error + warning)
     actionable = [d for d in all_diags if d.get("severity", 0) <= 2]
@@ -1715,7 +1762,7 @@ def main() -> None:
         epilog="""\
 examples:
   %(prog)s semantic-tokens samples/for_screenshots/03-completions.tcl
-  %(prog)s --server-dir editors/vscode/testFixture diagnostics editors/vscode/testFixture/diagnostics.tcl
+  %(prog)s diagnostics editors/vscode/testFixture/diagnostics.tcl
   %(prog)s hover editors/vscode/testFixture/procs.tcl 1 6
   %(prog)s all samples/for_screenshots/03-completions.tcl
 """,
@@ -1731,16 +1778,16 @@ examples:
     parser.add_argument(
         "--scan-timeout",
         type=float,
-        default=30.0,
+        default=None,
         help=(
             "Seconds to wait for the background workspace scan to complete "
             "before cross-file subcommands (definition, references, "
-            "diagnostics, code-actions, context, all) proceed. The default "
-            "keeps roughly 2x headroom over a worst-case scan — a workspace "
-            "at WORKSPACE_SCAN_FILE_CAP in a debug build under CPU "
-            "contention — and matches the Rust e2e harness's DEFAULT_TIMEOUT. "
-            "Raise it for a larger workspace or a slower machine. "
-            "Default: 30.0"
+            "diagnostics, code-actions, context, all) proceed. This is a "
+            "ceiling, not a delay: the wait ends as soon as the scan does. "
+            f"Defaults to {SCAN_TIMEOUT_RELEASE_S:g}s against a release "
+            f"binary and {SCAN_TIMEOUT_DEBUG_S:g}s against a debug one, "
+            "which analyses the workspace several times more slowly. Scope "
+            "--server-dir to shrink the scan itself."
         ),
     )
     parser.add_argument(
@@ -1878,6 +1925,12 @@ examples:
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)
 
+    scan_timeout = (
+        args.scan_timeout
+        if args.scan_timeout is not None
+        else default_scan_timeout(launch_cmd[0])
+    )
+
     # rootUri only needs a directory; the binary doesn't need a bundle.
     server_dir = args.server_dir or str(Path.cwd())
 
@@ -1938,7 +1991,7 @@ examples:
             # request issued below) already sees the fully-populated
             # workspace_index / package_resolver instead of racing the scan.
             if args.command in CROSS_FILE_COMMANDS:
-                client.wait_for_workspace_scan(timeout=args.scan_timeout)
+                client.wait_for_workspace_scan(timeout=scan_timeout)
 
             # `--also-open FILE` (repeatable): open every companion file
             # *before* the main one, in the order given, after the scan wait

--- a/.claude/skills/lsp-client/test_lsp_client.py
+++ b/.claude/skills/lsp-client/test_lsp_client.py
@@ -18,7 +18,12 @@ import pytest
 CLIENT = Path(__file__).resolve().parent / "lsp_client.py"
 sys.path.insert(0, str(CLIENT.parent))
 
-from lsp_client import LspClient
+from lsp_client import (
+    SCAN_TIMEOUT_DEBUG_S,
+    SCAN_TIMEOUT_RELEASE_S,
+    LspClient,
+    default_scan_timeout,
+)
 
 
 def run_cli(*args: str) -> subprocess.CompletedProcess[str]:
@@ -98,3 +103,60 @@ def test_launch_cmd_is_required():
 
     client = LspClient("/tmp", launch_cmd=["/nonexistent/tcl-lsp-server"])
     assert client._launch_cmd == ["/nonexistent/tcl-lsp-server"]
+
+
+@pytest.mark.parametrize(
+    ("server_bin", "expected"),
+    [
+        ("/repo/target/release/tcl-lsp-server", SCAN_TIMEOUT_RELEASE_S),
+        ("/repo/target/debug/tcl-lsp-server", SCAN_TIMEOUT_DEBUG_S),
+        ("/usr/local/bin/tcl-lsp-server", SCAN_TIMEOUT_DEBUG_S),
+    ],
+)
+def test_scan_timeout_follows_build_profile(server_bin: str, expected: float):
+    """A debug build needs a far larger ceiling; an unknown build gets it too."""
+    assert default_scan_timeout(server_bin) == expected
+
+
+def _client_with_publishes(*uris: str) -> LspClient:
+    client = LspClient("/tmp", launch_cmd=["/nonexistent/tcl-lsp-server"])
+    client._notifications = [
+        {
+            "method": "textDocument/publishDiagnostics",
+            "params": {"uri": uri, "diagnostics": [{"message": uri}]},
+        }
+        for uri in uris
+    ]
+    return client
+
+
+def test_diagnostics_wait_ignores_other_documents():
+    """A sibling file's publish must never answer for the requested one."""
+    client = _client_with_publishes("file:///other.tcl")
+
+    assert client.wait_for_diagnostics("file:///wanted.tcl", timeout=0.1) is None
+
+
+def test_diagnostics_wait_returns_the_requested_document():
+    client = _client_with_publishes("file:///other.tcl", "file:///wanted.tcl")
+
+    params = client.wait_for_diagnostics("file:///wanted.tcl", timeout=0.1)
+
+    assert params is not None
+    assert params["uri"] == "file:///wanted.tcl"
+
+
+def test_diagnostics_wait_takes_the_newest_publish():
+    """A republish supersedes the earlier set rather than adding to it."""
+    client = _client_with_publishes("file:///wanted.tcl")
+    client._notifications.append(
+        {
+            "method": "textDocument/publishDiagnostics",
+            "params": {"uri": "file:///wanted.tcl", "diagnostics": []},
+        }
+    )
+
+    params = client.wait_for_diagnostics("file:///wanted.tcl", timeout=0.1)
+
+    assert params is not None
+    assert params["diagnostics"] == []

--- a/.claude/skills/lsp-client/test_lsp_client.py
+++ b/.claude/skills/lsp-client/test_lsp_client.py
@@ -23,6 +23,7 @@ from lsp_client import (
     SCAN_TIMEOUT_RELEASE_S,
     LspClient,
     default_scan_timeout,
+    document_uri,
 )
 
 
@@ -111,6 +112,10 @@ def test_launch_cmd_is_required():
         ("/repo/target/release/tcl-lsp-server", SCAN_TIMEOUT_RELEASE_S),
         ("/repo/target/debug/tcl-lsp-server", SCAN_TIMEOUT_DEBUG_S),
         ("/usr/local/bin/tcl-lsp-server", SCAN_TIMEOUT_DEBUG_S),
+        # An ancestor named "release" is someone's build root, not this
+        # binary's profile.
+        ("/build/release/proj/target/debug/tcl-lsp-server", SCAN_TIMEOUT_DEBUG_S),
+        ("/build/debug/proj/target/release/tcl-lsp-server", SCAN_TIMEOUT_RELEASE_S),
     ],
 )
 def test_scan_timeout_follows_build_profile(server_bin: str, expected: float):
@@ -160,3 +165,16 @@ def test_diagnostics_wait_takes_the_newest_publish():
 
     assert params is not None
     assert params["diagnostics"] == []
+
+
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        ("/tmp/plain.tcl", "file:///tmp/plain.tcl"),
+        ("/tmp/has space.tcl", "file:///tmp/has%20space.tcl"),
+        ("/tmp/caf\u00e9.tcl", "file:///tmp/caf%C3%A9.tcl"),
+    ],
+)
+def test_document_uri_is_percent_encoded(path: str, expected: str):
+    """The server percent-encodes; a raw spelling never matches its publish."""
+    assert document_uri(path) == expected


### PR DESCRIPTION
## Summary

Follow-up to #2018, which documented a limit rather than fixing it: cross-file subcommands timed out at the workspace root on a debug build. Fixing that exposed a second, worse fault behind it.

- **Size `--scan-timeout` by build profile.** The ceiling only bounds a *wedged* scan — the wait ends the moment the scan signals — so a larger ceiling costs nothing when the scan succeeds, and the flat 30 s simply had to cover a real scan. Measured on this repository (~540 indexed files, same file set both ways): a `--release` server scans it in **8.8 s**, a `debug` server in **65.3 s**, a 7.4x ratio. One ceiling cannot serve both: sized for release it fails every healthy debug run at the root; sized for debug a wedged release server looks merely slow. `default_scan_timeout()` now reads the profile out of the binary path — 30 s release, 180 s debug, and the larger ceiling for a binary from neither, since waiting too long beats reporting a scan that was still running.

- **Never answer with another document's diagnostics.** With the root scan completing, `diagnostics` and `context` started reporting the *wrong file*. Both fell back to printing every `publishDiagnostics` when none matched the requested URI, and the workspace scan publishes for other documents too. Asking for `diagnostics.tcl` at the repo root returned two unrelated `.tclspec` findings — and nothing in the output named the file they came from, so the answer looked plausible. They now wait for a publish carrying the requested URI, take the newest (a republish supersedes rather than adds), and say plainly when none arrived. `code_actions` already filtered correctly and is unchanged.

- **Docs match behaviour again.** The repo-root examples work unscoped, so they are unscoped again; `--server-dir` is documented as the speed lever it is, with the measured numbers.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

```bash
make prep-pr          # exit 0, no drift
make lint-py          # ruff: 36 files, all passed
make typecheck-py     # ty + pyright: 0 errors
pytest .claude/skills/lsp-client/test_lsp_client.py   # 29 passed
```

Measured with both binaries against the same 538-file root:

| Profile | Scan | Ceiling | Headroom |
|---|---|---|---|
| release | 8.8 s | 30 s | 3.4x |
| debug | 65.3 s | 180 s | 2.8x |

The wrong-file bug, before and after, at the repo root with no flags:

```
before:  === Diagnostics (2 items) ===   # two unrelated .tclspec findings
after:   === Diagnostics (15 items) ===  # matches the --server-dir-scoped control exactly
```

Both fixes were mutation-tested rather than only observed passing: dropping the URI filter fails `test_diagnostics_wait_ignores_other_documents`, and collapsing to a flat ceiling fails two `test_scan_timeout_follows_build_profile` cases.

Every documented example was then run unscoped from the repo root — `diagnostics`, `hover`, `code-lens`, `semantic-tokens`, `context` — plus the two-file cross-file `definition` fixture from #2018, which still resolves.

## Compiler / diagnostics checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

Not applicable — this changes an agent skill's Python client only. No compiler fact contract, diagnostic code, optimisation code, or design doc is touched. The server-side scan is unchanged; `is_skipped_scan_dir` already excludes `tmp/`, `target/`, `node_modules/` and dot-dirs, and the 538-file root is well under `WORKSPACE_SCAN_FILE_CAP`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E3i6Kqq5ierpRZz3vA6rQL

---
_Generated by [Claude Code](https://claude.ai/code/session_01E3i6Kqq5ierpRZz3vA6rQL)_