### PR TITLE
docs(skill): make the stable line the release skill's primary path

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -2,11 +2,12 @@
 name: release
 description: >
   Run the full release workflow: validate the active `rust` release branch,
-  benchmark the release and regenerate the release-notes performance graphs,
-  write the changelog, land the notes PR, tag, then let CI build and publish —
-  approving the marketplace Environments with `gh` from the release laptop.
-  Asks for patch/minor/major if not specified. Driven by
-  `scripts/release/rust_release.sh`.
+  write the changelog, bump the Zed manifest, land the notes PR, tag, then let
+  CI build and publish — approving the marketplace Environments with `gh` from
+  the release laptop. Stable (even-minor) cuts go through `tag.sh`; the
+  odd-minor pre-release line adds a benchmark and regenerated performance
+  graphs via `scripts/release/rust_release.sh`. Asks for patch/minor/major if
+  not specified.
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 
@@ -17,28 +18,13 @@ any failure.
 
 The release is **tag-only**: every version literal derives from the latest
 annotated tag (Makefile + `git describe`). Cutting a release is pushing a
-`vX.Y.Z` tag — no source bump, no commit on the release branch. The one
-exception is `RELEASE_NOTES.md` with the release's benchmark result and
-regenerated graphs, which land via a PR before the tag.
+`vX.Y.Z` tag — no source bump, no commit on the release branch. The two
+exceptions land via a PR before the tag: `RELEASE_NOTES.md`, and
+`editors/zed/extension.toml` (Zed's registry builds the extension directory
+at the tagged commit, so the version must already be in the tree — `tag.sh`
+refuses to tag until it is).
 
-## The driver
-
-`scripts/release/rust_release.sh` implements everything except the prose
-changelog. Use it; it is what makes two releases come out the same way.
-
-```bash
-scripts/release/rust_release.sh next patch      # -> the next version
-scripts/release/rust_release.sh preflight X.Y.Z # branch, clean tree, free tag, ordering
-#   ...write the prose changelog (step 4)
-scripts/release/rust_release.sh prepare X.Y.Z   # preflight + bench + graphs + notes + verify + local commit
-#   ...push the branch, open + merge the notes PR, pull `rust`
-scripts/release/rust_release.sh tag X.Y.Z       # re-verifies, then tag.sh
-```
-
-`prepare` stops at a local commit and prints the push / PR commands — read
-the diff first.
-
-## One branch, two channels
+## One branch, two lines — and which one you are on
 
 Every release is cut from `rust`; the tag selects the channel.
 `scripts/release/prerelease.sh` is the single decider — pre-release when
@@ -46,13 +32,53 @@ major ≥ 2 and minor is odd (`v2.1.8` pre-release, `v2.2.0` stable) — and CI
 reads it for the GitHub release flag and the marketplace channel; nothing is
 passed by hand.
 
-| Line | Channel | GitHub release |
-|---|---|---|
-| even minor | VS Code / Open VSX / JetBrains stable | latest |
-| odd minor | VS Code / Open VSX pre-release, JetBrains eap | pre-release, never latest |
+| Line | Channel | GitHub release | Notes carry |
+|---|---|---|---|
+| **even minor (stable)** | VS Code / Open VSX / JetBrains stable | latest | prose only |
+| odd minor (pre-release) | VS Code / Open VSX pre-release, JetBrains eap | pre-release, never latest | prose + benchmark + graphs |
+
+**The project is on the stable line.** `v2.2.x` is current, so a `patch` bump
+is a stable cut and the steps below are written for it. The odd-minor
+pre-release path still exists in the tooling and is called out inline wherever
+it differs; resuming it means a `minor` bump onto `v2.3.x`.
+
+Check rather than assume — the bump the user picks decides it:
+
+```bash
+scripts/release/prerelease.sh X.Y.Z    # "true" = pre-release line, "false" = stable
+```
 
 `legacy-py` (the Python 1.x line) is a locked archive: never branch, merge,
 or tag from it.
+
+## The drivers
+
+- **Stable (even minor).** `scripts/release/tag.sh`, via
+  `make release-tag V=X.Y.Z`. There is no scripted prepare step: the notes are
+  hand-written prose and the Zed bump is one make target. No benchmark, no
+  graphs, no `## Performance` section — `scripts/perf/results/` legitimately
+  has no entry for a stable release.
+- **Pre-release (odd minor).** `scripts/release/rust_release.sh` implements
+  everything except the prose changelog, and adds the benchmark and graph
+  regeneration on top of the same tagging primitive.
+
+```bash
+scripts/release/rust_release.sh next patch      # -> the next version (either line)
+scripts/release/rust_release.sh preflight X.Y.Z # pre-release line only
+scripts/release/rust_release.sh prepare X.Y.Z   # pre-release line only: + bench + graphs + notes
+scripts/release/rust_release.sh tag X.Y.Z       # pre-release line only: re-verifies, then tag.sh
+```
+
+Only `next` accepts a stable version. `preflight`, `prepare` and `tag` refuse
+one outright —
+
+```
+error: v2.2.5 is a stable release (cut from rust via tag.sh). This script drives the
+       rust pre-release line only — see scripts/release/tag.sh.
+```
+
+— on purpose: running the pre-release path against a stable version would put
+pre-release graphs in stable notes. Do not work around it.
 
 ## Workflow
 
@@ -61,6 +87,7 @@ or tag from it.
 ```bash
 [ "$(git branch --show-current)" = rust ] || { echo "ERROR: release from rust"; exit 1; }
 git pull origin rust
+git fetch --tags origin
 ```
 
 ### 2. Validate
@@ -73,44 +100,87 @@ make check-all
 make test-ext test-rust runtime-rust-test test-emacs
 ```
 
+Also confirm the workflows that are not part of the PR gate are green on the
+tip — the **Pages** deploy in particular runs only on a push to `rust`, so a
+PR can merge green and still leave it broken:
+
+```bash
+gh run list --workflow github-pages.yml --limit 3 \
+  --json status,conclusion,headSha --jq '.[] | "\(.status) \(.conclusion) \(.headSha[0:9])"'
+```
+
 ### 3. Version
 
 Take `patch` / `minor` / `major` from `$ARGUMENTS`, else ask with
-`AskUserQuestion`. Then:
+`AskUserQuestion`. Say which channel each option lands on — an odd minor
+publishes as a pre-release, and that is rarely what someone means by "cut a
+release" while the project is on `v2.2.x`.
 
 ```bash
 scripts/release/rust_release.sh next <bump>       # prints X.Y.Z
-scripts/release/rust_release.sh preflight X.Y.Z   # branch, clean worktree, tag free locally and on origin, newer than latest
+scripts/release/prerelease.sh X.Y.Z               # which line: "true" | "false"
 ```
 
-### 4. Changelog (prose only)
+**Stable** — there is no scripted preflight, so check the same invariants by
+hand:
 
-Generate from the **source diff** since the previous tag, not the git log:
+```bash
+[ "$(git branch --show-current)" = rust ]                       # right branch
+git status --short                                              # clean tree
+git rev-parse -q --verify "refs/tags/vX.Y.Z" && echo "TAG EXISTS"   # must print nothing
+git ls-remote --tags origin "vX.Y.Z"                            # must be empty
+```
+
+**Pre-release** — `scripts/release/rust_release.sh preflight X.Y.Z` does all
+of that plus the ordering check.
+
+### 4. Changelog (prose)
+
+Generate from the **source diff** since the previous tag, not the git log —
+though on a range of a few hundred commits the conventional-commit subjects
+are the practical index into it:
 
 ```bash
 prev_tag=$(git describe --tags --abbrev=0)
 git diff "$prev_tag"..HEAD -- '*.rs' '*.ts' '*.kt' '*.toml' '*.json' '*.tcl' '*.tclspec' \
   ':!**/package-lock.json' ':!**/Cargo.lock'
+git log "$prev_tag"..HEAD --no-merges --format='%s' | grep -E '^(feat|fix|perf)' | sort -u
 ```
 
-Write `RELEASE_NOTES.md` at the root: `# vX.Y.Z`, then `## New Features`,
-`## Improvements`, `## Bug Fixes`, `## Breaking Changes` (omit empty
+Prepend to `RELEASE_NOTES.md` at the root — newest section first, since
+`github_release.sh` publishes the top section verbatim as the GitHub release
+body. Open with `# vX.Y.Z` and a short paragraph saying what the release is
+about, then `## New features`, `## Improvements`, `## Bug fixes`,
+`## Breaking changes` (sentence case, matching the file; omit empty
 sections). User-visible changes, grouped, UK spelling, no file lists.
-**Never write the `## Performance` section** — step 5 generates it, and a
-hand-edited one is how a release ships the previous release's graphs.
 
-### 5. Benchmark, graphs, notes, commit
+**The `## Performance` section belongs to the pre-release line only.** On that
+line, never hand-write it — step 5 generates it, and a hand-edited one is how
+a release ships the previous release's graphs. On a stable cut there is no
+such section at all.
+
+### 5. Prepare the notes commit
+
+**Stable.** Bump the Zed manifest and commit both files on a
+`release/vX.Y.Z` branch:
 
 ```bash
-scripts/release/rust_release.sh prepare X.Y.Z
+make release-zed-version V=X.Y.Z
+bash scripts/release/zed_version.sh check X.Y.Z    # the invariant tag.sh enforces
+git checkout -b release/vX.Y.Z
+git add RELEASE_NOTES.md editors/zed/extension.toml
+git commit    # "Release vX.Y.Z notes"
+make xtask-check
 ```
 
-Runs preflight, a release build of `tcl-lsp-server`, the pinned-corpus
-benchmark into `scripts/perf/results/X.Y.Z.json`, the `MANIFEST.toml` entry,
-a re-render of `scripts/perf/graphs/` with X.Y.Z highlighted, the
+**Pre-release.** `scripts/release/rust_release.sh prepare X.Y.Z` does the Zed
+bump for you, plus a release build of `tcl-lsp-server`, the pinned-corpus
+benchmark into `scripts/perf/results/X.Y.Z.json`, the `MANIFEST.toml` entry, a
+re-render of `scripts/perf/graphs/` with X.Y.Z highlighted, the
 `## Performance` section with its four release-asset URLs, `verify` (re-render
-and diff against the committed graphs), then a local commit on
-`release/vX.Y.Z`. Report rather than paper over:
+and diff against the committed graphs), then the local commit. It stops there
+and prints the push / PR commands — read the diff first. Report rather than
+paper over:
 
 - **Measurement host.** A warning that this release was measured on a
   different machine than the last means wall time and CPU are not
@@ -121,18 +191,20 @@ and diff against the committed graphs), then a local commit on
 
 ### 6. Land the notes PR
 
-The release branch is protected; the notes commit lands via a PR **against
+`rust` is ruleset-protected, so the notes commit lands via a PR **against
 `rust`** (a PR against another branch lands the notes on the wrong line):
 
 ```bash
 git push -u origin release/vX.Y.Z
 gh pr create --base rust --title "Release vX.Y.Z notes" --body "..."
+gh pr merge <n> --auto --squash      # both notes PRs to date landed squashed
 ```
 
-One PR carries `RELEASE_NOTES.md`, `scripts/perf/results/X.Y.Z.json`, the
-regenerated `scripts/perf/graphs/`, and the `MANIFEST.toml` entry — the
-graphs only mean something beside the result they were rendered from. Wait
-for green CI, ask the user to squash-merge, then:
+A stable PR carries `RELEASE_NOTES.md` and `editors/zed/extension.toml`. A
+pre-release PR carries those plus `scripts/perf/results/X.Y.Z.json`, the
+regenerated `scripts/perf/graphs/`, and the `MANIFEST.toml` entry — the graphs
+only mean something beside the result they were rendered from. Wait for green
+CI and the merge, then:
 
 ```bash
 git checkout rust && git pull origin rust
@@ -141,14 +213,24 @@ git checkout rust && git pull origin rust
 ### 7. Tag
 
 ```bash
-scripts/release/rust_release.sh tag X.Y.Z     # or: make release-rust-tag V=X.Y.Z
+make release-tag V=X.Y.Z                        # stable — tag.sh directly
+scripts/release/rust_release.sh tag X.Y.Z       # pre-release — re-verifies, then tag.sh
 ```
 
-It re-runs `verify`, refuses if the notes PR has not merged, then hands off
-to `tag.sh` (`make release-tag V=X.Y.Z` is the bare primitive: clean tree,
-correct branch, no existing tag, pushes only the tag). The tag push runs
-`ci.yml`: artefacts, `publish-checksums`, the GitHub release with the
-channel from `prerelease.sh`.
+`tag.sh` checks the Zed manifest invariant, refuses a dirty tree, refuses an
+existing tag, then pushes only the tag. The push runs `ci.yml`: artefacts,
+`publish-checksums`, the GitHub release with the channel from `prerelease.sh`.
+
+A maintainer's tag push reports a **bypassed ruleset** —
+
+```
+remote: Bypassed rule violations for refs/tags/vX.Y.Z:
+remote: - Cannot create ref due to creations being restricted.
+```
+
+— and succeeds. That is the ruleset working as configured for an account that
+can bypass it, not an error; say so in the report rather than treating the tag
+as suspect.
 
 `Permission denied (publickey)` means the SSH agent has no identities
 (a locked 1Password). Override the push URL for that one command instead of
@@ -204,7 +286,9 @@ Claude skills installed. Knobs: `TCL_LSP_PREFIX`, `TCL_LSP_OS`, `MIN_SKILLS`,
 `publish-vsix-marketplace`, `publish-vsix-openvsx`, and
 `publish-jetbrains-marketplace` on their protected Environments
 (`marketplace-vscode` / `marketplace-openvsx` / `marketplace-jetbrains`);
-approving is what ships. Approve all three with `gh` once step 8 passed:
+approving is what ships, so it is the user's call — surface the pending
+approvals and wait rather than approving unprompted. Once step 8 passed and
+the user has said to go:
 
 ```bash
 tag="vX.Y.Z"
@@ -255,12 +339,15 @@ external-repo PR is raised by the user.
 Release vX.Y.Z complete.
   Previous version: <prev>
   New version:      X.Y.Z
-  Tag:              vX.Y.Z
-  Benchmarked on:   <host from results/X.Y.Z.json>
+  Tag:              vX.Y.Z          (stable | pre-release)
+  Benchmarked on:   <host from results/X.Y.Z.json, or "n/a — stable line">
   Editors published: <list or "none">
 ```
 
-Say if the benchmark host differed from the previous release's — it is why
-the notes quote no delta.
+On the pre-release line, say if the benchmark host differed from the previous
+release's — it is why the notes quote no delta. On a stable cut say the line
+carries no benchmark, so nobody goes looking for the missing graphs.
+
+Issues never auto-close on a release; sweep them by hand after the cut.
 
 $ARGUMENTS


### PR DESCRIPTION
The release skill documented only the odd-minor pre-release flow, so cutting
v2.2.5 meant working the stable path out from scratch — from how v2.2.4 was
cut and from the scripts' own refusals.

Three things it got actively wrong for a stable release:

- It sent you to `scripts/release/rust_release.sh preflight` / `prepare` /
  `tag`. All three refuse a stable version outright, and deliberately so:
  running the pre-release path against one would put pre-release graphs in
  stable notes.
- It never mentioned `editors/zed/extension.toml`, which `tag.sh` checks
  before it will tag. On a stable cut nothing else bumps it, so the tag step
  fails at the last moment.
- It said never to hand-write the `## Performance` section because "step 5
  generates it". On the stable line nothing generates it and there is no such
  section — which is why `scripts/perf/results/` has no entry past 2.2.0 and
  the v2.2.4 notes have no performance section.

The project is on `v2.2.x`, so the stable line is now the path the steps are
written for, with the pre-release differences called out inline rather than
assumed. The pre-release material is kept, not deleted — resuming that line is
a `minor` bump onto `v2.3.x`.

Also records, from this cut:

- how to tell the two lines apart before choosing a bump, and that an odd
  minor publishes as a pre-release — rarely what "cut a release" means today;
- the hand-run preflight invariants that replace the scripted one;
- that `RELEASE_NOTES.md` is prepended and its top section becomes the GitHub
  release body verbatim, with the file's actual sentence-case headings;
- that a maintainer's tag push reports a bypassed tag-creation ruleset and
  still succeeds, so nobody reads it as a failure;
- that the Pages deploy runs only on a push to `rust`, so it can be red while
  every PR check is green — worth checking during validation, as it was today;
- that approving the marketplace Environments is the user's call, not
  something to do unprompted.

`make xtask-gen-ai-diagnostics` and `make xtask-kcs-index-links` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoYjXHMmULxxxQFULqC2iX
