### PR TITLE
ci(tank): let an operator sweep reclaim targets the retention window keeps

### DIFF
--- a/.github/workflows/tank-maintenance.yml
+++ b/.github/workflows/tank-maintenance.yml
@@ -25,6 +25,10 @@ on:
         description: Maximum targets to remove in this sweep
         default: "64"
         type: string
+      ignore_age:
+        description: Reclaim every unlocked target regardless of age (cold rebuilds follow)
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -49,6 +53,7 @@ jobs:
         env:
           TCL_LSP_TANK_RETENTION_DAYS: ${{ inputs.retention_days }}
           TCL_LSP_TANK_JANITOR_LIMIT: ${{ inputs.limit }}
+          TCL_LSP_TANK_SWEEP_ALL: ${{ inputs.ignore_age && '1' || '0' }}
         run: |
           set -euo pipefail
           root=${TCL_LSP_TANK_TARGET_ROOT:-/home/runner/.cache/tcl-lsp/cargo-targets}

--- a/scripts/dev/persistent-cargo-target.sh
+++ b/scripts/dev/persistent-cargo-target.sh
@@ -17,6 +17,12 @@ ROOT=${TCL_LSP_TANK_TARGET_ROOT:-/home/runner/.cache/tcl-lsp/cargo-targets}
 MIN_FREE_KB=${TCL_LSP_TANK_MIN_FREE_KB:-20971520}
 RETENTION_DAYS=${TCL_LSP_TANK_RETENTION_DAYS:-14}
 JANITOR_LIMIT=${TCL_LSP_TANK_JANITOR_LIMIT:-8}
+# Reclaim regardless of marker age. Only an operator sweep sets this: the
+# retention window is what keeps a *warm* target warm, and a target removed
+# here is rebuilt from scratch on its next job. Every other guard still
+# applies — the target must be marked, owned, safe-moded, and its Cargo lock
+# free, so a target a running job holds is still skipped.
+SWEEP_ALL=${TCL_LSP_TANK_SWEEP_ALL:-0}
 MARKER=.tcl-lsp-cargo-target
 LOCK=.tcl-lsp-cargo-target.lock
 ROOT_LOCK=.tcl-lsp-cargo-target.root.lock
@@ -36,6 +42,10 @@ number() {
 number "$MIN_FREE_KB" || die "TCL_LSP_TANK_MIN_FREE_KB must be a non-negative integer"
 number "$RETENTION_DAYS" || die "TCL_LSP_TANK_RETENTION_DAYS must be a non-negative integer"
 number "$JANITOR_LIMIT" || die "TCL_LSP_TANK_JANITOR_LIMIT must be a non-negative integer"
+case "$SWEEP_ALL" in
+    0|1) ;;
+    *) die "TCL_LSP_TANK_SWEEP_ALL must be 0 or 1" ;;
+esac
 
 cleanup() {
     local status=$?
@@ -207,7 +217,8 @@ janitor() {
         # Use the marker age, not the directory age: opening the Cargo lock
         # itself changes the directory mtime and must not make an old target
         # look young.
-        if find "$marker" -maxdepth 0 -mtime +"$RETENTION_DAYS" -print -quit | grep -q .; then
+        if [ "$SWEEP_ALL" = 1 ] ||
+            find "$marker" -maxdepth 0 -mtime +"$RETENTION_DAYS" -print -quit | grep -q .; then
             # Scan every direct child, but cap destructive work per invocation.
             # Fresh/unmarked entries must not starve old targets.
             [ "$removed" -lt "$JANITOR_LIMIT" ] || continue

--- a/scripts/dev/test-persistent-cargo-target.sh
+++ b/scripts/dev/test-persistent-cargo-target.sh
@@ -199,6 +199,31 @@ done
 bash "$HELPER" janitor "$TARGET_ROOT" >"$ROOT/starved.out"
 grep -q 'janitor_removed=1' "$ROOT/starved.out" || fail "expired target behind prefix was starved"
 [ ! -e "$starved" ] || fail "expired target behind prefix survived"
+# TCL_LSP_TANK_SWEEP_ALL=1 is the operator sweep: it reclaims a target the
+# retention window would keep, because a host can fill with targets that are
+# all in active use (the Tank root reached 174 GiB across four live
+# registrations on a 193 GiB disk, and an age-bounded sweep freed nothing).
+# Every other guard must still hold — in particular a locked target is still
+# skipped, since a running job owns it.
+sweep_young=$(prepare sweep-young)
+[ -e "$sweep_young" ] || fail "sweep fixture was not created"
+TCL_LSP_TANK_TARGET_ROOT="$TARGET_ROOT" bash "$HELPER" janitor "$TARGET_ROOT" >"$ROOT/sweep-off.out"
+[ -e "$sweep_young" ] || fail "a young target was removed without the sweep flag"
+sweep_locked=$(prepare sweep-locked)
+exec 8>"$sweep_locked/.tcl-lsp-cargo-target.lock"
+flock -n 8
+TCL_LSP_TANK_TARGET_ROOT="$TARGET_ROOT" TCL_LSP_TANK_SWEEP_ALL=1 \
+    bash "$HELPER" janitor "$TARGET_ROOT" >"$ROOT/sweep-on.out"
+[ ! -e "$sweep_young" ] || fail "sweep-all left a young unlocked target behind"
+[ -e "$sweep_locked" ] || fail "sweep-all removed a locked target"
+grep -q 'janitor_locked=1' "$ROOT/sweep-on.out" || fail "sweep-all did not report the locked target"
+exec 8>&-
+rm -rf "$sweep_locked"
+
+expect_failure env TCL_LSP_TANK_SWEEP_ALL=2 bash "$HELPER" janitor "$TARGET_ROOT"
+grep -q 'TCL_LSP_TANK_SWEEP_ALL must be 0 or 1' "$ROOT/unexpected.err" ||
+    fail "sweep flag must reject a non-boolean value"
+
 old_one=$(prepare bounded-one)
 old_two=$(prepare bounded-two)
 touch -d '30 days ago' "$old_one/.tcl-lsp-cargo-target" "$old_two/.tcl-lsp-cargo-target"


### PR DESCRIPTION
The sweep added in #2111 ran against the Tank host and freed nothing:

    /dev/sda1  193 GiB total, 98% used, 4.3 GiB free
    cargo-targets  174 GiB across 4 registrations
    janitor_removed=0 janitor_locked=0 janitor_unsafe=0 janitor_inspected=4

All four persistent targets had been touched that day, so the retention window
protected every one of them — and `find -mtime +0` means "older than 24
hours", so even `retention_days=0` could not reach them. One target per runner
registration, four live registrations at roughly 43 GiB each, is 90% of that
disk. No age-bounded sweep can recover it, which is why every Tank job now
fails at the 20 GiB floor before it starts.

## The flag

`TCL_LSP_TANK_SWEEP_ALL=1` reclaims an unlocked target regardless of age,
exposed as the dispatch's `ignore_age` input. Every other guard still holds:

- the target must carry a valid marker;
- it must be owned by the invoking user with the expected mode;
- a symlinked, unmarked or malformed directory is never a candidate;
- **a target whose Cargo lock a running job holds is skipped**, so a sweep
  cannot pull the target out from under a live build.

The default is unchanged (`0`), so the retention window still keeps a warm
target warm for ordinary jobs. A target reclaimed this way is rebuilt from
scratch on its next job — that is the point of the flag, and the reason it is
not the default.

## Verification

**Not exercised locally.** The helper needs `flock`, GNU `stat` and `/proc`;
the macOS release laptop has none of the last two, so
`scripts/dev/test-persistent-cargo-target.sh` skips there by design. The new
contract cases run on CI only:

- a young target survives a sweep without the flag;
- the same target is reclaimed with it;
- a locked target is skipped either way and reported as `janitor_locked=1`;
- a non-boolean value for the flag is rejected.

`make rust-check` passes.

## Longer term

Four active registrations will refill that host again. The durable answers are
fewer registrations or more disk; this only gives an operator a way to
recover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoYjXHMmULxxxQFULqC2iX
