### PR TITLE
fix(ci): keep the release graph intact on an already-green tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1206,9 +1206,14 @@ jobs:
   # `--all-features` workspace run costs no coverage.
   rust-tests-shard:
     name: rust-tests-shard (${{ matrix.shard }})
-    # Unaffected changes and already-green tags retain the aggregate status
-    # without allocating five test runners.
-    if: ${{ needs.channel.outputs.rust_tests_changed == 'true' && !(startsWith(github.ref, 'refs/tags/') && needs.channel.outputs.already_green == 'true') }}
+    # Unaffected changes retain the aggregate status without allocating five
+    # test runners. An already-green *tag* must not skip here: a tag forces
+    # rust_tests_changed true, so this job stays in the graph and step-skips
+    # its work below. Skipping it at job level instead took `create-release`
+    # and every release producer down with it on v2.2.5 — a skipped ancestor
+    # propagates through the needs graph, which is why the header bans
+    # job-level skips on the tag path.
+    if: ${{ needs.channel.outputs.rust_tests_changed == 'true' }}
     # Typically ~155s on the 16-core self-hosted box when healthy; if this
     # job blows past ~5 min, suspect a runaway test before suspecting the box
     # or the cache. Not the workflow's critical path: the three archived
@@ -1493,10 +1498,12 @@ jobs:
   # It remains a step-gated job so the stable aggregate context is preserved
   # for unrelated changes, docs-only changes, and already-green revisions.
   rust-tests-doctest:
-    # Match the shard matrix's job-level no-op rules. The stable aggregate is
-    # the required context and accepts this skipped result only when the
-    # channel facts prove that no test command was required.
-    if: ${{ needs.channel.outputs.rust_tests_changed == 'true' && !(startsWith(github.ref, 'refs/tags/') && needs.channel.outputs.already_green == 'true') }}
+    # Match the shard matrix's no-op rules. The stable aggregate is the
+    # required context and accepts this skipped result only when the channel
+    # facts prove that no test command was required — and a tag never proves
+    # that, so this job stays in the graph on the release path and step-skips
+    # its work instead (see the shard matrix's note).
+    if: ${{ needs.channel.outputs.rust_tests_changed == 'true' }}
     needs: [channel]
     runs-on: ubuntu-26.04
     steps:
@@ -1543,10 +1550,12 @@ jobs:
           if [ "$SHARDS_RESULT" = success ] && [ "$DOCTEST_RESULT" = success ]; then
             exit 0
           fi
-          if [ "$SHARDS_RESULT" = skipped ] && [ "$DOCTEST_RESULT" = skipped ] && {
-            [ "$RUST_TESTS_CHANGED" != true ] ||
-            { [ "$IS_TAG" = true ] && [ "$ALREADY_GREEN" = true ]; };
-          }; then
+          # A tag forces rust_tests_changed true, so this branch cannot absorb
+          # a skip on the release path: if the shards ever skip at job level
+          # there again, the tag run fails here rather than reporting success
+          # and silently producing no release (v2.2.5).
+          if [ "$SHARDS_RESULT" = skipped ] && [ "$DOCTEST_RESULT" = skipped ] &&
+            [ "$RUST_TESTS_CHANGED" != true ]; then
             echo 'Rust test shards and doctests were intentionally skipped by the channel decision'
             exit 0
           fi

--- a/scripts/dev/test-rust-tests-paths.sh
+++ b/scripts/dev/test-rust-tests-paths.sh
@@ -271,6 +271,23 @@ case "$rust_job" in
     *'if: always() && needs.channel.outputs.rust_tests_changed == '\''true'\'''*'sccache --show-stats'*) ;;
     *) fail "sccache statistics must be skipped when Rust setup is skipped" ;;
 esac
+# Neither Rust test job may skip at *job* level on a tag. A tag forces
+# rust_tests_changed true, so the only way to skip one there is an explicit
+# tag/already-green clause — and a skipped ancestor propagates through the
+# needs graph, which is what took create-release and every release producer
+# down on v2.2.5 while the run still reported success.
+for job in rust-tests-shard rust-tests-doctest; do
+    job_condition=$(awk -v want="  $job:" '
+        $0 == want { in_job = 1; next }
+        in_job && /^  [A-Za-z0-9_-]+:/ { exit }
+        in_job && /^    if:/ { print; exit }
+    ' "$WORKFLOW")
+    case "$job_condition" in
+        *already_green*|*refs/tags/*)
+            fail "$job must not skip at job level on a tag (release graph)" ;;
+    esac
+done
+
 doctest_job=$(awk '
     /^  rust-tests-doctest:/ { in_job = 1 }
     in_job && /^  [A-Za-z0-9_-]+:/ && $1 != "rust-tests-doctest:" { exit }
@@ -278,7 +295,7 @@ doctest_job=$(awk '
 ' "$WORKFLOW")
 [ -n "$doctest_job" ] || fail "ci.yml must define rust-tests-doctest"
 case "$doctest_job" in
-    *"if: \${{ needs.channel.outputs.rust_tests_changed == 'true' && !(startsWith(github.ref, 'refs/tags/') && needs.channel.outputs.already_green == 'true') }}"*'needs: [channel]'*'runs-on: ubuntu-26.04'*"if: needs.channel.outputs.rust_tests_changed == 'true' && needs.channel.outputs.docs_only != 'true' && needs.channel.outputs.already_green != 'true'"*'cargo test --workspace --all-features --doc --no-fail-fast'*) ;;
+    *"if: \${{ needs.channel.outputs.rust_tests_changed == 'true' }}"*'needs: [channel]'*'runs-on: ubuntu-26.04'*"if: needs.channel.outputs.rust_tests_changed == 'true' && needs.channel.outputs.docs_only != 'true' && needs.channel.outputs.already_green != 'true'"*'cargo test --workspace --all-features --doc --no-fail-fast'*) ;;
     *) fail "doctests must be independently hosted and retain changed-path/exact-green step gates" ;;
 esac
 

--- a/scripts/dev/test-rust-tests-runner.sh
+++ b/scripts/dev/test-rust-tests-runner.sh
@@ -188,7 +188,12 @@ END {
     doctest_job = "jobs.rust-tests-doctest"
     server_job = "jobs.build-tcl-lsp-server"
     need(values[shard_job ".name"] == "rust-tests-shard (${{ matrix.shard }})", "Rust shards must have an explicit matrix job name")
-    need(values[shard_job ".if"] == "${{ needs.channel.outputs.rust_tests_changed == '\''true'\'' && !(startsWith(github.ref, '\''refs/tags/'\'') && needs.channel.outputs.already_green == '\''true'\'') }}", "unaffected changes and already-green tags must skip the shard matrix")
+    # An already-green *tag* must not skip the matrix at job level: a skipped
+    # ancestor propagates through the needs graph and takes create-release and
+    # every release producer with it (v2.2.5 tagged, reported success, and
+    # published nothing). A tag forces rust_tests_changed true, so the job
+    # stays in the graph there and step-skips its work instead.
+    need(values[shard_job ".if"] == "${{ needs.channel.outputs.rust_tests_changed == '\''true'\'' }}", "unaffected changes must skip the shard matrix, and an already-green tag must not")
     need(values_seen[shard_job ".runs-on"], "rust-tests-shard must define runs-on")
     need(values_seen[aggregate_job ".needs"], "rust-tests aggregate must define needs")
     tank_jobs = 0
@@ -393,8 +398,13 @@ case "$(cat "$WORKFLOW")" in
     *) echo "fork, Dependabot, policy-change, and manual-dispatch routing must stay outside the mutable selector" >&2; exit 1 ;;
 esac
 
+# The aggregate must not absorb a skipped shard on a tag. It did, which is how
+# v2.2.5 reported success while create-release and every release producer were
+# skipped out of the graph; the tag path now has no skip to absorb, and this
+# job fails closed if one reappears. IS_TAG/ALREADY_GREEN stay in the env for
+# the diagnostic line.
 case "$aggregate" in
-    *'if: ${{ always() }}'*'needs: [channel, rust-tests-shard, rust-tests-doctest]'*'SHARDS_RESULT'*'DOCTEST_RESULT'*'RUST_TESTS_CHANGED'*'ALREADY_GREEN'*'IS_TAG'*'if [ "$SHARDS_RESULT" = success ] && [ "$DOCTEST_RESULT" = success ]'*'"$SHARDS_RESULT" = skipped'*'"$DOCTEST_RESULT" = skipped'*'"$RUST_TESTS_CHANGED" != true'*'"$IS_TAG" = true'*'"$ALREADY_GREEN" = true'*) ;;
+    *'if: ${{ always() }}'*'needs: [channel, rust-tests-shard, rust-tests-doctest]'*'SHARDS_RESULT'*'DOCTEST_RESULT'*'RUST_TESTS_CHANGED'*'ALREADY_GREEN'*'IS_TAG'*'if [ "$SHARDS_RESULT" = success ] && [ "$DOCTEST_RESULT" = success ]'*'"$SHARDS_RESULT" = skipped'*'"$DOCTEST_RESULT" = skipped'*'"$RUST_TESTS_CHANGED" != true'*) ;;
     *) echo "rust-tests aggregate must always run and fail closed over every shard plus doctests" >&2; exit 1 ;;
 esac
 case "$aggregate" in


### PR DESCRIPTION
## What happened

`v2.2.5` was tagged, its CI run reported **success**, and it published
nothing — no GitHub release, no `SHA256SUMS`, no artefacts. Skipped:
`create-release`, `linux-release-portability`, all five `build-*` jobs,
`publish-checksums`, `publish-native-binaries`, and the three marketplace
publishes.

## Root cause

`ci.yml`'s header states the invariant:

> the jobs themselves always run and report success, so required status checks
> and the tag-triggered release graph stay unbroken (GitHub's `success()`
> propagates a skipped ancestor through the needs graph, **so job-level skips
> are banned — step-level only**).

#1987 ("ci: shard root Rust tests directly", 2026-09-08) broke it. It gave
`rust-tests-shard` and `rust-tests-doctest` *job-level* conditions that go
false on `tag && already_green`, explicitly to avoid "allocating five test
runners".

That lay dormant until now:

| tag | `already_green` | outcome |
|---|---|---|
| v2.2.4 (2026-09-07) | `false` | shards ran → `create-release` ran → 60 assets |
| v2.2.5 (2026-09-10) | `true` | shards skipped at job level → release graph gone |

v2.2.5 is the first tag where the reuse path actually engaged. The skip
propagated past the `rust-tests` aggregate — which absorbs it correctly and
reports success — into every release producer below it.

Corroboration: `create-release`'s sibling `native …` matrix carries the
*identical* `if: startsWith(github.ref, 'refs/tags/v')` and ran fine, building
all 28 platform binaries. It needs only `channel`. That isolates the cause to
the needs graph rather than the ref condition, and all ten of
`create-release`'s declared prerequisites reported success.

## The fix

- Drop the tag clause from both job-level conditions. A tag forces
  `rust_tests_changed` true, so the jobs stay in the graph on the release path
  and step-skip their work through the guards already present on every
  expensive step — including the `cargo nextest` run itself. The changed-path
  skip is kept: a pull request has no release graph, and the aggregate has
  always absorbed that case.
- The `rust-tests` aggregate now **fails closed** instead of absorbing a
  skipped shard on a tag, so a re-introduction fails the tag run loudly rather
  than silently shipping nothing.

## Why no gate caught it

Both contract tests pinned the defect *as the requirement*.
`test-rust-tests-paths.sh` and `test-rust-tests-runner.sh` each asserted the
exact buggy condition string, so the workflow could not be corrected without
failing them. Both now assert the corrected shape, and the former gained an
explicit guard that neither job may carry a tag/already-green clause at job
level. Negative-tested by reverting `ci.yml` to the old shape: the guard
fails; restored, it passes.

`make check-release-dependency-graph` and `make check-already-green` both pass
on the *broken* workflow, so neither covers "an already-green tag still
produces a release". That gap is not closed here.

`make rust-check` passes.

## Still outstanding

`v2.2.5` is tagged with no release behind it. Recovering it needs either a
`workflow_dispatch` against the tag (the documented escape hatch) or a re-cut,
once this is on `rust`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoYjXHMmULxxxQFULqC2iX
