### PR TITLE
ci: add a manual sweep for the Tank persistent Cargo target root

### DIFF
--- a/.github/workflows/tank-maintenance.yml
+++ b/.github/workflows/tank-maintenance.yml
@@ -1,0 +1,81 @@
+name: Tank maintenance (persistent Cargo target sweep)
+
+# The Tank runner retains one Cargo target per runner registration
+# (scripts/dev/persistent-cargo-target.sh). `prepare` runs the janitor on
+# every job, but with a 14-day retention and a cap of 8 removals per
+# invocation — deliberately gentle, so an ordinary CI job never spends its
+# time reclaiming disk. When the host falls below the 20 GiB floor faster than
+# that reclaims, every Tank job fails before it starts:
+#
+#   persistent-cargo-target: free space 4317692KiB is below 20971520KiB floor
+#
+# This is the manual sweep for that. It calls the same hardened janitor verb —
+# which takes the root lock, refuses symlinked or unowned paths, and skips a
+# target whose Cargo lock is held — with a retention and cap the operator
+# chooses. It never removes an unmarked directory and never touches a target
+# a running job holds.
+on:
+  workflow_dispatch:
+    inputs:
+      retention_days:
+        description: Remove targets whose marker is older than this many days (0 = every unlocked target)
+        default: "0"
+        type: string
+      limit:
+        description: Maximum targets to remove in this sweep
+        default: "64"
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  sweep:
+    runs-on: tank
+    # Share the shard job's group so a sweep and a test run never contend for
+    # the same target root; the janitor's own lock is the second line, not the
+    # first.
+    concurrency:
+      group: rust-tests-tank
+      queue: max
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+
+      - name: Sweep the persistent Cargo target root
+        shell: bash
+        env:
+          TCL_LSP_TANK_RETENTION_DAYS: ${{ inputs.retention_days }}
+          TCL_LSP_TANK_JANITOR_LIMIT: ${{ inputs.limit }}
+        run: |
+          set -euo pipefail
+          root=${TCL_LSP_TANK_TARGET_ROOT:-/home/runner/.cache/tcl-lsp/cargo-targets}
+          echo "::group::Before"
+          df -Pk -- "$root" || df -Pk -- /
+          du -sh -- "$root" 2>/dev/null || echo "(root absent)"
+          echo "::endgroup::"
+
+          if [ ! -d "$root" ]; then
+            echo "no persistent target root at $root — nothing to sweep"
+            exit 0
+          fi
+          bash scripts/dev/persistent-cargo-target.sh janitor "$root"
+
+          echo "::group::After"
+          df -Pk -- "$root"
+          du -sh -- "$root" 2>/dev/null || true
+          echo "::endgroup::"
+
+      - name: Report free space against the floor
+        shell: bash
+        run: |
+          set -euo pipefail
+          root=${TCL_LSP_TANK_TARGET_ROOT:-/home/runner/.cache/tcl-lsp/cargo-targets}
+          floor=${TCL_LSP_TANK_MIN_FREE_KB:-20971520}
+          free=$(df -Pk -- "$root" | awk 'NR == 2 { print $4 }')
+          printf 'free=%sKiB floor=%sKiB\n' "$free" "$floor"
+          if [ "$free" -lt "$floor" ]; then
+            echo "::warning::still below the floor — the reclaimable targets are gone, so the host needs space freed outside the Cargo target root"
+          fi


### PR DESCRIPTION
`prepare` runs the janitor on every Tank job, but with a 14-day retention and
a cap of 8 removals per invocation — gentle on purpose, so an ordinary CI job
never spends its time reclaiming disk. When the host falls below the 20 GiB
floor faster than that reclaims, every Tank job fails before it starts:

    persistent-cargo-target: free space 4317692KiB is below 20971520KiB floor

That is what blocked the v2.2.5 re-tag, and there was no way to reclaim the
root short of reaching the host directly.

## What this does

A `workflow_dispatch` that calls the same hardened `janitor` verb with an
operator-chosen retention and cap. It reuses the vetted path rather than
removing anything itself:

- the root lock is taken for the sweep;
- symlinked or unowned paths are refused;
- an unmarked directory is never a janitor target;
- a target whose Cargo lock a running job holds is skipped.

It shares the shard job's `rust-tests-tank` concurrency group, so a sweep and
a test run never contend for the root — the janitor's own lock is the second
line of defence, not the first.

Defaults are `retention_days: 0` (every unlocked, marked target) and
`limit: 64`, both overridable at dispatch.

## Reading the result

The last step compares free space against the floor and warns if the host is
*still* under it. That distinction matters: the janitor can only reclaim the
Cargo target root, so a remaining shortfall means the space went somewhere
else on the host and needs attention there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoYjXHMmULxxxQFULqC2iX
