### PR TITLE
Canonicalize temp directory in git_inputs tests

### DIFF
--- a/rust/tcl-version/src/git_inputs.rs
+++ b/rust/tcl-version/src/git_inputs.rs
@@ -118,10 +118,14 @@ mod tests {
                 "tcl-version-git-inputs-{}-{nanos}-{serial}",
                 std::process::id()
             ));
-            let primary = root.join("primary");
-            let linked = root.join("linked");
 
             std::fs::create_dir_all(&root).expect("create temporary repository root");
+            // `git_path` canonicalizes, and some platforms hand out a symlinked
+            // temporary directory (macOS `/var` -> `/private/var`). Canonicalize
+            // the root so expectations compare against the same real paths.
+            let root = root.canonicalize().expect("canonicalize temporary root");
+            let primary = root.join("primary");
+            let linked = root.join("linked");
             git(&root, &["init", "--initial-branch=base", path(&primary)]);
             git(&primary, &["config", "user.name", "tcl-version test"]);
             git(


### PR DESCRIPTION
## Summary

- Fixed flaky test behavior in `git_inputs` tests by canonicalizing the temporary root directory before creating subdirectories. This ensures that symlinked temporary directories (common on macOS where `/var` → `/private/var`) are resolved to their real paths, allowing path comparisons to work correctly across different platforms.

## Details

The test was creating a temporary directory and then using it to initialize git repositories. However, on some platforms (notably macOS), the temporary directory path returned by the system may be a symlink. The `git_path` function canonicalizes paths, so when comparing paths later in the test, the symlinked temporary root would not match the canonicalized git paths, causing test failures.

The fix moves the `canonicalize()` call to happen immediately after creating the temporary directory, before deriving the `primary` and `linked` subdirectory paths. This ensures all subsequent path operations work with the real, canonical paths.

## Validation

- Existing unit tests in `git_inputs` module cover this behavior and will validate the fix on all platforms.

https://claude.ai/code/session_01NZMTDt51BcKF8MUGWMkH4c