### PR TITLE
ci: update VS Code test census

### DIFF
--- a/docs/design/contracts/test-tiers-and-ci-gates.md
+++ b/docs/design/contracts/test-tiers-and-ci-gates.md
@@ -43,8 +43,8 @@ local `npm test`. In CI, three isolated `test-ext-partition` producers run the
 separate mandatory producer. Each producer uploads its file inventory,
 per-file duration, discovered identities, completed identities, and outcome
 counts. The stable `test-ext` aggregate fails unless the producers succeed and
-their metadata proves exact-once coverage of all 976 single-root identities
-(975 passed plus the one deliberately pending manual edit-storm test) and all
+their metadata proves exact-once coverage of all 977 single-root identities
+(976 passed plus the one deliberately pending manual edit-storm test) and all
 14 passing multi-folder identities. The checked-in assignment records its
 hosted timing evidence and is balanced by measured duration rather than file
 or test count.

--- a/editors/vscode/test-partitions.json
+++ b/editors/vscode/test-partitions.json
@@ -9,8 +9,8 @@
   ],
   "expected_tests": {
     "single_root": {
-      "identities": 976,
-      "passed": 975,
+      "identities": 977,
+      "passed": 976,
       "pending": 1
     },
     "multi_folder": {

--- a/scripts/dev/test-vscode-test-partitions.sh
+++ b/scripts/dev/test-vscode-test-partitions.sh
@@ -26,14 +26,14 @@ for partition in 1 2 3; do
 done
 test "$(jq '[.partitions[][]] | length' "$manifest")" -eq 106
 test "$(jq '[.partitions[][]] | unique | length' "$manifest")" -eq 106
-test "$(jq '.expected_tests.single_root.identities' "$manifest")" -eq 976
-test "$(jq '.expected_tests.single_root.passed' "$manifest")" -eq 975
+test "$(jq '.expected_tests.single_root.identities' "$manifest")" -eq 977
+test "$(jq '.expected_tests.single_root.passed' "$manifest")" -eq 976
 test "$(jq '.expected_tests.single_root.pending' "$manifest")" -eq 1
 test "$(jq '.expected_tests.multi_folder.identities' "$manifest")" -eq 14
 test "$(jq '.expected_tests.multi_folder.passed' "$manifest")" -eq 14
 test "$(jq '.expected_tests.multi_folder.pending' "$manifest")" -eq 0
 test "$(jq -r '.multi_folder_files | join(",")' "$manifest")" = "multiFolderConfig.test.js"
-echo "VS Code test partitions: exact-once proof passed (106 files, 975 passed + 1 pending single-root identities, 14 multi-folder tests, 3 partitions)"
+echo "VS Code test partitions: exact-once proof passed (106 files, 976 passed + 1 pending single-root identities, 14 multi-folder tests, 3 partitions)"
 
 workflow="${root}/.github/workflows/ci.yml"
 check_workflow() {

--- a/scripts/dev/verify-vscode-test-partitions.mjs
+++ b/scripts/dev/verify-vscode-test-partitions.mjs
@@ -80,8 +80,8 @@ if (seen.get("serverHealth.test.js") !== "1") {
   throw new Error("serverHealth.test.js must run exactly once in partition 1");
 }
 if (
-  manifest.expected_tests?.single_root?.identities !== 976 ||
-  manifest.expected_tests?.single_root?.passed !== 975 ||
+  manifest.expected_tests?.single_root?.identities !== 977 ||
+  manifest.expected_tests?.single_root?.passed !== 976 ||
   manifest.expected_tests?.single_root?.pending !== 1 ||
   manifest.expected_tests?.multi_folder?.identities !== 14 ||
   manifest.expected_tests?.multi_folder?.passed !== 14 ||

--- a/scripts/dev/verify-vscode-test-results.mjs
+++ b/scripts/dev/verify-vscode-test-results.mjs
@@ -34,8 +34,8 @@ if (
 }
 const expected = new Set(Object.values(manifest.partitions).flat());
 if (
-  manifest.expected_tests?.single_root?.identities !== 976 ||
-  manifest.expected_tests?.single_root?.passed !== 975 ||
+  manifest.expected_tests?.single_root?.identities !== 977 ||
+  manifest.expected_tests?.single_root?.passed !== 976 ||
   manifest.expected_tests?.single_root?.pending !== 1 ||
   manifest.expected_tests?.multi_folder?.identities !== 14 ||
   manifest.expected_tests?.multi_folder?.passed !== 14 ||


### PR DESCRIPTION
## Summary

- update the extension test census to 977 identities / 976 passing / one pending
- keep the manifest, both verifier guards, shell contract, and CI documentation aligned
- preserve the exact-once and fail-closed outcome checks

## Experimental proof

- `make check-vscode-test-partitions`
- exact artifacts from failing run 34353310200 now verify as 266 + 205 + 506 = 977 single-root identities, 976 passed and one pending; the 14-test multi-folder suite also verifies
- `make prep-pr`
- `make rust-check`

Fixes #2045