### PR TITLE
Resolve every artefact glob the workflow declares

### DIFF
--- a/scripts/release/test-sign-and-upload-action.sh
+++ b/scripts/release/test-sign-and-upload-action.sh
@@ -43,10 +43,14 @@ while IFS= read -r glob; do
     globs+=("$glob")
 done < <(sed -n 's/^[[:space:]]*artefact-glob:[[:space:]]*"\(.*\)"[[:space:]]*$/\1/p' "$WORKFLOW")
 
+# Count the input rows, not every mention: anchoring to the start of the line
+# keeps prose about the input from inflating the total into a false mismatch,
+# while still counting a row whose value the parse above cannot read.
+#
 # `grep -c` exits non-zero on zero matches, which under `set -e` would abort
 # here with no diagnostic at all — the vacuity check below is the message worth
 # printing in that case.
-declared=$(grep -c 'artefact-glob:' "$WORKFLOW" || true)
+declared=$(grep -cE '^[[:space:]]*artefact-glob:' "$WORKFLOW" || true)
 if [[ ${#globs[@]} -eq 0 ]]; then
     echo "no artefact globs found in the workflow; resolver check is vacuous" >&2
     exit 1

--- a/scripts/release/test-sign-and-upload-action.sh
+++ b/scripts/release/test-sign-and-upload-action.sh
@@ -5,8 +5,9 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 # Offline contract test for the shared release attestation action (issue
-# #1685). It exercises representative release shapes and guards the action pin,
-# subject binding, SBOM inputs, and least-privilege workflow permissions.
+# #1685). It exercises every release glob the workflow actually passes the
+# action, and guards the action pin, subject binding, SBOM inputs, and
+# least-privilege workflow permissions.
 
 set -euo pipefail
 
@@ -17,14 +18,12 @@ ACTION=$REPO_ROOT/.github/actions/sign-and-upload/action.yml
 WORKFLOW=$REPO_ROOT/.github/workflows/ci.yml
 fixture=$(mktemp -d)
 trap 'rm -rf "$fixture"' EXIT
-mkdir -p "$fixture/build"
 
-zip=$fixture/build/tcl-lsp-claude-skills-2.2.0.zip
-vsix=$fixture/build/tcl-lsp-vscode-2.2.0-universal.vsix
-sublime=$fixture/build/LSP-Tcl.sublime-package
-: > "$zip"
-: > "$vsix"
-: > "$sublime"
+# The version a wildcard stands in for. Release names are version-stamped, so
+# any token that a `*` can match will do; two are needed because the
+# multiple-match case has to produce a second file for the same glob.
+VERSION=2.2.0
+OTHER_VERSION=2.2.1
 
 assert_resolves() {
     local pattern=$1 expected=$2 actual
@@ -35,17 +34,61 @@ assert_resolves() {
     fi
 }
 
-# Representative glob shapes from the shared action's real callers.
-assert_resolves "$fixture/build/tcl-lsp-claude-skills-*.zip" "$zip"
-assert_resolves "$fixture/build/tcl-lsp-vscode-*-universal.vsix" "$vsix"
-assert_resolves "$fixture/build/LSP-Tcl*.sublime-package" "$sublime"
+# Every glob the workflow hands the action, read from the workflow rather than
+# copied here: a glob this test never sees is a glob nothing checks until a
+# release runs. The parse is quoted-scalar only, so it is compared against the
+# raw occurrence count below rather than trusted to have found them all.
+globs=()
+while IFS= read -r glob; do
+    globs+=("$glob")
+done < <(sed -n 's/^[[:space:]]*artefact-glob:[[:space:]]*"\(.*\)"[[:space:]]*$/\1/p' "$WORKFLOW")
+
+# `grep -c` exits non-zero on zero matches, which under `set -e` would abort
+# here with no diagnostic at all — the vacuity check below is the message worth
+# printing in that case.
+declared=$(grep -c 'artefact-glob:' "$WORKFLOW" || true)
+if [[ ${#globs[@]} -eq 0 ]]; then
+    echo "no artefact globs found in the workflow; resolver check is vacuous" >&2
+    exit 1
+fi
+if [[ ${#globs[@]} -ne $declared ]]; then
+    echo "parsed ${#globs[@]} artefact globs but the workflow declares $declared;" >&2
+    echo "one is written in a form this test cannot read, so it goes unchecked" >&2
+    exit 1
+fi
+
+# Materialise one file per glob first, then resolve each against the full set.
+# Resolving against every file at once is what makes two globs that can match
+# the same artefact fail here rather than at release time.
+for glob in "${globs[@]}"; do
+    concrete=${glob//\*/$VERSION}
+    mkdir -p "$(dirname "$fixture/$concrete")"
+    : > "$fixture/$concrete"
+done
+for glob in "${globs[@]}"; do
+    assert_resolves "$fixture/$glob" "$fixture/${glob//\*/$VERSION}"
+done
 
 if $RESOLVER "$fixture/build/missing-*.zip" >/dev/null 2>&1; then
     echo "resolver accepted a zero-match release glob" >&2
     exit 1
 fi
-: > "$fixture/build/tcl-lsp-claude-skills-2.2.1.zip"
-if $RESOLVER "$fixture/build/tcl-lsp-claude-skills-*.zip" >/dev/null 2>&1; then
+
+# A second file for a real wildcard glob, so the ambiguity the resolver must
+# reject is one an actual caller could hit.
+wildcard_glob=
+for glob in "${globs[@]}"; do
+    if [[ $glob == *"*"* ]]; then
+        wildcard_glob=$glob
+        break
+    fi
+done
+if [[ -z $wildcard_glob ]]; then
+    echo "no wildcard glob in the workflow; the multiple-match case is vacuous" >&2
+    exit 1
+fi
+: > "$fixture/${wildcard_glob//\*/$OTHER_VERSION}"
+if $RESOLVER "$fixture/$wildcard_glob" >/dev/null 2>&1; then
     echo "resolver silently selected one of multiple release artefacts" >&2
     exit 1
 fi


### PR DESCRIPTION
## Summary

The last of the audit follow-ups, after [#2019](https://github.com/bitwisecook/tcl-lsp/pull/2019), [#2046](https://github.com/bitwisecook/tcl-lsp/pull/2046) and [#2094](https://github.com/bitwisecook/tcl-lsp/pull/2094).

`scripts/release/test-sign-and-upload-action.sh` hand-copied three of the workflow's twelve `artefact-glob` values. The other nine reached the resolver for the first time during a release, including `rust/tcl-lsp-server-wasi/dist/tcl-lsp-server-wasi.wasm`, the one glob with no wildcard at all. The test now reads them from the workflow.

To be clear about what this does and does not buy, since [#2094](https://github.com/bitwisecook/tcl-lsp/pull/2094) corrected the earlier claim: this does **not** catch a glob that names an asset nothing builds, because the fixture still materialises files from the globs and stays self-consistent. The retired-name gate added in #2094 covers that. What this adds is coverage of every real shape, and one new class of failure below.

## Over-broad globs now fail at PR time

Every glob resolves against the full set of materialised files rather than one at a time, so a pattern that can also match another job's artefact is caught here instead of at release. Broadening the Zed glob to `build/tcl-lsp-*.zip` demonstrates it:

```
release artefact glob …/build/tcl-lsp-*.zip matched 3 files; expected exactly one
  …/build/tcl-lsp-2.2.0.zip
  …/build/tcl-lsp-claude-skills-2.2.0.zip
  …/build/tcl-lsp-jetbrains-2.2.0.zip
```

## Three ways it could pass while checking nothing

Each is now an error, and each was verified by breaking the workflow deliberately:

| Failure mode | How it is caught |
|---|---|
| No globs found | Vacuity check |
| A glob the quoted-scalar parse cannot read | Parsed count compared against the raw `artefact-glob:` occurrence count |
| No wildcard glob to build the multiple-match case from | Vacuity check |

Unquoting one glob reports `parsed 11 artefact globs but the workflow declares 12`.

While testing the vacuity case I found a defect in my own first cut: `grep -c` exits non-zero when it counts none, so under `set -e` the script aborted before the check could report why. The count now tolerates the empty case and the diagnostic prints.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

```
bash scripts/release/test-sign-and-upload-action.sh   # 12 globs exercised, was 3
make check-sign-and-upload                            # exit 0
make check-retired-asset-names                        # exit 0
make rust-check                                       # exit 0
make prep-pr                                          # exit 0
```

Coverage confirmed by instrumenting the loop and counting what it exercised, so "it passes" is not mistaken for "it checks anything".

## Compiler / diagnostics checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [ ] Did this change alter a compiler fact contract? No — one release contract test.
- [ ] If yes, I updated the owning design doc under `docs/design/compiler/` or
      `docs/design/contracts/`.
- [ ] If I added or changed a diagnostic or optimisation code, I updated its
      page under `docs/kcs/codes/` and linked it from `docs/kcs/codes/README.md`.
- [ ] If I added a design doc, I linked it from `docs/design/README.md`
      (`cargo xtask kcs-index-links` enforces this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YKdc6J7NnbEV9ecYNgozVz

---
_Generated by [Claude Code](https://claude.ai/code/session_01YKdc6J7NnbEV9ecYNgozVz)_