### PR TITLE
fix(ci): make the Rust shard job no-op fully on an already-green tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1292,7 +1292,7 @@ jobs:
           fetch-depth: 1
 
       - name: Verify canonical Rust homes
-        if: needs.channel.outputs.rust_tests_changed == 'true' && (needs.channel.outputs.already_green != 'true' || matrix.shard == '1/5')
+        if: needs.channel.outputs.rust_tests_changed == 'true' && !(startsWith(github.ref, 'refs/tags/') && needs.channel.outputs.already_green == 'true') && (needs.channel.outputs.already_green != 'true' || matrix.shard == '1/5')
         shell: bash
         run: |
           set -euo pipefail
@@ -1315,7 +1315,7 @@ jobs:
       # The action installs the current stable and wires up the Swatinem cache
       # (keyed per job, so the concurrent cargo jobs don't race on save).
       - name: Set up Rust
-        if: needs.channel.outputs.rust_tests_changed == 'true' && (needs.channel.outputs.already_green != 'true' || matrix.shard == '1/5')
+        if: needs.channel.outputs.rust_tests_changed == 'true' && !(startsWith(github.ref, 'refs/tags/') && needs.channel.outputs.already_green == 'true') && (needs.channel.outputs.already_green != 'true' || matrix.shard == '1/5')
         uses: actions-rust-lang/setup-rust-toolchain@ecabd13d1c56bd1345c230e542e9144811ad706f # v2.0.0
         with:
           toolchain: stable
@@ -1333,7 +1333,7 @@ jobs:
       # that registrations with different absolute workspace paths share them.
       - name: Set up sccache
         id: sccache
-        if: needs.channel.outputs.rust_tests_changed == 'true' && (needs.channel.outputs.already_green != 'true' || matrix.shard == '1/5')
+        if: needs.channel.outputs.rust_tests_changed == 'true' && !(startsWith(github.ref, 'refs/tags/') && needs.channel.outputs.already_green == 'true') && (needs.channel.outputs.already_green != 'true' || matrix.shard == '1/5')
         continue-on-error: true
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
         with:
@@ -1345,7 +1345,7 @@ jobs:
       # Do not export the wrapper until both action setup and the installed
       # binary have succeeded; Cargo then falls back to rustc automatically.
       - name: Enable sccache when available
-        if: needs.channel.outputs.rust_tests_changed == 'true' && (needs.channel.outputs.already_green != 'true' || matrix.shard == '1/5')
+        if: needs.channel.outputs.rust_tests_changed == 'true' && !(startsWith(github.ref, 'refs/tags/') && needs.channel.outputs.already_green == 'true') && (needs.channel.outputs.already_green != 'true' || matrix.shard == '1/5')
         shell: bash
         env:
           SCCACHE_SETUP_OUTCOME: ${{ steps.sccache.outcome }}
@@ -1361,8 +1361,14 @@ jobs:
       # Tank is serialised by the job-level concurrency group, so this target
       # is safe to retain per runner registration.  Hosted overflow never
       # touches the root and keeps Cargo's ordinary ephemeral target.
+      #
+      # Every step here carries the same tag/already-green exclusion as the
+      # nextest step below: on an already-green tag the job stays in the graph
+      # (so the release producers keep their ancestor) but must do no work at
+      # all. Preparing the Tank target enforces a 20 GiB floor, which failed
+      # the first v2.2.5 re-tag for a shard that was never going to run a test.
       - name: Prepare persistent Tank Cargo target
-        if: needs.channel.outputs.rust_tests_changed == 'true' && (needs.channel.outputs.already_green != 'true' || matrix.shard == '1/5') && env.RUNNER_MODE == 'tank'
+        if: needs.channel.outputs.rust_tests_changed == 'true' && !(startsWith(github.ref, 'refs/tags/') && needs.channel.outputs.already_green == 'true') && (needs.channel.outputs.already_green != 'true' || matrix.shard == '1/5') && env.RUNNER_MODE == 'tank'
         shell: bash
         run: |
           registration="${TCL_LSP_TANK_REGISTRATION_ID:-${RUNNER_NAME:-}}"
@@ -1370,7 +1376,7 @@ jobs:
           printf 'CARGO_TARGET_DIR=%s\n' "$target" >> "$GITHUB_ENV"
 
       - name: Install cargo-nextest
-        if: needs.channel.outputs.rust_tests_changed == 'true' && (needs.channel.outputs.already_green != 'true' || matrix.shard == '1/5')
+        if: needs.channel.outputs.rust_tests_changed == 'true' && !(startsWith(github.ref, 'refs/tags/') && needs.channel.outputs.already_green == 'true') && (needs.channel.outputs.already_green != 'true' || matrix.shard == '1/5')
         uses: taiki-e/install-action@c3ec0de9ae7f1019cea21aa96aa0a895b9552063 # v2.87.9
         with:
           tool: nextest@0.9.143
@@ -1457,7 +1463,7 @@ jobs:
       # Setup is intentionally skipped when the root Rust-test closure is
       # unaffected, so sccache is unavailable on those required no-op runs.
       - name: Report sccache statistics
-        if: always() && needs.channel.outputs.rust_tests_changed == 'true' && (needs.channel.outputs.already_green != 'true' || matrix.shard == '1/5')
+        if: always() && needs.channel.outputs.rust_tests_changed == 'true' && !(startsWith(github.ref, 'refs/tags/') && needs.channel.outputs.already_green == 'true') && (needs.channel.outputs.already_green != 'true' || matrix.shard == '1/5')
         shell: bash
         run: |
           if ! command -v sccache >/dev/null 2>&1; then

--- a/scripts/dev/test-rust-tests-runner.sh
+++ b/scripts/dev/test-rust-tests-runner.sh
@@ -262,7 +262,12 @@ END {
     need(values[shard_job ".env.SCCACHE_GHA_ENABLED"] == "true", "Rust shards must enable GHA sccache")
 
     changed = "needs.channel.outputs.rust_tests_changed == '\''true'\''"
-    active = changed " && (needs.channel.outputs.already_green != '\''true'\'' || matrix.shard == '\''1/5'\'')"
+    # On an already-green tag the shard job stays in the graph so the release
+    # producers keep their ancestor, but every step must no-op: preparing the
+    # Tank target alone enforces a 20 GiB free-space floor, which failed a
+    # v2.2.5 re-tag for a shard that was never going to run a test.
+    not_green_tag = " && !(startsWith(github.ref, '\''refs/tags/'\'') && needs.channel.outputs.already_green == '\''true'\'')"
+    active = changed not_green_tag " && (needs.channel.outputs.already_green != '\''true'\'' || matrix.shard == '\''1/5'\'')"
     preflight = step(shard_job, "name", "Verify canonical Rust homes")
     need(preflight >= 0 && values[shard_job ".steps." preflight ".if"] == active, "canonical-home preflight must be path- and warm-path-gated")
     contains(shard_job ".steps." preflight ".run", "test ! -L \"$root\"", "canonical-home preflight must reject a symlinked root")
@@ -416,7 +421,7 @@ esac
 # For an already-green merge push, the matrix remains allocated but only shard
 # 1 may warm the cache; shards 2–5 must skip every expensive setup/report step.
 require_path_gate_count "        if: needs.channel.outputs.rust_tests_changed == 'true' && needs.channel.outputs.docs_only != 'true' && needs.channel.outputs.already_green != 'true'" 2
-require_path_gate_count "        if: needs.channel.outputs.rust_tests_changed == 'true' && (needs.channel.outputs.already_green != 'true' || matrix.shard == '1/5')" 5
+require_path_gate_count "        if: needs.channel.outputs.rust_tests_changed == 'true' && !(startsWith(github.ref, 'refs/tags/') && needs.channel.outputs.already_green == 'true') && (needs.channel.outputs.already_green != 'true' || matrix.shard == '1/5')" 5
 require_path_gate_count "        if: needs.channel.outputs.rust_tests_changed == 'true' && needs.channel.outputs.docs_only != 'true' && !(startsWith(github.ref, 'refs/tags/') && needs.channel.outputs.already_green == 'true') && (needs.channel.outputs.already_green != 'true' || matrix.shard == '1/5')" 1
 case "$(cat "$WORKFLOW")" in
     *'if [ "$rust_tests_changed" = "true" ]; then


### PR DESCRIPTION
Follow-up to #2109, which kept `rust-tests-shard` in the graph on an
already-green tag so the release producers keep their ancestor.

Only the `cargo nextest` step carried the tag/already-green exclusion. The
seven setup and reporting steps did not, so shard 1/5 still ran all of them —
including "Prepare persistent Tank Cargo target", which enforces a 20 GiB
free-space floor:

    persistent-cargo-target: free space 4317692KiB is below 20971520KiB floor

That failed the shard on the v2.2.5 re-tag, failed the `rust-tests` aggregate,
and gated `create-release` out again — this time *correctly*, on a genuinely
failed prerequisite, for a shard that was never going to execute a test.

All eight guards now carry the same exclusion, so on an already-green tag the
job stays in the graph and does nothing at all.

## Contracts

Both pinned the old shape again, in two different ways: the runner contract
composes the expected condition in awk (`active`), and separately counts five
steps matching the string verbatim via `require_path_gate_count`. Both are
updated. `make rust-check` passes.

## Not addressed here

The Tank host is 16 GiB under its own floor (4.3 GiB free against 20 GiB).
That is an operational problem in its own right — any real test run on that
runner will hit it. This change only stops an already-green tag from depending
on it.

Also still open from #2109: `check-release-dependency-graph` and
`check-already-green` both pass on a workflow where an already-green tag
produces no release, so neither proves the release path end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoYjXHMmULxxxQFULqC2iX
