### PR TITLE
ci: make Python engine cache source-stable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -633,6 +633,16 @@ TY_VERSION      := 0.0.78
 PYRIGHT_VERSION := 1.1.411
 PYTEST_VERSION  := 9.1.1
 
+# The cached typecheck/test venv is not a distributable report build.  Its
+# native extension must therefore not carry the checkout's mutable Git stamp:
+# source-identical commits may safely share the cache, and generated reports
+# never escape this environment. Keep this marker in python-engine-source-hash
+# so changing the cache provenance policy rebuilds an existing venv.
+PY_ENGINE_CACHE_VERSION      := 0.1.0
+PY_ENGINE_CACHE_GIT_HASH     := 0000000000000000000000000000000000000000
+PY_ENGINE_CACHE_GIT_DESCRIBE := python-engine-cache
+PY_ENGINE_CACHE_PROVENANCE   := cache-neutral-v1
+
 # The typecheck venv installs f5report — which maturin-compiles the native
 # `_engine` extension — plus pytest, so ty and pyright resolve every import for
 # real instead of suppressing `unresolved-import`. The Sublime host APIs
@@ -664,11 +674,15 @@ py-venv: ## Build the typecheck venv (f5report + native _engine + pytest)
 	@# (~4 min), so gate it on a content hash of the package tree: ty/pyright
 	@# read the committed `_engine.pyi` stub, never the compiled module, so the
 	@# venv needs a rebuild when the Python package or any local Rust input
-	@# compiled into its native extension changes.
+	@# compiled into its native extension changes. Its provenance is fixed below:
+	@# this cache only serves checks/tests and is never a report-artifact input.
 	@cd $(ROOT) && \
 	  stamp="$(PY_VENV)/.f5report-src-hash"; \
 	  hash=$$($(MAKE) --no-print-directory python-engine-source-hash); \
 	  if [ ! -f "$$stamp" ] || [ "$$(cat "$$stamp")" != "$$hash" ]; then \
+	    TCL_LSP_VERSION=$(PY_ENGINE_CACHE_VERSION) \
+	    GIT_HASH=$(PY_ENGINE_CACHE_GIT_HASH) \
+	    GIT_DESCRIBE=$(PY_ENGINE_CACHE_GIT_DESCRIBE) \
 	    uv pip install --python $(PY_VENV) --quiet \
 	        --reinstall-package f5report ./rust/bigip-report-gen/python pytest==$(PYTEST_VERSION) || exit; \
 	    printf '%s' "$$hash" > "$$stamp"; \
@@ -681,7 +695,12 @@ python-engine-source-hash: ## Hash every source/build input compiled into the f5
 	  files=$$(scripts/dev/python-engine-source-files.sh) && \
 	  { printf '%s\n' "$$files"; \
 	    printf '%s\n' "$$files" | git hash-object --stdin-paths; \
-	    printf '%s\n' "pytest=$(PYTEST_VERSION)"; \
+	    printf '%s\n' \
+	      "pytest=$(PYTEST_VERSION)" \
+	      "cache-version=$(PY_ENGINE_CACHE_VERSION)" \
+	      "cache-git-hash=$(PY_ENGINE_CACHE_GIT_HASH)" \
+	      "cache-git-describe=$(PY_ENGINE_CACHE_GIT_DESCRIBE)" \
+	      "provenance=$(PY_ENGINE_CACHE_PROVENANCE)"; \
 	  } | git hash-object --stdin
 
 typecheck-py: py-venv ## Type-check every tracked Python file (ty + pyright)
@@ -694,6 +713,8 @@ typecheck-py: py-venv ## Type-check every tracked Python file (ty + pyright)
 
 test-py-engine: py-venv ## Test the native f5report query-engine binding
 	@echo "==> Testing the native Python query-engine binding"
+	@cd $(ROOT) && $(PY_VENV)/bin/python -c \
+	    'import f5report._engine as engine; assert engine.__version__ == "$(PY_ENGINE_CACHE_VERSION)+g$(PY_ENGINE_CACHE_GIT_HASH)"; assert engine.__git_hash__ == "$(PY_ENGINE_CACHE_GIT_HASH)"; assert engine.__git_describe__ == "$(PY_ENGINE_CACHE_GIT_DESCRIBE)"'
 	@cd $(ROOT) && $(PY_VENV)/bin/pytest -q rust/bigip-report-gen/python/tests/test_engine.py
 
 # The lsp_e2e suite is native: rust/tcl-lsp-server/tests/*_e2e.rs, run by

--- a/docs/design/contracts/test-tiers-and-ci-gates.md
+++ b/docs/design/contracts/test-tiers-and-ci-gates.md
@@ -214,9 +214,15 @@ CI skips only what demonstrably did not change. The rules live in
   the native f5report engine's locked local Cargo dependency closure. The
   classifier and package manifest come from the PR base and fail closed;
   `make check-python-ci-paths` re-derives the closure from the engine lockfile.
-  The restored venv is keyed and stamped with the content of that same native
-  source closure, so a transitive Rust edit both schedules the job and forces
-  maturin to rebuild the extension.
+  The restored venv is keyed and stamped with the compilation inputs from that
+  same native source closure, so a transitive Rust edit both schedules the job
+  and forces maturin to rebuild the extension. The cache keeps that source set
+  broad: production code may include data stored under a `tests/` directory.
+  It excludes only exact Cargo target roots declared solely as integration
+  tests, benches, or examples, plus the Python binding's pytest tree; those
+  are not compiled by maturin. The venv is cache-neutral: it fixes Git
+  provenance rather than embedding its checkout's commit, and is never a
+  report-artifact input.
 - The root `rust-tests-shard` matrix produces five binary-aware legs when the
   Rust suite is required, while the concurrent hosted
   `rust-tests-doctest` job runs `cargo test --workspace --all-features --doc

--- a/scripts/dev/python-engine-source-files.sh
+++ b/scripts/dev/python-engine-source-files.sh
@@ -4,8 +4,15 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-# Print the tracked source/build inputs that determine the native f5report
+# Print the tracked compilation inputs that determine the native f5report
 # wheel. This is shared by the local venv stamp and GitHub Actions cache key.
+#
+# The Python job deliberately classifies whole dependency packages as relevant:
+# a Rust test change still needs the binding tests to run. The wheel cache stays
+# broad by default, because library sources may deliberately include fixture
+# data under `tests/`. It omits only exact Cargo target roots that are solely
+# integration tests, examples, or benches, plus the Python binding's own pytest
+# tree; neither is compiled by maturin into the extension.
 
 set -eu
 
@@ -27,7 +34,36 @@ awk '
 ' "$PACKAGE_MANIFEST" || exit 2
 
 paths=$(mktemp)
-trap 'rm -f "$paths"' EXIT HUP INT TERM
+target_roots=$(mktemp)
+filtered=$(mktemp)
+trap 'rm -f "$paths" "$target_roots" "$filtered"' EXIT HUP INT TERM
+
+if ! cargo metadata --locked --format-version 1 \
+    --manifest-path "$REPO_ROOT/rust/bigip-report-gen/python/Cargo.toml" | \
+    python3 -c '
+import json
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1]).resolve()
+metadata = json.load(sys.stdin)
+kinds_by_source = {}
+for package in metadata["packages"]:
+    for target in package["targets"]:
+        source = Path(target["src_path"]).resolve()
+        kinds_by_source.setdefault(source, set()).update(target["kind"])
+
+for source, kinds in kinds_by_source.items():
+    if not kinds or not kinds <= {"test", "bench", "example"}:
+        continue
+    try:
+        print(source.relative_to(root).as_posix())
+    except ValueError:
+        pass
+    ' "$REPO_ROOT" > "$target_roots"; then
+    echo "cannot derive Python engine non-compilation target roots" >&2
+    exit 2
+fi
 
 while IFS= read -r package_root || [ -n "$package_root" ]; do
     case "$package_root" in '' | \#*) continue ;; esac
@@ -37,10 +73,17 @@ while IFS= read -r package_root || [ -n "$package_root" ]; do
     fi
     git -C "$REPO_ROOT" ls-files -- "$package_root" >> "$paths"
 done < "$PACKAGE_MANIFEST"
+
+awk '
+    NR == FNR { omit[$0] = 1; next }
+    $0 ~ /^rust\/bigip-report-gen\/python\/tests\// { next }
+    !($0 in omit) { print }
+' "$target_roots" "$paths" > "$filtered"
+
 git -C "$REPO_ROOT" ls-files -- \
     .cargo/config.toml Cargo.toml Makefile rust-toolchain.toml \
     scripts/dev/python-ci-path.sh \
     scripts/dev/python-engine-package-paths.txt \
-    scripts/dev/python-engine-source-files.sh >> "$paths"
+    scripts/dev/python-engine-source-files.sh >> "$filtered"
 
-LC_ALL=C sort -u "$paths"
+LC_ALL=C sort -u "$filtered"

--- a/scripts/dev/test-python-ci-paths.sh
+++ b/scripts/dev/test-python-ci-paths.sh
@@ -118,14 +118,23 @@ for required in \
     rust/bigip-report-gen/python/src/lib.rs \
     rust/bigip-report-gen/frontend/dist/report.js \
     rust/tcl-bigip-query/src/value.rs \
+    rust/tcl-syntax/tests/data/namespace_op_vectors.txt \
     Cargo.toml Makefile rust-toolchain.toml \
     scripts/dev/python-engine-package-paths.txt; do
     grep -Fxq "$required" "$listed_file" \
         || fail "native-engine source identity omits $required"
 done
-if grep -Fxq editors/vscode/src/extension.ts "$listed_file"; then
-    fail "native-engine source identity includes unrelated VS Code source"
-fi
+for excluded in \
+    editors/vscode/src/extension.ts \
+    rust/bigip-report-gen/python/tests/test_engine.py \
+    rust/tcl-compiler/tests/codegen.rs \
+    rust/tcl-bigip/examples/dump_apl.rs; do
+    if grep -Fxq "$excluded" "$listed_file"; then
+        fail "native-engine source identity includes non-compilation input $excluded"
+    fi
+done
+grep -Fq 'cargo metadata --locked --format-version 1' "$SOURCE_FILES" \
+    || fail "native-engine source identity does not derive exact Cargo target roots"
 
 printf '%s\n' '../outside' > "$manifest_probe"
 if TCL_LSP_PYTHON_ENGINE_PACKAGE_MANIFEST=$manifest_probe \
@@ -157,6 +166,28 @@ grep -Fq "engine=\$(make --no-print-directory python-engine-source-hash)" "$WORK
     || fail "CI cache key does not use the native-engine source identity"
 grep -Fq 'hash=$$($(MAKE) --no-print-directory python-engine-source-hash)' "$REPO_ROOT/Makefile" \
     || fail "local venv stamp does not use the native-engine source identity"
+grep -Fq 'PY_ENGINE_CACHE_PROVENANCE   := cache-neutral-v1' "$REPO_ROOT/Makefile" \
+    || fail "native-engine cache does not declare its fixed provenance mode"
+grep -Fq 'TCL_LSP_VERSION=$(PY_ENGINE_CACHE_VERSION)' "$REPO_ROOT/Makefile" \
+    || fail "native-engine cache does not neutralise the engine version"
+grep -Fq 'GIT_HASH=$(PY_ENGINE_CACHE_GIT_HASH)' "$REPO_ROOT/Makefile" \
+    || fail "native-engine cache does not neutralise Git hash provenance"
+grep -Fq 'GIT_DESCRIBE=$(PY_ENGINE_CACHE_GIT_DESCRIBE)' "$REPO_ROOT/Makefile" \
+    || fail "native-engine cache does not neutralise Git describe provenance"
+for identity in \
+    '"cache-version=$(PY_ENGINE_CACHE_VERSION)"' \
+    '"cache-git-hash=$(PY_ENGINE_CACHE_GIT_HASH)"' \
+    '"cache-git-describe=$(PY_ENGINE_CACHE_GIT_DESCRIBE)"' \
+    '"provenance=$(PY_ENGINE_CACHE_PROVENANCE)"'; do
+    grep -Fq "$identity" "$REPO_ROOT/Makefile" \
+        || fail "native-engine cache identity omits $identity"
+done
+grep -Fq 'assert engine.__version__ == "$(PY_ENGINE_CACHE_VERSION)+g$(PY_ENGINE_CACHE_GIT_HASH)"' "$REPO_ROOT/Makefile" \
+    || fail "native-engine cache version is not checked in its cache-specific test path"
+grep -Fq 'assert engine.__git_hash__ == "$(PY_ENGINE_CACHE_GIT_HASH)"' "$REPO_ROOT/Makefile" \
+    || fail "native-engine cache Git hash is not checked in its cache-specific test path"
+grep -Fq 'assert engine.__git_describe__ == "$(PY_ENGINE_CACHE_GIT_DESCRIBE)"' "$REPO_ROOT/Makefile" \
+    || fail "native-engine cache Git describe is not checked in its cache-specific test path"
 grep -Fq 'run: make test-py-engine' "$WORKFLOW" \
     || fail "Python CI does not run the native-engine binding tests"
 


### PR DESCRIPTION
## Summary

- derive the cached Python engine build-input identity from Cargo target metadata
- exclude only non-compilation target roots and the binding pytest tree while retaining production-included fixture data
- use fixed cache-only version and Git provenance so source-identical commits can reuse the native extension safely
- include every provenance constant in the cache hash and keep cache-specific assertions out of the standalone package tests
- document and contract-test the cache boundary

This is the cache-correctness and performance fix-forward for #2041.

## Experimental proof

- `make check-python-ci-paths`: passed for the complete 21-package native dependency closure
- cold and warm `make test-py-engine`: 13/13 passed; the warm suite completed without rebuilding the extension
- `make lint-py`: passed
- `make typecheck-py`: ty clean; pyright reported zero errors and warnings
- changing excluded `rust/tcl-compiler/tests/codegen.rs`: source hash unchanged
- changing included `rust/tcl-compiler/src/lib.rs`: source hash changed, then restored exactly after revert
- independently overriding each fixed version/hash/describe/provenance constant produced a distinct cache hash
- `make prep-pr`: passed (30 smoke tests)
- `make rust-check`: passed

The cached extension reports the fixed cache-only version `0.1.0+g0000000000000000000000000000000000000000`; release and report artifacts do not use this venv.