### PR TITLE
ci: re-pin the VS Code expected test counts after the xcTranslate test

### DIFF
--- a/editors/vscode/test-partitions.json
+++ b/editors/vscode/test-partitions.json
@@ -9,8 +9,8 @@
   ],
   "expected_tests": {
     "single_root": {
-      "identities": 976,
-      "passed": 975,
+      "identities": 977,
+      "passed": 976,
       "pending": 1
     },
     "multi_folder": {

--- a/scripts/dev/test-vscode-test-partitions.sh
+++ b/scripts/dev/test-vscode-test-partitions.sh
@@ -26,14 +26,14 @@ for partition in 1 2 3; do
 done
 test "$(jq '[.partitions[][]] | length' "$manifest")" -eq 106
 test "$(jq '[.partitions[][]] | unique | length' "$manifest")" -eq 106
-test "$(jq '.expected_tests.single_root.identities' "$manifest")" -eq 976
-test "$(jq '.expected_tests.single_root.passed' "$manifest")" -eq 975
+test "$(jq '.expected_tests.single_root.identities' "$manifest")" -eq 977
+test "$(jq '.expected_tests.single_root.passed' "$manifest")" -eq 976
 test "$(jq '.expected_tests.single_root.pending' "$manifest")" -eq 1
 test "$(jq '.expected_tests.multi_folder.identities' "$manifest")" -eq 14
 test "$(jq '.expected_tests.multi_folder.passed' "$manifest")" -eq 14
 test "$(jq '.expected_tests.multi_folder.pending' "$manifest")" -eq 0
 test "$(jq -r '.multi_folder_files | join(",")' "$manifest")" = "multiFolderConfig.test.js"
-echo "VS Code test partitions: exact-once proof passed (106 files, 975 passed + 1 pending single-root identities, 14 multi-folder tests, 3 partitions)"
+echo "VS Code test partitions: exact-once proof passed (106 files, 976 passed + 1 pending single-root identities, 14 multi-folder tests, 3 partitions)"
 
 workflow="${root}/.github/workflows/ci.yml"
 check_workflow() {

--- a/scripts/dev/verify-vscode-test-partitions.mjs
+++ b/scripts/dev/verify-vscode-test-partitions.mjs
@@ -80,8 +80,8 @@ if (seen.get("serverHealth.test.js") !== "1") {
   throw new Error("serverHealth.test.js must run exactly once in partition 1");
 }
 if (
-  manifest.expected_tests?.single_root?.identities !== 976 ||
-  manifest.expected_tests?.single_root?.passed !== 975 ||
+  manifest.expected_tests?.single_root?.identities !== 977 ||
+  manifest.expected_tests?.single_root?.passed !== 976 ||
   manifest.expected_tests?.single_root?.pending !== 1 ||
   manifest.expected_tests?.multi_folder?.identities !== 14 ||
   manifest.expected_tests?.multi_folder?.passed !== 14 ||

--- a/scripts/dev/verify-vscode-test-results.mjs
+++ b/scripts/dev/verify-vscode-test-results.mjs
@@ -34,8 +34,8 @@ if (
 }
 const expected = new Set(Object.values(manifest.partitions).flat());
 if (
-  manifest.expected_tests?.single_root?.identities !== 976 ||
-  manifest.expected_tests?.single_root?.passed !== 975 ||
+  manifest.expected_tests?.single_root?.identities !== 977 ||
+  manifest.expected_tests?.single_root?.passed !== 976 ||
   manifest.expected_tests?.single_root?.pending !== 1 ||
   manifest.expected_tests?.multi_folder?.identities !== 14 ||
   manifest.expected_tests?.multi_folder?.passed !== 14 ||


### PR DESCRIPTION
## Summary

`test-ext` is red on `rust` itself, which fails every PR branched off it:

```
Error: single-root aggregate expected outcome counts drifted
    at validateOutcomes (scripts/dev/verify-vscode-test-results.mjs:94:11)
```

#2022 added one test — `tcl-lsp.xcTranslate returns both output documents` in `editors/vscode/src/test/commandExecution.test.ts` — without moving the counts it has to agree with.

Those counts are pinned in **four** places, each of which independently rejects a run that disagrees with it:

- `editors/vscode/test-partitions.json`, the manifest the rest validate against
- `scripts/dev/verify-vscode-test-results.mjs`, which checks the manifest and then the aggregate run against it
- `scripts/dev/verify-vscode-test-partitions.mjs`, which `make check-vscode-test-partitions` runs **before any test executes**
- `scripts/dev/test-vscode-test-partitions.sh`, which repeats the same assertions with `jq` and prints the counts in its summary line

All four move to **977 identities / 976 passed**. `pending` stays at 1 — the new test is active, not skipped — and the `multi_folder` counts are untouched because the file is single-root. The partition assignment needs no edit: `commandExecution.test.ts` was already in partition 3, and only its case count changed.

I first fixed only the manifest and the results verifier. That was wrong in a way worth recording: it would have moved the failure *earlier*, into `make check-vscode-test-partitions`, which the CI workflows invoke before running anything. Caught in review on this PR.

I found the drift while investigating a failure on #2058. It is not that PR's: nothing in its diff touches `editors/`, and the `lsp-e2e` and `pr-gate` failures reported alongside it were prerequisites cancelled by a newer push, not independent breaks.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

```
make check-vscode-test-partitions
```

Reproduced the failure before the fix and the pass after, rather than assuming: with only two of the four updated it fails with `manifest expected test counts drifted`; with all four it passes, printing

```
VS Code test partitions: exact-once proof passed (106 files, 976 passed + 1 pending single-root identities, 14 multi-folder tests, 3 partitions)
```

The VS Code harness itself does not run in this environment, so `test-ext` in CI is the real check — **and it passes on this head**.

The count comes from the diff that caused the drift: exactly one `test(` added between `1256bb9` (where the counts were last set, #2015) and `d1f4807` (the #2022 merge), none removed. Independently corroborated by another branch that hit the same failure and reports the three partitions as 265 + 205 + 506 passing, which sums to 976.

## Compiler / diagnostics checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? No — CI bookkeeping only, no compiler, diagnostic or analysis behaviour.
- [x] If yes, I updated the owning design doc. n/a.
- [x] If I added or changed a diagnostic or optimisation code, I updated its page. n/a.
- [x] If I added a design doc, I linked it from `docs/design/README.md`. n/a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQcgZFqEdz4Xy9WYCvCmNi