### PR TITLE
fix(cli): split the SslicTcl projection out of collect_rows to restore the clippy line ceiling

### DIFF
--- a/rust/tcl-cli/src/commands/diag.rs
+++ b/rust/tcl-cli/src/commands/diag.rs
@@ -209,6 +209,32 @@ fn document_proc_names(
 /// domain of the `optimise` verb, so they are dropped here — the same split the
 /// server draws with its optimiser toggle. Rows come back in a deterministic
 /// `(line, column, code)` order; `disabled` removes `--disable`d codes.
+/// Append the `SslicTcl` loader's own `SSLIC1xxx` findings, the same
+/// projection the server publishes.
+///
+/// It reads the same normalised `source` and maps through the same
+/// `line_index` as every other code here — the loader used to normalise for
+/// itself (#1794), which was correct but left every other code on the raw
+/// form.
+fn push_sslictcl_rows(
+    rows: &mut Vec<Row>,
+    source: &str,
+    line_index: &LineIndex,
+    disabled: &HashSet<String>,
+    suppressed_lines: &std::collections::HashMap<i32, HashSet<String>>,
+) {
+    for d in tcl_lsp_core::sslictcl_diagnostics::diagnostics(source, disabled, suppressed_lines) {
+        let pos = line_index.position_at_utf16(d.span.start(), source);
+        rows.push(Row {
+            line: pos.line + 1,
+            column: pos.character.get() + 1,
+            severity: d.severity,
+            code: d.code.to_string(),
+            message: d.message,
+        });
+    }
+}
+
 fn collect_rows(
     document: &InputDocument,
     dialect: &'static tcl_dialect::DialectProfile,
@@ -346,26 +372,14 @@ fn collect_rows(
         });
     }
 
-    // The `SslicTcl` loader's own `SSLIC1xxx` findings, the same projection the
-    // server publishes. It reads the same normalised `source` and maps through
-    // the same `line_index` as every other code here — the loader used to
-    // normalise for itself (#1794), which was correct but left every other code
-    // on the raw form.
     if sslictcl {
-        for d in tcl_lsp_core::sslictcl_diagnostics::diagnostics(
+        push_sslictcl_rows(
+            &mut rows,
             source,
+            &line_index,
             disabled,
             &result.suppressed_lines,
-        ) {
-            let pos = line_index.position_at_utf16(d.span.start(), source);
-            rows.push(Row {
-                line: pos.line + 1,
-                column: pos.character.get() + 1,
-                severity: d.severity,
-                code: d.code.to_string(),
-                message: d.message,
-            });
-        }
+        );
     }
 
     rows.sort_by(|a, b| {

--- a/rust/tcl-cli/src/commands/diag.rs
+++ b/rust/tcl-cli/src/commands/diag.rs
@@ -201,14 +201,6 @@ fn document_proc_names(
     .collect()
 }
 
-/// Collect every diagnostic the editor surfaces for one document: the analyser's
-/// syntactic / semantic checks plus the compiler-checks pass (shimmer `S1xx`,
-/// taint `T1xx` / `W2xx`, iRules data-flow). Mirrors the server's
-/// `lift_analyser_diagnostics` + `lift_compiler_diagnostics` concatenation so the
-/// CLI and the editor report the same set. Optimiser `O1xx` rewrites are the
-/// domain of the `optimise` verb, so they are dropped here — the same split the
-/// server draws with its optimiser toggle. Rows come back in a deterministic
-/// `(line, column, code)` order; `disabled` removes `--disable`d codes.
 /// Append the `SslicTcl` loader's own `SSLIC1xxx` findings, the same
 /// projection the server publishes.
 ///
@@ -235,6 +227,14 @@ fn push_sslictcl_rows(
     }
 }
 
+/// Collect every diagnostic the editor surfaces for one document: the analyser's
+/// syntactic / semantic checks plus the compiler-checks pass (shimmer `S1xx`,
+/// taint `T1xx` / `W2xx`, iRules data-flow). Mirrors the server's
+/// `lift_analyser_diagnostics` + `lift_compiler_diagnostics` concatenation so the
+/// CLI and the editor report the same set. Optimiser `O1xx` rewrites are the
+/// domain of the `optimise` verb, so they are dropped here — the same split the
+/// server draws with its optimiser toggle. Rows come back in a deterministic
+/// `(line, column, code)` order; `disabled` removes `--disable`d codes.
 fn collect_rows(
     document: &InputDocument,
     dialect: &'static tcl_dialect::DialectProfile,


### PR DESCRIPTION
## Summary

- `rust` is currently red: `collect_rows` in `rust/tcl-cli/src/commands/diag.rs` is 105 lines against the workspace's 100-line `clippy::too_many_lines` ceiling, and `-D warnings` turns that into a hard error. `make rust-check` fails on the base branch for every PR, not just one.

```
error: this function has too many lines (105/100)
   --> rust/tcl-cli/src/commands/diag.rs:212:1
    = note: `-D clippy::too-many-lines` implied by `-D warnings`
```

- It crossed the ceiling when #2020 ("fix(cli): honour `# noqa` in diag/lint/validate, through one shared helper", `e07620e`) added the two suppression checks to the function. CI on `rust` for `19fdd59` was cancelled by the next push before it reported, so nothing caught it on the way in.
- Moves the `SslicTcl` block into `push_sslictcl_rows`. It is the self-contained part of the function: it appends its own `SSLIC1xxx` findings from the same normalised `source` and `line_index`, and needs nothing else from the surrounding scope. No behavioural change — the same rows in the same order, still gated on `sslictcl` and still ahead of the final sort.
- No `#[allow]`: AGENTS.md rules those out, and the function genuinely reads better split.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

```
cargo clippy -p tcl-cli --all-targets --all-features -- -D warnings   # clean (was: 105/100)
cargo test -p tcl-cli                                                 # 24 + 22 passed, 0 failed
cargo fmt -p tcl-cli
```

Reproduced first, then fixed: I confirmed the base's own `diag.rs` fails this lint in an otherwise-identical tree before changing anything, so this is the base's breakage rather than a side effect of the branch I found it from.

## Compiler / diagnostics checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [ ] Did this change alter a compiler fact contract? — **No.** A function extraction in the CLI's reporting path; no diagnostic, code, or contract changed.
- [ ] If yes, I updated the owning design doc — n/a.
- [ ] If I added or changed a diagnostic or optimisation code, I updated its page under `docs/kcs/codes/` — n/a.
- [ ] If I added a design doc, I linked it from `docs/design/README.md` — n/a.

## Notes for review

Found while getting #2088 green. That PR carries this same commit so it is not blocked behind this one; it no-ops there once the base has it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LDrpuH4PaJu8YQqrFXGi73


---
_Generated by [Claude Code](https://claude.ai/code/session_01LDrpuH4PaJu8YQqrFXGi73)_