### PR TITLE
fix(bigip-query): gate with_note on probes, unbreaking the Pages deploy

### DIFF
--- a/rust/tcl-bigip-query/src/builtins/mod.rs
+++ b/rust/tcl-bigip-query/src/builtins/mod.rs
@@ -309,7 +309,7 @@ pub(crate) fn special(
 /// Only the probe builtins carry a caveat, so this follows `probes` — a
 /// build without them has nothing to annotate, and an ungated helper would
 /// be dead code there.
-#[cfg(any(feature = "x509", feature = "probes"))]
+#[cfg(feature = "probes")]
 pub(crate) fn with_note(
     entry: (&'static str, BuiltinSpec),
     note: &'static str,


### PR DESCRIPTION
Every GitHub Pages deploy has failed since 2026-09-09. The report-WASM build
step dies with:

    error: `tcl-bigip-query` (lib) generated 1 warning
    error: warnings are denied by `build.warnings` configuration
      --> rust/tcl-bigip-query/src/builtins/mod.rs:313
          function `with_note` is never used

`with_note` was gated `any(x509, probes)`, but #1999 removed the x509 caveats
along with the unreachable cert paths, leaving `probes.rs` as its only
caller. `bigip-report-gen` depends on this crate with
`default-features = false, features = ["x509"]` — x509 without probes — so
the helper is dead code in exactly the build Pages runs.

Follow `probes` alone, which is what the doc comment on the helper already
says: "Only the probe builtins carry a caveat, so this follows `probes` — a
build without them has nothing to annotate, and an ungated helper would be
dead code there."

No other gate caught this: `rust-check`'s clippy runs `--all-targets` on the
default feature set, where `with_note` is used.

Verified locally, all warning-free after the change: `tcl-bigip-query` with
`--features x509`, with `--features probes`, and on default features;
`bigip-report-gen-rust`; and the failing step itself,
`rust/bigip-report-gen/wasm/build-wasm.sh`, which now completes and writes
its 26 MiB `dist/index.html`. `make rust-check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoYjXHMmULxxxQFULqC2iX
